### PR TITLE
Cancel all hearing tasks without callbacks when canceling a ChangeHearingRequestTypeTask

### DIFF
--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -81,9 +81,7 @@ class ChangeHearingRequestTypeTask < Task
   # triggering callbacks that might automatically create other tasks or change the appeal's
   # location in VACOLS.
   def cancel_self_and_hearing_task_parents_without_callbacks
-    ancestor_task_of_type(HearingTask)&.descendants&.each do |task|
-      task.update_columns(status: Constants.TASK_STATUSES.cancelled)
-    end
+    ancestor_task_of_type(HearingTask)&.cancel_task_and_child_subtasks
   end
 
   def update_appeal_and_self(payload_values, params)

--- a/app/services/hearing_task_tree_initializer.rb
+++ b/app/services/hearing_task_tree_initializer.rb
@@ -23,8 +23,6 @@ class HearingTaskTreeInitializer
     def for_appeal_with_pending_travel_board_hearing(appeal)
       fail TypeError, "expected a legacy appeal" unless appeal.is_a?(LegacyAppeal)
 
-      return if appeal.tasks.open.where(type: HearingTask.name).any?
-
       ActiveRecord::Base.multi_transaction do
         create_args = { appeal: appeal, assigned_to: Bva.singleton }
 

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -58,8 +58,10 @@ class TasksForAppeal
 
   def initialize_hearing_tasks_for_travel_board?
     appeal.is_a?(LegacyAppeal) &&
-      appeal.current_hearing_request_type == :travel_board &&
       user.can_change_hearing_request_type? &&
+      appeal.tasks.open.where(type: HearingTask.name).empty? &&
+      appeal.tasks.closed.where(type: ChangeHearingRequestTypeTask.name).empty? &&
+      appeal.current_hearing_request_type == :travel_board &&
       appeal.active?
   end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -890,7 +890,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
           create(:legacy_appeal, vacols_case: vacols_case)
         end
 
-        let(:task_type) { :changed_hearing_request_type }
+        let(:task_type) { :change_hearing_request_type_task }
         let(:action) do
           create(task_type, appeal: legacy_appeal, assigned_by: assigned_by_user, assigned_to: assigned_to_user)
         end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -334,7 +334,7 @@ FactoryBot.define do
         assigned_to { HearingAdmin.singleton }
       end
 
-      factory :changed_hearing_request_type, class: ChangeHearingRequestTypeTask do
+      factory :change_hearing_request_type_task, class: ChangeHearingRequestTypeTask do
         assigned_to { Bva.singleton }
         parent { create(:schedule_hearing_task, parent: create(:hearing_task, appeal: appeal)) }
       end

--- a/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
@@ -118,9 +118,13 @@ RSpec.feature "Convert travel board appeal for 'Edit HearSched' (Hearing Coordin
         expect(page).to have_content(COPY::CANCEL_CONVERT_HEARING_TYPE_TO_VIRTUAL_SUCCESS_DETAIL)
       end
 
-      step "confirm task was cancelled" do
+      step "confirm hearing tasks were cancelled" do
         expect(ChangeHearingRequestTypeTask.count).to eq(1)
         expect(ChangeHearingRequestTypeTask.first.status).to eq(Constants.TASK_STATUSES.cancelled)
+        expect(ScheduleHearingTask.count).to eq(1)
+        expect(ScheduleHearingTask.first.status).to eq(Constants.TASK_STATUSES.cancelled)
+        expect(HearingTask.count).to eq(1)
+        expect(HearingTask.first.status).to eq(Constants.TASK_STATUSES.cancelled)
       end
     end
 

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -19,10 +19,31 @@ describe ChangeHearingRequestTypeTask do
 
       it "cancels the task" do
         expect { subject }.to(
-          change { task.status }
+          change { task.reload.status }
             .from(Constants.TASK_STATUSES.assigned)
             .to(Constants.TASK_STATUSES.cancelled)
         )
