### PR TITLE
Cache hearings related fields selectively

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -65,9 +65,11 @@ detectors:
       - AssignHearingDispositionTask#reschedule_or_schedule_later
       - AssignJudgeteamRoles#process
       - AsyncableJobsReporter
+      - CachedAppealService#ama_appeal_hearing_fields_to_cache
       - CachedAppealService#cache_ama_appeals
       - CachedAppealService#cache_legacy_appeal_postgres_data
       - CachedAppealService#cache_legacy_appeal_vacols_data
+      - CachedAppealService#legacy_postgres_hearing_fields_to_cache
       - CachedAppealService#poa_representative_name_for
       - CachedAppealService#case_fields_for_vacols_ids
       - ConvertToVirtualHearing#convert_hearing_to_virtual

--- a/app/jobs/hearings/geomatch_and_cache_appeal_job.rb
+++ b/app/jobs/hearings/geomatch_and_cache_appeal_job.rb
@@ -44,7 +44,7 @@ class Hearings::GeomatchAndCacheAppealJob < ApplicationJob
     if appeal.closest_regional_office.present?
       cached_appeal_service = CachedAppealService.new
       cached_appeal_service.cache_legacy_appeal_postgres_data([appeal])
-      cached_appeal_service.cache_legacy_appeal_vacols_data([appeal.vacols_id])
+      cached_appeal_service.cache_legacy_appeal_vacols_data([appeal])
     end
   end
 

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -56,7 +56,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     datadog_report_time_segment(segment: "cache_legacy_appeal_postgres_data", start_time: cache_postgres_data_start)
 
     cache_vacols_data_start = Time.zone.now
-    cache_legacy_appeal_vacols_data(all_vacols_ids)
+    cache_legacy_appeal_vacols_data(legacy_appeals)
     datadog_report_time_segment(segment: "cache_legacy_appeal_vacols_data", start_time: cache_vacols_data_start)
   end
 
@@ -69,9 +69,9 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     end
   end
 
-  def cache_legacy_appeal_vacols_data(all_vacols_ids)
-    all_vacols_ids.in_groups_of(VACOLS_BATCH_SIZE, false).each do |batch_vacols_ids|
-      cached_appeals = cached_appeal_service.cache_legacy_appeal_vacols_data(batch_vacols_ids)
+  def cache_legacy_appeal_vacols_data(legacy_appeals)
+    legacy_appeals.in_groups_of(VACOLS_BATCH_SIZE, false).each do |batch_legacy_appeals|
+      cached_appeals = cached_appeal_service.cache_legacy_appeal_vacols_data(batch_legacy_appeals)
 
       increment_vacols_update_count(cached_appeals.count)
     end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -31,7 +31,9 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
   end
 
   def cache_ama_appeals
-    appeals = Appeal.includes(:available_hearing_locations).where(id: open_appeals_from_tasks(Appeal.name))
+    appeals = Appeal.includes(:available_hearing_locations)
+      .where(id: open_appeals_from_tasks(Appeal.name))
+      .order(id: :desc) # cache most created appeals first
 
     cached_appeals = cached_appeal_service.cache_ama_appeals(appeals)
 
@@ -47,7 +49,7 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
     # was previously causing this code to insert legacy appeal attributes that corresponded to NULL ID fields.
     legacy_appeals = LegacyAppeal.includes(:available_hearing_locations)
       .where(id: open_appeals_from_tasks(LegacyAppeal.name))
-    all_vacols_ids = legacy_appeals.pluck(:vacols_id).flatten
+      .order(id: :desc) # cache most created appeals first
 
     cache_postgres_data_start = Time.zone.now
     cache_legacy_appeal_postgres_data(legacy_appeals)

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -286,7 +286,7 @@ class CachedAppealService
 
   # get all ids of appeals which have open ScheduleHearingTasks
   def appeal_ids_with_schedule_hearing_tasks(appeal_ids)
