### PR TITLE
Delete conference when hearing is postponed or cancelled

### DIFF
--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -94,7 +94,7 @@ class VirtualHearings::DeleteConferencesJob < VirtualHearings::ConferenceJob
   end
 
   def send_cancellation_emails(virtual_hearing)
-    if (!hearing_is_postponed_or_cancelled?(virtual_hearing)))
+    if !hearing_is_postponed_or_cancelled?(virtual_hearing)
       VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: :cancellation).call
     end
 

--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -87,8 +87,16 @@ class VirtualHearings::DeleteConferencesJob < VirtualHearings::ConferenceJob
     RequestStore.store[:current_user] ||= User.system_user
   end
 
+  def hearing_is_postponed_or_cancelled?(virtual_hearing)
+    return true if virtual_hearing.hearing.postponed? || virtual_hearing.hearing.cancelled?
+
+    false
+  end
+
   def send_cancellation_emails(virtual_hearing)
-    VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: :cancellation).call
+    if (!hearing_is_postponed_or_cancelled?(virtual_hearing)))
+      VirtualHearings::SendEmail.new(virtual_hearing: virtual_hearing, type: :cancellation).call
+    end
 
     if !virtual_hearing.cancellation_emails_sent?
       fail EmailsFailedToSend # failing so we can log errors

--- a/app/models/concerns/has_virtual_hearing.rb
+++ b/app/models/concerns/has_virtual_hearing.rb
@@ -7,10 +7,13 @@ module HasVirtualHearing
     has_one :virtual_hearing, -> { order(id: :desc) }, as: :hearing
   end
 
+  # NOTE: A hearing is virtual unless the hearing type was switched back to original
+  # indicated by status `cancelled`
   def virtual?
     [
       :pending,
-      :active
+      :active,
+      :closed
     ].include? virtual_hearing&.status
   end
 

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+##
+# Shared methods of Hearing and LegacyHearing models
+##
+module HearingConcern
+  extend ActiveSupport::Concern
+
+  # NOTE: for LegacyHearing, this makes a call to VACOLS
+  def postponed?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.postponed
+  end
+
+  # NOTE: for LegacyHearing, this makes a call to VACOLS
+  def cancelled?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.cancelled
+  end
+
+  # NOTE: for LegacyHearing, this makes a call to VACOLS
+  def no_show?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.no_show
+  end
+
+  # NOTE: for LegacyHearing, this makes a call to VACOLS
+  def held?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.held
+  end
+end

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -29,6 +29,7 @@ class Hearing < CaseflowRecord
   include HearingLocationConcern
   include HasSimpleAppealUpdatedSince
   include UpdatedByUserConcern
+  include HearingConcern
 
   belongs_to :hearing_day
   belongs_to :appeal
@@ -238,14 +239,6 @@ class Hearing < CaseflowRecord
     email_events.order(sent_at: :desc).map do |event|
       SentEmailEventSerializer.new(event).serializable_hash[:data][:attributes]
     end
-  end
-
-  def postponed?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.postponed
-  end
-
-  def cancelled?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.cancelled
   end
 
   private

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -240,6 +240,14 @@ class Hearing < CaseflowRecord
     end
   end
 
+  def postponed?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.postponed
+  end
+
+  def cancelled?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.cancelled
+  end
+
   private
 
   def assign_created_by_user

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -22,12 +22,13 @@
 #                 and indicates that the hearing type was switched back to original type and **NOT** that
 #                 conference was deleted or hearing was cancelled.
 #
-#   `closed`: We needed a way to distinguish between hearings which types were switched and hearings which were
-#             cancelled or postponed. This is derived from `conference_deleted` which indicates that we deleted the
-#             conference for a cancelled or postponed hearing.
+#   `closed`: This is derived from `conference_deleted` which indicates that we deleted the conference that was created.
+#             Though we delete conferences for every virtual hearing after the schedduled date, this helps us
+#             distinguish between hearings which types were switched and hearings which were cancelled or postponed
+#             because for the latter `request_cancelled` will not be set to `true`.
 #
 #   `active`: This indicates that the conference was created for a virtual hearing, derived from presence of
