### PR TITLE
Update rating issue descriptions when converting from nonrating

### DIFF
--- a/app/models/end_product_update.rb
+++ b/app/models/end_product_update.rb
@@ -48,7 +48,8 @@ class EndProductUpdate < CaseflowRecord
   def update_issue_type_to_rating
     request_issues.each do |ri|
       ri.update(
-        type: "RatingRequestIssue"
+        type: "RatingRequestIssue",
+        edited_description: ri.nonrating_issue_description
       )
     end
   end

--- a/spec/models/end_product_update_spec.rb
+++ b/spec/models/end_product_update_spec.rb
@@ -25,11 +25,14 @@ describe EndProductUpdate do
       let(:old_code) { "030HLRNR" }
       let(:new_code) { "030HLRR" }
 
-      it "updates issue type on request issues" do
+      it "updates type and attributes on request issues" do
         subject
 
         expect(epu.request_issues).not_to be_empty
-        expect(epu.request_issues).to all have_attributes(type: "RatingRequestIssue")
+        expect(epu.request_issues).to all have_attributes(
+          type: "RatingRequestIssue",
+          description: "nonrating issue description"
+        )
       end
     end
 


### PR DESCRIPTION
Connects #15126 

### Description
This PR finishes out the last bit of description-updating work, building on @Sjones352's work in #15528

### Acceptance Criteria
- [ ] Update description to equal the nonrating_issue_description, not including the nonrating_issue_category if the issue type is RatingRequestIssue and the nonrating_issue_description is present

### Testing Plan
1. Updated the EPU spec test for NR-to-R