### PR TITLE
Color Slack messages from jobs based on title then body contents

### DIFF
--- a/app/jobs/set_appeal_age_aod_job.rb
+++ b/app/jobs/set_appeal_age_aod_job.rb
@@ -30,21 +30,21 @@ class SetAppealAgeAodJob < CaseflowJob
 
   def log_success(details)
     duration = time_ago_in_words(start_time)
-    msg = "#{self.class.name} completed after running for #{duration}.\n#{details}"
-    Rails.logger.info(msg)
+    msg_title = "[INFO] #{self.class.name} completed after running for #{duration}."
+    Rails.logger.info("#{msg_title}\n#{details}")
 
-    slack_service.send_notification("[INFO] #{msg}")
+    slack_service.send_notification(details, msg_title)
   end
 
   def log_error(collector_name, err, details)
     duration = time_ago_in_words(start_time)
-    msg = "#{collector_name} failed after running for #{duration}. Fatal error: #{err.message}.\n#{details}"
-    Rails.logger.info(msg)
+    msg_title = "[ERROR] #{collector_name} failed after running for #{duration}. Fatal error: #{err.message}."
+    Rails.logger.info("#{msg_title}\n#{details}")
     Rails.logger.info(err.backtrace.join("\n"))
 
     Raven.capture_exception(err, extra: { stats_collector_name: collector_name })
 
-    slack_service.send_notification("[ERROR] #{msg}")
+    slack_service.send_notification(details, msg_title)
   end
 
   private

--- a/app/jobs/stats_collector_job.rb
+++ b/app/jobs/stats_collector_job.rb
@@ -96,7 +96,7 @@ class StatsCollectorJob < CaseflowJob
     msg = "#{self.class.name} completed after running for #{duration}."
     Rails.logger.info(msg)
 
-    slack_service.send_notification("[INFO] #{msg}") # may not need this
+    slack_service.send_notification("[INFO] #{msg}", self.class.to_s) # may not need this
   end
 
   def log_error(collector_name, err)
@@ -107,6 +107,6 @@ class StatsCollectorJob < CaseflowJob
 
     Raven.capture_exception(err, extra: { stats_collector_name: collector_name })
 
-    slack_service.send_notification("[ERROR] #{msg}")
+    slack_service.send_notification("[ERROR] #{msg}", self.class.to_s)
   end
 end

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -101,7 +101,7 @@ class UpdateAppellantRepresentationJob < CaseflowJob
 
     Raven.capture_exception(err)
 
-    slack_service.send_notification("[ERROR] #{msg}")
+    slack_service.send_notification("[ERROR] #{msg}", self.class.to_s)
 
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)
   end

--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -107,9 +107,8 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
   end
 
   def log_warning
-    slack_msg = "[WARN] UpdateCachedAppealsAttributesJob first 100 warnings:"\
-                "\n#{warning_msgs.join("\n")}"
-    slack_service.send_notification(slack_msg)
+    slack_msg = warning_msgs.join("\n")
+    slack_service.send_notification(slack_msg, "[WARN] UpdateCachedAppealsAttributesJob: first 100 warnings")
   end
 
   def log_error(start_time, err)
@@ -121,9 +120,9 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
 
     Raven.capture_exception(err)
 
-    slack_msg = "[ERROR] UpdateCachedAppealsAttributesJob failed after running for #{duration}. "\
-                "See Sentry event #{Raven.last_event_id}"
-    slack_service.send_notification(slack_msg) # do not leak PII
+    slack_msg = "See Sentry event #{Raven.last_event_id}"
+    slack_service.send_notification(slack_msg,
+                                    "[ERROR] UpdateCachedAppealsAttributesJob failed after running for #{duration}.")
 
     datadog_report_runtime(metric_group_name: METRIC_GROUP_NAME)
   end

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -36,9 +36,13 @@ class SlackService
   end
 
   def pick_color(title, msg)
-    if title =~ /error/i || msg =~ /error/i
+    if /error/i.match?(title)
       COLORS[:error]
-    elsif title =~ /warn/i || msg =~ /warn/i
+    elsif /warn/i.match?(title)
+      COLORS[:warn]
+    elsif /error/i.match?(msg)
+      COLORS[:error]
+    elsif /warn/i.match?(msg)
       COLORS[:warn]
     else
       COLORS[:info]

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -3,12 +3,6 @@
 describe SetAppealAgeAodJob, :postgres do
   include_context "Metrics Reports"
 
-  # rubocop:disable Metrics/LineLength
-  let(:success_msg) do
-    "[INFO] SetAppealAgeAodJob completed after running for less than a minute."
-  end
-  # rubocop:enable Metrics/LineLength
-
   describe "#perform" do
     let(:non_aod_appeal) { create(:appeal, :with_schedule_hearing_tasks) }
 
@@ -22,7 +16,10 @@ describe SetAppealAgeAodJob, :postgres do
     let(:cancelled_age_aod_appeal) { create(:appeal, :advanced_on_docket_due_to_age, :cancelled) }
 
     before do
-      allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| @slack_msg = first_arg }
+      allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
+        @slack_msg = msg
+        @slack_title = title
+      end
 
       age_aod_appeal_wrong_dob.update(aod_based_on_age: true)
       # simulate date-of-birth being corrected