-#             `conference_id`
+#             `conference_id`.
 #
 #   `pending`: This indicates that the conference has yet to be created.
 ##

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -13,7 +13,23 @@
 # emails to participants including the link to video conference as well as other details about
 # the hearing. DeleteConferencesJob is kicked off to delete the conference resource
 # when the the virtual hearing is cancelled or after the hearing takes place.
-
+#
+# A note about `status`:
+#   * Status can be `cancelled`, `closed`, `active`, or `pending` *
+#   `cancelled` : Initially virtual hearings could be only created when the hearing coordinator switched the hearing
+#                 type (`Video` or `Central`) to virtual. If that type is switched back to the orginal type,
+#                 this is tracked by `request_cancelled`. Essentially `cancelled` is derived from `request_cancelled`
+#                 and indicates that the hearing type was switched back to original type and **NOT** that
+#                 conference was deleted or hearing was cancelled.
+#
+#   `closed`: We needed a way to distinguish between hearings which types were switched and hearings which were
+#             cancelled or postponed. This is derived from `conference_deleted` which indicates that we deleted the
+#             conference for a cancelled or postponed hearing.
+#
+#   `active`: This indicates that the conference was created for a virtual hearing, derived from presence of `conference_id`
+#
+#   `pending`: This indicates that the conference has yet to be created.
+##
 class VirtualHearing < CaseflowRecord
   include UpdatedByUserConcern
 

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -116,7 +116,10 @@ class VirtualHearing < CaseflowRecord
     (active? || cancelled?) && all_emails_sent?
   end
 
-  # Determines if the hearing has been cancelled
+  # Determines if the hearing type has been switched to the original type
+  # NOTE: This can only happen from the hearing details page where the hearing coordinator
+  # can switch the type from virtual back to Video or Central. This essentailly cancels
+  # this virtual hearing.
   def cancelled?
     status == :cancelled
   end
@@ -131,11 +134,25 @@ class VirtualHearing < CaseflowRecord
     status == :active
   end
 
+  # Determines if the conference was deleted
+  # NOTE: Even though the conference is deleted for every virtual hearing,
+  # this status helps us distinguish between hearings that had their types
+  # switched back to original type and cancelled and postponed hearings which
+  # require us to delete the conference but not set `request_cancelled`.
+  def closed?
+    status == :closed
+  end
+
   # Determines the status of the Virtual Hearing based on the establishment
   def status
     # Check if the establishment has been cancelled by the user
     if request_cancelled?
       return :cancelled
+    end
+
+    # if the conference has been created the virtual hearing was deleted
+    if conference_id && conference_deleted?
+      return :closed
     end
 
     # If the conference has been created the virtual hearing is active

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -26,7 +26,8 @@
 #             cancelled or postponed. This is derived from `conference_deleted` which indicates that we deleted the
 #             conference for a cancelled or postponed hearing.
 #
-#   `active`: This indicates that the conference was created for a virtual hearing, derived from presence of `conference_id`
+#   `active`: This indicates that the conference was created for a virtual hearing, derived from presence of
+#             `conference_id`
 #
 #   `pending`: This indicates that the conference has yet to be created.
 ##

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -33,6 +33,7 @@ class LegacyHearing < CaseflowRecord
   include HearingLocationConcern
   include HearingTimeConcern
   include UpdatedByUserConcern
+  include HearingConcern
 
   # When these instance variable getters are called, first check if we've
   # fetched the values from VACOLS. If not, first fetch all values and save them
@@ -176,24 +177,8 @@ class LegacyHearing < CaseflowRecord
     !!disposition
   end
 
-  def no_show?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.no_show
-  end
-
-  def held?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.held
-  end
-
   def scheduled_pending?
     scheduled_for && !closed?
-  end
-
-  def postponed?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.postponed
-  end
-
-  def cancelled?
-    disposition == Constants.HEARING_DISPOSITION_TYPES.cancelled
   end
 
   def scheduled_for_past?

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -188,6 +188,14 @@ class LegacyHearing < CaseflowRecord
     scheduled_for && !closed?
   end
 
