### PR TITLE
Adding filtering for hearing type column on schedule veterans page

### DIFF
--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -99,9 +99,9 @@ class AssignHearingTab
 
     if former_travel_count > 0
       label = QueueColumn.format_option_label(
-                Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key,
-                former_travel_count
-              )
+        Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key,
+        former_travel_count
+      )
       options.append(QueueColumn.filter_option_hash(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key, label))
     end
 

--- a/app/models/queue_tabs/assign_hearing_tab.rb
+++ b/app/models/queue_tabs/assign_hearing_tab.rb
@@ -68,6 +68,10 @@ class AssignHearingTab
       {
         name: Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME,
         filter_options: suggested_location_options
+      },
+      {
+        name: Constants.QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME,
+        filter_options: hearing_request_type_options
       }
     ]
   end
@@ -83,6 +87,25 @@ class AssignHearingTab
       Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME,
       Constants.QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME
     ]
+  end
+
+  def hearing_request_type_options
+    options = tasks.with_cached_appeals.group(:hearing_request_type).count.each_pair.map do |option, count|
+      label = QueueColumn.format_option_label(option, count)
+      QueueColumn.filter_option_hash(option, label)
+    end
+
+    former_travel_count = tasks.with_cached_appeals.where("cached_appeal_attributes.formally_travel = ?", true).count
+
+    if former_travel_count > 0
+      label = QueueColumn.format_option_label(
+                Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key,
+                former_travel_count
+              )
+      options.append(QueueColumn.filter_option_hash(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key, label))
+    end
+
+    options
   end
 
   def power_of_attorney_name_options

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -20,11 +20,20 @@ class TaskFilter
     def create_where_clause(filter)
       clause = "#{table_column_from_name(filter.column)} IN (?)"
       filter_selections = filter.values
+      if filter.column == Constants.QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME &&
+         filter_selections.include?(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key)
+         clause = extract_former_travel_clause(filter, clause)
+      end
       if filter.column == Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name &&
          filter_selections.include?(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_AOD.key)
         clause = extract_aod_clause(filter, clause)
       end
       clause
+    end
+
+    def extract_former_travel_clause(filter, orig_clause)
+      is_former_travel_clause = "cached_appeal_attributes.formally_travel = true"
+      filter.values.size == 1 ? is_former_travel_clause : "(#{orig_clause} OR #{is_former_travel_clause})"
     end
 
     def extract_aod_clause(filter, orig_clause)
@@ -50,6 +59,8 @@ class TaskFilter
         "cached_appeal_attributes.power_of_attorney_name"
       when Constants.QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME
         "cached_appeal_attributes.suggested_hearing_location"
+      when Constants.QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME
+        "cached_appeal_attributes.hearing_request_type"
       else
         fail(Caseflow::Error::InvalidTaskTableColumnFilter, column: column_name)
       end

--- a/app/models/task_filter.rb
+++ b/app/models/task_filter.rb
@@ -17,12 +17,14 @@ class TaskFilter
       end.compact.join(" AND ")
     end
 
+    private
+
     def create_where_clause(filter)
       clause = "#{table_column_from_name(filter.column)} IN (?)"
       filter_selections = filter.values
       if filter.column == Constants.QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME &&
          filter_selections.include?(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_FORMER_TRAVEL.key)
-         clause = extract_former_travel_clause(filter, clause)
+        clause = extract_former_travel_clause(filter, clause)
       end
       if filter.column == Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name &&
          filter_selections.include?(Constants.QUEUE_CONFIG.FILTER_OPTIONS.IS_AOD.key)
@@ -33,7 +35,7 @@ class TaskFilter
 
     def extract_former_travel_clause(filter, orig_clause)
       is_former_travel_clause = "cached_appeal_attributes.formally_travel = true"
