### PR TITLE
Fix video room and dockets per date constants

### DIFF
--- a/app/services/hearing_schedule/generate_hearing_days_schedule.rb
+++ b/app/services/hearing_schedule/generate_hearing_days_schedule.rb
@@ -13,8 +13,8 @@ class HearingSchedule::GenerateHearingDaysSchedule
 
   attr_reader :available_days, :ros
 
-  MAX_NUMBER_OF_DAYS_PER_DATE = 12
-  BVA_VIDEO_ROOMS = [1, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13].freeze
+  BVA_VIDEO_ROOMS = Constants::HEARING_ROOMS_LIST.keys.map(&:to_i).freeze
+  MAX_NUMBER_OF_DAYS_PER_DATE = BVA_VIDEO_ROOMS.size
 
   CO_DAYS_OF_WEEK = [1, 2, 3, 4].freeze
 


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-336

### Description

- Adjust constants for rooms and dockets per date in build schedule algorithm to match actual number of rooms