-    Task.open.where(appeal_id: appeal_ids, type: ScheduleHearingTask.name).pluck(:appeal_id)
+    Task.open.where(appeal_id: appeal_ids, type: ScheduleHearingTask.name).pluck(:appeal_id).uniq
   end
 
   # vacols_id => appeal_id mapping

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -81,7 +81,7 @@ class CachedAppealService
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
           is_aod: aod_status_to_cache[folder[:vacols_id]],
           power_of_attorney_name: vacols_case[:power_of_attorney_name],
-          veteran_name: veteran_names_to_cache[folder[:correspondent_id]].first
+          veteran_name: veteran_names_to_cache[folder[:correspondent_id]]
         }
       end
     end

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -57,7 +57,7 @@ class CachedAppealService
   # rubocop:disable Metrics/AbcSize
   def cache_legacy_appeal_vacols_data(legacy_appeals)
     import_cached_appeals([:vacols_id], VACOLS_CACHED_COLUMNS) do
-      vacols_id_to_appeal_id_mapping = vacols_id_to_appeal_id_mapping(legacy_appeals)
+      vacols_id_to_appeal_id_mapping = legacy_appeals.pluck(:vacols_id, :id).to_h
       vacols_ids = vacols_id_to_appeal_id_mapping.keys
       appeal_ids_with_schedule_hearing_tasks = appeal_ids_with_schedule_hearing_tasks(
         vacols_id_to_appeal_id_mapping.values,
@@ -292,11 +292,6 @@ class CachedAppealService
       .where(appeal_id: appeal_ids, appeal_type: appeal_type)
       .pluck(:appeal_id)
       .uniq
-  end
-
-  # vacols_id => appeal_id mapping
-  def vacols_id_to_appeal_id_mapping(legacy_appeals)
-    legacy_appeals.pluck(:vacols_id, :id).to_h
   end
 
   def ama_appeal_hearing_fields_to_cache(appeal, representative_names, appeal_ids_with_schedule_hearing_tasks)

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -9,7 +9,7 @@ class CachedAppealService
 
       appeal_aod_status = aod_status_for_appeals(appeals)
       representative_names = representative_names_for_appeals(appeals)
-      filter_appeals_by_schedule_hearing_tasks(appeals.pluck(:id), Appeal.name)
+      append_appeals_with_open_schedule_hearing_tasks(appeals.pluck(:id), Appeal.name)
 
       appeals.map do |appeal|
         {
@@ -33,7 +33,7 @@ class CachedAppealService
 
   def cache_legacy_appeal_postgres_data(legacy_appeals)
     import_cached_appeals([:appeal_id, :appeal_type], POSTGRES_LEGACY_CACHED_COLUMNS) do
-      filter_appeals_by_schedule_hearing_tasks(legacy_appeals.pluck(:id), LegacyAppeal.name)
+      append_appeals_with_open_schedule_hearing_tasks(legacy_appeals.pluck(:id), LegacyAppeal.name)
 
       legacy_appeals.map do |appeal|
         {
@@ -54,9 +54,9 @@ class CachedAppealService
   # rubocop:disable Metrics/AbcSize
   def cache_legacy_appeal_vacols_data(legacy_appeals)
     import_cached_appeals([:vacols_id], VACOLS_CACHED_COLUMNS) do
-      map_vacols_id_to_appeal_id(legacy_appeals)
+      append_vacols_id_appeal_id_mapping(legacy_appeals)
       vacols_ids = vacols_id_to_appeal_id_mapping.keys
-      filter_appeals_by_schedule_hearing_tasks(
+      append_appeals_with_open_schedule_hearing_tasks(
         vacols_id_to_appeal_id_mapping.values,
         LegacyAppeal.name
       )

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -77,7 +77,7 @@ class CachedAppealService
           hearing_request_type: vacols_case[:hearing_request_type] if ids_with_sh_task.include?(appeal_id),
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
           is_aod: aod_status_to_cache[folder[:vacols_id]],
-          power_of_attorney_name: poa_representative_name_for(vacols_case[:veteran_file_number]) if ids_with_sh_task.include?(appeal_id),
+          power_of_attorney_name: poa_representative_name_for(vacols_case[:veteran_file_number], appeal_id) if ids_with_sh_task.include?(appeal_id),
           veteran_name: veteran_names_to_cache[folder[:correspondent_id]].first
         }
       end
@@ -149,12 +149,11 @@ class CachedAppealService
   end
 
   # bypass PowerOfAttorney model completely and always prefer BGS cache
-  def poa_representative_name_for(veteran_file_number)
+  def poa_representative_name_for(veteran_file_number, appeal_id)
     bgs_poa = fetch_bgs_power_of_attorney_by_file_number(veteran_file_number)
-    # both representative_name calls can result in BGS connection error
     bgs_poa&.representative_name
   rescue Errno::ECONNRESET, Savon::HTTPError => error
-    warning_msgs << "#{LegacyAppeal.name} #{veteran_file_number}: #{error}" if warning_msgs.count < 100
+    warning_msgs << "#{LegacyAppeal.name} #{appeal_id}: #{error}" if warning_msgs.count < 100
     nil
   end
 

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -9,7 +9,7 @@ class CachedAppealService
 
       appeal_aod_status = aod_status_for_appeals(appeals)
       representative_names = representative_names_for_appeals(appeals)
-      ids_with_sh_task = appeal_ids_with_schedule_hearing_tasks(appeals.pluck(:id), Appeal.name)
+      sh_appeal_ids = appeal_ids_with_schedule_hearing_tasks(appeals.pluck(:id), Appeal.name)
 
       appeals.map do |appeal|
         {
@@ -20,12 +20,12 @@ class CachedAppealService
           docket_type: appeal.docket_type,
           docket_number: appeal.docket_number,
           hearing_request_type: (
-            appeal.current_hearing_request_type(readable: true) if ids_with_sh_task.include?(appeal.id)
+            sh_appeal_ids.include?(appeal.id) ?appeal.current_hearing_request_type(readable: true): nil
           ),
           is_aod: appeal_aod_status.include?(appeal.id),
-          power_of_attorney_name: representative_names[appeal.id] if ids_with_sh_task.include?(appeal.id),
+          power_of_attorney_name: representative_names[appeal.id] unless !sh_appeal_ids.include?(appeal.id),
           suggested_hearing_location: (
-            appeal.suggested_hearing_location&.formatted_location if ids_with_sh_task.include?(appeal.id)
+            sh_appeal_ids.include?(appeal.id) ? appeal.suggested_hearing_location&.formatted_location : nil
           ),
           veteran_name: veteran_names_to_cache[appeal.veteran_file_number]
         }.merge(
@@ -38,7 +38,7 @@ class CachedAppealService
 
   def cache_legacy_appeal_postgres_data(legacy_appeals)
     import_cached_appeals([:appeal_id, :appeal_type], POSTGRES_LEGACY_CACHED_COLUMNS) do
-      ids_with_sh_task = appeal_ids_with_schedule_hearing_tasks(legacy_appeals.pluck(:id), LegacyAppeal.name)
+      sh_appeal_ids = appeal_ids_with_schedule_hearing_tasks(legacy_appeals.pluck(:id), LegacyAppeal.name)
       legacy_appeals.map do |appeal|
         {
           vacols_id: appeal.vacols_id,
@@ -46,7 +46,7 @@ class CachedAppealService
           appeal_type: LegacyAppeal.name,
           docket_type: appeal.docket_name, # "legacy"
           suggested_hearing_location: (
-            appeal.suggested_hearing_location&.formatted_location if ids_with_sh_task.include?(appeal.id)
+            sh_appeal_ids.include?(appeal.id) ? appeal.suggested_hearing_location&.formatted_location : nil
           ),
         }.merge(
           regional_office_fields_to_cache(appeal)
@@ -58,7 +58,7 @@ class CachedAppealService
   # rubocop:disable Metrics/MethodLength
   def cache_legacy_appeal_vacols_data(legacy_appeals)
     import_cached_appeals([:vacols_id], VACOLS_CACHED_COLUMNS) do
-      vacols_id_to_appeal_ids_mapping = vacols_id_to_appeal_id_mapping(legacy_appeals)
+      vacols_id_to_appeal_id_mapping = vacols_id_to_appeal_id_mapping(legacy_appeals)
       vacols_ids = vacols_id_to_appeal_ids_mapping.keys
 
       vacols_folders = folder_fields_for_vacols_ids(vacols_ids)
@@ -82,13 +82,13 @@ class CachedAppealService
           vacols_id: folder[:vacols_id],
           case_type: vacols_case[:status],
           docket_number: folder[:docket_number],
-          former_travel: vacols_case[:former_travel] if ids_with_sh_task.include?(appeal_id), # true or false
-          hearing_request_type: vacols_case[:hearing_request_type] if ids_with_sh_task.include?(appeal_id),
+          former_travel: vacols_case[:former_travel], # true or false
+          hearing_request_type: vacols_case[:hearing_request_type],
           issue_count: issue_counts_to_cache[folder[:vacols_id]] || 0,
           is_aod: aod_status_to_cache[folder[:vacols_id]],
-          power_of_attorney_name: poa_representative_name_for(
-            vacols_case[:veteran_file_number], appeal_id
-          ) if ids_with_sh_task.include?(appeal_id),
+          power_of_attorney_name: (
+            ids_with_sh_task.include?(appeal_id) ? poa_representative_name_for(vacols_case[:veteran_file_number]) : nil
+          ),
           veteran_name: veteran_names_to_cache[folder[:correspondent_id]].first
         }
       end
@@ -160,11 +160,11 @@ class CachedAppealService
   end
 
   # bypass PowerOfAttorney model completely and always prefer BGS cache
-  def poa_representative_name_for(veteran_file_number, appeal_id)
+  def poa_representative_name_for(veteran_file_number, vacols_id)
     bgs_poa = fetch_bgs_power_of_attorney_by_file_number(veteran_file_number)
     bgs_poa&.representative_name
   rescue Errno::ECONNRESET, Savon::HTTPError => error
-    warning_msgs << "#{LegacyAppeal.name} #{appeal_id}: #{error}" if warning_msgs.count < 100
+    warning_msgs << "#{LegacyAppeal.name} #{vacols_id}: #{error}" if warning_msgs.count < 100
     nil
   end
 
@@ -237,15 +237,22 @@ class CachedAppealService
       changed_request = changed_hearing_request_type_for_all_vacols_ids[vacols_case.bfkey]
       # Replicates LegacyAppeal#current_hearing_request_type
       current_request = HearingDay::REQUEST_TYPES.key(changed_request)&.to_sym || original_request
+      veteran_file_number = LegacyAppeal.veteran_file_number_from_bfcorlid(vacols_case.bfcorlid)
 
       [
         vacols_case.bfkey,
         {
           location: vacols_case.bfcurloc,
           status: VACOLS::Case::TYPES[vacols_case.bfac],
-          hearing_request_type: LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[current_request],
-          former_travel: original_request == :travel_board && current_request != :travel_board,
-          veteran_file_number: LegacyAppeal.veteran_file_number_from_bfcorlid(vacols_case.bfcorlid)
+          hearing_request_type: (
+            sh_appeal_ids.include?(vacols_case.bfkey) ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[current_request] : nil
+          ),
+          former_travel: (
+            sh_appeal_ids.include?(vacols_case.bfkey) ?  original_request == :travel_board && current_request != :travel_board : nil
+          ),
+          power_of_attorney_name: (
+            sh_appeal_ids.include?(vacols_case.bfkey) ? poa_representative_name_for(veteran_file_number, vacols_case.bfkey) : nil
+          )
         }
       ]
     end.to_h
@@ -296,7 +303,7 @@ class CachedAppealService
 
   # get all ids of appeals which have open ScheduleHearingTasks
   def appeal_ids_with_schedule_hearing_tasks(appeal_ids, appeal_type)
-    Task.open
+    @sh_appeal_ids ||= Task.open
       .where(appeal_id: appeal_ids, type: ScheduleHearingTask.name, appeal_type: appeal_type)
       .pluck(:appeal_id)
       .uniq
@@ -304,6 +311,6 @@ class CachedAppealService
 
   # vacols_id => appeal_id mapping
   def vacols_id_to_appeal_id_mapping(legacy_appeals)
-    legacy_appeals.pluck(:vacols_id, :id).to_h
+    vacols_id_to_appeal_id_mapping = legacy_appeals.pluck(:vacols_id, :id).to_h
   end
 end

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -145,16 +145,14 @@ class CachedAppealService
 
     values_to_cache = yield
 
-    ActiveRecord::Base.transaction do
-      CachedAppeal.import(
-        values_to_cache,
-        on_duplicate_key_update: {
-          conflict_target: conflict_columns,
-          condition: conflict_clause(start_time),
-          columns: columns
-        }
-      )
-    end
+    CachedAppeal.import(
+      values_to_cache,
+      on_duplicate_key_update: {
+        conflict_target: conflict_columns,
+        condition: conflict_clause(start_time),
+        columns: columns
+      }
+    )
 
     values_to_cache
   end

--- a/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
+++ b/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
@@ -8,6 +8,7 @@ describe Hearings::GeomatchAndCacheAppealJob do
 
     context "with AMA appeal" do
       let(:appeal) { create(:appeal) }
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal)}
 
       it "throws an error" do
         expect { subject }.to raise_error ArgumentError
@@ -25,6 +26,7 @@ describe Hearings::GeomatchAndCacheAppealJob do
           vacols_case: vacols_case
         )
       end
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal)}
 
       context "when closest regional office is not set" do
         it "sets the closest regional office field" do

