### PR TITLE
Cancel virtual hearing when hearing is postponed or cancelled

### DIFF
--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -15,6 +15,8 @@
 # The task is marked complete when the children tasks are completed.
 
 class AssignHearingDispositionTask < Task
+  include RunAsyncable
+
   validates :parent, presence: true
   before_create :check_parent_type
   delegate :hearing, to: :hearing_task, allow_nil: true
@@ -160,6 +162,19 @@ class AssignHearingDispositionTask < Task
     created_tasks
   end
 
+  def clean_up_virtual_hearing
+    # need to delete conference for current virtual hearing
+    if hearing.virtual?
+      hearing.virtual_hearing.update!(request_cancelled: true)
+
+      if run_async?
+        VirtualHearings::DeleteConferencesJob.perform_later
+      else
+        VirtualHearings::DeleteConferencesJob.perform_now
+      end
+    end
+  end
+
   def update_hearing_disposition(disposition:)
     # Ensure the hearing exists
     fail HearingAssociationMissing, hearing_task&.id if hearing.nil?
@@ -201,6 +216,7 @@ class AssignHearingDispositionTask < Task
   def mark_hearing_cancelled
     multi_transaction do
       update_hearing_disposition(disposition: Constants.HEARING_DISPOSITION_TYPES.cancelled)
+      clean_up_virtual_hearing # virtual hearing should be indicated as cancelled
       cancel!
     end
   end
@@ -222,6 +238,7 @@ class AssignHearingDispositionTask < Task
   def mark_hearing_postponed(instructions: nil, after_disposition_update: nil)
     multi_transaction do
       update_hearing_disposition(disposition: Constants.HEARING_DISPOSITION_TYPES.postponed)
+      clean_up_virtual_hearing # virtual hearing should be indicated as cancelled
       reschedule_or_schedule_later(instructions: instructions, after_disposition_update: after_disposition_update)
     end
   end


### PR DESCRIPTION
Resolves #15447

### Description
- set `request_cancelled` on virtual hearings 
- call `DeleteConferencesJob` when a hearing is cancelled or postponed 

### Acceptance Criteria
- [x] Ensure that when a virtual hearing is postponed, the:
  - [x] Delete conference job runs
  - [x] `request_cancelled` is set to true on the virtual hearing
- [ ] Cleanup data in production