### PR TITLE
Change VACOLS location when creating a ChangeHearingRequestTypeTask

### DIFF
--- a/app/services/hearing_task_tree_initializer.rb
+++ b/app/services/hearing_task_tree_initializer.rb
@@ -34,6 +34,8 @@ class HearingTaskTreeInitializer
         ChangeHearingRequestTypeTask.find_or_create_by!(**create_args, parent: schedule_hearing_task)
       end
 
+      AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
+
       appeal.reload
     end
 

--- a/app/services/hearing_task_tree_initializer.rb
+++ b/app/services/hearing_task_tree_initializer.rb
@@ -23,7 +23,7 @@ class HearingTaskTreeInitializer
     def for_appeal_with_pending_travel_board_hearing(appeal)
       fail TypeError, "expected a legacy appeal" unless appeal.is_a?(LegacyAppeal)
 
-      return if appeal.tasks.open.where(type: ChangeHearingRequestTypeTask.name).any?
+      return if appeal.tasks.open.where(type: HearingTask.name).any?
 
       ActiveRecord::Base.multi_transaction do
         create_args = { appeal: appeal, assigned_to: Bva.singleton }

--- a/spec/services/hearing_task_tree_initializer_spec.rb
+++ b/spec/services/hearing_task_tree_initializer_spec.rb
@@ -5,6 +5,7 @@ describe HearingTaskTreeInitializer do
     let(:vacols_case) do
       create(
         :case,
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
         bfhr: "2"
       )
     end
@@ -33,6 +34,11 @@ describe HearingTaskTreeInitializer do
         ).to eq(true)
       end
 
+      it "changes the vacols location to CASEFLOW" do
+        expect { subject }
+          .to change { vacols_case.reload.bfcurloc }
+          .from(LegacyAppeal::LOCATION_CODES[:schedule_hearing])
+          .to(LegacyAppeal::LOCATION_CODES[:caseflow])
       end
     end
 

--- a/spec/services/hearing_task_tree_initializer_spec.rb
+++ b/spec/services/hearing_task_tree_initializer_spec.rb
@@ -32,16 +32,18 @@ describe HearingTaskTreeInitializer do
             .all? { |task| task.assigned_to == Bva.singleton }
         ).to eq(true)
       end
+
+      end
     end
 
-    context "if task tree already exists" do
-      before do
-        described_class.for_appeal_with_pending_travel_board_hearing(appeal)
-      end
+    context "if an open hearing task already exists" do
+      let(:root_task) { create(:root_task, appeal: appeal) }
+      let(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
 
       it "does not create a duplicate task tree" do
         subject
-        expect(ChangeHearingRequestTypeTask.count).to eq(1)
+        expect(ChangeHearingRequestTypeTask.count).to eq(0)
         expect(ScheduleHearingTask.count).to eq(1)
         expect(HearingTask.count).to eq(1)
       end


### PR DESCRIPTION
### Description
Changes the VACOLS location of a case to CASEFLOW when creating a new `ChangeHearingRequestTypeTask`.

Also, doesn't create a new `ChangeHearingRequestTypeTask` if there's an open `HearingTask` on the appeal (this is more restrictive than before)