--- a/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
+++ b/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
@@ -8,7 +8,7 @@ describe Hearings::GeomatchAndCacheAppealJob do
 
     context "with AMA appeal" do
       let(:appeal) { create(:appeal) }
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal)}
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
 
       it "throws an error" do
         expect { subject }.to raise_error ArgumentError
@@ -26,7 +26,7 @@ describe Hearings::GeomatchAndCacheAppealJob do
           vacols_case: vacols_case
         )
       end
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal)}
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
 
       context "when closest regional office is not set" do
         it "sets the closest regional office field" do

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -169,7 +169,7 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
         before do
           bgs = Fakes::BGSService.new
           allow(Fakes::BGSService).to receive(:new).and_return(bgs)
-          allow(bgs).to receive(:fetch_person_by_ssn)
+          allow(bgs).to receive(:fetch_poa_by_file_number)
             .and_raise(Errno::ECONNRESET, "mocked error for testing")
         end
         include_examples "rescues error"

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -101,7 +101,7 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
     end
   end
 
-  context "caches hearing_request_type and former_travel correctly" do
+  context "caches hearings related field correctly" do
     let(:appeal) { create(:appeal, closest_regional_office: "C") } # central
     let(:legacy_appeal3) do # former travel, currently virtual
       create(
@@ -117,8 +117,7 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
 
     before do
       open_appeals.each do |appeal|
-        create_list(:bva_dispatch_task, 3, appeal: appeal)
-        create_list(:ama_judge_assign_task, 8, appeal: appeal)
+        create_list(:schedule_hearing_task, 1, appeal: appeal)
       end
     end
 

--- a/spec/services/cached_appeal_service_spec.rb
+++ b/spec/services/cached_appeal_service_spec.rb
@@ -12,17 +12,18 @@ describe CachedAppealService do
         changed_request_type: HearingDay::REQUEST_TYPES[:virtual]
       )
     end