@@ -39,7 +36,7 @@ describe SetAppealAgeAodJob, :postgres do
       expect(age_aod_appeal_wrong_dob.aod_based_on_age).to eq(true)
 
       described_class.perform_now
-      expect(@slack_msg).to include(success_msg)
+      expect(@slack_title).to include("[INFO] SetAppealAgeAodJob completed after running for less than a minute.")
 
       # `aod_based_on_age` will be nil
       # `aod_based_on_age` being false means that it was once true (in the case where the claimant's DOB was updated)
@@ -56,14 +53,15 @@ describe SetAppealAgeAodJob, :postgres do
       let(:error_msg) { "Some dummy error" }
 
       it "sends a message to Slack that includes the error" do
-        slack_msg = ""
-        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+        allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
+          @slack_msg = msg
+          @slack_title = title
+        end
 
         allow_any_instance_of(described_class).to receive(:appeals_to_set_age_based_aod).and_raise(error_msg)
         described_class.perform_now
 
-        expected_msg = "#{described_class.name} failed after running for .*. Fatal error: #{error_msg}"
-        expect(slack_msg).to match(/#{expected_msg}/)
+        expect(@slack_title).to match(/#{described_class.name} failed after running for .*. Fatal error: #{error_msg}/)
       end
     end
   end

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -90,17 +90,15 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
     end
 
     it "sends a message to Slack that includes the error" do
-      slack_msg = ""
-      slack_title = ""
       allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
-        slack_msg = msg
-        slack_title = title
+        @slack_msg = msg
+        @slack_title = title
       end
 
       subject
 
-      expect(slack_title).to match(/\[ERROR\] UpdateCachedAppealsAttributesJob failed after running for .*/)
-      expect(slack_msg).to match(/See Sentry event .*/)
+      expect(@slack_title).to match(/\[ERROR\] UpdateCachedAppealsAttributesJob failed after running for .*/)
+      expect(@slack_msg).to match(/See Sentry event .*/)
     end
   end
 
@@ -156,19 +154,17 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
     context "when BGS fails" do
       shared_examples "rescues error" do
         it "completes and sends warning to Slack" do
-          slack_msg = ""
-          slack_title = ""
           allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
-            slack_msg = msg
-            slack_title = title
+            @slack_msg = msg
+            @slack_title = title
           end
 
           job = described_class.new
           job.perform_now
           expect(job.warning_msgs.count).to eq 3
 
-          expect(slack_msg.lines.count).to eq 3
-          expect(slack_title).to match(/\[WARN\] UpdateCachedAppealsAttributesJob: .*/)
+          expect(@slack_msg.lines.count).to eq 3
+          expect(@slack_title).to match(/\[WARN\] UpdateCachedAppealsAttributesJob: .*/)
         end
       end
 

--- a/spec/jobs/update_cached_appeals_attributes_job_spec.rb
+++ b/spec/jobs/update_cached_appeals_attributes_job_spec.rb
@@ -91,13 +91,16 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
 
     it "sends a message to Slack that includes the error" do
       slack_msg = ""
-      allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+      slack_title = ""
+      allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
+        slack_msg = msg
+        slack_title = title
+      end
 
       subject
 
-      expected_msg = "UpdateCachedAppealsAttributesJob failed after running for .*. See Sentry event .*"
-
-      expect(slack_msg).to match(/#{expected_msg}/)
+      expect(slack_title).to match(/\[ERROR\] UpdateCachedAppealsAttributesJob failed after running for .*/)
+      expect(slack_msg).to match(/See Sentry event .*/)
     end
   end
 
@@ -154,15 +157,18 @@ describe UpdateCachedAppealsAttributesJob, :all_dbs do
       shared_examples "rescues error" do
         it "completes and sends warning to Slack" do
           slack_msg = ""
-          allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+          slack_title = ""
+          allow_any_instance_of(SlackService).to receive(:send_notification) do |_, msg, title|
+            slack_msg = msg
+            slack_title = title
+          end
 
           job = described_class.new
           job.perform_now
           expect(job.warning_msgs.count).to eq 3
 
-          expect(slack_msg.lines.count).to eq 4
-          expected_msg = "\\[WARN\\] UpdateCachedAppealsAttributesJob .*"
-          expect(slack_msg).to match(/#{expected_msg}/)
+          expect(slack_msg.lines.count).to eq 3
+          expect(slack_title).to match(/\[WARN\] UpdateCachedAppealsAttributesJob: .*/)
         end
       end
 

--- a/spec/services/slack_service_spec.rb
+++ b/spec/services/slack_service_spec.rb
@@ -38,6 +38,13 @@ describe SlackService do
       end
     end
 
+    context "message contains error but title contains warning" do
+      it "picks yellow color" do
+        slack_service.send_notification("there was an error", "Really just a warning")
+        expect(@http_params[:body]).to match(/"#ffff00"/)
+      end
+    end
+
     context "message contains error" do
       it "picks red color" do
         slack_service.send_notification("there was an error")


### PR DESCRIPTION
### Description
Warning message from jobs are shown as red because the message body contains the word "error" ([example1](https://dsva.slack.com/archives/CN3FQR4A1/p1604588199012500), [example2](https://dsva.slack.com/archives/CN3FQR4A1/p1604398921004900)). This PR distinguishes the Slack title from the Slack message body and colors based on the Slack title first.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Check #appeals-job-alerts to check message coloring.