### PR TITLE
Feature test click_dropdown performance

### DIFF
--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -3,371 +3,295 @@
 ##
 # Tests various aspects of scheduling a hearing as an admin hearing coordinator
 RSpec.feature "Schedule Veteran For A Hearing" do
-  let!(:current_user) do
-    user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
-    User.authenticate!(user: user)
-  end
-
-  let(:other_user) { create(:user) }
-  let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
-  let(:fill_in_veteran_email) { "vet@testingEmail.com" }
-  let(:fill_in_representative_email) { "email@testingEmail.com" }
-
-  before do
-    HearingsManagement.singleton.add_user(current_user)
-    HearingAdmin.singleton.add_user(current_user)
-    HearingsManagement.singleton.add_user(other_user)
-    HearingAdmin.singleton.add_user(other_user)
-  end
-
-  shared_context "central_hearings" do
-    let!(:hearing_day) { create(:hearing_day, scheduled_for: Time.zone.today + 30.days) }
-    let!(:vacols_case) do
-      create(
-        :case, :central_office_hearing,
-        bfcorlid: "123454787S",
-        bfcurloc: "CASEFLOW"
-      )
-    end
-    let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case, closest_regional_office: "C") }
-    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: legacy_appeal) }
-
-    let!(:veteran) { create(:veteran, file_number: "123454787") }
-    let!(:hearing_location_dropdown_label) { "Hearing Location" }
-    let(:appellant_appeal_link_text) do
-      "#{legacy_appeal.appellant[:first_name]} #{legacy_appeal.appellant[:last_name]} | #{veteran.file_number}"
+  ensure_stable do
+    let!(:current_user) do
+      user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
+      User.authenticate!(user: user)
     end
 
-    let!(:expected_alert) do
-      COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
-    end
-
-    def navigate_to_schedule_veteran
-      visit "hearings/schedule/assign"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Central")
-      click_button("Legacy Veterans Waiting", exact: true)
-      click_link appellant_appeal_link_text
-      expect(page).not_to have_content("loading to VACOLS.", wait: 30)
-      expect(page).to have_content("Currently active tasks", wait: 30)
-      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-      expect(page).to have_content("Time")
-    end
-  end
-
-  shared_context "video_hearing" do
-    let!(:hearing_day) do
-      create(
-        :hearing_day,
-        request_type: HearingDay::REQUEST_TYPES[:video],
-        scheduled_for: Time.zone.today + 60.days,
-        regional_office: "RO39"
-      )
-    end
-    let!(:staff) { create(:staff, stafkey: "RO39", stc2: 2, stc3: 3, stc4: 4) }
-    let!(:vacols_case) do
-      create(
-        :case,
-        :video_hearing_requested,
-        folder: create(:folder, tinum: "docket-number"),
-        bfcorlid: "123456789S",
-        bfcurloc: "CASEFLOW",
-        bfregoff: "RO39"
-      )
-    end
-    let!(:legacy_appeal) do
-      create(
-        :legacy_appeal,
-        vacols_case: vacols_case,
-        closest_regional_office: "RO39"
-      )
-    end
-    let!(:schedule_hearing_task) do
-      create(
-        :schedule_hearing_task, appeal: legacy_appeal
-      )
-    end
-    let!(:veteran) { create(:veteran, file_number: "123456789") }
+    let(:other_user) { create(:user) }
     let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
-    let(:room_label) { HearingRooms.find!(hearing_day.room)&.label }
+    let(:fill_in_veteran_email) { "vet@testingEmail.com" }
+    let(:fill_in_representative_email) { "email@testingEmail.com" }
 
-    let!(:expected_alert) do
-      COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
+    before do
+      HearingsManagement.singleton.add_user(current_user)
+      HearingAdmin.singleton.add_user(current_user)
+      HearingsManagement.singleton.add_user(other_user)
+      HearingAdmin.singleton.add_user(other_user)
     end
 
-    def navigate_to_schedule_veteran
-      visit "hearings/schedule/assign"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Denver, CO")
-      click_button("Legacy Veterans Waiting", exact: true)
-      appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
-      appeal_link.click
-      expect(page).not_to have_content("loading to VACOLS.", wait: 30)
-      expect(page).to have_content("Currently active tasks", wait: 30)
-      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-      expect(page).to have_content("Time")
-    end
-  end
+    shared_context "central_hearings" do
+      let!(:hearing_day) { create(:hearing_day, scheduled_for: Time.zone.today + 30.days) }
+      let!(:vacols_case) do
+        create(
+          :case, :central_office_hearing,
+          bfcorlid: "123454787S",
+          bfcurloc: "CASEFLOW"
+        )
+      end
+      let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case, closest_regional_office: "C") }
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: legacy_appeal) }
 
-  shared_context "ama_hearing" do
-    let!(:room) { "1" }
-    let!(:regional_office) { "RO39" }
-    let!(:hearing_day) do
-      create(
-        :hearing_day,
-        request_type: HearingDay::REQUEST_TYPES[:video],
-        scheduled_for: Time.zone.today + 160,
-        regional_office: regional_office,
-        room: room
-      )
-    end
-    let!(:staff) { create(:staff, stafkey: regional_office, stc2: 2, stc3: 3, stc4: 4) }
-    let!(:appeal) do
-      create(
-        :appeal,
-        :with_post_intake_tasks,
-        docket_type: Constants.AMA_DOCKETS.hearing,
-        closest_regional_office: regional_office,
-        veteran: create(:veteran)
-      )
-    end
-    let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
-    let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
-    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
-  end
+      let!(:veteran) { create(:veteran, file_number: "123454787") }
+      let!(:hearing_location_dropdown_label) { "Hearing Location" }
+      let(:appellant_appeal_link_text) do
+        "#{legacy_appeal.appellant[:first_name]} #{legacy_appeal.appellant[:last_name]} | #{veteran.file_number}"
+      end
 
-  shared_context "legacy_hearing" do
-    let(:regional_office) { "RO39" }
-    let(:vacols_case) do
-      create(
-        :case,
-        bfregoff: regional_office
-      )
-    end
-    let!(:legacy_appeal) do
-      create(
-        :legacy_appeal,
-        :with_schedule_hearing_tasks,
-        :with_veteran,
-        closest_regional_office: regional_office,
-        vacols_case: vacols_case
-      )
-    end
-  end
+      let!(:expected_alert) do
+        COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
+      end
 
-  shared_context "full_hearing_day" do
-    let(:appeal) { create(:appeal) }
-    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
-    let!(:hearing_day) do
-      create(
-        :hearing_day,
-        scheduled_for: Time.zone.today + 5,
-        request_type: HearingDay::REQUEST_TYPES[:video],
-        regional_office: "RO17"
-      )
+      def navigate_to_schedule_veteran
+        visit "hearings/schedule/assign"
+        expect(page).to have_content("Regional Office")
+        click_dropdown(text: "Central")
+        click_button("Legacy Veterans Waiting", exact: true)
+        click_link appellant_appeal_link_text
+        expect(page).not_to have_content("loading to VACOLS.", wait: 30)
+        expect(page).to have_content("Currently active tasks", wait: 30)
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+        expect(page).to have_content("Time")
+      end
     end
-    let!(:hearings) do
-      (1...hearing_day.total_slots + 1).map do |idx|
+
+    shared_context "video_hearing" do
+      let!(:hearing_day) do
+        create(
+          :hearing_day,
+          request_type: HearingDay::REQUEST_TYPES[:video],
+          scheduled_for: Time.zone.today + 60.days,
+          regional_office: "RO39"
+        )
+      end
+      let!(:staff) { create(:staff, stafkey: "RO39", stc2: 2, stc3: 3, stc4: 4) }
+      let!(:vacols_case) do
+        create(
+          :case,
+          :video_hearing_requested,
+          folder: create(:folder, tinum: "docket-number"),
+          bfcorlid: "123456789S",
+          bfcurloc: "CASEFLOW",
+          bfregoff: "RO39"
+        )
+      end
+      let!(:legacy_appeal) do
+        create(
+          :legacy_appeal,
+          vacols_case: vacols_case,
+          closest_regional_office: "RO39"
+        )
+      end
+      let!(:schedule_hearing_task) do
+        create(
+          :schedule_hearing_task, appeal: legacy_appeal
+        )
+      end
+      let!(:veteran) { create(:veteran, file_number: "123456789") }
+      let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
+      let(:room_label) { HearingRooms.find!(hearing_day.room)&.label }
+
+      let!(:expected_alert) do
+        COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
+      end
+
+      def navigate_to_schedule_veteran
+        visit "hearings/schedule/assign"
+        expect(page).to have_content("Regional Office")
+        click_dropdown(text: "Denver, CO")
+        click_button("Legacy Veterans Waiting", exact: true)
+        appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
+        appeal_link.click
+        expect(page).not_to have_content("loading to VACOLS.", wait: 30)
+        expect(page).to have_content("Currently active tasks", wait: 30)
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+        expect(page).to have_content("Time")
+      end
+    end
+
+    shared_context "ama_hearing" do
+      let!(:room) { "1" }
+      let!(:regional_office) { "RO39" }
+      let!(:hearing_day) do
+        create(
+          :hearing_day,
+          request_type: HearingDay::REQUEST_TYPES[:video],
+          scheduled_for: Time.zone.today + 160,
+          regional_office: regional_office,
+          room: room
+        )
+      end
+      let!(:staff) { create(:staff, stafkey: regional_office, stc2: 2, stc3: 3, stc4: 4) }
+      let!(:appeal) do
+        create(
+          :appeal,
+          :with_post_intake_tasks,
+          docket_type: Constants.AMA_DOCKETS.hearing,
+          closest_regional_office: regional_office,
+          veteran: create(:veteran)
+        )
+      end
+      let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
+      let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
+      let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
+    end
+
+    shared_context "legacy_hearing" do
+      let(:regional_office) { "RO39" }
+      let(:vacols_case) do
+        create(
+          :case,
+          bfregoff: regional_office
+        )
+      end
+      let!(:legacy_appeal) do
+        create(
+          :legacy_appeal,
+          :with_schedule_hearing_tasks,
+          :with_veteran,
+          closest_regional_office: regional_office,
+          vacols_case: vacols_case
+        )
+      end
+    end
+
+    shared_context "full_hearing_day" do
+      let(:appeal) { create(:appeal) }
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
+      let!(:hearing_day) do
+        create(
+          :hearing_day,
+          scheduled_for: Time.zone.today + 5,
+          request_type: HearingDay::REQUEST_TYPES[:video],
+          regional_office: "RO17"
+        )
+      end
+      let!(:hearings) do
+        (1...hearing_day.total_slots + 1).map do |idx|
+          create(
+            :hearing,
+            appeal: create(:appeal, receipt_date: Date.new(2019, 1, idx)),
+            hearing_day: hearing_day
+          )
+        end
+      end
+    end
+
+    shared_context "open_hearing" do
+      let(:regional_office) { "RO39" }
+      let(:hearing_day) do
+        create(
+          :hearing_day,
+          request_type: HearingDay::REQUEST_TYPES[:video],
+          scheduled_for: Time.zone.today + 160,
+          regional_office: regional_office
+        )
+      end
+      let(:appeal) do
+        create(
+          :appeal,
+          :hearing_docket,
+          :with_post_intake_tasks,
+          closest_regional_office: regional_office
+        )
+      end
+      let!(:hearing) do
         create(
           :hearing,
-          appeal: create(:appeal, receipt_date: Date.new(2019, 1, idx)),
-          hearing_day: hearing_day
+          :with_tasks,
+          appeal: appeal,
+          hearing_day: hearing_day,
+          regional_office: regional_office
         )
       end
     end
