### PR TITLE
Add Support for Webpack Aliases to Storybook Config

### DIFF
--- a/client/.storybook/main.js
+++ b/client/.storybook/main.js
@@ -20,6 +20,13 @@ module.exports = {
 
     return {
       ...config,
+      resolve: {
+        ...config.resolve,
+        alias: {
+          ...config.resolve.alias,
+          ...custom.resolve.alias
+        }
+      },
       module: {
         ...config.module,
         rules: [...config.module.rules, ...customRules],


### PR DESCRIPTION
### Description
This extends the Webpack config used by Storybook to include our custom Webpack aliases