+      end
+
+      context "when there's a full task tree" do
+        let(:loc_schedule_hearing) { LegacyAppeal::LOCATION_CODES[:schedule_hearing] }
+        let(:vacols_case) { create(:case, :travel_board_hearing, bfcurloc: loc_schedule_hearing) }
+        let!(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+        let(:root_task) { create(:root_task, appeal: appeal) }
+        let(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
+        let(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
+        let!(:task) { create(:change_hearing_request_type_task, appeal: appeal, parent: schedule_hearing_task) }
+
+        it "cancels the hearing task tree without triggering callbacks" do
+          expect(hearing_task).to_not receive(:when_child_task_completed)
+
+          subject
+
+          expect(task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(schedule_hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(vacols_case.reload.bfcurloc).to eq(loc_schedule_hearing)
+        end
       end
     end
   end

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 describe ChangeHearingRequestTypeTask do
-  let(:task) { create(:changed_hearing_request_type, :assigned) }
+  let(:task) { create(:change_hearing_request_type_task, :assigned) }
   let(:user) { create(:user, roles: ["Edit HearSched"]) }
 
   before { FeatureToggle.enable!(:convert_travel_board_to_video_or_virtual) }

--- a/spec/services/hearing_task_tree_initializer_spec.rb
+++ b/spec/services/hearing_task_tree_initializer_spec.rb
@@ -35,19 +35,6 @@ describe HearingTaskTreeInitializer do
       end
     end
 
-    context "an open hearing task already exists" do
-      let(:root_task) { create(:root_task, appeal: appeal) }
-      let(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
-
-      it "does not create a duplicate task tree" do
-        subject
-        expect(ChangeHearingRequestTypeTask.count).to eq(0)
-        expect(ScheduleHearingTask.count).to eq(1)
-        expect(HearingTask.count).to eq(1)
-      end
-    end
-
     context "there's a closed hearing task on the appeal" do
       let(:root_task) { create(:root_task, appeal: appeal) }
       let!(:hearing_task) do

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -45,13 +45,10 @@ describe TasksForAppeal do
         context "the appeal has a closed change hearing request type task" do
           let(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
           let!(:change_hearing_request_type_task) do
-            create(
-              :change_hearing_request_type_task,
-              appeal: appeal,
-              parent: schedule_hearing_task,
-              status: Constants.TASK_STATUSES.cancelled
-            )
+            create(:change_hearing_request_type_task, appeal: appeal, parent: schedule_hearing_task)
           end
+
+          before { change_hearing_request_type_task.update!(status: Constants.TASK_STATUSES.cancelled) }
 
           it "doesn't call the hearing task tree intitializer" do
             expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+describe TasksForAppeal do
+  describe "#call" do
+    context "for a legacy appeal with a travel board hearing request" do
+      let(:user_roles) { ["Build HearSched"] }
+      let!(:user) { create(:user, roles: user_roles) }
+      let(:vacols_case) { create(:case, :travel_board_hearing) }
+      let!(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+
+      before { FeatureToggle.enable!(:convert_travel_board_to_video_or_virtual) }
+      after { FeatureToggle.disable!(:convert_travel_board_to_video_or_virtual) }
+
+      subject { TasksForAppeal.new(appeal: appeal, user: user, user_role: "").call }
+
+      it "calls the hearing task tree initializer" do
+        expect(HearingTaskTreeInitializer)
+          .to receive(:for_appeal_with_pending_travel_board_hearing)
+          .with(appeal)
+          .once
+
+        subject
+      end
+
+      context "the appeal is not a legacy appeal" do
+        let!(:appeal) { create(:appeal) }
+
+        it "doesn't call the hearing task tree intitializer" do
+          expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+          subject
+        end
+      end
+
+      context "the appeal has an open hearing task" do
+        let(:root_task) { create(:root_task, appeal: appeal) }
+        let!(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
+
+        it "doesn't call the hearing task tree intitializer" do
+          expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+          subject
+        end
+
+        context "the appeal has a closed change hearing request type task" do
+          let(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
+          let!(:change_hearing_request_type_task) do
+            create(
+              :change_hearing_request_type_task,
+              appeal: appeal,
+              parent: schedule_hearing_task,
+              status: Constants.TASK_STATUSES.cancelled
+            )
+          end
+
+          it "doesn't call the hearing task tree intitializer" do
+            expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+            subject
+          end
+        end
+      end
+
+      context "the appeal doesn't have a travel board hearing request type" do
+        let(:vacols_case) { create(:case, :video_hearing_requested) }
+
+        it "doesn't call the hearing task tree intitializer" do
+          expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+          subject
+        end
+      end
+
+      context "the appeal isn't active" do
+        it "doesn't call the hearing task tree intitializer" do
+          allow(appeal).to receive(:active?).and_return(false)
+          expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+          subject
+        end
+      end
+    end
+  end
+end

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -32,23 +32,25 @@ describe TasksForAppeal do
         end
       end
 
-      context "the appeal has an open hearing task" do
+      context "the appeal has a hearing task" do
         let(:root_task) { create(:root_task, appeal: appeal) }
         let!(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
 
-        it "doesn't call the hearing task tree intitializer" do
-          expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+        context "the hearing task is open" do
+          it "doesn't call the hearing task tree intitializer" do
+            expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
 
-          subject
+            subject
+          end
         end
 
-        context "the appeal has a closed change hearing request type task" do
+        context "the appeal has a canceled hearing task tree with a change hearing request type task" do
           let(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task) }
           let!(:change_hearing_request_type_task) do
             create(:change_hearing_request_type_task, appeal: appeal, parent: schedule_hearing_task)
           end
 
-          before { change_hearing_request_type_task.update!(status: Constants.TASK_STATUSES.cancelled) }
+          before { hearing_task.cancel_task_and_child_subtasks }
 
           it "doesn't call the hearing task tree intitializer" do
             expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)


### PR DESCRIPTION
Connects #15507

### Description
Modifies the behavior introduced in #15525 to cancel all the ancestor and sibling hearing tasks that were created along with the `ChangeHearingRequestTypeTask`. The tasks are canceled without triggering callbacks so that the appeal's location isn't changed in VACOLS.

We're making this change because the `ChangeHearingRequestTypeTask` behaves unlike other tasks in that it only changes its appeal's VACOLS location and assigns its parent when it's completed. If the task is canceled, we want to interpret that as the user saying they don't want to convert the hearing request type or schedule a hearing of any type.