### PR TITLE
[Part 3] Do not send status field in Virtual Hearing payload

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -109,12 +109,13 @@ class TasksController < ApplicationController
   rescue ActiveRecord::RecordInvalid => error
     invalid_record_error(error.record)
   rescue AssignHearingDispositionTask::HearingAssociationMissing => error
-    Raven.capture_exception(error)
+    Raven.capture_exception(error, extra: { application: "hearings" })
+
     render json: {
       "errors": ["title": "Missing Associated Hearing", "detail": error]
     }, status: :bad_request
   rescue Caseflow::Error::VirtualHearingConversionFailed => error
-    Raven.capture_exception(error)
+    Raven.capture_exception(error, extra: { application: "hearings" })
 
     render json: {
       "errors": ["title": COPY::FAILED_HEARING_UPDATE, "message": error.message, "code": error.code]

--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -152,7 +152,7 @@ class AssignHearingDispositionTask < Task
                         after_disposition_update: payload_values[:after_disposition_update]
                       )
                     else
-                      raise "unknown disposition"
+                      fail "unknown disposition"
                     end
 
     update_with_instructions(instructions: params[:instructions]) if params[:instructions].present?
@@ -243,7 +243,7 @@ class AssignHearingDispositionTask < Task
         admin_action_instructions: after_disposition_update[:admin_action_instructions]
       )
     else
-      raise "unknown disposition action"
+      fail "unknown disposition action"
     end
   end
 
@@ -273,9 +273,13 @@ class AssignHearingDispositionTask < Task
       parent: self,
       assigned_to: TranscriptionTeam.singleton
     )
-    
+
     evidence_task = unless hearing&.evidence_window_waived
-                      EvidenceSubmissionWindowTask.create!(appeal: appeal, parent: self, assigned_to: MailTeam.singleton)
+                      EvidenceSubmissionWindowTask.create!(
+                        appeal: appeal,
+                        parent: self,
+                        assigned_to: MailTeam.singleton
+                      )
                     end
 
     [transcription_task, evidence_task].compact

--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -152,7 +152,7 @@ class AssignHearingDispositionTask < Task
                         after_disposition_update: payload_values[:after_disposition_update]
                       )
                     else
-                      fail "unknown disposition"
+                      fail ArgumentError, "unknown disposition"
                     end
 
     update_with_instructions(instructions: params[:instructions]) if params[:instructions].present?
@@ -243,7 +243,7 @@ class AssignHearingDispositionTask < Task
         admin_action_instructions: after_disposition_update[:admin_action_instructions]
       )
     else
-      fail "unknown disposition action"
+      fail ArgumentError, "unknown disposition action"
     end
   end
 

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -57,7 +57,7 @@ class ScheduleHearingTask < Task
             .convert_hearing_to_virtual(hearing, task_values[:virtual_hearing_attributes])
         end
 
-        created_tasks <<  AssignHearingDispositionTask.create_assign_hearing_disposition_task!(appeal, parent, hearing)
+        created_tasks << AssignHearingDispositionTask.create_assign_hearing_disposition_task!(appeal, parent, hearing)
       elsif params[:status] == Constants.TASK_STATUSES.cancelled
         created_tasks << withdraw_hearing
       end

--- a/app/services/virtual_hearings/convert_to_virtual_hearing_service.rb
+++ b/app/services/virtual_hearings/convert_to_virtual_hearing_service.rb
@@ -22,25 +22,22 @@ class VirtualHearings::ConvertToVirtualHearingService
 
       [{ hearing: form.hearing_alerts }, { virtual_hearing: form.virtual_hearing_alert }]
     rescue ActiveRecord::RecordNotUnique => error
-      raise(
-        Caseflow::Error::VirtualHearingConversionFailed,
-        error_type: error.class,
-        message: COPY::VIRTUAL_HEARING_ALREADY_CREATED,
-        code: 1003
-      )
+      raise wrap_error(error, 1003, COPY::VIRTUAL_HEARING_ALREADY_CREATED)
     rescue ActiveRecord::RecordInvalid => error
