### PR TITLE
format start and end dates before sending to bgs

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -286,6 +286,8 @@ class ExternalApi::BGSService
   def fetch_ratings_in_range(participant_id:, start_date:, end_date:)
     DBService.release_db_connections
 
+    start_date, end_date = formatted_start_and_end_dates(start_date, end_date)
+
     MetricsService.record("BGS: fetch ratings in range: \
                            participant_id = #{participant_id}, \
                            start_date = #{start_date} \
@@ -314,6 +316,8 @@ class ExternalApi::BGSService
 
   def fetch_rating_profiles_in_range(participant_id:, start_date:, end_date:)
     DBService.release_db_connections
+
+    start_date, end_date = formatted_start_and_end_dates(start_date, end_date)
 
     MetricsService.record("BGS: fetch rating profile in range: \
                            participant_id = #{participant_id}, \
@@ -461,6 +465,14 @@ class ExternalApi::BGSService
       jumpbox_url: ENV["RUBY_BGS_JUMPBOX_URL"],
       log: true
     )
+  end
+
+  def formatted_start_and_end_dates(start_date, end_date)
+    # start_date and end_date should be Dates with different values
+    return_start_date = start_date&.to_date
+    return_end_date = end_date&.to_date
+    return_end_date += 1.day if return_end_date.present? && return_end_date == return_start_date
+    [return_start_date, return_end_date]
   end
   # :nocov:
 end

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -287,4 +287,45 @@ describe ExternalApi::BGSService do
       end
     end
   end
+
+  describe "fetch_ratings_in_range" do
+    let!(:veteran) { create(:veteran) }
+    let!(:rating) { double("rating") }
+    let(:start_date) { Time.zone.now - 5.years }
+    let(:start_date_formatted) { start_date.to_date.to_datetime.iso8601 }
+    let(:end_date) { start_date }
+
+    before do
+      allow(bgs_client).to receive(:rating).and_return rating
+    end
+
+    subject do
+      bgs.fetch_ratings_in_range(participant_id: veteran.participant_id, start_date: start_date, end_date: end_date)
+    end
+
+    context "the start and end dates are the same" do
+      let(:end_date_formatted) { (start_date + 1.day).to_date.to_datetime.iso8601 }
+
+      it "formats dates correctly" do
+        expect(rating)
+          .to receive(:find_by_participant_id_and_date_range)
+          .with(veteran.participant_id, start_date_formatted, end_date_formatted)
+
+        subject
+      end
+    end
+
+    context "the start and end dates are different" do
+      let(:end_date) { Time.zone.now }
+      let(:end_date_formatted) { end_date.to_date.to_datetime.iso8601 }
+
+      it "formats dates correctly" do
+        expect(rating)
+          .to receive(:find_by_participant_id_and_date_range)
+          .with(veteran.participant_id, start_date_formatted, end_date_formatted)
+
+        subject
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description
Fixes errors resulting from wrong formatted dates passed to BGS endpoints `rating.find_by_participant_id_and_date_range` and `rating_profile.find_in_date_range`.

Resolves [this support issue.](https://dsva.slack.com/archives/CHX8FMP28/p1603120378296600)