### PR TITLE
WIP | Non-rating to rating updates 

### DIFF
--- a/app/models/end_product_update.rb
+++ b/app/models/end_product_update.rb
@@ -11,8 +11,9 @@ class EndProductUpdate < CaseflowRecord
 
   def perform!
     transaction do
-      end_product_establishment.update(code: new_code)
+      end_product_establishment.update(code: new_code, source_type: original_decision_review_type)
       update_correction_type
+      update_issue_type
     end
   end
 
@@ -23,6 +24,13 @@ class EndProductUpdate < CaseflowRecord
     return if correction_type == old_code_hash[:correction_type]
 
     end_product_establishment.request_issues.update(correction_type: correction_type)
+  end
+
+  def update_issue_type
+    issue_type = new_code_hash[:issue_type]
+    return if issue_type == old_code_hash[:issue_type]
+
+    end_product_establishment.request_issues.update(type: RatingRequestIssue)
   end
 
   def old_code_hash

--- a/spec/factories/end_product_update.rb
+++ b/spec/factories/end_product_update.rb
@@ -3,7 +3,11 @@
 FactoryBot.define do
   factory :end_product_update do
     user { create(:user) }
-    end_product_establishment { create(:end_product_establishment, code: original_code) }
+    end_product_establishment do
+      create(:end_product_establishment,
+             code: original_code,
+             source_type: original_decision_review_type)
+    end
 
     transient do
       number_of_request_issues { 2 }

--- a/spec/models/end_product_update_spec.rb
+++ b/spec/models/end_product_update_spec.rb
@@ -2,7 +2,15 @@
 
 describe EndProductUpdate do
   describe "#perform!" do
-    let(:epu) { create(:end_product_update, original_code: old_code, new_code: new_code) }
+    let(:epu) do
+      create(:end_product_update,
+             original_code: old_code,
+             new_code: new_code,
+             original_decision_review_type: nonrating)
+    end
+
+    let(:nonrating) { "NonratingRequestIssue" }
+    let(:rating) { "RatingRequestIssue" }
     subject { epu.perform! }
 
     context "when correction type changes" do
@@ -14,6 +22,26 @@ describe EndProductUpdate do
         expect(epe.code).to eq(new_code)
         expect(epe.request_issues).not_to be_empty
         expect(epe.request_issues).to all have_attributes(correction_type: "national_quality_error")
+      end
+    end
+
+    context "when issue type changes" do
+      let(:epu) do
+        create(:end_product_update,
+               original_code: old_code,
+               new_code: new_code,
+               original_decision_review_type: nonrating)
+      end
+      let(:old_code) { "930AHCNRNQE" }
+      let(:new_code) { "930AHCRLQPMC" }
+
+      it "updates correction type on request issues" do
+        subject
+
+        epe = epu.end_product_establishment
+        expect(epe.source_type).to eq(nonrating)
+        expect(epe.request_issues).not_to be_empty
+        expect(epe.request_issues).to all have_attributes(type: "RatingRequestIssue")
       end
     end
   end


### PR DESCRIPTION
Connects  #15126

### Description
After an edit is submitted, if the non-rating -> rating change type applies, this code will handle the data updates to convert the request issues to rating issues.

### Acceptance Criteria
- [ ] When performing the data updates, detect if one of the change types is nonrating --> rating
- [ ] Update all of the active request issues on the end product in Caseflow DB
  - [ ] Set the request issue type to RatingRequestIssue
  - [ ] Update description to equal the nonrating_issue_description, not including the nonrating_issue_category if the issue type is RatingRequestIssue and the nonrating_issue_description is present

### User Facing Changes
<img width="840" alt="Screen Shot 2020-10-29 at 1 10 59 PM" src="https://user-images.githubusercontent.com/23080951/97614817-cc938f00-19f0-11eb-9c7d-b81d354afe4c.png">