-  end
 
-  shared_context "open_hearing" do
-    let(:regional_office) { "RO39" }
-    let(:hearing_day) do
-      create(
-        :hearing_day,
-        request_type: HearingDay::REQUEST_TYPES[:video],
-        scheduled_for: Time.zone.today + 160,
-        regional_office: regional_office
-      )
-    end
-    let(:appeal) do
-      create(
-        :appeal,
-        :hearing_docket,
-        :with_post_intake_tasks,
-        closest_regional_office: regional_office
-      )
-    end
-    let!(:hearing) do
-      create(
-        :hearing,
-        :with_tasks,
-        appeal: appeal,
-        hearing_day: hearing_day,
-        regional_office: regional_office
-      )
-    end
-  end
+    shared_examples "scheduling a central hearing" do
+      include_context "central_hearings"
 
-  shared_examples "scheduling a central hearing" do
-    include_context "central_hearings"
+      before { cache_appeals }
 
-    before { cache_appeals }
+      scenario "and address from BGS is displayed in schedule veteran workflow" do
+        navigate_to_schedule_veteran
 
-    scenario "and address from BGS is displayed in schedule veteran workflow" do
-      navigate_to_schedule_veteran
-
-      expect(page).to have_content FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1
-      expect(page).to have_content(
-        "#{FakeConstants.BGS_SERVICE.DEFAULT_CITY}, " \
-        "#{FakeConstants.BGS_SERVICE.DEFAULT_STATE} #{FakeConstants.BGS_SERVICE.DEFAULT_ZIP}"
-      )
-    end
-
-    scenario "Schedule Veteran for central hearing" do
-      navigate_to_schedule_veteran
-      # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
-      expect(page).to have_content(hearing_location_dropdown_label)
-      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-      find(".cf-form-radio-option", text: "9:00").click
-      click_button("Schedule", exact: true)
-      click_on "Back to Schedule Veterans"
-      expect(page).to have_content("Schedule Veterans")
-      click_button("Scheduled Veterans", exact: true)
-      expect(VACOLS::Case.where(bfcorlid: "123454787S"))
-      click_button("Legacy Veterans Waiting", exact: true)
-      expect(page.has_no_content?("123454787S")).to eq(true)
-      expect(page).to have_content("There are no schedulable veterans")
-      expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
-    end
-  end
-
-  shared_examples "scheduling a video hearing" do
-    include_context "video_hearing"
-
-    scenario "Schedule Veteran for video" do
-      cache_appeals
-      navigate_to_schedule_veteran
-      find(".cf-form-radio-option", text: "8:30").click
-      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-      expect(page).not_to have_content("Could not find hearing locations for this veteran")
-      expect(page).not_to have_content("There are no upcoming hearing dates for this regional office.")
-      click_dropdown(
-        text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots}) #{room_label}",
-        name: "hearingDate"
-      )
-      click_button("Schedule", exact: true)
-      click_on "Back to Schedule Veterans"
-      expect(page).to have_content("Schedule Veterans")
-      click_button("Scheduled Veterans", exact: true)
-      expect(VACOLS::Case.where(bfcorlid: "123456789S"))
-      click_button("Legacy Veterans Waiting", exact: true)
-      expect(page.has_no_content?("123456789S")).to eq(true)
-      expect(page).to have_content("There are no schedulable veterans")
-      expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
-    end
-
-    context "but facilities api throws an error" do
-      before do
-        facilities_response = ExternalApi::VADotGovService::FacilitiesResponse.new(
-          HTTPI::Response.new(200, {}, {}.to_json)
-        )
-        allow(facilities_response).to receive(:data).and_return([])
-        allow(facilities_response).to receive(:code).and_return(429)
-        allow(VADotGovService).to receive(:get_distance).and_return(facilities_response)
-      end
-
-      scenario "Schedule Veteran for video error" do
-        visit "queue/appeals/#{legacy_appeal.vacols_id}"
-        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-        expect(page).to have_css(
-          ".usa-alert-error",
-          text: "Mapping service is temporarily unavailable. Please try again later."
+        expect(page).to have_content FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1
+        expect(page).to have_content(
+          "#{FakeConstants.BGS_SERVICE.DEFAULT_CITY}, " \
+          "#{FakeConstants.BGS_SERVICE.DEFAULT_STATE} #{FakeConstants.BGS_SERVICE.DEFAULT_ZIP}"
         )
       end
-    end
-  end
 
-  shared_examples "scheduling an AMA hearing" do
-    include_context "ama_hearing"
-
-    before { cache_appeals }
-
-    scenario "Can create multiple admin actions and reassign them" do
-      visit "hearings/schedule/assign"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Denver")
-      click_button("AMA Veterans Waiting", exact: true)
-      click_on "Bob Smith"
-
-      # Case details screen
-      click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h[:label])
-
-      # Admin action screen
-
-      # First admin action
-      expect(page).to have_content("Submit admin action")
-      click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
-      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: incarcerated_veteran_task_instructions
-
-      # Second admin action
-      click_on COPY::ADD_COLOCATED_TASK_ANOTHER_BUTTON_LABEL
-      within all('div[id^="action_"]', count: 2)[1] do
-        click_dropdown(text: HearingAdminActionContestedClaimantTask.label)
-        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: contested_claimant_task_instructions
+      scenario "Schedule Veteran for central hearing" do
+        navigate_to_schedule_veteran
+        # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
+        expect(page).to have_content(hearing_location_dropdown_label)
+        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+        find(".cf-form-radio-option", text: "9:00").click
+        click_button("Schedule", exact: true)
+        click_on "Back to Schedule Veterans"
+        expect(page).to have_content("Schedule Veterans")
+        click_button("Scheduled Veterans", exact: true)
+        expect(VACOLS::Case.where(bfcorlid: "123454787S"))
+        click_button("Legacy Veterans Waiting", exact: true)
+        expect(page.has_no_content?("123454787S")).to eq(true)
+        expect(page).to have_content("There are no schedulable veterans")
+        expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
       end
+    end
 
-      click_on "Assign Action"
+    shared_examples "scheduling a video hearing" do
+      include_context "video_hearing"
 
-      # The banner has the correct content
-      expect(page).to have_content(
-        format(
-          COPY::ADD_COLOCATED_TASK_CONFIRMATION_TITLE,
-          "2",
-          "actions",
-          [HearingAdminActionIncarceratedVeteranTask.label, HearingAdminActionContestedClaimantTask.label].join(", ")
+      scenario "Schedule Veteran for video" do
+        cache_appeals
+        navigate_to_schedule_veteran
+        find(".cf-form-radio-option", text: "8:30").click
+        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+        expect(page).not_to have_content("Could not find hearing locations for this veteran")
+        expect(page).not_to have_content("There are no upcoming hearing dates for this regional office.")
+        click_dropdown(
+          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots}) #{room_label}",
+          name: "hearingDate"
         )
-      )
-
-      # The timeline has the correct content
-      incarcerated_row = find("dd", text: HearingAdminActionIncarceratedVeteranTask.label).find(:xpath, "ancestor::tr")
-      incarcerated_row.click_on(
-        COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
-      )
-      expect(incarcerated_row).to have_content incarcerated_veteran_task_instructions
-
-      contested_row = find("dd", text: HearingAdminActionContestedClaimantTask.label).find(:xpath, "ancestor::tr")
-      contested_row.click_on(
-        COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
-      )
-      expect(contested_row).to have_content contested_claimant_task_instructions
-
-      within all("div", class: "cf-select", count: 2).first do
-        click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
+        click_button("Schedule", exact: true)
+        click_on "Back to Schedule Veterans"
+        expect(page).to have_content("Schedule Veterans")
+        click_button("Scheduled Veterans", exact: true)
+        expect(VACOLS::Case.where(bfcorlid: "123456789S"))
+        click_button("Legacy Veterans Waiting", exact: true)
+        expect(page.has_no_content?("123456789S")).to eq(true)
+        expect(page).to have_content("There are no schedulable veterans")
+        expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
       end
 
-      click_on "Submit"
+      context "but facilities api throws an error" do
+        before do
+          facilities_response = ExternalApi::VADotGovService::FacilitiesResponse.new(
+            HTTPI::Response.new(200, {}, {}.to_json)
+          )
+          allow(facilities_response).to receive(:data).and_return([])
+          allow(facilities_response).to receive(:code).and_return(429)
+          allow(VADotGovService).to receive(:get_distance).and_return(facilities_response)
+        end
 
-      # Your queue
-      visit "/queue"
-      click_on "Bob Smith"
-
-      # Reassign
-      within find("tr", text: "BVATWARNER") do
-        click_dropdown(text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h[:label])
+        scenario "Schedule Veteran for video error" do
+          visit "queue/appeals/#{legacy_appeal.vacols_id}"
+          click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+          expect(page).to have_css(
+            ".usa-alert-error",
+            text: "Mapping service is temporarily unavailable. Please try again later."
+          )
+        end
       end
-
-      click_dropdown({ text: other_user.full_name }, find(".cf-modal-body"))
-      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Reassign"
-      click_on "Submit"
-
-      # Case should exist in other users' queue
-      User.authenticate!(user: other_user)
-      visit "/queue"
-
-      expect(page).to have_content(appeal.veteran_full_name)
     end
 
-    scenario "Schedule Veteran for a video hearing with admin actions that can be put on hold and completed" do
-      # Do the first part of the test in the past so we can wait for our hold to complete.
-      Timecop.travel(17.days.ago) do
+    shared_examples "scheduling an AMA hearing" do
+      include_context "ama_hearing"
+
+      before { cache_appeals }
+
+      scenario "Can create multiple admin actions and reassign them" do
         visit "hearings/schedule/assign"
         expect(page).to have_content("Regional Office")
         click_dropdown(text: "Denver")
@@ -382,179 +306,286 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         # First admin action
         expect(page).to have_content("Submit admin action")
         click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
-        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Action 1"
+        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: incarcerated_veteran_task_instructions
+
+        # Second admin action
+        click_on COPY::ADD_COLOCATED_TASK_ANOTHER_BUTTON_LABEL
+        within all('div[id^="action_"]', count: 2)[1] do
+          click_dropdown(text: HearingAdminActionContestedClaimantTask.label)
+          fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: contested_claimant_task_instructions
+        end
 
         click_on "Assign Action"
-        expect(page).to have_content("You have assigned an administrative action")
 
-        click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
+        # The banner has the correct content
+        expect(page).to have_content(
+          format(
+            COPY::ADD_COLOCATED_TASK_CONFIRMATION_TITLE,
+            "2",
+            "actions",
+            [HearingAdminActionIncarceratedVeteranTask.label, HearingAdminActionContestedClaimantTask.label].join(", ")
+          )
+        )
+
+        # The timeline has the correct content
+        incarcerated_row = find("dd", text: HearingAdminActionIncarceratedVeteranTask.label).find(:xpath, "ancestor::tr")
+        incarcerated_row.click_on(
+          COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
+        )
+        expect(incarcerated_row).to have_content incarcerated_veteran_task_instructions
+
+        contested_row = find("dd", text: HearingAdminActionContestedClaimantTask.label).find(:xpath, "ancestor::tr")
+        contested_row.click_on(
+          COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
+        )
+        expect(contested_row).to have_content contested_claimant_task_instructions
+
+        within all("div", class: "cf-select", count: 2).first do
+          click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
+        end
+
         click_on "Submit"
 
         # Your queue
         visit "/queue"
         click_on "Bob Smith"