+  def postponed?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.postponed
+  end
+
+  def cancelled?
+    disposition == Constants.HEARING_DISPOSITION_TYPES.cancelled
+  end
+
   def scheduled_for_past?
     # FIXME: scheduled_for date is inconsistent in many places.
     # (https://github.com/department-of-veterans-affairs/caseflow/issues/13273)

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -70,6 +70,14 @@ class VACOLS::CaseHearing < VACOLS::Record
   after_update :create_or_update_diaries
 
   class << self
+    def hearings_with_postponed_or_cancelled_disposition
+      VACOLS::CaseHearing.where(
+        hearing_disp: [
+          HEARING_DISPOSITIONS.key(Constants.HEARING_DISPOSITION_TYPES.postponed).to_s,
+          HEARING_DISPOSITIONS.key(Constants.HEARING_DISPOSITION_TYPES.cancelled).to_s
+        ]
+      )
+    end
     # Finds all hearings for specific days.
     #
     # @deprecated Use {#where}

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -19,6 +19,8 @@ class VACOLS::CaseHearing < VACOLS::Record
   has_one :folder, foreign_key: :ticknum, primary_key: :folder_nr
   has_one :corres, foreign_key: :stafkey, primary_key: :bfcorkey, class_name: "Correspondent"
 
+  scope :by_dispositions, ->(dispositions) { where(hearing_disp: dispositions) }
+
   HEARING_TYPE_LOOKUP = {
     central: "C",
     travel: "T",
@@ -70,14 +72,6 @@ class VACOLS::CaseHearing < VACOLS::Record
   after_update :create_or_update_diaries
 
   class << self
-    def hearings_with_postponed_or_cancelled_disposition
-      VACOLS::CaseHearing.where(
-        hearing_disp: [
-          HEARING_DISPOSITIONS.key(Constants.HEARING_DISPOSITION_TYPES.postponed).to_s,
-          HEARING_DISPOSITIONS.key(Constants.HEARING_DISPOSITION_TYPES.cancelled).to_s
-        ]
-      )
-    end
     # Finds all hearings for specific days.
     #
     # @deprecated Use {#where}

--- a/app/repositories/virtual_hearing_repository.rb
+++ b/app/repositories/virtual_hearing_repository.rb
@@ -65,7 +65,10 @@ class VirtualHearingRepository
     private
 
     def postponed_or_cancelled_vacols_ids
-      VACOLS::CaseHearing.hearings_with_postponed_or_cancelled_disposition.pluck(:hearing_pkseq).map(&:to_s)
+      VACOLS::CaseHearing.by_dispositions([
+        VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("postponed"),
+        VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("cancelled")
+      ]).pluck(:hearing_pkseq).map(&:to_s)
     end
   end
 end

--- a/app/repositories/virtual_hearing_repository.rb
+++ b/app/repositories/virtual_hearing_repository.rb
@@ -60,6 +60,8 @@ class VirtualHearingRepository
             )
           )
         SQL
+    end
+
     private
 
     def postponed_or_cancelled_vacols_ids

--- a/app/repositories/virtual_hearing_repository.rb
+++ b/app/repositories/virtual_hearing_repository.rb
@@ -9,10 +9,8 @@ class VirtualHearingRepository
         .joins("INNER JOIN hearing_days ON hearing_days.id = hearings.hearing_day_id")
         .where(
           "hearing_days.scheduled_for < :today OR
-          hearings.disposition='postponed' OR
-          hearings.disposition='cancelled' OR
-          virtual_hearings.request_cancelled = true",
-          today: Time.zone.today,
+          hearings.disposition='postponed' OR hearings.disposition='cancelled' OR
+          virtual_hearings.request_cancelled = true", today: Time.zone.today
         )
 
       virtual_hearings_for_legacy_hearings = VirtualHearing.eligible_for_deletion
@@ -23,8 +21,7 @@ class VirtualHearingRepository
           "hearing_days.scheduled_for < :today OR
           legacy_hearings.vacols_id in (:postponed_or_cancelled_vacols_ids) OR
           virtual_hearings.request_cancelled = true",
