### PR TITLE
Revert "Edit EP Claim Labels | Add "type" to request issue (#15340)"

### DIFF
--- a/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
+++ b/db/migrate/20200928194138_add_request_issue_type_to_request_issues.rb
@@ -1,5 +1,0 @@
-class AddRequestIssueTypeToRequestIssues < ActiveRecord::Migration[5.2]
-  def change
-    add_column :request_issues, :request_issue_type, :string, default: "RequestIssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
-  end
-end

--- a/db/migrate/20200928194631_backfill_request_issue_type.rb
+++ b/db/migrate/20200928194631_backfill_request_issue_type.rb
@@ -1,8 +1,0 @@
-class BackfillRequestIssueType < ActiveRecord::Migration[5.2]
-  def change
-  	RequestIssue.unscoped.in_batches do |relation|
-      relation.update_all type: "RequestIssue"
-      sleep(0.1)
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_28_194631) do
+ActiveRecord::Schema.define(version: 2020_09_23_004430) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1140,7 +1140,6 @@ ActiveRecord::Schema.define(version: 2020_09_28_194631) do
     t.text "notes", comment: "Notes added by the Claims Assistant when adding request issues. This may be used to capture handwritten notes on the form, or other comments the CA wants to capture."
     t.string "ramp_claim_id", comment: "If a rating issue was created as a result of an issue intaken for a RAMP Review, it will be connected to the former RAMP issue by its End Product's claim ID."
     t.datetime "rating_issue_associated_at", comment: "Timestamp when a contention and its contested rating issue are associated in VBMS."
-    t.string "request_issue_type", default: "RequestIssue", comment: "Determines whether the issue is a rating issue or a nonrating issue"
     t.string "unidentified_issue_text", comment: "User entered description if the request issue is neither a rating or a nonrating issue"
     t.boolean "untimely_exemption", comment: "If the contested issue's decision date was more than a year before the receipt date, it is considered untimely (unless it is a Supplemental Claim). However, an exemption to the timeliness can be requested. If so, it is indicated here."
     t.text "untimely_exemption_notes", comment: "Notes related to the untimeliness exemption requested."

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -886,7 +886,6 @@ request_issues,veteran_participant_id,string,,,,,,The veteran participant ID. Th
 request_issues_updates,,,,,,,,"Keeps track of edits to request issues on a decision review that happen after the initial intake, such as removing and adding issues.  When the decision review is processed in VBMS, this also tracks whether adding or removing contentions in VBMS for the update has succeeded."
 request_issues_updates,after_request_issue_ids,integer ∗,x,,,,,An array of the active request issue IDs after a user has finished editing a decision review. Used with before_request_issue_ids to determine appropriate actions (such as which contentions need to be added).
 request_issues_updates,attempted_at,datetime,,,,,,Timestamp for when the request issue update processing was last attempted.
-request_issues,request_issue_type,string,,,,,,This determines whether the issue is a rating issue or a nonrating issue.
 request_issues_updates,before_request_issue_ids,integer ∗,x,,,,,An array of the active request issue IDs previously on the decision review before this editing session. Used with after_request_issue_ids to determine appropriate actions (such as which contentions need to be removed).
 request_issues_updates,canceled_at,datetime,,,,,,Timestamp when job was abandoned
 request_issues_updates,corrected_request_issue_ids,integer,,,,,,An array of the request issue IDs that were corrected during this request issues update.


### PR DESCRIPTION
This reverts commit 36719f49371c82d8a06f5c7a970c3f20a8a07fa8.

There were a few issues with the way the migration was structured. Let's backtrack and give ourselves the time to work through it without the urgency of a prod deploy.