### PR TITLE
Disable unlisted claimant UI and update copy

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -623,7 +623,7 @@
   "CLAIMANT_NOT_FOUND_START": "Please select the claimant listed on the form. If the claimant is a Veteran's dependant (spouse, child, or parent) and they are not listed or their information needs to be updated, ",
   "CLAIMANT_NOT_FOUND_END": " for assistance. Note: Remember to encrypt any emails that contain PII (such as a veteran or claimant's name, file number or SSN).",
   "ADD_CLAIMANT_MODAL_TITLE": "Add Claimant",
-  "ADD_CLAIMANT_MODAL_DESCRIPTION": "To add a claimant, select their relationship to the veteran and type to search for their name. **Please note:** at this time, you are only able to add attorneys as claimants.\n\n If you are unable to find attorney in the list of names below, select \"Claimant not listed\" and add their name, address, and law firm (if applicable) in the notes section.",
+  "ADD_CLAIMANT_MODAL_DESCRIPTION": "To add a claimant, select their relationship to the Veteran and type to search for their name. **Please note:** at this time, you are only able to add attorneys as claimants.\n\nIf you are unable to find the attorney in the list of names below, please cancel the intake and [email](mailto:VACaseflowIntake@va.gov) for assistance. Remember to encrypt any emails that contain PII.",
   "INTAKE_EDIT_WITHDRAW_DATE": "Please include the date the withdrawal was requested",
   "INTAKE_WITHDRAWN_BANNER": "This review will be withdrawn. You can intake these issues as a different type of decision review, if that was requested.",
   "INTAKE_RATING_MAY_BE_PROCESS": "Rating may be in progress",

--- a/client/app/intake/components/AddClaimantModal.jsx
+++ b/client/app/intake/components/AddClaimantModal.jsx
@@ -12,6 +12,8 @@ import ApiUtil from '../../util/ApiUtil';
 import Checkbox from '../../components/Checkbox';
 import TextareaField from '../../components/TextareaField';
 
+const ALLOW_UNLISTED_CLAIMANTS = false;
+
 const relationshipOpts = [
   { label: 'Attorney (previously or currently)', value: 'attorney' },
 ];
@@ -124,14 +126,17 @@ export const AddClaimantModal = ({
         debounce={250}
         strongLabel
         isClearable
+        placeholder="Type to search..."
       />
 
-      <Checkbox
-        label="Claimant not listed"
-        name="notListed"
-        onChange={handleNotListed}
-        value={unlistedClaimant}
-      />
+      {ALLOW_UNLISTED_CLAIMANTS && (
+        <Checkbox
+          label="Claimant not listed"
+          name="notListed"
+          onChange={handleNotListed}
+          value={unlistedClaimant}
+        />
+      )}
       {unlistedClaimant && (
         <TextareaField
           label={

--- a/client/test/app/intake/components/AddClaimantModal.test.js
+++ b/client/test/app/intake/components/AddClaimantModal.test.js
@@ -65,7 +65,7 @@ describe('AddClaimantModal', () => {
     expect(onCancel).toHaveBeenCalled();
   });
 
-  it('should display notes only if "claimant not listed" is selected', () => {
+  it.skip('should display notes only if "claimant not listed" is selected', () => {
     render(
       <AddClaimantModal
         onSearch={performQuery}
@@ -110,7 +110,7 @@ it('should clear dropdown', async () => {
     expect(screen.queryByText(data[0].name)).not.toBeTruthy();
   });
 
-  describe('changes based on "claimant not listed" selection', () => {
+  describe.skip('changes based on "claimant not listed" selection', () => {
     it('should display notes only if "claimant not listed" is selected', () => {
       render(
         <AddClaimantModal
@@ -189,7 +189,7 @@ it('should clear dropdown', async () => {
       );
     });
 
-    test('with unlisted claimant', async () => {
+    test.skip('with unlisted claimant', async () => {
       render(
         <AddClaimantModal
           onSearch={performQuery}

--- a/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
@@ -50,7 +50,7 @@ exports[`AddClaimantModal renders correctly 1`] = `
           >
             <div>
               <p>
-                To add a claimant, select their relationship to the veteran and type to search for their name. 
+                To add a claimant, select their relationship to the Veteran and type to search for their name. 
                 <strong>
                   Please note:
                 </strong>

--- a/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/AddClaimantModal.test.js.snap
@@ -57,7 +57,13 @@ exports[`AddClaimantModal renders correctly 1`] = `
                  at this time, you are only able to add attorneys as claimants.
               </p>
               <p>
-                 If you are unable to find attorney in the list of names below, select "Claimant not listed" and add their name, address, and law firm (if applicable) in the notes section.
+                If you are unable to find the attorney in the list of names below, please cancel the intake and 
+                <a
+                  href="mailto:VACaseflowIntake@va.gov"
+                >
+                  email
+                </a>
+                 for assistance. Remember to encrypt any emails that contain PII.
               </p>
             </div>
             <div
@@ -178,7 +184,7 @@ exports[`AddClaimantModal renders correctly 1`] = `
                         <div
                           class="cf-select__placeholder css-1wa3eu0-placeholder"
                         >
-                          Select...
+                          Type to search...
                         </div>
                         <div
                           class="css-81nyic-Input"
@@ -246,30 +252,6 @@ exports[`AddClaimantModal renders correctly 1`] = `
                     </div>
                   </div>
                 </div>
-              </div>
-            </div>
-            <div
-              class="checkbox-wrapper-notListed cf-form-checkboxes"
-            >
-              <div
-                class="cf-form-checkbox"
-              >
-                <input
-                  aria-label="notListed"
-                  id="notListed"
-                  name="notListed"
-                  type="checkbox"
-                />
-                <label
-                  for="notListed"
-                >
-                  <span
-                    class=""
-                  >
-                    Claimant not listed
-                  </span>
-                   
-                </label>
               </div>
             </div>
           </div>

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -326,7 +326,7 @@ feature "Intake Review Page", :postgres do
             expect(page).to have_content("#{attorney.name}, Attorney")
           end
 
-          scenario "when claimant is not listed" do
+          scenario "when claimant is not listed", skip: "Unlisted claimants are disabled for now" do
             appeal, _intake = start_appeal(
               veteran,
               claim_participant_id: claim_participant_id,
@@ -367,7 +367,7 @@ feature "Intake Review Page", :postgres do
             expect(page).to have_content(notes)
           end
 
-          scenario "when veteran has no relationships" do
+          scenario "when veteran has no relationships", skip: "Unlisted claimants are disabled for now" do
             allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return([])
 
             start_appeal(


### PR DESCRIPTION
Connects #15367 

### Description
In order to move forward with the Attorney Fees feature, we are disabling the ability to add unlisted claimants for now.

### Acceptance Criteria
- [x] Hide ability to add unlisted claimant
- [x] Update copy (see copy and design below)
- [x] Update searchable dropdown placeholder text to "Type to search..."
- [x] Double check that "Veteran" is capitalized throughout feature
- [x] Skip tests related to unlisted claimants
- [x] Update storybook and jest tests

### Testing Plan
1. As a board intake user, start an intake for an appeal with any veteran
2. On the review page, select claimant is not veteran, and click `Add Claimant` to enter the add claimant modal
3. Verify that unlisted claimants are disabled, and copy is updated

### User Facing Changes
Before:
<img width="497" src="https://user-images.githubusercontent.com/282869/95371415-2dbfbb00-08a8-11eb-9f92-c92765b2ddc5.png">

After:
<img width="499" src="https://user-images.githubusercontent.com/282869/95371447-37492300-08a8-11eb-8814-c12255c08ad8.png">