### PR TITLE
Handle race conditions when concurrently fetching POA by PID

### DIFF
--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -43,6 +43,10 @@ class BgsPowerOfAttorney < CaseflowRecord
 
     def find_or_create_by_claimant_participant_id(claimant_participant_id)
       find_or_create_by!(claimant_participant_id: claimant_participant_id)
+    rescue ActiveRecord::RecordNotUnique
+      # Handle race conditions similarly to find_or_create_by_file_number.
+      # For an example of this in the wild, see Sentry event 17c302faae0b48bcb0e1816a58e8b7f5.
+      find_by(claimant_participant_id: claimant_participant_id)
     end
 
     def find_or_load_by_file_number(file_number)

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -71,8 +71,8 @@ describe BgsPowerOfAttorney do
 
     context "db record does not exist" do
       it "creates new db record" do
+        expect { subject }.to change { described_class.count }.by(1)
         expect(subject).to be_a(described_class)
-        expect(described_class.count).to eq(1)
       end
     end
 
@@ -80,8 +80,8 @@ describe BgsPowerOfAttorney do
       let!(:poa) { create(:bgs_power_of_attorney, file_number: file_number) }
 
       it "fetches existing record" do
+        expect { subject }.to change { described_class.count }.by(0)
         expect(subject).to eq(poa)
-        expect(described_class.count).to eq(1)
       end
     end
 

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -32,6 +32,38 @@ describe BgsPowerOfAttorney do
         expect(Rails.cache.fetch("bgs-participant-poa-not-found-no-such-pid")).to eq(true)
       end
     end
+
+    context "when concurrent calls cause a race condition" do
+      let(:concurrency) { 4 }
+      let(:pid) { "7108346" }
+      let(:file_number) { "fn" }
+      let(:bgs_record) do
+        {
+          claimant_participant_id: claimant_participant_id,
+          participant_id: pid,
+          file_number: file_number,
+          representative_name: "some",
+          representative_type: "vso"
+        }
+      end
+
+      before do
+        allow(BgsPowerOfAttorney).to receive(:fetch_bgs_poa_by_participant_id) do
+          sleep 1
+          bgs_record
+        end
+      end
+
+      it "does not raise an error on unique constraint violation" do
+        threads = []
+        concurrency.times do
+          threads << Thread.new do
+            BgsPowerOfAttorney.find_or_create_by_claimant_participant_id(claimant_participant_id).poa_participant_id
+          end
+        end
+        expect(threads.map(&:value)).to eq([pid] * concurrency)
+      end
+    end
   end
 
   describe ".find_or_create_by_file_number" do


### PR DESCRIPTION
### Description
Resolves a race condition error as seen in this [Sentry event](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/10678/).

The fix is analogous to what I did in #14650.

### Testing Plan
1. New concurrent test added for this method
2. To verify that the new test actually tests the right thing:
    - Check out the branch
    - Comment out lines 46 (`rescue`) and 49 (`find_by`) in the new model code
    - Confirm that the new test fails