### PR TITLE
Refactored the LastRetrievalInfo component

### DIFF
--- a/client/app/2.0/components/reader/DocumentList/LastRetrievalInfo.jsx
+++ b/client/app/2.0/components/reader/DocumentList/LastRetrievalInfo.jsx
@@ -1,0 +1,35 @@
+// External Dependencies
+import React from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * Last Retrieval Info for Documents Table
+ * @param {Object} props -- Contains the last fetched manifest for VVA and VBMS
+ */
+export const LastRetrievalInfo = ({ manifestVbmsFetchedAt, manifestVvaFetchedAt }) => (
+  <React.Fragment>
+    {manifestVbmsFetchedAt ? (
+      <div id="vbms-manifest-retrieved-at" key="vbms">
+          Last VBMS retrieval: {manifestVbmsFetchedAt.slice(0, -5)}
+      </div>
+    ) : (
+      <div className="cf-red-text" key="vbms">
+          Unable to display VBMS documents at this time
+      </div>
+    )}
+    {manifestVvaFetchedAt ? (
+      <div id="vva-manifest-retrieved-at" key="vva">
+          Last VVA retrieval: {manifestVvaFetchedAt.slice(0, -5)}
+      </div>
+    ) : (
+      <div className="cf-red-text" key="vva">
+          Unable to display VVA documents at this time
+      </div>
+    )}
+  </React.Fragment>
+);
+
+LastRetrievalInfo.propTypes = {
+  manifestVbmsFetchedAt: PropTypes.string,
+  manifestVvaFetchedAt: PropTypes.string
+};


### PR DESCRIPTION
### Description

Part 5i of [the stack](https://github.com/department-of-veterans-affairs/caseflow/pull/15456) Refactors the `LastRetrievalInfo` component

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Shadow user AAABSHIRE and click the Reader tab and then Documents list on the test users page: http://localhost:3000/test/users
1. Make sure that you can still use Reader the same as before
1. Open a rails console and toggle the feature on: FeatureToggle.enable!(:interface_version_2)
1. Reload the page and ensure you see the app container and navigation bar, but that nothing renders in the main part of the screen