### PR TITLE
Changes to the judge team management page should not rely on a feature toggle

### DIFF
--- a/app/controllers/organizations/users_controller.rb
+++ b/app/controllers/organizations/users_controller.rb
@@ -9,7 +9,7 @@ class Organizations::UsersController < OrganizationsController
 
         render json: {
           organization_name: organization.name,
-          judge_team: FeatureToggle.enabled?(:judge_admin_scm) && organization.type == JudgeTeam.name,
+          judge_team: organization.type == JudgeTeam.name,
           dvc_team: organization.type == DvcTeam.name,
           organization_users: json_administered_users(organization_users)
         }


### PR DESCRIPTION
Resolves judge being removed from adminship of their team: https://dsva.slack.com/archives/CLRTL92TW/p1603125921062700

### Description
Adminship of a judge team should not be reliant on a feature toggle that will be rolled back.

### Acceptance Criteria
- [ ] Judges cannot be made a non admin of their own team

### Testing Plan
1. Sign in as a system admin (TEAM_ADMIN)
1. Untoggle `judge_admin_scm` feature toggle
1. Go to a judge team team management page http://localhost:3000/organizations/bvaaabshire/users
1. No option to modify adminship for judge teams

### User Facing Changes

 BEFORE| BEFORE|AFTER
 ---|---|---
![Screen Shot 2020-10-19 at 1 15 52 PM](https://user-images.githubusercontent.com/45575454/96490102-5d5ab580-120e-11eb-87c7-b84b0c4b07fa.png)|![Screen Shot 2020-10-19 at 1 16 00 PM](https://user-images.githubusercontent.com/45575454/96490112-60ee3c80-120e-11eb-8f70-8c5a6d582fd0.png)|![Screen Shot 2020-10-19 at 1 17 07 PM](https://user-images.githubusercontent.com/45575454/96490116-62b80000-120e-11eb-9296-014b046a448e.png)