### PR TITLE
Removes not null constraint on CavcRemand updated_by

### DIFF
--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -3,11 +3,12 @@
 # Model to store information captured when processing a form for an appeal remanded by CAVC
 
 class CavcRemand < CaseflowRecord
+  include UpdatedByUserConcern
+
   belongs_to :created_by, class_name: "User"
-  belongs_to :updated_by, class_name: "User"
   belongs_to :appeal
 
-  validates :created_by, :updated_by, :appeal, :cavc_docket_number, :represented_by_attorney, :cavc_judge_full_name,
+  validates :created_by, :appeal, :cavc_docket_number, :represented_by_attorney, :cavc_judge_full_name,
             :cavc_decision_type, :decision_date, :decision_issue_ids, :instructions, presence: true
   validates :remand_subtype, presence: true, if: :remand?
   validates :judgement_date, :mandate_date, presence: true, unless: :mdr?

--- a/db/migrate/20201020135542_cavc_remand_updated_by_nullable.rb
+++ b/db/migrate/20201020135542_cavc_remand_updated_by_nullable.rb
@@ -1,0 +1,6 @@
+class CavcRemandUpdatedByNullable < Caseflow::Migration
+  def change
+    safety_assured { remove_column :cavc_remands, :updated_by_id, :bigint, null: false, comment: "User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created." }
+    add_column  :cavc_remands, :updated_by_id, :bigint, comment: "User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_05_190456) do
+ActiveRecord::Schema.define(version: 2020_10_20_135542) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -280,7 +280,7 @@ ActiveRecord::Schema.define(version: 2020_10_05_190456) do
     t.string "remand_subtype", comment: "Type of remand. If the cavc_decision_type is 'remand', expecting one of 'jmp', 'jmpr', or 'mdr'. Otherwise, this can be null."
     t.boolean "represented_by_attorney", null: false, comment: "Whether or not the appellant was represented by an attorney"
     t.datetime "updated_at", null: false, comment: "Default timestamps"
-    t.bigint "updated_by_id", null: false, comment: "User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created."
+    t.bigint "updated_by_id", comment: "User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created."
     t.index ["appeal_id"], name: "index_cavc_remands_on_appeal_id"
   end
 

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -194,7 +194,7 @@ cavc_remands,mandate_date,date ∗,x,,,,,Date that CAVC reported the mandate w
 cavc_remands,remand_subtype,string ∗,x,,,,,"Type of remand. If the cavc_decision_type is 'remand', expecting one of 'jmp', 'jmpr', or 'mdr'. Otherwise, this can be null."
 cavc_remands,represented_by_attorney,boolean ∗,x,,,,,Whether or not the appellant was represented by an attorney
 cavc_remands,updated_at,datetime ∗,x,,,,,Default timestamps
-cavc_remands,updated_by_id,integer (8) ∗ FK,x,,x,,,"User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created."
+cavc_remands,updated_by_id,integer (8) FK,,,x,,,"User that updated this record. For MDR remands, judgement and mandate dates will be added after the record is first created."
 certifications,,,,,,,,
 certifications,already_certified,boolean,,,,,,
 certifications,bgs_rep_address_line_1,string,,,,,,
@@ -409,16 +409,6 @@ end_product_code_updates,created_at,datetime ∗,x,,,,,
 end_product_code_updates,end_product_establishment_id,integer (8) ∗ FK,x,,x,,x,
 end_product_code_updates,id,integer (8) PK,x,x,,,,
 end_product_code_updates,updated_at,datetime ∗,x,,,,x,
-end_product_updates,,,,,,,, "Updates the claim label for end products established from Caseflow."
-end_product_updates,user_id,integer,"The ID of the user who makes an end product update."
-end_product_updates,end_product_establishment_id,bigint,"The end product establishment id used to track the end product being updated"
-end_product_updates,original_decision_review_id,bigint,"The original ID of the decision review that this end product update belongs to; has a non-nil value only if a new decision_review was created."
-end_product_updates,original_decision_review_type,string,"The original decision review type that this end product update belongs to"
-end_product_updates,status,string,"Status after an attempt to update the end product; expected values: 'success', 'error', ..."
-end_product_updates,error,string,"The error message captured from BGS if the end product update failed."
-end_product_updates,original_code,string,"The original end product code before the update was submitted"
-end_product_updates,new_code,string,"The new end product code the user wants to update to."
-end_product_updates,active_request_issue_ids,integer,"A list of active request issue IDs when a user has finished editing a decision review. Used to keep track of which request issues may have been impacted by the update."
 end_product_establishments,,,,,,,,"Represents end products that have been, or need to be established by Caseflow. Used to track the status of those end products as they are processed in VBMS and/or SHARE."
 end_product_establishments,benefit_type_code,string,,,,,,"1 if the Veteran is alive, and 2 if the Veteran is deceased. Not to be confused with benefit_type, which is unrelated."
 end_product_establishments,claim_date,date,,,,,,The claim_date for end product established.