-        click_dropdown(text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label)
 
-        # On hold
-        click_dropdown({ text: "15 days" }, find(".cf-modal-body"))
-        fill_in "Notes:", with: "Waiting for response"
+        # Reassign
+        within find("tr", text: "BVATWARNER") do
+          click_dropdown(text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h[:label])
+        end
 
-        click_on(COPY::MODAL_SUBMIT_BUTTON)
+        click_dropdown({ text: other_user.full_name }, find(".cf-modal-body"))
+        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Reassign"
+        click_on "Submit"
 
-        expect(page).to have_content("case has been placed on hold")
+        # Case should exist in other users' queue
+        User.authenticate!(user: other_user)
+        visit "/queue"
+
+        expect(page).to have_content(appeal.veteran_full_name)
       end
 
-      # Refresh the page in the present, and the hold should be completed.
-      TaskTimerJob.perform_now
-      visit "/queue"
-      click_on "Bob Smith"
+      scenario "Schedule Veteran for a video hearing with admin actions that can be put on hold and completed" do
+        # Do the first part of the test in the past so we can wait for our hold to complete.
+        Timecop.travel(17.days.ago) do
+          visit "hearings/schedule/assign"
+          expect(page).to have_content("Regional Office")
+          click_dropdown(text: "Denver")
+          click_button("AMA Veterans Waiting", exact: true)
+          click_on "Bob Smith"
 
-      # Complete the admin action
-      click_dropdown(text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label])
-      click_on "Mark complete"
+          # Case details screen
+          click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h[:label])
 
-      expect(page).to have_content("has been marked complete")
+          # Admin action screen
 
-      # Schedule veteran!
-      visit "hearings/schedule/assign"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Denver")
-      click_button("AMA Veterans Waiting", exact: true)
+          # First admin action
+          expect(page).to have_content("Submit admin action")
+          click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
+          fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Action 1"
 
-      click_on "Bob Smith"
-      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-      click_dropdown({ text: "Denver" }, find(".dropdown-regionalOffice"))
-      click_dropdown(name: "hearingDate", index: 1)
+          click_on "Assign Action"
+          expect(page).to have_content("You have assigned an administrative action")
 
-      find("label", text: "8:30").click
-      expect(page).to_not have_content("Finding hearing locations", wait: 30)
-      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-      click_on "Schedule"
+          click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
+          click_on "Submit"
 
-      expect(page).to have_content("You have successfully assigned")
+          # Your queue
+          visit "/queue"
+          click_on "Bob Smith"
+          click_dropdown(text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label)
 
-      # Ensure the veteran appears on the scheduled page
+          # On hold
+          click_dropdown({ text: "15 days" }, find(".cf-modal-body"))
+          fill_in "Notes:", with: "Waiting for response"
 
-      expect(page).to have_content(appeal.docket_number)
+          click_on(COPY::MODAL_SUBMIT_BUTTON)
 
-      # Ensure the veteran is no longer in the veterans waiting to be scheduled
-      click_on "Back to Schedule Veterans"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Denver")
-      click_button("AMA Veterans Waiting", exact: true)
-      expect(page).to have_content("There are no schedulable veterans")
-    end
+          expect(page).to have_content("case has been placed on hold")
+        end
 
-    scenario "Withdraw Veteran's hearing request" do
-      visit "hearings/schedule/assign"
-      expect(page).to have_content("Regional Office")
-      click_dropdown(text: "Denver")
-      click_button("AMA Veterans Waiting", exact: true)
-      click_on "Bob Smith"
-
-      click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
-      fill_in "taskInstructions", with: "Withdrawing hearing"
-
-      click_on "Submit"
-
-      expect(page).to have_content("You have successfully withdrawn")
-      expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(Constants.TASK_STATUSES.cancelled)
-      expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
-
-      click_on "Back to Hearing Schedule"
-      expect(page).to have_content("Denver")
-    end
-
-    context "and room is null" do
-      let(:room) { nil }
-
-      scenario "can schedule a veteran without an error" do
-        visit "hearings/schedule/assign"
-
-        click_dropdown(text: "Denver")
-        click_button("AMA Veterans Waiting", exact: true)
+        # Refresh the page in the present, and the hold should be completed.
+        TaskTimerJob.perform_now
+        visit "/queue"
         click_on "Bob Smith"
 
-        click_dropdown(text: "Schedule Veteran")
-        click_dropdown(
-          text: RegionalOffice.find!(regional_office).city,
-          name: "regionalOffice"
-        )
-        click_dropdown(
-          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
-          name: "hearingDate"
-        )
-        click_dropdown(
-          text: "Holdrege, NE (VHA) 0 miles away",
-          name: "appealHearingLocation"
-        )
-        click_dropdown(text: "10:00", name: "optionalHearingTime0")
-        click_button("Schedule", exact: true)
+        # Complete the admin action
+        click_dropdown(text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label])
+        click_on "Mark complete"
 
-        expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
-      end
+        expect(page).to have_content("has been marked complete")
 
-      scenario "should not see room displayed under Available Hearing Days and Assign Hearing Tabs" do
+        # Schedule veteran!
         visit "hearings/schedule/assign"
-
+        expect(page).to have_content("Regional Office")
         click_dropdown(text: "Denver")
         click_button("AMA Veterans Waiting", exact: true)
-        click_on "Bob Smith"
 
-        click_dropdown(text: "Schedule Veteran")
-        click_dropdown(
-          text: RegionalOffice.find!(regional_office).city,
-          name: "regionalOffice"
-        )
-        click_dropdown(
-          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
-          name: "hearingDate"
-        )
-        click_dropdown(
-          text: "Holdrege, NE (VHA) 0 miles away",
-          name: "appealHearingLocation"
-        )
-        click_dropdown(text: "10:00", name: "optionalHearingTime0")
-        click_button("Schedule", exact: true)
+        click_on "Bob Smith"
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+        click_dropdown({ text: "Denver" }, find(".dropdown-regionalOffice"))
+        click_dropdown(name: "hearingDate", index: 1)
+
+        find("label", text: "8:30").click
+        expect(page).to_not have_content("Finding hearing locations", wait: 30)
+        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+        click_on "Schedule"
+
+        expect(page).to have_content("You have successfully assigned")
+
+        # Ensure the veteran appears on the scheduled page
+
+        expect(page).to have_content(appeal.docket_number)
+
+        # Ensure the veteran is no longer in the veterans waiting to be scheduled
         click_on "Back to Schedule Veterans"
-
-        expect(page).not_to have_content("null")
-      end
-    end
-  end
-
-  shared_examples "scheduling a Legacy hearing" do
-    include_context "legacy_hearing"
-
-    before { cache_appeals }
-
-    context "and room is null" do
-      let!(:hearing_day) do
-        create(
-          :hearing_day,
-          request_type: HearingDay::REQUEST_TYPES[:video],
-          scheduled_for: Time.zone.today + 160,
-          regional_office: regional_office,
-          room: nil
-        )
-      end
-
-      scenario "can schedule a veteran without an error" do
-        visit "hearings/schedule/assign"
-
+        expect(page).to have_content("Regional Office")
         click_dropdown(text: "Denver")
-        click_button("Legacy Veterans Waiting", exact: true)
+        click_button("AMA Veterans Waiting", exact: true)
+        expect(page).to have_content("There are no schedulable veterans")
+      end
+
+      scenario "Withdraw Veteran's hearing request" do
+        visit "hearings/schedule/assign"
+        expect(page).to have_content("Regional Office")
+        click_dropdown(text: "Denver")
+        click_button("AMA Veterans Waiting", exact: true)
         click_on "Bob Smith"
 
+        click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
+        fill_in "taskInstructions", with: "Withdrawing hearing"
+
+        click_on "Submit"
+
+        expect(page).to have_content("You have successfully withdrawn")
+        expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(Constants.TASK_STATUSES.cancelled)
+        expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
+
+        click_on "Back to Hearing Schedule"
+        expect(page).to have_content("Denver")
+      end
+
+      context "and room is null" do
+        let(:room) { nil }
+
+        scenario "can schedule a veteran without an error" do
+          visit "hearings/schedule/assign"
+
+          click_dropdown(text: "Denver")
+          click_button("AMA Veterans Waiting", exact: true)
+          click_on "Bob Smith"
+
+          click_dropdown(text: "Schedule Veteran")
+          click_dropdown(
+            text: RegionalOffice.find!(regional_office).city,
+            name: "regionalOffice"
+          )
+          click_dropdown(
+            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+            name: "hearingDate"
+          )
+          click_dropdown(
+            text: "Holdrege, NE (VHA) 0 miles away",
+            name: "appealHearingLocation"
+          )
+          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          click_button("Schedule", exact: true)
+
+          expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
+        end
+
+        scenario "should not see room displayed under Available Hearing Days and Assign Hearing Tabs" do
+          visit "hearings/schedule/assign"
+
+          click_dropdown(text: "Denver")
+          click_button("AMA Veterans Waiting", exact: true)
+          click_on "Bob Smith"
+
+          click_dropdown(text: "Schedule Veteran")
+          click_dropdown(
+            text: RegionalOffice.find!(regional_office).city,
+            name: "regionalOffice"
+          )
+          click_dropdown(
+            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+            name: "hearingDate"
+          )
+          click_dropdown(
+            text: "Holdrege, NE (VHA) 0 miles away",
+            name: "appealHearingLocation"
+          )
+          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          click_button("Schedule", exact: true)
+          click_on "Back to Schedule Veterans"
+
+          expect(page).not_to have_content("null")
+        end
+      end
+    end
+
+    shared_examples "scheduling a Legacy hearing" do
+      include_context "legacy_hearing"
+
+      before { cache_appeals }
+
+      context "and room is null" do
+        let!(:hearing_day) do
+          create(
+            :hearing_day,
+            request_type: HearingDay::REQUEST_TYPES[:video],
+            scheduled_for: Time.zone.today + 160,
+            regional_office: regional_office,
+            room: nil
+          )
+        end
+
+        scenario "can schedule a veteran without an error" do
+          visit "hearings/schedule/assign"
+
+          click_dropdown(text: "Denver")
+          click_button("Legacy Veterans Waiting", exact: true)
+          click_on "Bob Smith"
+
+          click_dropdown(text: "Schedule Veteran")
+          click_dropdown(
+            text: RegionalOffice.find!(regional_office).city,
+            name: "regionalOffice"
+          )
+          click_dropdown(
+            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+            name: "hearingDate"
+          )
+          click_dropdown(
+            text: "Holdrege, NE (VHA) 0 miles away",
+            name: "appealHearingLocation"
+          )
+          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          click_button("Schedule", exact: true)
+
+          expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
+        end
+      end
+    end
+
+    shared_examples "an appeal with a full hearing day" do
+      include_context "full_hearing_day"
+
+      scenario "can still schedule veteran successfully" do
+        visit "/queue/appeals/#{appeal.external_id}"
+
+        total_slots = hearing_day.total_slots
+
         click_dropdown(text: "Schedule Veteran")
