### PR TITLE
don't use an existing hearing task as the parent of a new change hearing request type task

### DIFF
--- a/app/services/hearing_task_tree_initializer.rb
+++ b/app/services/hearing_task_tree_initializer.rb
@@ -29,9 +29,9 @@ class HearingTaskTreeInitializer
         create_args = { appeal: appeal, assigned_to: Bva.singleton }
 
         root_task = RootTask.find_or_create_by!(**create_args)
-        hearing_task = HearingTask.find_or_create_by!(**create_args, parent: root_task)
-        schedule_hearing_task = ScheduleHearingTask.find_or_create_by!(**create_args, parent: hearing_task)
-        ChangeHearingRequestTypeTask.find_or_create_by!(**create_args, parent: schedule_hearing_task)
+        hearing_task = HearingTask.create!(**create_args, parent: root_task)
+        schedule_hearing_task = ScheduleHearingTask.create!(**create_args, parent: hearing_task)
+        ChangeHearingRequestTypeTask.create!(**create_args, parent: schedule_hearing_task)
       end
 
       appeal.reload

--- a/spec/services/hearing_task_tree_initializer_spec.rb
+++ b/spec/services/hearing_task_tree_initializer_spec.rb
@@ -13,7 +13,7 @@ describe HearingTaskTreeInitializer do
 
     subject { described_class.for_appeal_with_pending_travel_board_hearing(appeal) }
 
-    context "if task tree does not already exist" do
+    context "the task tree does not already exist" do
       it "it creates the expected tasks" do
         expect(ChangeHearingRequestTypeTask.count).to eq(0)
         expect(ScheduleHearingTask.count).to eq(0)
@@ -35,7 +35,7 @@ describe HearingTaskTreeInitializer do
       end
     end
 
-    context "if an open hearing task already exists" do
+    context "an open hearing task already exists" do
       let(:root_task) { create(:root_task, appeal: appeal) }
       let(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
       let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
@@ -45,6 +45,25 @@ describe HearingTaskTreeInitializer do
         expect(ChangeHearingRequestTypeTask.count).to eq(0)
         expect(ScheduleHearingTask.count).to eq(1)
         expect(HearingTask.count).to eq(1)
+      end
+    end
+
+    context "there's a closed hearing task on the appeal" do
+      let(:root_task) { create(:root_task, appeal: appeal) }
+      let!(:hearing_task) do
+        create(:hearing_task, appeal: appeal, parent: root_task)
+      end
+
+      before do
+        hearing_task.update!(status: Constants.TASK_STATUSES.completed)
+      end
+
+      it "creates a new hearing task parent" do
+        expect(HearingTask.count).to eq(1)
+        subject
+        expect(ChangeHearingRequestTypeTask.count).to eq(1)
+        expect(ScheduleHearingTask.count).to eq(1)
+        expect(HearingTask.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Resolves #15466

### Description
Stop using a closed `HearingTask` as a parent for our new `ChangeHearingRequestTypeTask`.