### PR TITLE
Add CAVC lit support team

### DIFF
--- a/app/models/organizations/cavc_litigation_support.rb
+++ b/app/models/organizations/cavc_litigation_support.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CavcLitigationSupport < Organization
+  def self.singleton
+    CavcLitigationSupport.first ||
+      CavcLitigationSupport.create(name: "CAVC Litigation Support", url: "cavc-lit-support")
+  end
+
+  def users_can_create_mail_task?
+    true
+  end
+end

--- a/app/models/organizations/cavc_litigation_support.rb
+++ b/app/models/organizations/cavc_litigation_support.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+##
+# Team that handles CAVC-related tasks.
+# For Litigation Support team members who only work on CAVC cases.
+
 class CavcLitigationSupport < Organization
   def self.singleton
     CavcLitigationSupport.first ||

--- a/app/models/organizations/cavc_litigation_support.rb
+++ b/app/models/organizations/cavc_litigation_support.rb
@@ -9,8 +9,4 @@ class CavcLitigationSupport < Organization
     CavcLitigationSupport.first ||
       CavcLitigationSupport.create(name: "CAVC Litigation Support", url: "cavc-lit-support")
   end
-
-  def users_can_create_mail_task?
-    true
-  end
 end

--- a/spec/models/organizations/cavc_litigation_support_spec.rb
+++ b/spec/models/organizations/cavc_litigation_support_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe CavcLitigationSupport do
+    describe ".singleton" do
+      it "is named correctly" do
+        expect(CavcLitigationSupport.singleton).to have_attributes(name: "CAVC Litigation Support")
+      end
+    end
+  
+    describe ".users_can_create_mail_task?" do
+      it "should always be true" do
+        expect(CavcLitigationSupport.singleton.users_can_create_mail_task?).to eq(true)
+      end
+    end
+  end
+  

--- a/spec/models/organizations/cavc_litigation_support_spec.rb
+++ b/spec/models/organizations/cavc_litigation_support_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 describe CavcLitigationSupport do
-    describe ".singleton" do
-      it "is named correctly" do
-        expect(CavcLitigationSupport.singleton).to have_attributes(name: "CAVC Litigation Support")
-      end
-    end
-  
-    describe ".users_can_create_mail_task?" do
-      it "should always be true" do
-        expect(CavcLitigationSupport.singleton.users_can_create_mail_task?).to eq(true)
-      end
+  describe ".singleton" do
+    it "is named correctly" do
+      expect(CavcLitigationSupport.singleton).to have_attributes(name: "CAVC Litigation Support")
     end
   end
-  
+
+  describe ".users_can_create_mail_task?" do
+    it "should always be true" do
+      expect(CavcLitigationSupport.singleton.users_can_create_mail_task?).to eq(true)
+    end
+  end
+end

--- a/spec/models/organizations/cavc_litigation_support_spec.rb
+++ b/spec/models/organizations/cavc_litigation_support_spec.rb
@@ -6,10 +6,4 @@ describe CavcLitigationSupport do
       expect(CavcLitigationSupport.singleton).to have_attributes(name: "CAVC Litigation Support")
     end
   end
-
-  describe ".users_can_create_mail_task?" do
-    it "should always be true" do
-      expect(CavcLitigationSupport.singleton.users_can_create_mail_task?).to eq(true)
-    end
-  end
 end


### PR DESCRIPTION
Resolves #15278 

### Description
Added a new organization called "CAVC Litigation Support" for the new team that handles CAVC-related tasks.

### Acceptance Criteria
- [ ] Include screenshot(s) in the Github issue if there are front-end changes, showing new org
- [ ] Update documentation: https://github.com/department-of-veterans-affairs/caseflow/wiki/Organizations
- [ ] New organization added to Caseflow for CAVC Litigation Support Team
- [ ] Reminder to self: https://github.com/department-of-veterans-affairs/caseflow/issues/15278#issuecomment-698472349

### Testing Plan
1. Create team in dev environment and check its information
```ruby
CavcLitigationSupport.singleton
```
2. Check the UI: http://localhost:3000/organizations/cavc-lit-support/users
3. Add and remove users in the UI and check in Rails console: 
```ruby
team=CavcLitigationSupport.singleton
team.users
````

Review new bullet for CavcLitigationSupport in https://github.com/department-of-veterans-affairs/caseflow/wiki/Organizations#existing-organizations


### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue


 BEFORE|AFTER
 ---|---
(none) | ![image](https://user-images.githubusercontent.com/55255674/96464218-2c1dbd80-11ed-11eb-9beb-fe2fad4a129f.png)
(doesn't have CAVC Lit Support team) | ![image](https://user-images.githubusercontent.com/55255674/96464356-53748a80-11ed-11eb-83ab-52098a8b5bc8.png)


### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

