### PR TITLE
Rescue Savon::HTTPError in UpdateCachedAppealsAttributesJob and continue processing

### DIFF
--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -144,7 +144,7 @@ class CachedAppealService
     bgs_poa = fetch_bgs_power_of_attorney_by_file_number(appeal.veteran_file_number)
     # both representative_name calls can result in BGS connection error
     bgs_poa&.representative_name || appeal.representative_name
-  rescue Errno::ECONNRESET => error
+  rescue Errno::ECONNRESET, Savon::HTTPError => error
     warning_msgs << "#{appeal.class.name} #{appeal.id}: #{error}" if warning_msgs.count < 100
     nil
   end

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -151,24 +151,44 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
     end
 
     context "when BGS fails" do
-      before do
-        bgs = Fakes::BGSService.new
-        allow(Fakes::BGSService).to receive(:new).and_return(bgs)
-        allow(bgs).to receive(:fetch_person_by_ssn)
-          .and_raise(Errno::ECONNRESET, "mocked error for testing")
+
+      shared_examples "rescues error" do
+        it "completes and sends warning to Slack" do
+          slack_msg = ""
+          allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+
+          job = described_class.new
+          job.perform_now
+          expect(job.warning_msgs.count).to eq 3
+
+          expect(slack_msg.lines.count).to eq 4
+          expected_msg = "\\[WARN\\] UpdateCachedAppealsAttributesJob .*"
+          expect(slack_msg).to match(/#{expected_msg}/)
+        end
       end
 
-      it "completes and sends warning to Slack" do
-        slack_msg = ""
-        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+      context "BGSService fails with ECONNRESET" do
+        before do
+          bgs = Fakes::BGSService.new
+          allow(Fakes::BGSService).to receive(:new).and_return(bgs)
+          allow(bgs).to receive(:fetch_person_by_ssn)
+            .and_raise(Errno::ECONNRESET, "mocked error for testing")
+        end
+        include_examples "rescues error"
+      end
+      context "BGSService fails with Savon::HTTPError" do
+        before do
+          bgs = Fakes::BGSService.new
+          allow(Fakes::BGSService).to receive(:new).and_return(bgs)
 
-        job = described_class.new
-        job.perform_now
-        expect(job.warning_msgs.count).to eq 3
-
-        expect(slack_msg.lines.count).to eq 4
-        expected_msg = "\\[WARN\\] UpdateCachedAppealsAttributesJob .*"
-        expect(slack_msg).to match(/#{expected_msg}/)
+          httperror_mock = double("httperror")
+          allow(httperror_mock).to receive(:code).and_return(408)
+          allow(httperror_mock).to receive(:headers).and_return({})
+          allow(httperror_mock).to receive(:body).and_return("stream timeout")
+          allow(bgs).to receive(:fetch_poa_by_file_number)
+            .and_raise(Savon::HTTPError, httperror_mock)
+        end
+        include_examples "rescues error"
       end
     end
   end


### PR DESCRIPTION
UpdateCachedAppealsAttributesJob [failed](https://dsva.slack.com/archives/CN3FQR4A1/p1604044974000100) [due to BGS `Savon::HTTPError: HTTP error (408): stream timeout`](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/12047/events/903946/?environment=production)

### Description
Rescue from the Savon::HTTPError and log it as a warning so that the job can complete.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Can do something like the test plan described in #15482, but it's hard to replicate the error other than what's done in the rspec test.