+    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: legacy_appeal) }
 
     it "caches hearing_request_type correctly", :aggregate_failures do
       subject.cache_legacy_appeal_postgres_data([legacy_appeal])
-      subject.cache_legacy_appeal_vacols_data([vacols_case.bfkey])
+      subject.cache_legacy_appeal_vacols_data([legacy_appeal])
 
       expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).hearing_request_type).to eq("Virtual")
     end
 
     it "caches former_travel correctly", :aggregate_failures do
       subject.cache_legacy_appeal_postgres_data([legacy_appeal])
-      subject.cache_legacy_appeal_vacols_data([vacols_case.bfkey])
+      subject.cache_legacy_appeal_vacols_data([legacy_appeal])
 
       expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).former_travel).to eq(true)
     end
@@ -53,7 +54,7 @@ describe CachedAppealService do
     it "does not update appeals that were recently cached" do
       subject.cache_ama_appeals([ama_appeal])
       subject.cache_legacy_appeal_postgres_data([legacy_appeal])
-      subject.cache_legacy_appeal_vacols_data([vacols_case.bfkey])
+      subject.cache_legacy_appeal_vacols_data([legacy_appeal])
 
       legacy_cached_appeal = CachedAppeal.find_by(appeal_id: legacy_appeal.id, appeal_type: LegacyAppeal.name)
       ama_cached_appeal = CachedAppeal.find_by(appeal_id: ama_appeal.id, appeal_type: Appeal.name)