+        click_dropdown(name: "regionalOffice", text: "St. Petersburg, FL")
         click_dropdown(
-          text: RegionalOffice.find!(regional_office).city,
-          name: "regionalOffice"
-        )
-        click_dropdown(
-          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (#{total_slots}/#{total_slots})",
           name: "hearingDate"
         )
+
+        expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_TITLE)
+        expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_MESSAGE_DETAIL)
+
         click_dropdown(
           text: "Holdrege, NE (VHA) 0 miles away",
           name: "appealHearingLocation"
@@ -565,151 +596,122 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
       end
     end
-  end
 
-  shared_examples "an appeal with a full hearing day" do
-    include_context "full_hearing_day"
+    shared_examples "an appeal where there is an open hearing" do
+      include_context "open_hearing"
 
-    scenario "can still schedule veteran successfully" do
-      visit "/queue/appeals/#{appeal.external_id}"
-
-      total_slots = hearing_day.total_slots
-
-      click_dropdown(text: "Schedule Veteran")
-      click_dropdown(name: "regionalOffice", text: "St. Petersburg, FL")
-      click_dropdown(
-        text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (#{total_slots}/#{total_slots})",
-        name: "hearingDate"
-      )
-
-      expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_TITLE)
-      expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_MESSAGE_DETAIL)
-
-      click_dropdown(
-        text: "Holdrege, NE (VHA) 0 miles away",
-        name: "appealHearingLocation"
-      )
-      click_dropdown(text: "10:00", name: "optionalHearingTime0")
-      click_button("Schedule", exact: true)
-
-      expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
-    end
-  end
-
-  shared_examples "an appeal where there is an open hearing" do
-    include_context "open_hearing"
-
-    scenario "shows an error message in the schedule veteran's modal" do
-      visit "queue/appeals/#{appeal.external_id}"
-      # Expected dropdowns on page:
-      #   [0] - Assign disposition task
-      #   [1] - Schedule hearing task
-      within page.all(".cf-form-dropdown")[1] do
-        click_dropdown(text: "Schedule Veteran")
+      scenario "shows an error message in the schedule veteran's modal" do
+        visit "queue/appeals/#{appeal.external_id}"
+        # Expected dropdowns on page:
+        #   [0] - Assign disposition task
+        #   [1] - Schedule hearing task
+        within page.all(".cf-form-dropdown")[1] do
+          click_dropdown(text: "Schedule Veteran")
+        end
+        expect(page).to have_content("Open Hearing")
       end
-      expect(page).to have_content("Open Hearing")
-    end
-  end
-
-  shared_examples "scheduling a virtual hearing" do |fill_in_timezones, ro_key, time|
-    scenario "can successfully schedule virtual hearing" do
-      navigate_to_schedule_veteran
-      expect(page).to have_content("Schedule Veteran for a Hearing")
-      click_dropdown(name: "hearingType", text: "Virtual")
-      click_dropdown(name: "hearingDate", index: 1)
-
-      expected_time_radio_text = if fill_in_timezones
-                                   "#{time} AM Eastern Time (US & Canada)"
-                                 else
-                                   "#{time} AM Mountain Time (US & Canada) / 10:30 AM Eastern Time (US & Canada)"
-                                 end
-      find(".cf-form-radio-option", text: expected_time_radio_text).click
-
-      # Fill in appellant details
-      click_dropdown(name: "appellantTz", index: 1) if fill_in_timezones
-      fill_in "Veteran Email", with: fill_in_veteran_email
-
-      # Fill in POA/Representative details
-      click_dropdown(name: "representativeTz", index: 1) if fill_in_timezones
-      fill_in "POA/Representative Email", with: fill_in_representative_email
-
-      click_button("Schedule")
-
-      expect(page).to have_content(expected_alert)
-      expect(VirtualHearing.count).to eq(1)
-      expect(LegacyHearing.where(hearing_day_id: hearing_day.id).count).to eq 1
-
-      # Retrieve the newly created hearing
-      new_hearing = LegacyHearing.find_by(hearing_day_id: hearing_day.id)
-
-      # Test the hearing was created correctly with the virtual hearing
-      expect(new_hearing.hearing_location).to eq nil
-      expect(new_hearing.virtual_hearing).to eq VirtualHearing.first
-      expect(new_hearing.regional_office.key).to eq ro_key
-
-      # Test the emails were sent
-      events = SentHearingEmailEvent.where(hearing_id: new_hearing.id)
-      expect(events.count).to eq 2
-      expect(events.where(sent_by_id: current_user.id).count).to eq 2
-      expect(events.where(email_type: "confirmation").count).to eq 2
-      expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
-      expect(events.sent_to_appellant.count).to eq 1
-      expect(events.where(email_address: fill_in_representative_email).count).to eq 1
-      expect(events.where(recipient_role: "representative").count).to eq 1
-    end
-  end
-
-  context "with schedule direct to video/virtual feature enabled" do
-    # Ensure the feature flag is enabled before testing
-    before do
-      FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
     end
 
-    it_behaves_like "scheduling a central hearing"
+    shared_examples "scheduling a virtual hearing" do |fill_in_timezones, ro_key, time|
+      scenario "can successfully schedule virtual hearing" do
+        navigate_to_schedule_veteran
+        expect(page).to have_content("Schedule Veteran for a Hearing")
+        click_dropdown(name: "hearingType", text: "Virtual")
+        click_dropdown(name: "hearingDate", index: 1)
 
-    it_behaves_like "scheduling a video hearing"
+        expected_time_radio_text = if fill_in_timezones
+                                    "#{time} AM Eastern Time (US & Canada)"
+                                  else
+                                    "#{time} AM Mountain Time (US & Canada) / 10:30 AM Eastern Time (US & Canada)"
+                                  end
+        find(".cf-form-radio-option", text: expected_time_radio_text).click
 
-    it_behaves_like "scheduling an AMA hearing"
+        # Fill in appellant details
+        click_dropdown(name: "appellantTz", index: 1) if fill_in_timezones
+        fill_in "Veteran Email", with: fill_in_veteran_email
 
-    it_behaves_like "scheduling a Legacy hearing"
+        # Fill in POA/Representative details
+        click_dropdown(name: "representativeTz", index: 1) if fill_in_timezones
+        fill_in "POA/Representative Email", with: fill_in_representative_email
 
-    it_behaves_like "an appeal with a full hearing day"
+        click_button("Schedule")
 
-    it_behaves_like "an appeal where there is an open hearing"
+        expect(page).to have_content(expected_alert)
+        expect(VirtualHearing.count).to eq(1)
+        expect(LegacyHearing.where(hearing_day_id: hearing_day.id).count).to eq 1
 
-    context "when changing from Central hearing" do
-      include_context "central_hearings"
+        # Retrieve the newly created hearing
+        new_hearing = LegacyHearing.find_by(hearing_day_id: hearing_day.id)
 
-      before { cache_appeals }
+        # Test the hearing was created correctly with the virtual hearing
+        expect(new_hearing.hearing_location).to eq nil
+        expect(new_hearing.virtual_hearing).to eq VirtualHearing.first
+        expect(new_hearing.regional_office.key).to eq ro_key
 
-      it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
+        # Test the emails were sent
+        events = SentHearingEmailEvent.where(hearing_id: new_hearing.id)
+        expect(events.count).to eq 2
+        expect(events.where(sent_by_id: current_user.id).count).to eq 2
+        expect(events.where(email_type: "confirmation").count).to eq 2
+        expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
+        expect(events.sent_to_appellant.count).to eq 1
+        expect(events.where(email_address: fill_in_representative_email).count).to eq 1
+        expect(events.where(recipient_role: "representative").count).to eq 1
+      end
     end
 
-    context "when changing from Video hearing" do
-      include_context "video_hearing"
+    context "with schedule direct to video/virtual feature enabled" do
+      # Ensure the feature flag is enabled before testing
+      before do
+        FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
+      end
 
-      before { cache_appeals }
+      it_behaves_like "scheduling a central hearing"
 
-      it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
+      it_behaves_like "scheduling a video hearing"
+
+      it_behaves_like "scheduling an AMA hearing"
+
+      it_behaves_like "scheduling a Legacy hearing"
+
+      it_behaves_like "an appeal with a full hearing day"
+
+      it_behaves_like "an appeal where there is an open hearing"
+
+      context "when changing from Central hearing" do
+        include_context "central_hearings"
+
+        before { cache_appeals }
+
+        it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
+      end
+
+      context "when changing from Video hearing" do
+        include_context "video_hearing"
+
+        before { cache_appeals }
+
+        it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
+      end
     end
-  end
 
-  context "with schedule direct to video/virtual feature disabled" do
-    # Ensure the feature flag is disabled before testing
-    before do
-      FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
+    context "with schedule direct to video/virtual feature disabled" do
+      # Ensure the feature flag is disabled before testing
+      before do
+        FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
+      end
+
+      it_behaves_like "scheduling a central hearing"
+
+      it_behaves_like "scheduling a video hearing"
+
+      it_behaves_like "scheduling an AMA hearing"
+
+      it_behaves_like "scheduling a Legacy hearing"
+
+      it_behaves_like "an appeal with a full hearing day"
+
+      it_behaves_like "an appeal where there is an open hearing"
     end
-
-    it_behaves_like "scheduling a central hearing"
-
-    it_behaves_like "scheduling a video hearing"
-
-    it_behaves_like "scheduling an AMA hearing"
-
-    it_behaves_like "scheduling a Legacy hearing"
-
-    it_behaves_like "an appeal with a full hearing day"
-
-    it_behaves_like "an appeal where there is an open hearing"
   end
 end

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -3,295 +3,371 @@
 ##
 # Tests various aspects of scheduling a hearing as an admin hearing coordinator
 RSpec.feature "Schedule Veteran For A Hearing" do
-  ensure_stable do
-    let!(:current_user) do
-      user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
-      User.authenticate!(user: user)
+  let!(:current_user) do
+    user = create(:user, css_id: "BVATWARNER", roles: ["Build HearSched"])
+    User.authenticate!(user: user)
+  end
+
+  let(:other_user) { create(:user) }
+  let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
+  let(:fill_in_veteran_email) { "vet@testingEmail.com" }
+  let(:fill_in_representative_email) { "email@testingEmail.com" }
+
+  before do
+    HearingsManagement.singleton.add_user(current_user)
+    HearingAdmin.singleton.add_user(current_user)
+    HearingsManagement.singleton.add_user(other_user)
+    HearingAdmin.singleton.add_user(other_user)
+  end
+
+  shared_context "central_hearings" do
+    let!(:hearing_day) { create(:hearing_day, scheduled_for: Time.zone.today + 30.days) }
+    let!(:vacols_case) do
+      create(
+        :case, :central_office_hearing,
+        bfcorlid: "123454787S",
+        bfcurloc: "CASEFLOW"
+      )
+    end
+    let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case, closest_regional_office: "C") }
+    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: legacy_appeal) }
+
+    let!(:veteran) { create(:veteran, file_number: "123454787") }
+    let!(:hearing_location_dropdown_label) { "Hearing Location" }
+    let(:appellant_appeal_link_text) do
+      "#{legacy_appeal.appellant[:first_name]} #{legacy_appeal.appellant[:last_name]} | #{veteran.file_number}"
     end
 