-      filter.values.size == 1 ? is_former_travel_clause : "(#{orig_clause} OR #{is_former_travel_clause})"
+      (filter.values.size == 1) ? is_former_travel_clause : "(#{orig_clause} OR #{is_former_travel_clause})"
     end
 
     def extract_aod_clause(filter, orig_clause)

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -125,11 +125,18 @@ export default class AssignHearingsTable extends React.PureComponent {
         name: 'hearingRequestType',
         header: 'Hearing Type',
         align: 'left',
+        columnName: 'Hearing Type',
         valueFunction: (row) => (
           <HearingRequestType
             hearingRequestType={row.hearingRequestType}
             isFormerTravel={row.isFormerTravel}
           />
+        ),
+        label: 'Filter by hearing request type',
+        enableFilter: true,
+        anyFiltersAreSet: true,
+        filterOptions: (
+          colsFromApi?.find((col) => col.name === QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME)?.filter_options ?? []
         )
       },
       {

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -78,11 +78,13 @@ export default class AssignHearingsTable extends React.PureComponent {
     return Number(queryParams[QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]) || 1;
   }
 
+  /* eslint-disable camelcase */
   getFilterOptionsFromApi = (columnName) => {
     const { colsFromApi } = this.state;
 
     return colsFromApi?.find((col) => col.name === columnName)?.filter_options ?? [];
   }
+  /* eslint-enable camelcase */
 
   /*
    * Gets the list of columns to populate the QueueTable with.

--- a/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearingsTable.jsx
@@ -78,6 +78,12 @@ export default class AssignHearingsTable extends React.PureComponent {
     return Number(queryParams[QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]) || 1;
   }
 
+  getFilterOptionsFromApi = (columnName) => {
+    const { colsFromApi } = this.state;
+
+    return colsFromApi?.find((col) => col.name === columnName)?.filter_options ?? [];
+  }
+
   /*
    * Gets the list of columns to populate the QueueTable with.
    */
@@ -135,9 +141,7 @@ export default class AssignHearingsTable extends React.PureComponent {
         label: 'Filter by hearing request type',
         enableFilter: true,
         anyFiltersAreSet: true,
-        filterOptions: (
-          colsFromApi?.find((col) => col.name === QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME)?.filter_options ?? []
-        )
+        filterOptions: this.getFilterOptionsFromApi(QUEUE_CONFIG.HEARING_REQUEST_TYPE_COLUMN_NAME)
       },
       {
         name: 'docketNum',
@@ -162,7 +166,7 @@ export default class AssignHearingsTable extends React.PureComponent {
         filterValueTransform: this.formatSuggestedHearingLocation,
         enableFilter: true,
         anyFiltersAreSet: true,
-        filterOptions: colsFromApi && colsFromApi.find((col) => col.name === 'suggestedLocation').filter_options
+        filterOptions: this.getFilterOptionsFromApi(QUEUE_CONFIG.SUGGESTED_HEARING_LOCATION_COLUMN_NAME)
       },
       {
         name: 'veteranState',
@@ -183,7 +187,7 @@ export default class AssignHearingsTable extends React.PureComponent {
         label: 'Filter by Power of Attorney',
         enableFilter: true,
         anyFiltersAreSet: true,
-        filterOptions: colsFromApi && colsFromApi.find((col) => col.name === 'powerOfAttorneyName').filter_options
+        filterOptions: this.getFilterOptionsFromApi(QUEUE_CONFIG.POWER_OF_ATTORNEY_COLUMN_NAME)
       }
     ];
 

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -109,6 +109,9 @@
   "FILTER_OPTIONS": {
     "IS_AOD": {
       "key": "is_aod"
+    },
+    "IS_FORMER_TRAVEL": {
+      "key": "former Travel"
     }
   }
 }

--- a/spec/feature/hearings/assign_hearings_table_spec.rb
+++ b/spec/feature/hearings/assign_hearings_table_spec.rb
@@ -323,8 +323,8 @@ RSpec.feature "Assign Hearings Table" do
 
         step "check if the filter options are as expected" do
           expect(page).to have_content("Suggested Location")
-          expect(page).to have_selector(".unselected-filter-icon-inner", count: 2)
-          page.find(".unselected-filter-icon-inner", match: :first).click
+          expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
+          page.find_all(".unselected-filter-icon-inner")[1].click
           expect(page).to have_content("#{Appeal.first.suggested_hearing_location.formatted_location} (1)")
           expect(page).to have_content("#{Appeal.second.suggested_hearing_location.formatted_location} (1)")
           expect(page).to have_content("#{Appeal.third.suggested_hearing_location.formatted_location} (1)")
@@ -357,8 +357,8 @@ RSpec.feature "Assign Hearings Table" do
 
         step "check if the filter options are as expected" do
           expect(page).to have_content("Power of Attorney (POA)")
-          expect(page).to have_selector(".unselected-filter-icon-inner", count: 2)
-          page.find_all(".unselected-filter-icon-inner")[1].click
+          expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
+          page.find_all(".unselected-filter-icon-inner").last.click
           expect(page).to have_content("#{Appeal.first.representative_name} (1)")
           expect(page).to have_content("#{Appeal.second.representative_name} (1)")
           expect(page).to have_content("#{Appeal.third.representative_name} (1)")

--- a/spec/feature/hearings/assign_hearings_table_spec.rb
+++ b/spec/feature/hearings/assign_hearings_table_spec.rb
@@ -429,8 +429,9 @@ RSpec.feature "Assign Hearings Table" do
         )
       end
 
