### PR TITLE
in AppealAvailableHearingLocations.suggested_hearing_location, use reject to skip nil distances

### DIFF
--- a/app/models/concerns/appeal_available_hearing_locations.rb
+++ b/app/models/concerns/appeal_available_hearing_locations.rb
@@ -5,12 +5,8 @@ module AppealAvailableHearingLocations
 
   # :nocov:
   def suggested_hearing_location
-    # return the closest hearing location
-    available_hearing_locations&.min_by do |loc|
-      next if loc.distance.nil?
-
-      loc.distance
-    end
+    # return the closest hearing location, rejecting locations with nil distances
+    available_hearing_locations&.reject { |loc| loc.distance.nil? }&.min_by { |loc| loc.distance }
   end
   # :nocov:
 end


### PR DESCRIPTION
### Description
Fixes a bug in `AppealAvailableHearingLocations.suggested_hearing_location` when skipping available hearing locations with nil distances.

before:
```ruby
sample = [{distance: 12.5}, {distance: nil}, {distance: 2.7}]

sample&.min_by do |loc|
  next if loc[:distance].nil?

  loc[:distance]
end

ArgumentError (comparison of NilClass with 12.5 failed)
```

after:
```ruby
sample = [{distance: 12.5}, {distance: nil}, {distance: 2.7}]

sample&.reject { |loc| loc[:distance].nil? }&.min_by { |loc| loc[:distance] }

=> {:distance=>2.7}
```