-    let(:other_user) { create(:user) }
+    let!(:expected_alert) do
+      COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
+    end
+
+    def navigate_to_schedule_veteran
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Central")
+      click_button("Legacy Veterans Waiting", exact: true)
+      click_link appellant_appeal_link_text
+      expect(page).not_to have_content("loading to VACOLS.", wait: 30)
+      expect(page).to have_content("Currently active tasks", wait: 30)
+      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+      expect(page).to have_content("Time")
+    end
+  end
+
+  shared_context "video_hearing" do
+    let!(:hearing_day) do
+      create(
+        :hearing_day,
+        request_type: HearingDay::REQUEST_TYPES[:video],
+        scheduled_for: Time.zone.today + 60.days,
+        regional_office: "RO39"
+      )
+    end
+    let!(:staff) { create(:staff, stafkey: "RO39", stc2: 2, stc3: 3, stc4: 4) }
+    let!(:vacols_case) do
+      create(
+        :case,
+        :video_hearing_requested,
+        folder: create(:folder, tinum: "docket-number"),
+        bfcorlid: "123456789S",
+        bfcurloc: "CASEFLOW",
+        bfregoff: "RO39"
+      )
+    end
+    let!(:legacy_appeal) do
+      create(
+        :legacy_appeal,
+        vacols_case: vacols_case,
+        closest_regional_office: "RO39"
+      )
+    end
+    let!(:schedule_hearing_task) do
+      create(
+        :schedule_hearing_task, appeal: legacy_appeal
+      )
+    end
+    let!(:veteran) { create(:veteran, file_number: "123456789") }
     let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
-    let(:fill_in_veteran_email) { "vet@testingEmail.com" }
-    let(:fill_in_representative_email) { "email@testingEmail.com" }
+    let(:room_label) { HearingRooms.find!(hearing_day.room)&.label }
 
-    before do
-      HearingsManagement.singleton.add_user(current_user)
-      HearingAdmin.singleton.add_user(current_user)
-      HearingsManagement.singleton.add_user(other_user)
-      HearingAdmin.singleton.add_user(other_user)
+    let!(:expected_alert) do
+      COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
     end
 
-    shared_context "central_hearings" do
-      let!(:hearing_day) { create(:hearing_day, scheduled_for: Time.zone.today + 30.days) }
-      let!(:vacols_case) do
-        create(
-          :case, :central_office_hearing,
-          bfcorlid: "123454787S",
-          bfcurloc: "CASEFLOW"
-        )
-      end
-      let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case, closest_regional_office: "C") }
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: legacy_appeal) }
-
-      let!(:veteran) { create(:veteran, file_number: "123454787") }
-      let!(:hearing_location_dropdown_label) { "Hearing Location" }
-      let(:appellant_appeal_link_text) do
-        "#{legacy_appeal.appellant[:first_name]} #{legacy_appeal.appellant[:last_name]} | #{veteran.file_number}"
-      end
-
-      let!(:expected_alert) do
-        COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
-      end
-
-      def navigate_to_schedule_veteran
-        visit "hearings/schedule/assign"
-        expect(page).to have_content("Regional Office")
-        click_dropdown(text: "Central")
-        click_button("Legacy Veterans Waiting", exact: true)
-        click_link appellant_appeal_link_text
-        expect(page).not_to have_content("loading to VACOLS.", wait: 30)
-        expect(page).to have_content("Currently active tasks", wait: 30)
-        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-        expect(page).to have_content("Time")
-      end
+    def navigate_to_schedule_veteran
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Denver, CO")
+      click_button("Legacy Veterans Waiting", exact: true)
+      appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
+      appeal_link.click
+      expect(page).not_to have_content("loading to VACOLS.", wait: 30)
+      expect(page).to have_content("Currently active tasks", wait: 30)
+      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+      expect(page).to have_content("Time")
     end
+  end
 
-    shared_context "video_hearing" do
-      let!(:hearing_day) do
-        create(
-          :hearing_day,
-          request_type: HearingDay::REQUEST_TYPES[:video],
-          scheduled_for: Time.zone.today + 60.days,
-          regional_office: "RO39"
-        )
-      end
-      let!(:staff) { create(:staff, stafkey: "RO39", stc2: 2, stc3: 3, stc4: 4) }
-      let!(:vacols_case) do
-        create(
-          :case,
-          :video_hearing_requested,
-          folder: create(:folder, tinum: "docket-number"),
-          bfcorlid: "123456789S",
-          bfcurloc: "CASEFLOW",
-          bfregoff: "RO39"
-        )
-      end
-      let!(:legacy_appeal) do
-        create(
-          :legacy_appeal,
-          vacols_case: vacols_case,
-          closest_regional_office: "RO39"
-        )
-      end
-      let!(:schedule_hearing_task) do
-        create(
-          :schedule_hearing_task, appeal: legacy_appeal
-        )
-      end
-      let!(:veteran) { create(:veteran, file_number: "123456789") }
-      let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_legacy_appeals }
-      let(:room_label) { HearingRooms.find!(hearing_day.room)&.label }
-
-      let!(:expected_alert) do
-        COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % legacy_appeal.veteran.name
-      end
-
-      def navigate_to_schedule_veteran
-        visit "hearings/schedule/assign"
-        expect(page).to have_content("Regional Office")
-        click_dropdown(text: "Denver, CO")
-        click_button("Legacy Veterans Waiting", exact: true)
-        appeal_link = page.find(:xpath, "//tbody/tr/td[2]/a")
-        appeal_link.click
-        expect(page).not_to have_content("loading to VACOLS.", wait: 30)
-        expect(page).to have_content("Currently active tasks", wait: 30)
-        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-        expect(page).to have_content("Time")
-      end
+  shared_context "ama_hearing" do
+    let!(:room) { "1" }
+    let!(:regional_office) { "RO39" }
+    let!(:hearing_day) do
+      create(
+        :hearing_day,
+        request_type: HearingDay::REQUEST_TYPES[:video],
+        scheduled_for: Time.zone.today + 160,
+        regional_office: regional_office,
+        room: room
+      )
     end
-
-    shared_context "ama_hearing" do
-      let!(:room) { "1" }
-      let!(:regional_office) { "RO39" }
-      let!(:hearing_day) do
-        create(
-          :hearing_day,
-          request_type: HearingDay::REQUEST_TYPES[:video],
-          scheduled_for: Time.zone.today + 160,
-          regional_office: regional_office,
-          room: room
-        )
-      end
-      let!(:staff) { create(:staff, stafkey: regional_office, stc2: 2, stc3: 3, stc4: 4) }
-      let!(:appeal) do
-        create(
-          :appeal,
-          :with_post_intake_tasks,
-          docket_type: Constants.AMA_DOCKETS.hearing,
-          closest_regional_office: regional_office,
-          veteran: create(:veteran)
-        )
-      end
-      let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
-      let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
-      let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
+    let!(:staff) { create(:staff, stafkey: regional_office, stc2: 2, stc3: 3, stc4: 4) }
+    let!(:appeal) do
+      create(
+        :appeal,
+        :with_post_intake_tasks,
+        docket_type: Constants.AMA_DOCKETS.hearing,
+        closest_regional_office: regional_office,
+        veteran: create(:veteran)
+      )
     end
+    let(:incarcerated_veteran_task_instructions) { "Incarcerated veteran task instructions" }
+    let(:contested_claimant_task_instructions) { "Contested claimant task instructions" }
+    let(:cache_appeals) { UpdateCachedAppealsAttributesJob.new.cache_ama_appeals }
+  end
 
-    shared_context "legacy_hearing" do
-      let(:regional_office) { "RO39" }
-      let(:vacols_case) do
-        create(
-          :case,
-          bfregoff: regional_office
-        )
-      end
-      let!(:legacy_appeal) do
-        create(
-          :legacy_appeal,
-          :with_schedule_hearing_tasks,
-          :with_veteran,
-          closest_regional_office: regional_office,
-          vacols_case: vacols_case
-        )
-      end
+  shared_context "legacy_hearing" do
+    let(:regional_office) { "RO39" }
+    let(:vacols_case) do
+      create(
+        :case,
+        bfregoff: regional_office
+      )
     end
-
-    shared_context "full_hearing_day" do
-      let(:appeal) { create(:appeal) }
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
-      let!(:hearing_day) do
-        create(
-          :hearing_day,
-          scheduled_for: Time.zone.today + 5,
-          request_type: HearingDay::REQUEST_TYPES[:video],
-          regional_office: "RO17"
-        )
-      end
-      let!(:hearings) do
-        (1...hearing_day.total_slots + 1).map do |idx|
-          create(
-            :hearing,
-            appeal: create(:appeal, receipt_date: Date.new(2019, 1, idx)),
-            hearing_day: hearing_day
-          )
-        end
-      end
+    let!(:legacy_appeal) do
+      create(
+        :legacy_appeal,
+        :with_schedule_hearing_tasks,
+        :with_veteran,
+        closest_regional_office: regional_office,
+        vacols_case: vacols_case
+      )
     end
+  end
 
-    shared_context "open_hearing" do
-      let(:regional_office) { "RO39" }
-      let(:hearing_day) do
-        create(
-          :hearing_day,
-          request_type: HearingDay::REQUEST_TYPES[:video],
-          scheduled_for: Time.zone.today + 160,
-          regional_office: regional_office
-        )
-      end
-      let(:appeal) do
-        create(
-          :appeal,
-          :hearing_docket,
-          :with_post_intake_tasks,
-          closest_regional_office: regional_office
-        )
-      end
-      let!(:hearing) do
+  shared_context "full_hearing_day" do
+    let(:appeal) { create(:appeal) }
+    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
+    let!(:hearing_day) do
+      create(
+        :hearing_day,
+        scheduled_for: Time.zone.today + 5,
+        request_type: HearingDay::REQUEST_TYPES[:video],
+        regional_office: "RO17"
+      )
+    end
+    let!(:hearings) do
+      (1...hearing_day.total_slots + 1).map do |idx|
         create(
           :hearing,
-          :with_tasks,
-          appeal: appeal,
-          hearing_day: hearing_day,
-          regional_office: regional_office
+          appeal: create(:appeal, receipt_date: Date.new(2019, 1, idx)),
+          hearing_day: hearing_day
         )
       end
     end
+  end
 
-    shared_examples "scheduling a central hearing" do
-      include_context "central_hearings"
+  shared_context "open_hearing" do
+    let(:regional_office) { "RO39" }
+    let(:hearing_day) do
+      create(
+        :hearing_day,
+        request_type: HearingDay::REQUEST_TYPES[:video],
+        scheduled_for: Time.zone.today + 160,
+        regional_office: regional_office
+      )
+    end
+    let(:appeal) do
+      create(
+        :appeal,
+        :hearing_docket,
+        :with_post_intake_tasks,
+        closest_regional_office: regional_office
+      )
+    end
+    let!(:hearing) do
+      create(
+        :hearing,
+        :with_tasks,
+        appeal: appeal,
+        hearing_day: hearing_day,
+        regional_office: regional_office
+      )
+    end
+  end
 
-      before { cache_appeals }
+  shared_examples "scheduling a central hearing" do
+    include_context "central_hearings"
 
-      scenario "and address from BGS is displayed in schedule veteran workflow" do
-        navigate_to_schedule_veteran
+    before { cache_appeals }
 
-        expect(page).to have_content FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1
-        expect(page).to have_content(
-          "#{FakeConstants.BGS_SERVICE.DEFAULT_CITY}, " \
-          "#{FakeConstants.BGS_SERVICE.DEFAULT_STATE} #{FakeConstants.BGS_SERVICE.DEFAULT_ZIP}"
-        )
-      end
+    scenario "and address from BGS is displayed in schedule veteran workflow" do
+      navigate_to_schedule_veteran
 