@@ -443,6 +433,19 @@ end_product_establishments,synced_status,string,,,,,,"The status of the end prod
 end_product_establishments,updated_at,datetime,,,,,x,
 end_product_establishments,user_id,integer FK,,,x,,x,The ID of the user who performed the decision review intake.
 end_product_establishments,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran submitted when establishing the end product.
+end_product_updates,,,,,,,,Updates the claim label for end products established from Caseflow
+end_product_updates,active_request_issue_ids,integer (8) ∗,x,,,,,A list of active request issue IDs when a user has finished editing a decision review. Used to keep track of which request issues may have been impacted by the update.
+end_product_updates,created_at,datetime ∗,x,,,,,
+end_product_updates,end_product_establishment_id,integer (8) ∗ FK,x,,x,,x,The end product establishment id used to track the end product being updated.
+end_product_updates,error,string,,,,,,The error message captured from BGS if the end product update failed.
+end_product_updates,id,integer (8) PK,x,x,,,,
+end_product_updates,new_code,string,,,,,,The new end product code the user wants to update to.
+end_product_updates,original_code,string,,,,,,The original end product code before the update was submitted.
+end_product_updates,original_decision_review_id,integer (8),,,,,x,The original decision review that this end product update belongs to; has a non-nil value only if a new decision_review was created.
+end_product_updates,original_decision_review_type,string,,,,,x,The original decision review type that this end product update belongs to
+end_product_updates,status,string,,,,,,"Status after an attempt to update the end product; expected values: 'success', 'error', ..."
+end_product_updates,updated_at,datetime ∗,x,,,,,
+end_product_updates,user_id,integer (8) ∗,x,,,,x,The ID of the user who makes an end product update.
 form8s,,,,,,,,
 form8s,_initial_appellant_name,string,,,,,,
 form8s,_initial_appellant_relationship,string,,,,,,


### PR DESCRIPTION
Connects #14792 

### Description
Fixes the CavcRemand updated_by field to not be required

### Acceptance Criteria
- [x] Tests pass
- [ ] on the console you can create a valid CavcRemand with or without an updated_by


### Testing Plan
```
## No User Set - Valid

cavc_remand = CavcRemand.new(appeal: Appeal.find(346), cavc_decision_type: Constants.CAVC_DECISION_TYPES.remand, cavc_docket_number: 5, cavc_judge_full_name: "Joseph L. Toth", created_by: User.first, decision_date: 5.days.ago, decision_issue_ids: Appeal.find(346).decision_issues.pluck(:id), instructions: "foo", judgement_date: 3.days.ago, mandate_date: 3.days.ago, remand_subtype: Constants.CAVC_REMAND_SUBTYPES.jmr, represented_by_attorney: true)

cavc_remand.validate!
=> true

cavc_remand.save!
=> true

cavc_remand.reload
=> # should not have updated_by set

# lets set us a user!
RequestStore.store[:current_user] = User.second

## Updates with user sets it
cavc_remand.update!(instructions: "bar")
cavc_remand.reload
=> # should  have updated_by set

## create another with the user set
cavc_remand2 = CavcRemand.new(appeal: Appeal.find(346), cavc_decision_type: Constants.CAVC_DECISION_TYPES.remand, cavc_docket_number: 5, cavc_judge_full_name: "Joseph L. Toth", created_by: User.first, decision_date: 5.days.ago, decision_issue_ids: Appeal.find(346).decision_issues.pluck(:id), instructions: "foo", judgement_date: 3.days.ago, mandate_date: 3.days.ago, remand_subtype: Constants.CAVC_REMAND_SUBTYPES.jmr, represented_by_attorney: true)

cavc_remand2.validate!
=> true

cavc_remand2.save!
=> true

cavc_remand2.reload
=> # should have updated_by set
```

### Database Changes
*Only for Schema Changes*

* [x] Timestamps (created_at, updated_at) for new tables
* [x] Column comments updated
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Query profiling performed (eyeball Rails log, check bullet and fasterer output)
* [x] Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR