### PR TITLE
Remove diagnostic code validation

### DIFF
--- a/app/models/decision_issue.rb
+++ b/app/models/decision_issue.rb
@@ -9,8 +9,6 @@ class DecisionIssue < CaseflowRecord
 
   with_options if: :appeal? do
     validates :disposition, inclusion: { in: Constants::ISSUE_DISPOSITIONS_BY_ID.keys.map(&:to_s) }
-    validates :diagnostic_code, inclusion: { in: Constants::DIAGNOSTIC_CODE_DESCRIPTIONS.keys.map(&:to_s) },
-                                allow_nil: true
   end
 
   # Attorneys will be entering in a description of the decision manually for appeals

--- a/spec/models/decision_issue_spec.rb
+++ b/spec/models/decision_issue_spec.rb
@@ -185,19 +185,6 @@ describe DecisionIssue, :postgres do
         context "when it is nil" do
           it { is_expected.to be true }
         end
-
-        context "when it is set to an allowed value" do
-          let(:diagnostic_code) { "5000" }
-          it { is_expected.to be true }
-        end
-
-        context "when it is not an allowed value" do
-          let(:diagnostic_code) { "bogus_diagnostic_code" }
-          it "adds an error to diagnostic_code" do
-            is_expected.to be false
-            expect(decision_issue.errors[:diagnostic_code]).to include("is not included in the list")
-          end
-        end
       end
     end
 


### PR DESCRIPTION
Resolves #14915

### Description
This PR removes the validation that causes [this](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/9479/) unrecognized diagnostic codes error.  This is a piece of a larger effort (#14870, #14871, #14872, #14877) overhauling how we receive and check diagnostic codes.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass