### PR TITLE
Update VACOLS location when ChangeHearingRequestTypeTask is completed

### DIFF
--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -70,6 +70,9 @@ class ChangeHearingRequestTypeTask < Task
     multi_transaction do
       appeal.update!(changed_request_type: payload_values[:changed_request_type])
 
+      # update location to `CASEFLOW`
+      AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
+
       update!(params)
     end
   end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -74,7 +74,7 @@ class ChangeHearingRequestTypeTask < Task
       appeal.update!(changed_request_type: payload_values[:changed_request_type])
 
       # update location to `CASEFLOW`
-      if (appeal.is_a?(LegacyAppeal))
+      if appeal.is_a?(LegacyAppeal)
         AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
       end
 

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -4,6 +4,9 @@
 # Task created when a hearing coordinator visits the Case Details page of an appeal with a
 # Travel Board hearing request. Gives the user the option to convert that request to a video
 # or virtual hearing request so it can be scheduled in Caseflow.
+#
+# When task is completed, i.e the field `changed_request_type` is passed as payload, the location
+# of LegacyAppeal is moved `CASEFLOW` and the parent `ScheduleHearingTask` is set to be `assigned`
 class ChangeHearingRequestTypeTask < Task
   validates :parent, presence: true
 
@@ -71,7 +74,9 @@ class ChangeHearingRequestTypeTask < Task
       appeal.update!(changed_request_type: payload_values[:changed_request_type])
 
       # update location to `CASEFLOW`
-      AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
+      if (appeal.is_a?(LegacyAppeal))
+        AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
+      end
 
       update!(params)
     end

--- a/app/services/hearing_task_tree_initializer.rb
+++ b/app/services/hearing_task_tree_initializer.rb
@@ -34,8 +34,6 @@ class HearingTaskTreeInitializer
         ChangeHearingRequestTypeTask.find_or_create_by!(**create_args, parent: schedule_hearing_task)
       end
 
-      AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
-
       appeal.reload
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -864,9 +864,16 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
       context "when task is ChangeHearingRequestTypeTask" do
         let(:attorney_user) { create(:user) }
+        let(:vacols_case) do
+          create(
+            :case,
+            :assigned,
+            bfcorlid: "0000000000S",
+            bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+          )
+        end
         let!(:legacy_appeal) do
-          create(:legacy_appeal,
-                 vacols_case: create(:case, :assigned, bfcorlid: "0000000000S", user: attorney_user))
+          create(:legacy_appeal, vacols_case: vacols_case)
         end
 
         let(:task_type) { :changed_hearing_request_type }
@@ -901,6 +908,13 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
             appeal: legacy_appeal
           ).status).to eq(Constants.TASK_STATUSES.completed)
           expect(ScheduleHearingTask.find_by(appeal: legacy_appeal).status).to eq(Constants.TASK_STATUSES.assigned)
+        end
+
+        it "changes the vacols location to CASEFLOW" do
+          expect { subject }
+            .to change { vacols_case.reload.bfcurloc }
+            .from(LegacyAppeal::LOCATION_CODES[:schedule_hearing])
+            .to(LegacyAppeal::LOCATION_CODES[:caseflow])
         end
       end
     end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -869,7 +869,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
             :case,
             :assigned,
             bfcorlid: "0000000000S",
-            bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+            bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing]
           )
         end
         let!(:legacy_appeal) do

--- a/spec/services/hearing_task_tree_initializer_spec.rb
+++ b/spec/services/hearing_task_tree_initializer_spec.rb
@@ -33,13 +33,6 @@ describe HearingTaskTreeInitializer do
             .all? { |task| task.assigned_to == Bva.singleton }
         ).to eq(true)
       end
-
-      it "changes the vacols location to CASEFLOW" do
-        expect { subject }
-          .to change { vacols_case.reload.bfcurloc }
-          .from(LegacyAppeal::LOCATION_CODES[:schedule_hearing])
-          .to(LegacyAppeal::LOCATION_CODES[:caseflow])
-      end
     end
 
     context "if an open hearing task already exists" do


### PR DESCRIPTION
Connects #15427

### Description
- update location of legacy appeals to caseflow at completion of task instead of when the task is initially created
- update test

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.
