### PR TITLE
Limit the creation of ChangeHearingRequestTypeTasks

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -392,7 +392,7 @@ class LegacyAppeal < CaseflowRecord
     scheduled_hearings.any?
   end
 
-  def completed_hearing?
+  def any_held_hearings?
     hearings.any?(&:held?)
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -392,6 +392,10 @@ class LegacyAppeal < CaseflowRecord
     scheduled_hearings.any?
   end
 
+  def completed_hearing?
+    hearings.any?(&:held?)
+  end
+
   def completed_hearing_on_previous_appeal?
     vacols_ids = VACOLS::Case.where(bfcorlid: vbms_id).pluck(:bfkey)
     hearings = HearingRepository.hearings_for_appeals(vacols_ids)
@@ -854,6 +858,10 @@ class LegacyAppeal < CaseflowRecord
 
   def cavc
     type == "Court Remand"
+  end
+
+  def original?
+    type_code == "original"
   end
 
   alias cavc? cavc

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -119,7 +119,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def can_change_hearing_request_type?
-    (can?("Admin Intake") || can?("Build HearSched") || can?("Edit HearSched")) &&
+    (can?("Build HearSched") || can?("Edit HearSched")) &&
       FeatureToggle.enabled?(:convert_travel_board_to_video_or_virtual, user: self)
   end
 

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -62,7 +62,9 @@ class TasksForAppeal
       appeal.tasks.open.where(type: HearingTask.name).empty? &&
       appeal.tasks.closed.where(type: ChangeHearingRequestTypeTask.name).empty? &&
       appeal.current_hearing_request_type == :travel_board &&
-      appeal.active?
+      appeal.active? &&
+      appeal.original? &&
+      !appeal.completed_hearing?
   end
 
   def legacy_appeal_tasks

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -64,7 +64,7 @@ class TasksForAppeal
       appeal.current_hearing_request_type == :travel_board &&
       appeal.active? &&
       appeal.original? &&
-      !appeal.completed_hearing?
+      !appeal.any_held_hearings?
   end
 
   def legacy_appeal_tasks

--- a/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_travel_board_hearing/edit_hearsched_spec.rb
@@ -5,6 +5,7 @@ RSpec.feature "Convert travel board appeal for 'Edit HearSched' (Hearing Coordin
   let!(:vacols_case) do
     create(
       :case,
+      :type_original,
       bfhr: "2" # Travel Board
     )
   end

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -101,6 +101,10 @@ describe TasksForAppeal do
       context "the appeal has a hearing" do
         let!(:hearing) { create(:legacy_hearing, appeal: appeal, disposition: disposition) }
 
+        before do
+          hearing.vacols_record.update!(folder_nr: vacols_case.bfkey)
+        end
+
         context "hearing was held" do
           let(:disposition) { "H" }
 

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -5,7 +5,14 @@ describe TasksForAppeal do
     context "for a legacy appeal with a travel board hearing request" do
       let(:user_roles) { ["Build HearSched"] }
       let!(:user) { create(:user, roles: user_roles) }
-      let(:vacols_case) { create(:case, :travel_board_hearing) }
+      let(:appeal_type) { "1" } # Original
+      let(:vacols_case) do
+        create(
+          :case,
+          :travel_board_hearing,
+          bfac: appeal_type
+        )
+      end
       let!(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
 
       before { FeatureToggle.enable!(:convert_travel_board_to_video_or_virtual) }
@@ -76,6 +83,32 @@ describe TasksForAppeal do
           expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
 
           subject
+        end
+      end
+
+      VACOLS::Case::TYPES.drop(1).each do |code, readable|
+        context "appeal is #{readable}" do
+          let(:appeal_type) { code }
+
+          it "doesn't call the hearing task tree initializer" do
+            expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+            subject
+          end
+        end
+      end
+
+      context "the appeal has a hearing" do
+        let!(:hearing) { create(:legacy_hearing, appeal: appeal, disposition: disposition) }
+
+        context "hearing was held" do
+          let(:disposition) { "H" }
+
+          it "doesn't call the hearing task tree intitializer" do
+            expect(HearingTaskTreeInitializer).to_not receive(:for_appeal_with_pending_travel_board_hearing)
+
+            subject
+          end
         end
       end
     end


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-281

### Description

  - Update conditions for when to create a `ChangeHearingRequestTypeTask`
  - Add test cases

### Acceptance Criteria

- [x] When a user with the "Admin Intake", "Build HearSched", or "Edit HearSched" permissions loads the Case Details page for an appeal with a Travel Board request type, do not create the ChangeHearingRequestTypeTask if the appeal fits either of these conditions:
  - [x] Is outside the original appeal stream (e.g., post-remand)
  - [x] Has a held hearing of any type in the case history
