### PR TITLE
recover from RecordNotUnique race condition when creating new legacy appeal

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -1028,7 +1028,14 @@ class LegacyAppeal < CaseflowRecord
 
       fail ActiveRecord::RecordNotFound unless appeal.check_and_load_vacols_data!
 
-      appeal.save
+      # recover if another process has saved a record for this
+      # appeal since this method started
+      begin
+        appeal.save
+      rescue ActiveRecord::RecordNotUnique
+        appeal = find_by!(vacols_id: vacols_id)
+      end
+
       appeal
     end
 


### PR DESCRIPTION
### Description
If `LegacyAppeal.find_or_create_by_vacols_id` is hit multiple times for an appeal that doesn't yet exist, it's possible for a race condition to arise where the appeal is saved by one process in between the time another process initializes and attempts to save it.

I observed this happening when loading the case details page for appeals that exist in VACOLS but not Caseflow, when `find_or_create_by_vacols_id` is invoked from the appeals controller and the tasks controller in quick succession. When the second process attempts to save its version of the appeal, it fails with `PG::UniqueViolation` / `ActiveRecord::RecordNotUnique`.

I changed the method to capture the `ActiveRecord::RecordNotUnique` and return the existing record via `find_by!` (which'll raise a `ActiveRecord::RecordNotFound` if it's unsuccessful), following [this pattern](https://github.com/rails/rails/pull/31989), from the Rails 6 `create_or_find_by` method.

It's not ideal to [use an exception as flow control](https://wiki.c2.com/?DontUseExceptionsForFlowControl), but I think it's okay in this case to let the database constraint determine the action.