+      before { cache_legacy_appeals }
+
       scenario "Verify rows are populated correctly" do
-        cache_legacy_appeals
         visit "hearings/schedule/assign"
         expect(page).to have_content("Regional Office")
         click_dropdown(text: "St. Petersburg")
@@ -442,6 +443,30 @@ RSpec.feature "Assign Hearings Table" do
         expect(table_row).to have_content("Travel")
         table_row = page.find("tr", id: "table-row-2")
         expect(table_row).to have_content("former Travel, Virtual")
+      end
+
+      context "Filter by Hearing Type column" do
+        it "filters are correct, and filter as expected" do
+          step "navigate to St. Petersburg legacy veterans tab" do
+            visit "hearings/schedule/assign"
+            click_dropdown(text: "St. Petersburg")
+            click_button("Legacy Veterans Waiting", exact: true)
+          end
+
+          step "check if the filter options are as expected" do
+            expect(page).to have_content("Hearing Type")
+            expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
+            page.find_all(".unselected-filter-icon-inner").first.click
+            expect(page).to have_content("Virtual (1)")
+            expect(page).to have_content("Video (1)")
+            expect(page).to have_content("former Travel (1)")
+          end
+
+          step "clicking on a filter reduces the number of results by the expect amount" do
+            page.find("label", text: "former Travel (1)", match: :prefer_exact).click
+            expect(find("tbody").find_all("tr").length).to eq(1)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #15058

### Description

* Return filter options from server for hearing type
* Add special logic for handling hearing type filter values from frontend
* Refactor common logic for populating filter options from API

### Acceptance Criteria
- [x] Show a filter button next to the Hearing Type header
- [x] Clicking the filter button opens up menu showing all hearing types in the list and the total number of cases for each type
- [x] Checking boxes next to hearing types filters the list to show only the selected type(s)
- [x] A "clear filter" button appears at the top of the menu, and clicking it clears the checkbox selections and shows all cases in the list
- [ ] ~~The queue can be sorted by hearing type (if this is a recommended outcome from spike #15203)~~

### Testing Plan

1. Find a travel board appeal (VACOLS id = 1986897 should be a travel board appeal in dev)
2. Complete the change hearing request type task
3. Geomatch the appeal with `appeal.va_dot_gov_address_validator.update_closest_ro_and_ahls`
4. Run `UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals` to generate cached data
5. Navigate to assign hearing schedule page, and look for the travel board appeal

### User Facing Changes

![Screen Recording 2020-10-05 at 4 32 16 PM mov](https://user-images.githubusercontent.com/1298274/95129158-9718c000-0728-11eb-891d-5b742059c5d7.gif)
