### PR TITLE
Do not fail age_of_oldest_priority_appeal when there are no ready priority appeals

### DIFF
--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -44,7 +44,7 @@ class Docket
   end
 
   def age_of_oldest_priority_appeal
-    @age_of_oldest_priority_appeal ||= appeals(priority: true, ready: true).limit(1).first.ready_for_distribution_at
+    @age_of_oldest_priority_appeal ||= appeals(priority: true, ready: true).limit(1).first&.ready_for_distribution_at
   end
 
   def oldest_priority_appeal_days_waiting

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -207,10 +207,20 @@ describe Docket, :all_dbs do
     end
 
     context "age_of_oldest_priority_appeal" do
-      subject { DirectReviewDocket.new.age_of_oldest_priority_appeal }
+      let(:docket) { DirectReviewDocket.new }
+
+      subject { docket.age_of_oldest_priority_appeal }
 
       it "returns the 'ready at' field of the oldest priority appeal that is ready for distribution" do
         expect(subject).to eq(aod_age_appeal.ready_for_distribution_at)
+      end
+
+      context "when there are no ready priority appeals" do
+        let(:docket) { EvidenceSubmissionDocket.new }
+
+        it "returns nil" do
+          expect(subject.nil?).to be true
+        end
       end
     end
 


### PR DESCRIPTION
Resolves [this sentry alert](https://dsva.slack.com/archives/CLRTL92TW/p1603133600064100)and the probably failure of the priority push job

### Description
accounts for `undefined method 'ready_for_distribution_at' for nil:NilClass` when there are no ready priority cases of that docket type

### Acceptance Criteria
- [ ] Calling age_of_oldest_priority_appeal does not fail, but returns nil instead

### Testing Plan
1. master
```ruby
DirectReviewDocket.new.age_of_oldest_priority_appeal
NoMethodError: undefined method `ready_for_distribution_at' for nil:NilClass
from /Users/hschallhorn/git/caseflow/app/models/docket.rb:47:in `age_of_oldest_priority_appeal'
```
2. This branch
```ruby
DirectReviewDocket.new.age_of_oldest_priority_appeal
=> nil
```