-      scenario "Schedule Veteran for central hearing" do
-        navigate_to_schedule_veteran
-        # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
-        expect(page).to have_content(hearing_location_dropdown_label)
-        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-        find(".cf-form-radio-option", text: "9:00").click
-        click_button("Schedule", exact: true)
-        click_on "Back to Schedule Veterans"
-        expect(page).to have_content("Schedule Veterans")
-        click_button("Scheduled Veterans", exact: true)
-        expect(VACOLS::Case.where(bfcorlid: "123454787S"))
-        click_button("Legacy Veterans Waiting", exact: true)
-        expect(page.has_no_content?("123454787S")).to eq(true)
-        expect(page).to have_content("There are no schedulable veterans")
-        expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
-      end
+      expect(page).to have_content FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1
+      expect(page).to have_content(
+        "#{FakeConstants.BGS_SERVICE.DEFAULT_CITY}, " \
+        "#{FakeConstants.BGS_SERVICE.DEFAULT_STATE} #{FakeConstants.BGS_SERVICE.DEFAULT_ZIP}"
+      )
     end
 
-    shared_examples "scheduling a video hearing" do
-      include_context "video_hearing"
+    scenario "Schedule Veteran for central hearing" do
+      navigate_to_schedule_veteran
+      # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
+      expect(page).to have_content(hearing_location_dropdown_label)
+      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+      find(".cf-form-radio-option", text: "9:00").click
+      click_button("Schedule", exact: true)
+      click_on "Back to Schedule Veterans"
+      expect(page).to have_content("Schedule Veterans")
+      click_button("Scheduled Veterans", exact: true)
+      expect(VACOLS::Case.where(bfcorlid: "123454787S"))
+      click_button("Legacy Veterans Waiting", exact: true)
+      expect(page.has_no_content?("123454787S")).to eq(true)
+      expect(page).to have_content("There are no schedulable veterans")
+      expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
+    end
+  end
 
-      scenario "Schedule Veteran for video" do
-        cache_appeals
-        navigate_to_schedule_veteran
-        find(".cf-form-radio-option", text: "8:30").click
-        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-        expect(page).not_to have_content("Could not find hearing locations for this veteran")
-        expect(page).not_to have_content("There are no upcoming hearing dates for this regional office.")
-        click_dropdown(
-          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots}) #{room_label}",
-          name: "hearingDate"
-        )
-        click_button("Schedule", exact: true)
-        click_on "Back to Schedule Veterans"
-        expect(page).to have_content("Schedule Veterans")
-        click_button("Scheduled Veterans", exact: true)
-        expect(VACOLS::Case.where(bfcorlid: "123456789S"))
-        click_button("Legacy Veterans Waiting", exact: true)
-        expect(page.has_no_content?("123456789S")).to eq(true)
-        expect(page).to have_content("There are no schedulable veterans")
-        expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
-      end
+  shared_examples "scheduling a video hearing" do
+    include_context "video_hearing"
 
-      context "but facilities api throws an error" do
-        before do
-          facilities_response = ExternalApi::VADotGovService::FacilitiesResponse.new(
-            HTTPI::Response.new(200, {}, {}.to_json)
-          )
-          allow(facilities_response).to receive(:data).and_return([])
-          allow(facilities_response).to receive(:code).and_return(429)
-          allow(VADotGovService).to receive(:get_distance).and_return(facilities_response)
-        end
-
-        scenario "Schedule Veteran for video error" do
-          visit "queue/appeals/#{legacy_appeal.vacols_id}"
-          click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-          expect(page).to have_css(
-            ".usa-alert-error",
-            text: "Mapping service is temporarily unavailable. Please try again later."
-          )
-        end
-      end
+    scenario "Schedule Veteran for video" do
+      cache_appeals
+      navigate_to_schedule_veteran
+      find(".cf-form-radio-option", text: "8:30").click
+      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+      expect(page).not_to have_content("Could not find hearing locations for this veteran")
+      expect(page).not_to have_content("There are no upcoming hearing dates for this regional office.")
+      click_dropdown(
+        text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots}) #{room_label}",
+        name: "hearingDate"
+      )
+      click_button("Schedule", exact: true)
+      click_on "Back to Schedule Veterans"
+      expect(page).to have_content("Schedule Veterans")
+      click_button("Scheduled Veterans", exact: true)
+      expect(VACOLS::Case.where(bfcorlid: "123456789S"))
+      click_button("Legacy Veterans Waiting", exact: true)
+      expect(page.has_no_content?("123456789S")).to eq(true)
+      expect(page).to have_content("There are no schedulable veterans")
+      expect(VACOLS::CaseHearing.first.folder_nr).to eq vacols_case.bfkey
     end
 
-    shared_examples "scheduling an AMA hearing" do
-      include_context "ama_hearing"
+    context "but facilities api throws an error" do
+      before do
+        facilities_response = ExternalApi::VADotGovService::FacilitiesResponse.new(
+          HTTPI::Response.new(200, {}, {}.to_json)
+        )
+        allow(facilities_response).to receive(:data).and_return([])
+        allow(facilities_response).to receive(:code).and_return(429)
+        allow(VADotGovService).to receive(:get_distance).and_return(facilities_response)
+      end
 
-      before { cache_appeals }
+      scenario "Schedule Veteran for video error" do
+        visit "queue/appeals/#{legacy_appeal.vacols_id}"
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+        expect(page).to have_css(
+          ".usa-alert-error",
+          text: "Mapping service is temporarily unavailable. Please try again later."
+        )
+      end
+    end
+  end
 
-      scenario "Can create multiple admin actions and reassign them" do
+  shared_examples "scheduling an AMA hearing" do
+    include_context "ama_hearing"
+
+    before { cache_appeals }
+
+    scenario "Can create multiple admin actions and reassign them" do
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Denver")
+      click_button("AMA Veterans Waiting", exact: true)
+      click_on "Bob Smith"
+
+      # Case details screen
+      click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h[:label])
+
+      # Admin action screen
+
+      # First admin action
+      expect(page).to have_content("Submit admin action")
+      click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
+      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: incarcerated_veteran_task_instructions
+
+      # Second admin action
+      click_on COPY::ADD_COLOCATED_TASK_ANOTHER_BUTTON_LABEL
+      within all('div[id^="action_"]', count: 2)[1] do
+        click_dropdown(text: HearingAdminActionContestedClaimantTask.label)
+        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: contested_claimant_task_instructions
+      end
+
+      click_on "Assign Action"
+
+      # The banner has the correct content
+      expect(page).to have_content(
+        format(
+          COPY::ADD_COLOCATED_TASK_CONFIRMATION_TITLE,
+          "2",
+          "actions",
+          [HearingAdminActionIncarceratedVeteranTask.label, HearingAdminActionContestedClaimantTask.label].join(", ")
+        )
+      )
+
+      # The timeline has the correct content
+      incarcerated_row = find("dd", text: HearingAdminActionIncarceratedVeteranTask.label).find(:xpath, "ancestor::tr")
+      incarcerated_row.click_on(
+        COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
+      )
+      expect(incarcerated_row).to have_content incarcerated_veteran_task_instructions
+
+      contested_row = find("dd", text: HearingAdminActionContestedClaimantTask.label).find(:xpath, "ancestor::tr")
+      contested_row.click_on(
+        COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
+      )
+      expect(contested_row).to have_content contested_claimant_task_instructions
+
+      within all("div", class: "cf-select", count: 2).first do
+        click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
+      end
+
+      click_on "Submit"
+
+      # Your queue
+      visit "/queue"
+      click_on "Bob Smith"
+
+      # Reassign
+      within find("tr", text: "BVATWARNER") do
+        click_dropdown(text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h[:label])
+      end
+
+      click_dropdown({ text: other_user.full_name }, find(".cf-modal-body"))
+      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Reassign"
+      click_on "Submit"
+
+      # Case should exist in other users' queue
+      User.authenticate!(user: other_user)
+      visit "/queue"
+
+      expect(page).to have_content(appeal.veteran_full_name)
+    end
+
+    scenario "Schedule Veteran for a video hearing with admin actions that can be put on hold and completed" do
+      # Do the first part of the test in the past so we can wait for our hold to complete.
+      Timecop.travel(17.days.ago) do
         visit "hearings/schedule/assign"
         expect(page).to have_content("Regional Office")
         click_dropdown(text: "Denver")
@@ -306,286 +382,179 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         # First admin action
         expect(page).to have_content("Submit admin action")
         click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
-        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: incarcerated_veteran_task_instructions
-
-        # Second admin action
-        click_on COPY::ADD_COLOCATED_TASK_ANOTHER_BUTTON_LABEL
-        within all('div[id^="action_"]', count: 2)[1] do
-          click_dropdown(text: HearingAdminActionContestedClaimantTask.label)
-          fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: contested_claimant_task_instructions
-        end
+        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Action 1"
 
         click_on "Assign Action"
+        expect(page).to have_content("You have assigned an administrative action")
 
-        # The banner has the correct content
-        expect(page).to have_content(
-          format(
-            COPY::ADD_COLOCATED_TASK_CONFIRMATION_TITLE,
-            "2",
-            "actions",
-            [HearingAdminActionIncarceratedVeteranTask.label, HearingAdminActionContestedClaimantTask.label].join(", ")
-          )
-        )
-
-        # The timeline has the correct content
-        incarcerated_row = find("dd", text: HearingAdminActionIncarceratedVeteranTask.label).find(:xpath, "ancestor::tr")
-        incarcerated_row.click_on(
-          COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
-        )
-        expect(incarcerated_row).to have_content incarcerated_veteran_task_instructions
-
-        contested_row = find("dd", text: HearingAdminActionContestedClaimantTask.label).find(:xpath, "ancestor::tr")
-        contested_row.click_on(
-          COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL
-        )
-        expect(contested_row).to have_content contested_claimant_task_instructions
-
-        within all("div", class: "cf-select", count: 2).first do
-          click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
-        end
-
+        click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
         click_on "Submit"
 
         # Your queue
         visit "/queue"
         click_on "Bob Smith"
+        click_dropdown(text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label)
 
-        # Reassign
-        within find("tr", text: "BVATWARNER") do
-          click_dropdown(text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.to_h[:label])
-        end
+        # On hold
+        click_dropdown({ text: "15 days" }, find(".cf-modal-body"))
+        fill_in "Notes:", with: "Waiting for response"
 
-        click_dropdown({ text: other_user.full_name }, find(".cf-modal-body"))
-        fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Reassign"
-        click_on "Submit"
+        click_on(COPY::MODAL_SUBMIT_BUTTON)
 
-        # Case should exist in other users' queue
-        User.authenticate!(user: other_user)
-        visit "/queue"
-
-        expect(page).to have_content(appeal.veteran_full_name)
+        expect(page).to have_content("case has been placed on hold")
       end
 
-      scenario "Schedule Veteran for a video hearing with admin actions that can be put on hold and completed" do
-        # Do the first part of the test in the past so we can wait for our hold to complete.
-        Timecop.travel(17.days.ago) do
-          visit "hearings/schedule/assign"
-          expect(page).to have_content("Regional Office")
-          click_dropdown(text: "Denver")
-          click_button("AMA Veterans Waiting", exact: true)
-          click_on "Bob Smith"
+      # Refresh the page in the present, and the hold should be completed.
+      TaskTimerJob.perform_now
+      visit "/queue"
+      click_on "Bob Smith"
 
-          # Case details screen
-          click_dropdown(text: Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h[:label])
+      # Complete the admin action
+      click_dropdown(text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label])
+      click_on "Mark complete"
 
-          # Admin action screen
+      expect(page).to have_content("has been marked complete")
 
-          # First admin action
-          expect(page).to have_content("Submit admin action")
-          click_dropdown(text: HearingAdminActionIncarceratedVeteranTask.label)
-          fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: "Action 1"
+      # Schedule veteran!
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Denver")
+      click_button("AMA Veterans Waiting", exact: true)
 
