### PR TITLE
Shalliburton/15435 05 components no search results

### DIFF
--- a/client/app/2.0/components/reader/DocumentList/NoSearchResults.jsx
+++ b/client/app/2.0/components/reader/DocumentList/NoSearchResults.jsx
@@ -1,0 +1,30 @@
+// External Dependencies
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+
+// Local Dependencies
+import StatusMessage from 'app/components/StatusMessage';
+import { clearSearch } from 'app/reader/DocumentList/DocumentListActions';
+
+/**
+ * No Search Results Component
+ * @param {Object} props -- Props containing the search query
+ */
+export const NoSearchResults = ({ searchQuery }) => {
+  // Create the Dispatcher
+  const dispatch = useDispatch();
+
+  return (
+    <div className="section--no-search-results">
+      <StatusMessage title="Search results not found">
+        Sorry! We couldn't find anything for "{searchQuery.trim()}."<br />
+        Please search again or <a href="#" onClick={() => dispatch(clearSearch())}>go back to the document list.</a>
+      </StatusMessage>
+    </div>
+  );
+};
+
+NoSearchResults.propTypes = {
+  searchQuery: PropTypes.string
+};


### PR DESCRIPTION
### Description

Part 5f of [the stack](https://github.com/department-of-veterans-affairs/caseflow/pull/15456) Refactors the `NoSearchResults` component

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Shadow user AAABSHIRE and click the Reader tab and then Documents list on the test users page: http://localhost:3000/test/users
1. Make sure that you can still use Reader the same as before
1. Open a rails console and toggle the feature on: FeatureToggle.enable!(:interface_version_2)
1. Reload the page and ensure you see the app container and navigation bar, but that nothing renders in the main part of the screen