### PR TITLE
 Edit EP Claim Labels | Add "type" to request issue

### DIFF
--- a/app/models/nonrating_request_issue.rb
+++ b/app/models/nonrating_request_issue.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class NonratingRequestIssue < RequestIssue
+end

--- a/app/models/nonrating_request_issue.rb
+++ b/app/models/nonrating_request_issue.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class NonratingRequestIssue < RequestIssue
+  def rating?
+    false
+  end
 end

--- a/app/models/rating_request_issue.rb
+++ b/app/models/rating_request_issue.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 
 class RatingRequestIssue < RequestIssue
+  def rating?
+    true
+  end
 end

--- a/app/models/rating_request_issue.rb
+++ b/app/models/rating_request_issue.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class RatingRequestIssue < RequestIssue
+end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -235,8 +235,9 @@ class RequestIssue < CaseflowRecord
   end
 
   def rating?
-    # binding.pry
-    #  update!(type:) if RatingRequestIssue || NonratingRequestIssue ||
+    return true if type == "RatingRequestIssue"
+    return false if type == "NonRatingRequestIssue"
+
     !!associated_rating_issue? ||
       !!previous_rating_issue? ||
       !!associated_rating_decision? ||

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -235,6 +235,8 @@ class RequestIssue < CaseflowRecord
   end
 
   def rating?
+    # binding.pry
+    #  update!(type:) if RatingRequestIssue || NonratingRequestIssue ||
     !!associated_rating_issue? ||
       !!previous_rating_issue? ||
       !!associated_rating_decision? ||

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -235,9 +235,6 @@ class RequestIssue < CaseflowRecord
   end
 
   def rating?
-    return true if type == "RatingRequestIssue"
-    return false if type == "NonRatingRequestIssue"
-
     !!associated_rating_issue? ||
       !!previous_rating_issue? ||
       !!associated_rating_decision? ||


### PR DESCRIPTION
Connects #15236

### Description
This pr checks for type on the rating? method in RequestIssue

### Acceptance Criteria
- [x] Separate PR - request issue type subclasses
  - [x] Add `RatingRequestIssue` and `NonratingRequestIssue` subclasses to `RequestIssue`
- [x] Update definition of `rating?` on `RequestIssue` to use `type` if populated with `RatingRequestIssue` or `NonratingRequestIssue`, and otherwise fallback on current calculations