-          click_on "Assign Action"
-          expect(page).to have_content("You have assigned an administrative action")
+      click_on "Bob Smith"
+      click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+      click_dropdown({ text: "Denver" }, find(".dropdown-regionalOffice"))
+      click_dropdown(name: "hearingDate", index: 1)
 
-          click_dropdown(text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.to_h[:label])
-          click_on "Submit"
+      find("label", text: "8:30").click
+      expect(page).to_not have_content("Finding hearing locations", wait: 30)
+      click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+      click_on "Schedule"
 
-          # Your queue
-          visit "/queue"
-          click_on "Bob Smith"
-          click_dropdown(text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label)
+      expect(page).to have_content("You have successfully assigned")
 
-          # On hold
-          click_dropdown({ text: "15 days" }, find(".cf-modal-body"))
-          fill_in "Notes:", with: "Waiting for response"
+      # Ensure the veteran appears on the scheduled page
 
-          click_on(COPY::MODAL_SUBMIT_BUTTON)
+      expect(page).to have_content(appeal.docket_number)
 
-          expect(page).to have_content("case has been placed on hold")
-        end
-
-        # Refresh the page in the present, and the hold should be completed.
-        TaskTimerJob.perform_now
-        visit "/queue"
-        click_on "Bob Smith"
-
-        # Complete the admin action
-        click_dropdown(text: Constants.TASK_ACTIONS.MARK_COMPLETE.to_h[:label])
-        click_on "Mark complete"
-
-        expect(page).to have_content("has been marked complete")
-
-        # Schedule veteran!
-        visit "hearings/schedule/assign"
-        expect(page).to have_content("Regional Office")
-        click_dropdown(text: "Denver")
-        click_button("AMA Veterans Waiting", exact: true)
-
-        click_on "Bob Smith"
-        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-        click_dropdown({ text: "Denver" }, find(".dropdown-regionalOffice"))
-        click_dropdown(name: "hearingDate", index: 1)
-
-        find("label", text: "8:30").click
-        expect(page).to_not have_content("Finding hearing locations", wait: 30)
-        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-        click_on "Schedule"
-
-        expect(page).to have_content("You have successfully assigned")
-
-        # Ensure the veteran appears on the scheduled page
-
-        expect(page).to have_content(appeal.docket_number)
-
-        # Ensure the veteran is no longer in the veterans waiting to be scheduled
-        click_on "Back to Schedule Veterans"
-        expect(page).to have_content("Regional Office")
-        click_dropdown(text: "Denver")
-        click_button("AMA Veterans Waiting", exact: true)
-        expect(page).to have_content("There are no schedulable veterans")
-      end
-
-      scenario "Withdraw Veteran's hearing request" do
-        visit "hearings/schedule/assign"
-        expect(page).to have_content("Regional Office")
-        click_dropdown(text: "Denver")
-        click_button("AMA Veterans Waiting", exact: true)
-        click_on "Bob Smith"
-
-        click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
-        fill_in "taskInstructions", with: "Withdrawing hearing"
-
-        click_on "Submit"
-
-        expect(page).to have_content("You have successfully withdrawn")
-        expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
-
-        click_on "Back to Hearing Schedule"
-        expect(page).to have_content("Denver")
-      end
-
-      context "and room is null" do
-        let(:room) { nil }
-
-        scenario "can schedule a veteran without an error" do
-          visit "hearings/schedule/assign"
-
-          click_dropdown(text: "Denver")
-          click_button("AMA Veterans Waiting", exact: true)
-          click_on "Bob Smith"
-
-          click_dropdown(text: "Schedule Veteran")
-          click_dropdown(
-            text: RegionalOffice.find!(regional_office).city,
-            name: "regionalOffice"
-          )
-          click_dropdown(
-            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
-            name: "hearingDate"
-          )
-          click_dropdown(
-            text: "Holdrege, NE (VHA) 0 miles away",
-            name: "appealHearingLocation"
-          )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
-          click_button("Schedule", exact: true)
-
-          expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
-        end
-
-        scenario "should not see room displayed under Available Hearing Days and Assign Hearing Tabs" do
-          visit "hearings/schedule/assign"
-
-          click_dropdown(text: "Denver")
-          click_button("AMA Veterans Waiting", exact: true)
-          click_on "Bob Smith"
-
-          click_dropdown(text: "Schedule Veteran")
-          click_dropdown(
-            text: RegionalOffice.find!(regional_office).city,
-            name: "regionalOffice"
-          )
-          click_dropdown(
-            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
-            name: "hearingDate"
-          )
-          click_dropdown(
-            text: "Holdrege, NE (VHA) 0 miles away",
-            name: "appealHearingLocation"
-          )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
-          click_button("Schedule", exact: true)
-          click_on "Back to Schedule Veterans"
-
-          expect(page).not_to have_content("null")
-        end
-      end
+      # Ensure the veteran is no longer in the veterans waiting to be scheduled
+      click_on "Back to Schedule Veterans"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Denver")
+      click_button("AMA Veterans Waiting", exact: true)
+      expect(page).to have_content("There are no schedulable veterans")
     end
 
-    shared_examples "scheduling a Legacy hearing" do
-      include_context "legacy_hearing"
+    scenario "Withdraw Veteran's hearing request" do
+      visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
+      click_dropdown(text: "Denver")
+      click_button("AMA Veterans Waiting", exact: true)
+      click_on "Bob Smith"
 
-      before { cache_appeals }
+      click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
+      fill_in "taskInstructions", with: "Withdrawing hearing"
 
-      context "and room is null" do
-        let!(:hearing_day) do
-          create(
-            :hearing_day,
-            request_type: HearingDay::REQUEST_TYPES[:video],
-            scheduled_for: Time.zone.today + 160,
-            regional_office: regional_office,
-            room: nil
-          )
-        end
+      click_on "Submit"
 
-        scenario "can schedule a veteran without an error" do
-          visit "hearings/schedule/assign"
+      expect(page).to have_content("You have successfully withdrawn")
+      expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(Constants.TASK_STATUSES.cancelled)
+      expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
 
-          click_dropdown(text: "Denver")
-          click_button("Legacy Veterans Waiting", exact: true)
-          click_on "Bob Smith"
-
-          click_dropdown(text: "Schedule Veteran")
-          click_dropdown(
-            text: RegionalOffice.find!(regional_office).city,
-            name: "regionalOffice"
-          )
-          click_dropdown(
-            text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
-            name: "hearingDate"
-          )
-          click_dropdown(
-            text: "Holdrege, NE (VHA) 0 miles away",
-            name: "appealHearingLocation"
-          )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
-          click_button("Schedule", exact: true)
-
-          expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
-        end
-      end
+      click_on "Back to Hearing Schedule"
+      expect(page).to have_content("Denver")
     end
 
-    shared_examples "an appeal with a full hearing day" do
-      include_context "full_hearing_day"
+    context "and room is null" do
+      let(:room) { nil }
 
-      scenario "can still schedule veteran successfully" do
-        visit "/queue/appeals/#{appeal.external_id}"
+      scenario "can schedule a veteran without an error" do
+        visit "hearings/schedule/assign"
 
-        total_slots = hearing_day.total_slots
+        click_dropdown(text: "Denver")
+        click_button("AMA Veterans Waiting", exact: true)
+        click_on "Bob Smith"
 
         click_dropdown(text: "Schedule Veteran")
-        click_dropdown(name: "regionalOffice", text: "St. Petersburg, FL")
         click_dropdown(
-          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (#{total_slots}/#{total_slots})",
+          text: RegionalOffice.find!(regional_office).city,
+          name: "regionalOffice"
+        )
+        click_dropdown(
+          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
           name: "hearingDate"
         )
+        click_dropdown(
+          text: "Holdrege, NE (VHA) 0 miles away",
+          name: "appealHearingLocation"
+        )
+        click_dropdown(text: "10:00", name: "optionalHearingTime0")
+        click_button("Schedule", exact: true)
 
-        expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_TITLE)
-        expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_MESSAGE_DETAIL)
+        expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
+      end
 
