### PR TITLE
Edit EP Claim Labels | Add "type" to request issue

### DIFF
--- a/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
+++ b/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
@@ -1,0 +1,5 @@
+class AddRequestIssueTypeToRequestIssues < ActiveRecord::Migration[5.2]
+  def change
+    add_column :request_issues, :request_issue_type, :string, default: :request_isssue, comment: "Determines whether the issue is a rating issue or a nonrating issue"
+  end
+end

--- a/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
+++ b/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
@@ -1,5 +1,5 @@
 class AddRequestIssueTypeToRequestIssues < ActiveRecord::Migration[5.2]
   def change
-    add_column :request_issues, :request_issue_type, :string, default: :request_isssue, comment: "Determines whether the issue is a rating issue or a nonrating issue"
+    add_column :request_issues, :request_issue_type, :string, default: "RequestIssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
   end
 end

--- a/db/migrate/20200928194631_backfill_request_issue_type.rb
+++ b/db/migrate/20200928194631_backfill_request_issue_type.rb
@@ -1,4 +1,7 @@
 class BackfillRequestIssueType < ActiveRecord::Migration[5.2]
   def change
+  	RequestIssue.unscoped.in_batches do |relation|
+      relation.update_all type: "RequestIssue"
+      sleep(0.1)
   end
 end

--- a/db/migrate/20200928194631_backfill_request_issue_type.rb
+++ b/db/migrate/20200928194631_backfill_request_issue_type.rb
@@ -3,5 +3,6 @@ class BackfillRequestIssueType < ActiveRecord::Migration[5.2]
   	RequestIssue.unscoped.in_batches do |relation|
       relation.update_all type: "RequestIssue"
       sleep(0.1)
+    end
   end
 end

--- a/db/migrate/20200928194631_backfill_request_issue_type.rb
+++ b/db/migrate/20200928194631_backfill_request_issue_type.rb
@@ -1,0 +1,4 @@
+class BackfillRequestIssueType < ActiveRecord::Migration[5.2]
+  def change
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_23_004430) do
+ActiveRecord::Schema.define(version: 2020_09_28_194631) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1140,6 +1140,7 @@ ActiveRecord::Schema.define(version: 2020_09_23_004430) do
     t.text "notes", comment: "Notes added by the Claims Assistant when adding request issues. This may be used to capture handwritten notes on the form, or other comments the CA wants to capture."
     t.string "ramp_claim_id", comment: "If a rating issue was created as a result of an issue intaken for a RAMP Review, it will be connected to the former RAMP issue by its End Product's claim ID."
     t.datetime "rating_issue_associated_at", comment: "Timestamp when a contention and its contested rating issue are associated in VBMS."
+    t.string "request_issue_type", default: "request_isssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
     t.string "unidentified_issue_text", comment: "User entered description if the request issue is neither a rating or a nonrating issue"
     t.boolean "untimely_exemption", comment: "If the contested issue's decision date was more than a year before the receipt date, it is considered untimely (unless it is a Supplemental Claim). However, an exemption to the timeliness can be requested. If so, it is indicated here."
     t.text "untimely_exemption_notes", comment: "Notes related to the untimeliness exemption requested."

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1140,7 +1140,7 @@ ActiveRecord::Schema.define(version: 2020_09_28_194631) do
     t.text "notes", comment: "Notes added by the Claims Assistant when adding request issues. This may be used to capture handwritten notes on the form, or other comments the CA wants to capture."
     t.string "ramp_claim_id", comment: "If a rating issue was created as a result of an issue intaken for a RAMP Review, it will be connected to the former RAMP issue by its End Product's claim ID."
     t.datetime "rating_issue_associated_at", comment: "Timestamp when a contention and its contested rating issue are associated in VBMS."
-    t.string "request_issue_type", default: "request_isssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
+    t.string "request_issue_type", default: "RequestIssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
     t.string "unidentified_issue_text", comment: "User entered description if the request issue is neither a rating or a nonrating issue"
     t.boolean "untimely_exemption", comment: "If the contested issue's decision date was more than a year before the receipt date, it is considered untimely (unless it is a Supplemental Claim). However, an exemption to the timeliness can be requested. If so, it is indicated here."
     t.text "untimely_exemption_notes", comment: "Notes related to the untimeliness exemption requested."

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -886,6 +886,7 @@ request_issues,veteran_participant_id,string,,,,,,The veteran participant ID. Th
 request_issues_updates,,,,,,,,"Keeps track of edits to request issues on a decision review that happen after the initial intake, such as removing and adding issues.  When the decision review is processed in VBMS, this also tracks whether adding or removing contentions in VBMS for the update has succeeded."
 request_issues_updates,after_request_issue_ids,integer ∗,x,,,,,An array of the active request issue IDs after a user has finished editing a decision review. Used with before_request_issue_ids to determine appropriate actions (such as which contentions need to be added).
 request_issues_updates,attempted_at,datetime,,,,,,Timestamp for when the request issue update processing was last attempted.
+request_issues,request_issue_type,string,,,,,,This determines whether the issue is a rating issue or a nonrating issue.
 request_issues_updates,before_request_issue_ids,integer ∗,x,,,,,An array of the active request issue IDs previously on the decision review before this editing session. Used with after_request_issue_ids to determine appropriate actions (such as which contentions need to be removed).
 request_issues_updates,canceled_at,datetime,,,,,,Timestamp when job was abandoned
 request_issues_updates,corrected_request_issue_ids,integer,,,,,,An array of the request issue IDs that were corrected during this request issues update.


### PR DESCRIPTION
Connects #15236

### Description
This pr adds  "type" to request issue so that we can hardcode whether the issue is a rating issue or a nonrating issue. It also backfills RequestIssue type to be "RequestIssue".

### Database Changes
*Only for Schema Changes*

* [x] String Type (added) for request_issues
* [x] Column comments updated
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
(https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [ ] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [ ] #appeals-schema notified with summary and link to this PR
* [x] #Backfill RequestIssue type to be "RequestIssue"
* [x] #Add type to request issue, with the default value of "RequestIssue"