-      raise(
-        Caseflow::Error::VirtualHearingConversionFailed,
-        error_type: error.class,
-        message: error.message,
-        code: 1002
-      )
+      raise wrap_error(error, 1002, error.message)
     rescue StandardError => error
-      raise(
-        Caseflow::Error::VirtualHearingConversionFailed,
+      raise wrap_error(error, 1099, error.message)
+    end
+
+    private
+
+    # Wraps an error in the class `Caseflow::Error::VirtualHearingConversionFailed`, allowing
+    # errors thrown by this class to be handled with specialized logic.
+    def wrap_error(error, code, message)
+      Caseflow::Error::VirtualHearingConversionFailed.new(
         error_type: error.class,
-        message: error.message,
-        code: 1099
+        message: message,
+        code: code
       )
     end
   end

--- a/app/services/virtual_hearings/convert_to_virtual_hearing_service.rb
+++ b/app/services/virtual_hearings/convert_to_virtual_hearing_service.rb
@@ -21,12 +21,26 @@ class VirtualHearings::ConvertToVirtualHearingService
       form.update
 
       [{ hearing: form.hearing_alerts }, { virtual_hearing: form.virtual_hearing_alert }]
-    rescue StandardError => error
+    rescue ActiveRecord::RecordNotUnique => error
+      raise(
+        Caseflow::Error::VirtualHearingConversionFailed,
+        error_type: error.class,
+        message: COPY::VIRTUAL_HEARING_ALREADY_CREATED,
+        code: 1003
+      )
+    rescue ActiveRecord::RecordInvalid => error
       raise(
         Caseflow::Error::VirtualHearingConversionFailed,
         error_type: error.class,
         message: error.message,
         code: 1002
+      )
+    rescue StandardError => error
+      raise(
+        Caseflow::Error::VirtualHearingConversionFailed,
+        error_type: error.class,
+        message: error.message,
+        code: 1099
       )
     end
   end

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -248,7 +248,7 @@ export const ScheduleVeteran = ({
       } else if (msg?.title) {
         props.showErrorMessage({
           title: msg?.title,
-          detail: msg?.detail
+          detail: msg?.detail ?? msg?.message
         });
 
       // Handle legacy appeals

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Button from '../../components/Button';
 import { sprintf } from 'sprintf-js';
-import { maxBy, omit, find, get } from 'lodash';
+import { isNil, maxBy, omit, find, get } from 'lodash';
 
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import COPY from '../../../COPY';
@@ -147,7 +147,12 @@ export const ScheduleVeteran = ({
 
   // Format the payload for the API
   const getPayload = () => {
-    const virtualHearing = omit(hearing.virtualHearing, ['status']);
+    // The API can't accept a payload if the field `status` is provided because it is a generated
+    // (not editable) field.
+    //
+    // `omit` returns an empty object if `null` is provided as an argument, so the `isNil` check here
+    // prevents `omit` from returning an empty object.`
+    const virtualHearing = isNil(hearing.virtualHearing) ? null : omit(hearing.virtualHearing, ['status']);
 
     // Format the shared hearing values
     const hearingValues = {

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -101,9 +101,6 @@ export const ScheduleVeteran = ({
 
   // Reset the component state
   const reset = () => {
-    // Clear the loading state
-    setLoading(false);
-
     // Clear any lingering errors
     setErrors({});
 
@@ -248,9 +245,6 @@ export const ScheduleVeteran = ({
 
         setErrors(errList);
 
-        // Remove the loading state on error
-        setLoading(false);
-
       // Handle errors in the standard format
       } else if (msg?.title) {
         props.showErrorMessage({
@@ -274,6 +268,9 @@ export const ScheduleVeteran = ({
                 'Please contact the Caseflow Team for assistance.',
         });
       }
+    } finally {
+      // Clear the loading state
+      setLoading(false);
     }
   };
 

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -151,12 +151,14 @@ export const ScheduleVeteran = ({
 
   // Format the payload for the API
   const getPayload = () => {
+    const virtualHearing = omit(hearing.virtualHearing, ['status']);
+
     // Format the shared hearing values
     const hearingValues = {
       scheduled_time_string: hearing.scheduledTimeString,
       hearing_day_id: hearing.hearingDay.hearingId,
       hearing_location: hearing.hearingLocation ? ApiUtil.convertToSnakeCase(hearing.hearingLocation) : null,
-      virtual_hearing_attributes: hearing.virtualHearing ? ApiUtil.convertToSnakeCase(hearing.virtualHearing) : null,
+      virtual_hearing_attributes: virtualHearing ? ApiUtil.convertToSnakeCase(virtualHearing) : null,
     };
 
     // Determine whether to send the reschedule payload

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import Button from '../../components/Button';
 import { sprintf } from 'sprintf-js';
-import { maxBy, find, get } from 'lodash';
+import { maxBy, omit, find, get } from 'lodash';
 
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import COPY from '../../../COPY';
@@ -18,7 +18,6 @@ import { onReceiveAppealDetails } from '../../queue/QueueActions';
 import { formatDateStr } from '../../util/DateUtil';
 import Alert from '../../components/Alert';
 import { setMargin, marginTop, regionalOfficeSection, saveButton, cancelButton } from './details/style';
-
 import { getAppellantTitle, processAlerts, parseVirtualHearingErrors } from '../utils';
 import {
   onChangeFormData,

--- a/client/test/app/hearings/components/ScheduleVeteran.test.js
+++ b/client/test/app/hearings/components/ScheduleVeteran.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import { omit } from 'lodash';
 
 import COPY from 'COPY';
 import ScheduleVeteran from 'app/hearings/components/ScheduleVeteran';
@@ -378,7 +379,9 @@ describe('ScheduleVeteran', () => {
               description: 'Update Task',
               values: {
                 ...scheduleHearingDetails.apiFormattedValues,
-                virtual_hearing_attributes: ApiUtil.convertToSnakeCase(virtualHearing.virtualHearing),
+                virtual_hearing_attributes: ApiUtil.convertToSnakeCase(
+                  omit(virtualHearing.virtualHearing, ['status'])
+                ),
                 override_full_hearing_day_validation: false,
               },
             },

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -364,8 +364,8 @@ module Caseflow::Error
 
     def initialize(args = {})
       @error_type = args[:error_type]
-      @code = (@error_type == ActiveRecord::RecordNotUnique) ? :conflict : args[:code]
-      @message = (@error_type == ActiveRecord::RecordNotUnique) ? COPY::VIRTUAL_HEARING_ALREADY_CREATED : args[:message]
+      @code = args[:code]
+      @message = args[:message]
     end
   end
 end

--- a/spec/feature/hearings/change_hearing_disposition_spec.rb
+++ b/spec/feature/hearings/change_hearing_disposition_spec.rb
@@ -125,7 +125,9 @@ RSpec.shared_examples "Change hearing disposition" do
 
       step "change the hearing disposition to cancelled" do
         expect(Raven).to receive(:capture_exception)
-          .with(AssignHearingDispositionTask::HearingAssociationMissing) { @raven_called = true }
+          .with(AssignHearingDispositionTask::HearingAssociationMissing, any_args) do
+            @raven_called = true
+          end
 
         click_dropdown(prompt: "Select an action", text: "Change hearing disposition")
         click_dropdown({ prompt: "Select", text: "Cancelled" }, find(".cf-modal-body"))


### PR DESCRIPTION
Related to #15460 

Resolves #15430 

### Description

- Update the frontend to omit `status` field in virtual hearings payload
- Update backend to differentiate errors based on code so frontend can handle them separately
- Update tasks controller to re-route hearings-specific errors to the hearings channel

### Acceptance Criteria
- [x]  Fix frontend TypeError
- [x] Fix backend unknown attribute error
- [x] Ensure the VirtualHearingConversationFailed error gets routed to #appeals-hearings instead of #appeals-queue-alerts