@@ -61,6 +62,35 @@ describe CachedAppealService do
       # updated_at shouldn't change
       expect(legacy_cached_appeal.updated_at.utc).to be_within(1.in_milliseconds).of(future_time)
       expect(ama_cached_appeal.updated_at.utc).to be_within(1.in_milliseconds).of(future_time)
+    end
+  end
+
+  context "does not cache hearing related fields in the absence of an open ScheduleHearingTask" do
+    context "ama appeal" do
+      let(:appeal) { create(:appeal) }
+
+      it "does not cache hearing related fields", :aggregate_failures do
+        subject.cache_ama_appeals([appeal])
+
+        expect(CachedAppeal.find_by(appeal_id: appeal.id).hearing_request_type).to eq(nil)
+        expect(CachedAppeal.find_by(appeal_id: appeal.id).power_of_attorney_name).to eq(nil)
+        expect(CachedAppeal.find_by(appeal_id: appeal.id).suggested_hearing_location).to eq(nil)
+      end
+    end
+
+    context "legacy appeal" do
+      let(:vacols_case) { create(:case) }
+      let(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+
+      it "does not cache hearing realated fields", :aggregate_failures do
+        subject.cache_legacy_appeal_postgres_data([legacy_appeal])
+        subject.cache_legacy_appeal_vacols_data([legacy_appeal])
+
+        expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).hearing_request_type).to eq(nil)
+        expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).former_travel).to eq(nil)
+        expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).power_of_attorney_name).to eq(nil)
+        expect(CachedAppeal.find_by(vacols_id: legacy_appeal.vacols_id).suggested_hearing_location).to eq(nil)
+      end
     end
   end
 end

