### PR TITLE
Do not recreate a hearing for cancelled missing hearing transcript admin actions

### DIFF
--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -49,7 +49,7 @@ class TranscriptionTask < Task
     multi_transaction do
       verify_user_can_update!(current_user)
 
-      if params[:status] == Constants.TASK_STATUSES.cancelled
+      if params[:status] == Constants.TASK_STATUSES.cancelled && hearing_task.type == HearingTask.name
         recreate_hearing
       else
         super(params, current_user)


### PR DESCRIPTION
Resolves this sentry alert https://dsva.slack.com/archives/CLRTL92TW/p1603107922060100

### Description
Transcription tasks are automatically created for `MissingHearingTranscriptColocatedTask`s. The logic around recreating a hearing when the task is cancelled is broken in the case as we assume all transcription tasks were grandchildren of a hearing task. If a hearing does need to be recreated, whoever created the missing hearing transcripts admin action can also send the case to be scheduled for a hearing.

### Acceptance Criteria
- [ ] Transcription tasks created by a judge or attorney admin action do not attempt to recreate hearings when cancelled

### Testing Plan
1. Log in as bvaaabshire and add a missing hearing transcripts admin action to one of your cases
1. Log in as a transcription team member and cancel the task
1. Ensure the recreation of a hearing is not attempted
