### PR TITLE
Do not add CO as a location to geomatch from if veteran lives in VA or MD

### DIFF
--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -126,8 +126,6 @@ class VaDotGovAddressValidator
     # facility ID to the Houston RO.
     facility_ids << "vha_671BY" if veteran_lives_in_texas? # include San Antonio facility id
 
-    facility_ids << "vba_372" if appeal_is_legacy_and_veteran_lives_in_va_or_md?
-
     facility_ids
   end
 

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -75,10 +75,6 @@ module VaDotGovAddressValidator::Validations
     appeal.is_a?(LegacyAppeal) && appeal.sanitized_hearing_request_type == :central_office
   end
 
-  def appeal_is_legacy_and_veteran_lives_in_va_or_md?
-    appeal.is_a?(LegacyAppeal) && %w[VA MD].include?(state_code)
-  end
-
   def veteran_lives_in_texas?
     state_code == "TX"
   end

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -232,7 +232,7 @@ describe VaDotGovAddressValidator do
       end
     end
 
-    context "when veteran with legacy appeal requests central office and does not live in DC, MD, or VA" do
+    context "when veteran with legacy appeal requests central office" do
       let!(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfhr: "1")) }
 
       it "returns DC" do
@@ -246,15 +246,6 @@ describe VaDotGovAddressValidator do
 
       it "adds San Antonio Satellite Office" do
         expect(subject).to match_array %w[vba_349 vba_362 vha_671BY]
-      end
-    end
-
-    context "when veteran with legacy appeal lives in MD" do
-      let!(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
-      let!(:valid_address_state_code) { "MD" }
-
-      it "adds DC regional office" do
-        expect(subject).to match_array %w[vba_313 vba_372]
       end
     end
   end


### PR DESCRIPTION
Resolves #15415

### Description
We discovered that there was a stale logic adding CO to locations to geomatch from if Veteran lives in VA or MD. If CO ends up becoming the closest location to Veteran then they are geomatched to central office but the central queue has logic to only display appeals which have specifically requested central office hearing. In other words, if veterans who did not request central office hearings but are geomatched to central office, they would not show up in central queue. This PR removes that stale logic per permission from the hearing branch.
