### PR TITLE
when retrying fetching the rating profile, return an empty object if a BGS ShareError or a Rating NilRatingProfileListError is raised

### DIFF
--- a/app/models/promulgated_rating.rb
+++ b/app/models/promulgated_rating.rb
@@ -82,6 +82,9 @@ class PromulgatedRating < Rating
     )
     matching_rating = ratings_at_issue.find { |rating| profile_date_matches(rating.profile_date) }
     matching_rating.present? ? matching_rating.rating_profile : {}
+  rescue BGS::ShareError, Rating::NilRatingProfileListError => error
+    Raven.capture_exception(error)
+    {}
   end
 
   # The profile date is used as a key when fetching a rating by profile date.


### PR DESCRIPTION
### Description
Handles cases where BGS errors are raised when retrying fetching the rating profile using the new BGS endpoint.

See [this discussion in a bat team thread.](https://dsva.slack.com/archives/CHX8FMP28/p1602865691287800)