-          postponed_or_cancelled_vacols_ids: postponed_or_cancelled_vacols_ids,
-          today: Time.zone.today
+          postponed_or_cancelled_vacols_ids: postponed_or_cancelled_vacols_ids, today: Time.zone.today
         )
 
       virtual_hearings_for_ama_hearings + virtual_hearings_for_legacy_hearings
@@ -65,10 +62,12 @@ class VirtualHearingRepository
     private
 
     def postponed_or_cancelled_vacols_ids
-      VACOLS::CaseHearing.by_dispositions([
-        VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("postponed"),
-        VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("cancelled")
-      ]).pluck(:hearing_pkseq).map(&:to_s)
+      VACOLS::CaseHearing.by_dispositions(
+        [
+          VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("postponed"),
+          VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("cancelled")
+        ]
+      ).pluck(:hearingsing_pkseq).map(&:to_s)
     end
   end
 end

--- a/app/repositories/virtual_hearing_repository.rb
+++ b/app/repositories/virtual_hearing_repository.rb
@@ -67,7 +67,7 @@ class VirtualHearingRepository
           VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("postponed"),
           VACOLS::CaseHearing::HEARING_DISPOSITIONS.key("cancelled")
         ]
-      ).pluck(:hearingsing_pkseq).map(&:to_s)
+      ).pluck(:hearing_pkseq).map(&:to_s)
     end
   end
 end

--- a/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
+++ b/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
@@ -334,5 +334,21 @@ describe VirtualHearings::DeleteConferencesJob do
         include_examples "job is retried", 5
       end
     end
+
+    context "for hearings that are postponed or cancelled" do
+      context "cancelled hearing" do
+        let(:cancelled_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.cancelled )}
+        let!(:virtual_hearing) { create(:virtual_hearing, status: :active, hearing: cancelled_hearing) }
+
+        include_examples "doesn't send any emails"
+      end
+
+      context "postponed hearing" do
+        let(:postponed_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.postponed )}
+        let!(:virtual_hearing) { create(:virtual_hearing, status: :active, hearing: postponed_hearing) }
+
+        include_examples "doesn't send any emails"
+      end
+    end
   end
 end

--- a/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
+++ b/spec/jobs/virtual_hearings/delete_conferences_job_spec.rb
@@ -337,14 +337,14 @@ describe VirtualHearings::DeleteConferencesJob do
 
     context "for hearings that are postponed or cancelled" do
       context "cancelled hearing" do
-        let(:cancelled_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.cancelled )}
+        let(:cancelled_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.cancelled) }
         let!(:virtual_hearing) { create(:virtual_hearing, status: :active, hearing: cancelled_hearing) }
 
         include_examples "doesn't send any emails"
       end
 
       context "postponed hearing" do
-        let(:postponed_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.postponed )}
+        let(:postponed_hearing) { create(:hearing, disposition: Constants.HEARING_DISPOSITION_TYPES.postponed) }
         let!(:virtual_hearing) { create(:virtual_hearing, status: :active, hearing: postponed_hearing) }
 
         include_examples "doesn't send any emails"

--- a/spec/models/hearings/virtual_hearing_spec.rb
+++ b/spec/models/hearings/virtual_hearing_spec.rb
@@ -189,7 +189,7 @@ describe VirtualHearing do
     end
   end
 
-  context "#status"do
+  context "#status" do
     subject { virtual_hearing.status }
 
     context "cancelled" do

--- a/spec/models/hearings/virtual_hearing_spec.rb
+++ b/spec/models/hearings/virtual_hearing_spec.rb
@@ -188,4 +188,77 @@ describe VirtualHearing do
       it_behaves_like "hearing with existing virtual hearing"
     end
   end