+      scenario "should not see room displayed under Available Hearing Days and Assign Hearing Tabs" do
+        visit "hearings/schedule/assign"
+
+        click_dropdown(text: "Denver")
+        click_button("AMA Veterans Waiting", exact: true)
+        click_on "Bob Smith"
+
+        click_dropdown(text: "Schedule Veteran")
+        click_dropdown(
+          text: RegionalOffice.find!(regional_office).city,
+          name: "regionalOffice"
+        )
+        click_dropdown(
+          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+          name: "hearingDate"
+        )
+        click_dropdown(
+          text: "Holdrege, NE (VHA) 0 miles away",
+          name: "appealHearingLocation"
+        )
+        click_dropdown(text: "10:00", name: "optionalHearingTime0")
+        click_button("Schedule", exact: true)
+        click_on "Back to Schedule Veterans"
+
+        expect(page).not_to have_content("null")
+      end
+    end
+  end
+
+  shared_examples "scheduling a Legacy hearing" do
+    include_context "legacy_hearing"
+
+    before { cache_appeals }
+
+    context "and room is null" do
+      let!(:hearing_day) do
+        create(
+          :hearing_day,
+          request_type: HearingDay::REQUEST_TYPES[:video],
+          scheduled_for: Time.zone.today + 160,
+          regional_office: regional_office,
+          room: nil
+        )
+      end
+
+      scenario "can schedule a veteran without an error" do
+        visit "hearings/schedule/assign"
+
+        click_dropdown(text: "Denver")
+        click_button("Legacy Veterans Waiting", exact: true)
+        click_on "Bob Smith"
+
+        click_dropdown(text: "Schedule Veteran")
+        click_dropdown(
+          text: RegionalOffice.find!(regional_office).city,
+          name: "regionalOffice"
+        )
+        click_dropdown(
+          text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (0/#{hearing_day.total_slots})",
+          name: "hearingDate"
+        )
         click_dropdown(
           text: "Holdrege, NE (VHA) 0 miles away",
           name: "appealHearingLocation"
@@ -596,122 +565,151 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
       end
     end
+  end
 
-    shared_examples "an appeal where there is an open hearing" do
-      include_context "open_hearing"
+  shared_examples "an appeal with a full hearing day" do
+    include_context "full_hearing_day"
 
-      scenario "shows an error message in the schedule veteran's modal" do
-        visit "queue/appeals/#{appeal.external_id}"
-        # Expected dropdowns on page:
-        #   [0] - Assign disposition task
-        #   [1] - Schedule hearing task
-        within page.all(".cf-form-dropdown")[1] do
-          click_dropdown(text: "Schedule Veteran")
-        end
-        expect(page).to have_content("Open Hearing")
+    scenario "can still schedule veteran successfully" do
+      visit "/queue/appeals/#{appeal.external_id}"
+
+      total_slots = hearing_day.total_slots
+
+      click_dropdown(text: "Schedule Veteran")
+      click_dropdown(name: "regionalOffice", text: "St. Petersburg, FL")
+      click_dropdown(
+        text: "#{hearing_day.scheduled_for.to_formatted_s(:short_date)} (#{total_slots}/#{total_slots})",
+        name: "hearingDate"
+      )
+
+      expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_TITLE)
+      expect(page).to have_content(COPY::SCHEDULE_VETERAN_FULL_HEARING_DAY_MESSAGE_DETAIL)
+
+      click_dropdown(
+        text: "Holdrege, NE (VHA) 0 miles away",
+        name: "appealHearingLocation"
+      )
+      click_dropdown(text: "10:00", name: "optionalHearingTime0")
+      click_button("Schedule", exact: true)
+
+      expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
+    end
+  end
+
+  shared_examples "an appeal where there is an open hearing" do
+    include_context "open_hearing"
+
+    scenario "shows an error message in the schedule veteran's modal" do
+      visit "queue/appeals/#{appeal.external_id}"
+      # Expected dropdowns on page:
+      #   [0] - Assign disposition task
+      #   [1] - Schedule hearing task
+      within page.all(".cf-form-dropdown")[1] do
+        click_dropdown(text: "Schedule Veteran")
       end
+      expect(page).to have_content("Open Hearing")
+    end
+  end
+
+  shared_examples "scheduling a virtual hearing" do |fill_in_timezones, ro_key, time|
+    scenario "can successfully schedule virtual hearing" do
+      navigate_to_schedule_veteran
+      expect(page).to have_content("Schedule Veteran for a Hearing")
+      click_dropdown(name: "hearingType", text: "Virtual")
+      click_dropdown(name: "hearingDate", index: 1)
+
+      expected_time_radio_text = if fill_in_timezones
+                                   "#{time} AM Eastern Time (US & Canada)"
+                                 else
+                                   "#{time} AM Mountain Time (US & Canada) / 10:30 AM Eastern Time (US & Canada)"
+                                 end
+      find(".cf-form-radio-option", text: expected_time_radio_text).click
+
+      # Fill in appellant details
+      click_dropdown(name: "appellantTz", index: 1) if fill_in_timezones
+      fill_in "Veteran Email", with: fill_in_veteran_email
+
+      # Fill in POA/Representative details
+      click_dropdown(name: "representativeTz", index: 1) if fill_in_timezones
+      fill_in "POA/Representative Email", with: fill_in_representative_email
+
+      click_button("Schedule")
+
+      expect(page).to have_content(expected_alert)
+      expect(VirtualHearing.count).to eq(1)
+      expect(LegacyHearing.where(hearing_day_id: hearing_day.id).count).to eq 1
+
+      # Retrieve the newly created hearing
+      new_hearing = LegacyHearing.find_by(hearing_day_id: hearing_day.id)
+
+      # Test the hearing was created correctly with the virtual hearing
+      expect(new_hearing.hearing_location).to eq nil
+      expect(new_hearing.virtual_hearing).to eq VirtualHearing.first
+      expect(new_hearing.regional_office.key).to eq ro_key
+
+      # Test the emails were sent
+      events = SentHearingEmailEvent.where(hearing_id: new_hearing.id)
+      expect(events.count).to eq 2
+      expect(events.where(sent_by_id: current_user.id).count).to eq 2
+      expect(events.where(email_type: "confirmation").count).to eq 2
+      expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
+      expect(events.sent_to_appellant.count).to eq 1
+      expect(events.where(email_address: fill_in_representative_email).count).to eq 1
+      expect(events.where(recipient_role: "representative").count).to eq 1
+    end
+  end
+
+  context "with schedule direct to video/virtual feature enabled" do
+    # Ensure the feature flag is enabled before testing
+    before do
+      FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
     end
 
-    shared_examples "scheduling a virtual hearing" do |fill_in_timezones, ro_key, time|
-      scenario "can successfully schedule virtual hearing" do
-        navigate_to_schedule_veteran
-        expect(page).to have_content("Schedule Veteran for a Hearing")
-        click_dropdown(name: "hearingType", text: "Virtual")
-        click_dropdown(name: "hearingDate", index: 1)
+    it_behaves_like "scheduling a central hearing"
 
-        expected_time_radio_text = if fill_in_timezones
-                                    "#{time} AM Eastern Time (US & Canada)"
-                                  else
-                                    "#{time} AM Mountain Time (US & Canada) / 10:30 AM Eastern Time (US & Canada)"
-                                  end
-        find(".cf-form-radio-option", text: expected_time_radio_text).click
+    it_behaves_like "scheduling a video hearing"
 
-        # Fill in appellant details
-        click_dropdown(name: "appellantTz", index: 1) if fill_in_timezones
-        fill_in "Veteran Email", with: fill_in_veteran_email
+    it_behaves_like "scheduling an AMA hearing"
 
-        # Fill in POA/Representative details
-        click_dropdown(name: "representativeTz", index: 1) if fill_in_timezones
-        fill_in "POA/Representative Email", with: fill_in_representative_email
+    it_behaves_like "scheduling a Legacy hearing"
 
-        click_button("Schedule")
+    it_behaves_like "an appeal with a full hearing day"
 
-        expect(page).to have_content(expected_alert)
-        expect(VirtualHearing.count).to eq(1)
-        expect(LegacyHearing.where(hearing_day_id: hearing_day.id).count).to eq 1
+    it_behaves_like "an appeal where there is an open hearing"
 
-        # Retrieve the newly created hearing
-        new_hearing = LegacyHearing.find_by(hearing_day_id: hearing_day.id)
+    context "when changing from Central hearing" do
+      include_context "central_hearings"
 
-        # Test the hearing was created correctly with the virtual hearing
-        expect(new_hearing.hearing_location).to eq nil
-        expect(new_hearing.virtual_hearing).to eq VirtualHearing.first
-        expect(new_hearing.regional_office.key).to eq ro_key
+      before { cache_appeals }
 
-        # Test the emails were sent
-        events = SentHearingEmailEvent.where(hearing_id: new_hearing.id)
-        expect(events.count).to eq 2
-        expect(events.where(sent_by_id: current_user.id).count).to eq 2
-        expect(events.where(email_type: "confirmation").count).to eq 2
-        expect(events.where(email_address: fill_in_veteran_email).count).to eq 1
-        expect(events.sent_to_appellant.count).to eq 1
-        expect(events.where(email_address: fill_in_representative_email).count).to eq 1
-        expect(events.where(recipient_role: "representative").count).to eq 1
-      end
+      it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
     end
 
-    context "with schedule direct to video/virtual feature enabled" do
-      # Ensure the feature flag is enabled before testing
-      before do
-        FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
-      end
+    context "when changing from Video hearing" do
+      include_context "video_hearing"
 
-      it_behaves_like "scheduling a central hearing"
+      before { cache_appeals }
 
-      it_behaves_like "scheduling a video hearing"
+      it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
+    end
+  end
 
-      it_behaves_like "scheduling an AMA hearing"
-
-      it_behaves_like "scheduling a Legacy hearing"
-
-      it_behaves_like "an appeal with a full hearing day"
-
-      it_behaves_like "an appeal where there is an open hearing"
-
-      context "when changing from Central hearing" do
-        include_context "central_hearings"
-
-        before { cache_appeals }
-
-        it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
-      end
-
-      context "when changing from Video hearing" do
-        include_context "video_hearing"
-
-        before { cache_appeals }
-
-        it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
-      end
+  context "with schedule direct to video/virtual feature disabled" do
+    # Ensure the feature flag is disabled before testing
+    before do
+      FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
     end
 
-    context "with schedule direct to video/virtual feature disabled" do
-      # Ensure the feature flag is disabled before testing
-      before do
-        FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
-      end
+    it_behaves_like "scheduling a central hearing"
 
-      it_behaves_like "scheduling a central hearing"
+    it_behaves_like "scheduling a video hearing"
 
-      it_behaves_like "scheduling a video hearing"
+    it_behaves_like "scheduling an AMA hearing"
 
-      it_behaves_like "scheduling an AMA hearing"
+    it_behaves_like "scheduling a Legacy hearing"
 
-      it_behaves_like "scheduling a Legacy hearing"
+    it_behaves_like "an appeal with a full hearing day"
 
-      it_behaves_like "an appeal with a full hearing day"
-
-      it_behaves_like "an appeal where there is an open hearing"
-    end
+    it_behaves_like "an appeal where there is an open hearing"
   end
 end

--- a/spec/support/feature_helper.rb
+++ b/spec/support/feature_helper.rb
@@ -132,7 +132,7 @@ module FeatureHelper
   end
 
   def dropdown_menu_visible?(dropdown)
-    dropdown.sibling(".cf-select__menu")
+    dropdown.sibling(".cf-select__menu", wait: false)
   rescue Capybara::ElementNotFound
     false
   else


### PR DESCRIPTION
Resolves 5+ second call we make 308 times in feature tests

### Description
Every time we call the spec feature helper `click_dropdown`, we call a [function](https://github.com/department-of-veterans-affairs/caseflow/blob/e5578264afe56c64744e45a02942f179c61450d0/spec/support/feature_helper.rb#L134-L140) to check to see if the actual menu is open. The call relies on the method `sibling` which waits 5 seconds before throwing an `Capybara::ElementNotFound`. This means every call to `click_dropdown` takes at least 5 seconds to run. We have 308+ instances of `click_dropdown` in our tests (+ as they're used in shared examples as well).
```bash
cd spec/feature
git grep click_dropdown | wc -l
308
```

Removing this wait time drops the call down to less than 1 second and resulted in no flakes when run in ci with an ensure_stable

### Acceptance Criteria
- [x] [No flakes](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/36193/workflows/5d26a78f-1b75-46d5-bdaa-9f8ce0c93044/jobs/134468) when wrapping test file with most instances of `click_dropdown` in an [`ensure_stable`](https://github.com/department-of-veterans-affairs/caseflow/pull/15532/commits/481afd4b681ac0fbad1a76391c48d6334189af5a#diff-241535ff479333e36fdb6f0397437c0c02fb56df87058f9e86c1361a90cc9e7bR6)
- [ ] Faster feature tests

### Testing Plan
1. Benchmark a single call! Throw a binding.pry [here](https://github.com/department-of-veterans-affairs/caseflow/blob/8ab2355f4be5472ca6b3125edc2c094fe236d77c/spec/feature/queue/mail_task_spec.rb#L41)
    1. master: 
    ```ruby
    Benchmark.measure { click_dropdown(prompt: prompt, text: text) }
    => #<Benchmark::Tms:0x00007f817bc00018
     @cstime=0.0,
     @cutime=0.0,
     @label="",
     @real=5.62093500001356,
     @stime=0.11391000000000062,
     @total=0.7551169999999985,
     @utime=0.6412069999999979>
    ```
    1. this branch:
    ```ruby
    Benchmark.measure { click_dropdown(prompt: prompt, text: text) }
    => #<Benchmark::Tms:0x00007faf4a0f2a48
     @cstime=0.0,
     @cutime=0.0,
     @label="",
     @real=0.8050880003720522,
     @stime=0.04735200000000006,
     @total=0.25439900000000293,
     @utime=0.20704700000000287>
    ```
1. Benchmark an entire feature test file
    1. master:
    
    ```bash
    bundle exec rake SPEC=spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
    ...
    Finished in 14 minutes 58 seconds (files took 6.15 seconds to load)
    ```
  
    1. this branch:
    ```bash
    bundle exec rake SPEC=spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
    ...
    Finished in 4 minutes 9.9 seconds (files took 6.45 seconds to load)
    ```
1. Benchmark the whole suite

Before
<img width="847" alt="Screen Shot 2020-10-30 at 9 06 12 AM" src="https://user-images.githubusercontent.com/45575454/97708754-ac66dd00-1a8f-11eb-8d22-a36cd80b6a86.png">
After
<img width="850" alt="Screen Shot 2020-10-30 at 9 05 09 AM" src="https://user-images.githubusercontent.com/45575454/97708758-acff7380-1a8f-11eb-8dbe-4592af3a0855.png">