--- a/spec/services/cached_appeal_service_spec.rb
+++ b/spec/services/cached_appeal_service_spec.rb
@@ -65,7 +65,7 @@ describe CachedAppealService do
     end
   end
 
-  context "does not cache hearing related fields in the absence of an open ScheduleHearingTask" do
+  context "in the absence of an open ScheduleHearingTask" do
     context "ama appeal" do
       let(:appeal) { create(:appeal) }
 


### PR DESCRIPTION
May help with #15417
Resolves #15580

### Description
- cache all appeals in a determined order (descending order of Ids) which may prevent deadlock if two instances of job run at the same time
- only cache some hearing related expensive fields for appeal if there exists at least one open `ScheduleHearingTask`

#### breakdown of appeals with open `ScheduleHearingTask` vs without (PROD)

```ruby
as = Task.open.where(appeal_type: Appeal.name).pluck(:appeal_id).uniq
as.count
=> 56919
Task.open.where(appeal_id: as, type: ScheduleHearingTask.name, appeal_type: "Appeal").pluck(:appeal_id).uniq.count
=> 32620 # 57% -24299 difference

las = Task.open.where(appeal_type: LegacyAppeal.name).pluck(:appeal_id).uniq
las.count
=> 209664 
Task.open.where(appeal_id: las, type: ScheduleHearingTask.name, appeal_type: "LegacyAppeal").pluck(:appeal_id).uniq.count
=> 45036 21% -164,628 # we'd be avoiding making calls to BGS for 164,628 appeals
```