+
+  context "#status"do
+    subject { virtual_hearing.status }
+
+    context "cancelled" do
+      let(:virtual_hearing) do
+        build(
+          :virtual_hearing,
+          :initialized,
+          hearing: build(
+            :hearing,
+            hearing_day: build(:hearing_day, request_type: HearingDay::REQUEST_TYPES[:central])
+          ),
+          request_cancelled: true
+        )
+      end
+
+      it "returns correct status" do
+        expect(subject).to eq(:cancelled)
+      end
+    end
+
+    context "closed" do
+      let(:virtual_hearing) do
+        build(
+          :virtual_hearing,
+          :initialized,
+          hearing: build(
+            :hearing,
+            hearing_day: build(:hearing_day, request_type: HearingDay::REQUEST_TYPES[:central])
+          ),
+          conference_deleted: true
+        )
+      end
+
+      it "returns correct status" do
+        expect(subject).to eq(:closed)
+      end
+    end
+
+    context "active" do
+      let(:virtual_hearing) do
+        build(
+          :virtual_hearing,
+          :initialized,
+          hearing: build(
+            :hearing,
+            hearing_day: build(:hearing_day, request_type: HearingDay::REQUEST_TYPES[:central])
+          )
+        )
+      end
+
+      it "returns correct status" do
+        expect(subject).to eq(:active)
+      end
+    end
+
+    context "pending" do
+      let(:virtual_hearing) do
+        build(
+          :virtual_hearing,
+          hearing: build(
+            :hearing,
+            hearing_day: build(:hearing_day, request_type: HearingDay::REQUEST_TYPES[:central])
+          )
+        )
+      end
+
+      it "returns correct status" do
+        expect(subject).to eq(:pending)
+      end
+    end
+  end
 end

--- a/spec/repositories/virtual_hearing_repository_spec.rb
+++ b/spec/repositories/virtual_hearing_repository_spec.rb
@@ -49,6 +49,22 @@ describe VirtualHearingRepository, :all_dbs do
         end
       end
 
+      context "for pending virtual hearing" do
+        let(:virtual_hearing) { create(:virtual_hearing, hearing: hearing) }
+
+        it "does not return the virtual hearing" do
+          expect(subject).to eq []
+        end
+      end
+
+      context "for cancelled virtual hearing" do
+        let(:virtual_hearing) { create(:virtual_hearing, status: :cancelled, hearing: hearing) }
+
+        it "returns the virtual hearing" do
+          expect(subject).to eq [virtual_hearing]
+        end
+      end
+
       context "on the day of" do
         it "does not return the virtual hearing" do
           expect(subject).to eq []

--- a/spec/repositories/virtual_hearing_repository_spec.rb
+++ b/spec/repositories/virtual_hearing_repository_spec.rb
@@ -33,7 +33,6 @@ describe VirtualHearingRepository, :all_dbs do
 
       context "that was postponed" do
         let(:ama_disposition) { Constants.HEARING_DISPOSITION_TYPES.postponed }
-        let(:hearing_date) { Time.zone.now - 1.day }
 
         it "returns the virtual hearing" do
           expect(subject).to eq [virtual_hearing]
@@ -42,7 +41,6 @@ describe VirtualHearingRepository, :all_dbs do
 
       context "that was cancelled" do
         let(:ama_disposition) { Constants.HEARING_DISPOSITION_TYPES.cancelled }
-        let(:hearing_date) { Time.zone.now - 1.day }
 
         it "returns the virtual hearing" do
           expect(subject).to eq [virtual_hearing]
@@ -93,7 +91,6 @@ describe VirtualHearingRepository, :all_dbs do
 
       context "that was postponed" do
         let(:legacy_dispositon) { "P" }
-        let(:hearing_date) { Time.zone.now - 1.day }
 
         it "returns the virtual hearing" do
           expect(subject).to eq [virtual_hearing]
@@ -102,7 +99,6 @@ describe VirtualHearingRepository, :all_dbs do
 
       context "that was cancelled" do
         let(:legacy_dispositon) { "C" }
-        let(:hearing_date) { Time.zone.now - 1.day }
 
         it "returns the virtual hearing" do
           expect(subject).to eq [virtual_hearing]


### PR DESCRIPTION
Resolves #15447

### Description
- Ensure `VirtualHearingRepository` considers hearing that have disposition of `cancelled` or `postponed`
- Ensure `DeleteConferencesJob` does not send cancellation emails if hearing is `postponed` or `cancelled`
- Write tests

### Acceptance Criteria
- [x] Ensure that when a virtual hearing is postponed, the:
  - [x] Delete conference job runs
  - ~[ ] `request_cancelled` is set to true on the virtual hearing~
- [ ] Cleanup data in production
