### PR TITLE
Update reschedule/cancel email language in virtual hearing email

### DIFF
--- a/app/views/virtual_hearing_mailer/sections/_rescheduling_or_canceling_your_hearing.erb
+++ b/app/views/virtual_hearing_mailer/sections/_rescheduling_or_canceling_your_hearing.erb
@@ -1,7 +1,12 @@
-<h3>
-  Rescheduling or Canceling Your Hearing
-</h3>
+<h3>What if I need to reschedule my hearing?</h3>
 <p>
-  If you need to reschedule or cancel your virtual hearing, contact us by email at
-  <%= mail_to "bvahearingteamhotline@va.gov" %>
+  Send a written request to reschedule your hearing at least two weeks before your scheduled hearing explaining why you have “good cause” for rescheduling the hearing. If your hearing is less than 15 days away, or you missed your hearing and would like to reschedule, you must file a written motion for a new hearing date within 15 days of the originally scheduled hearing date, explaining why you missed the hearing and/or why a timely request for a new hearing date could not have been submitted.
+</p>
+<p>
+  A VLJ will review your request and decide if the hearing can be rescheduled. You will get a decision about rescheduling your hearing in the mail. Examples of good cause include, but are not limited to, illness of the appellant and/or representative, difficulty in obtaining necessary records, and unavailability of a necessary witness.
+</p>
+
+<h3>What if I need to withdraw (cancel) my hearing?</h3>
+<p>
+  If you no longer want a hearing, please send a written request to withdraw or cancel your hearing by fax to (844) 678-8979, or by mail to Board of Veterans’ Appeals, P.O. Box 27063, Washington, DC 20038.
 </p>

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -42,13 +42,13 @@ namespace :emails do
             virtual_hearing: hearing.virtual_hearing
           )
 
-          if email.html_part.present?
-            File.write(
-              Rails.root.join("tmp", "#{func}_#{recipient.title}.html"),
-              email.html_part.body.decoded,
-              mode: "w"
-            )
-          end
+          next if email.html_part.nil?
+
+          File.write(
+            Rails.root.join("tmp", "#{func}_#{recipient.title}.html"),
+            email.html_part.body.decoded,
+            mode: "w"
+          )
         end
       end
     end

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+namespace :emails do
+  namespace :virtual_hearings do
+    desc "creates sample emails for virtual hearings mailer"
+    task sample: :environment do
+      include FactoryBot::Syntax::Methods
+
+      # Create a fake Hearing that *is not* saved to the database.
+      hearing = build(
+        :hearing,
+        virtual_hearing: build(:virtual_hearing, :initialized)
+      )
+
+      recipients = [
+        MailRecipient.new(
+          name: "Appellant", # Can't create a fake appellant without saving to the DB
+          email: hearing.virtual_hearing.appellant_email,
+          title: MailRecipient::RECIPIENT_TITLES[:appellant]
+        ),
+        MailRecipient.new(
+          name: hearing.judge.full_name,
+          email: hearing.virtual_hearing.judge_email,
+          title: MailRecipient::RECIPIENT_TITLES[:judge]
+        ),
+        MailRecipient.new(
+          name: "Power of Attorney", # POA name is too complicated to fake for this
+          email: hearing.virtual_hearing.representative_email,
+          title: MailRecipient::RECIPIENT_TITLES[:representative]
+        )
+      ]
+
+      recipients.each do |recipient|
+        [
+          :confirmation,
+          :updated_time_confirmation,
+          :cancellation
+        ].each do |func|
+          email = VirtualHearingMailer.send(
+            func,
+            mail_recipient: recipient,
+            virtual_hearing: hearing.virtual_hearing
+          )
+
+          if email.html_part.present?
+            File.write(
+              Rails.root.join("tmp", "#{func}_#{recipient.title}.html"),
+              email.html_part.body.decoded,
+              mode: "w"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -4,23 +4,25 @@ FactoryBot.define do
   factory :hearing do
     transient do
       regional_office { nil }
-      judge { create(:user, roles: ["Hearing Prep"]) }
-      adding_user { create(:user) }
+      adding_user { association(:user) }
     end
-    appeal { create(:appeal, :hearing_docket) }
+    appeal { association(:appeal, :hearing_docket) }
+    judge { association(:user, roles: ["Hearing Prep"]) }
     uuid { SecureRandom.uuid }
     hearing_day do
-      create(:hearing_day,
-             regional_office: regional_office,
-             scheduled_for: Time.zone.today,
-             judge: judge,
-             request_type: regional_office.nil? ? "C" : "V",
-             created_by: adding_user,
-             updated_by: adding_user)
+      association(
+        :hearing_day,
+        regional_office: regional_office,
+        scheduled_for: Time.zone.today,
+        judge: judge,
+        request_type: regional_office.nil? ? "C" : "V",
+        created_by: adding_user,
+        updated_by: adding_user
+      )
     end
     hearing_location do
       if regional_office.present?
-        create(:hearing_location, regional_office: regional_office)
+        association(:hearing_location, regional_office: regional_office)
       end
     end
     scheduled_time { "8:30AM" }

--- a/spec/factories/virtual_hearing.rb
+++ b/spec/factories/virtual_hearing.rb
@@ -28,7 +28,7 @@ FactoryBot.define do
     trait :initialized do
       alias_name { rand(1..9).to_s[0..6] }
       conference_id { rand(1..9) }
-      before(:create, &:generate_conference_pins)
+      after(:build, &:generate_conference_pins)
     end
 
     trait :previously_central do


### PR DESCRIPTION
Resolves #15422 
Resolves https://vajira.max.gov/browse/CASEFLOW-208

### Description

- Update email template for rescheduling and cancelling a virtual hearing
- Add `emails:virtual_hearings:sample` rake task to generate HTML files with email content

### User Facing Changes

<img width="956" alt="Screen Shot 2020-11-02 at 1 52 02 PM" src="https://user-images.githubusercontent.com/1298274/97907702-a8e38800-1d13-11eb-9c87-6126b2fb2a01.png">
