### PR TITLE
Docket Switch Denial View

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -618,6 +618,8 @@
   "DOCKET_SWITCH_REQUEST_MESSAGE": "This task will appear on your hold tab until it has been addressed by the VLJ.",
   "DOCKET_SWITCH_RULING_TITLE": "Switch Docket: Rule on %s's Request",
   "DOCKET_SWITCH_RULING_INSTRUCTIONS": "**Provided below is a summary of the pertinent facts used by the Office of the Clerk of the Board to prepare a docket switch ruling. Determine how you would like to rule on this request to switch dockets and select the corresponding button below.**\n\nThe hyperlink takes you to a draft ruling letter based on the recommended ruling. Please feel free to make any necessary edits to the ruling letter. You may then sign the letter. Inserting a hyperlink to a signed ruling letter is recommended, but optional.\n\nIf you have any questions, or need assistance making edits to the ruling letter, please [email](mailto:BVA.Clerk@va.gov) the Office of the Clerk of the Board or use the text box below to provide any additional context or instructions.\n\nWhen you click \"Confirm,\" the task will automatically be returned to the individual who assigned it to you. If you would like to return the task to a different individual, please use the drop down box to select a different name.",
+  "DOCKET_SWITCH_DENIAL_TITLE": "Switch Docket: Deny %s's Request",
+  "DOCKET_SWITCH_DENIAL_INSTRUCTIONS": "Add the date and add any context for the denial of this switch",
   "DENIED_DOCKET_SWITCH_TASK_LABEL": "Denied Docket Switch",
   "GRANTED_DOCKET_SWITCH_TASK_LABEL": "Granted Docket Switch",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -619,7 +619,7 @@
   "DOCKET_SWITCH_RULING_TITLE": "Switch Docket: Rule on %s's Request",
   "DOCKET_SWITCH_RULING_INSTRUCTIONS": "**Provided below is a summary of the pertinent facts used by the Office of the Clerk of the Board to prepare a docket switch ruling. Determine how you would like to rule on this request to switch dockets and select the corresponding button below.**\n\nThe hyperlink takes you to a draft ruling letter based on the recommended ruling. Please feel free to make any necessary edits to the ruling letter. You may then sign the letter. Inserting a hyperlink to a signed ruling letter is recommended, but optional.\n\nIf you have any questions, or need assistance making edits to the ruling letter, please [email](mailto:BVA.Clerk@va.gov) the Office of the Clerk of the Board or use the text box below to provide any additional context or instructions.\n\nWhen you click \"Confirm,\" the task will automatically be returned to the individual who assigned it to you. If you would like to return the task to a different individual, please use the drop down box to select a different name.",
   "DOCKET_SWITCH_DENIAL_TITLE": "Switch Docket: Deny %s's Request",
-  "DOCKET_SWITCH_DENIAL_INSTRUCTIONS": "Add the date and add any context for the denial of this switch",
+  "DOCKET_SWITCH_DENIAL_INSTRUCTIONS": "Add the date and add any context for the denial of this switch.",
   "DENIED_DOCKET_SWITCH_TASK_LABEL": "Denied Docket Switch",
   "GRANTED_DOCKET_SWITCH_TASK_LABEL": "Granted Docket Switch",
 

--- a/client/app/queue/docketSwitch/denial/DocketSwitchDenialContainer.jsx
+++ b/client/app/queue/docketSwitch/denial/DocketSwitchDenialContainer.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useHistory, useParams } from 'react-router';
+import { useDispatch, useSelector } from 'react-redux';
+import { DocketSwitchDenialForm } from './DocketSwitchDenialForm';
+import { completeDocketSwitchDenial } from './docketSwitchDenialSlice';
+import { appealWithDetailSelector } from '../../selectors';
+
+export const DocketSwitchDenialContainer = () => {
+  const { appealId } = useParams();
+  const { goBack, push } = useHistory();
+  const dispatch = useDispatch();
+
+  const appeal = useSelector((state) =>
+    appealWithDetailSelector(state, { appealId })
+  );
+
+  const handleCancel = () => goBack();
+  const handleSubmit = async (formData) => {
+    await dispatch(completeDocketSwitchDenial(formData));
+
+    // Add success alert
+
+    // Redirect to user's queue
+    push('/queue');
+  };
+
+  return <DocketSwitchDenialForm
+    appellantName={appeal.appellantFullName}
+    onCancel={handleCancel}
+    onSubmit={handleSubmit}
+  />;
+};

--- a/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.jsx
+++ b/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers';
+import * as yup from 'yup';
+
+import {
+  DOCKET_SWITCH_DENIAL_TITLE,
+  DOCKET_SWITCH_DENIAL_INSTRUCTIONS,
+} from 'app/../COPY';
+import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import Button from 'app/components/Button';
+import { sprintf } from 'sprintf-js';
+import DateSelector from 'app/components/DateSelector';
+import TextareaField from 'app/components/TextareaField';
+import { css } from 'glamor';
+
+const schema = yup.object().shape({
+  receiptDate: yup.date().required(),
+  context: yup.string().required(),
+});
+
+export const DocketSwitchDenialForm = ({
+  appellantName,
+  onCancel,
+  onSubmit,
+}) => {
+  const { register, handleSubmit, formState } = useForm({
+    resolver: yupResolver(schema),
+    mode: 'onChange',
+  });
+
+  const sectionStyle = css({ marginBottom: '24px' });
+
+  return (
+    <form
+      className="docket-switch-denial"
+      onSubmit={handleSubmit(onSubmit)}
+      aria-label="Deny Docket Switch"
+    >
+      <AppSegment filledBackground>
+        <h1>{sprintf(DOCKET_SWITCH_DENIAL_TITLE, appellantName)}</h1>
+        <div {...sectionStyle}>{DOCKET_SWITCH_DENIAL_INSTRUCTIONS}</div>
+
+        <DateSelector
+          inputRef={register}
+          type="date"
+          name="receiptDate"
+          label="What is the Receipt Date of the docket switch request?"
+          strongLabel
+        />
+
+        <TextareaField
+          inputRef={register}
+          name="context"
+          label="Provide context for this denial (this will be visible in the Case Timeline)"
+          strongLabel
+        />
+      </AppSegment>
+      <div className="controls cf-app-segment">
+        <Button
+          type="submit"
+          name="submit"
+          disabled={!formState.isValid}
+          classNames={['cf-right-side']}
+        >
+          Confirm
+        </Button>
+        {onCancel && (
+          <Button
+            type="button"
+            name="Cancel"
+            classNames={['cf-right-side', 'usa-button-secondary']}
+            onClick={onCancel}
+            styling={{ style: { marginRight: '1rem' } }}
+          >
+            Cancel
+          </Button>
+        )}
+      </div>
+    </form>
+  );
+};
+
+DocketSwitchDenialForm.propTypes = {
+  appellantName: PropTypes.string.isRequired,
+  onCancel: PropTypes.func,
+  onSubmit: PropTypes.func.isRequired,
+};

--- a/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.stories.js
+++ b/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.stories.js
@@ -1,0 +1,32 @@
+import React from 'react';
+
+import { DocketSwitchDenialForm } from './DocketSwitchDenialForm';
+
+const instructions = ['**Summary:** Summary\n\n**Is this a timely request:** Yes\n\n**Recommendation:** Grant all issues\n\n**Draft letter:** http://www.va.gov'];
+
+export default {
+  title: 'Queue/Docket Switch/DocketSwitchDenialForm',
+  component: DocketSwitchDenialForm,
+  decorators: [],
+  parameters: {},
+  args: {
+    appellantName: 'Jane Doe',
+    instructions,
+  },
+  argTypes: {
+    onCancel: { action: 'cancel' },
+    onSubmit: { action: 'submit' },
+  },
+};
+
+const Template = (args) => <DocketSwitchDenialForm {...args} />;
+
+export const Basic = Template.bind({});
+
+Basic.parameters = {
+  docs: {
+    storyDescription:
+      'Used by attorney in Clerk of the Board office to complete a denial of a docket switch request',
+  },
+};
+

--- a/client/app/queue/docketSwitch/denial/docketSwitchDenialSlice.js
+++ b/client/app/queue/docketSwitch/denial/docketSwitchDenialSlice.js
@@ -1,0 +1,18 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import ApiUtil from '../../../util/ApiUtil';
+
+export const completeDocketSwitchDenial = createAsyncThunk(
+  'docketSwitch/deny',
+  async (data) => {
+    try {
+      // Update this to conform to submission endpoint expectations
+      const res = await ApiUtil.post('/docket_switch', { data });
+      const result = res.body?.data;
+
+      return result;
+    } catch (error) {
+      console.error('Error denying docket switch', error);
+      throw error;
+    }
+  }
+);

--- a/client/app/queue/docketSwitch/docketSwitchRoutes.js
+++ b/client/app/queue/docketSwitch/docketSwitchRoutes.js
@@ -1,10 +1,11 @@
 import React from 'react';
-import { Route } from 'react-router';
+import { Route, Switch } from 'react-router';
 import PageRoute from '../../components/PageRoute';
 
 import TASK_ACTIONS from '../../../constants/TASK_ACTIONS';
 import { RecommendDocketSwitchContainer } from './recommendDocketSwitch/RecommendDocketSwitchContainer';
 import { DocketSwitchRulingContainer } from './judgeRuling/DocketSwitchRulingContainer';
+import { DocketSwitchDenialContainer } from './denial/DocketSwitchDenialContainer';
 
 const PageRoutes = [
   <PageRoute
@@ -28,7 +29,16 @@ const PageRoutes = [
   // This route handles the remaining checkout flow
   <Route path="/queue/appeals/:appealId/tasks/:taskId/docket_switch/checkout">
     {/* The component here will add additional `Switch` and child routes */}
-    <h2>Checkout Container</h2>
+    <Switch>
+      <PageRoute
+        path={`/queue/appeals/:appealId/tasks/:taskId/${
+      TASK_ACTIONS.DOCKET_SWITCH_DENIED.value
+    }`}
+        title={`${TASK_ACTIONS.DOCKET_SWITCH_DENIED.label} | Caseflow`}
+      >
+        <DocketSwitchDenialContainer />
+      </PageRoute>
+    </Switch>
   </Route>,
 ];
 

--- a/client/test/app/queue/docketSwitch/DocketSwitchDenialForm.test.js
+++ b/client/test/app/queue/docketSwitch/DocketSwitchDenialForm.test.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DocketSwitchDenialForm } from 'app/queue/docketSwitch/denial/DocketSwitchDenialForm';
+import {
+  DOCKET_SWITCH_DENIAL_TITLE,
+  DOCKET_SWITCH_DENIAL_INSTRUCTIONS,
+} from 'app/../COPY';
+import { sprintf } from 'sprintf-js';
+
+const instructions = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit';
+
+describe('DocketSwitchDenialForm', () => {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  const appellantName = 'Claimant 1';
+  const defaults = { onSubmit, onCancel, appellantName };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { container } = render(<DocketSwitchDenialForm {...defaults} />);
+
+    expect(container).toMatchSnapshot();
+
+    expect(screen.getByText(sprintf(DOCKET_SWITCH_DENIAL_TITLE, appellantName))).toBeInTheDocument();
+    expect(screen.getByText(DOCKET_SWITCH_DENIAL_INSTRUCTIONS)).toBeInTheDocument();
+  });
+
+  it('fires onCancel', async () => {
+    render(<DocketSwitchDenialForm {...defaults} />);
+    expect(onCancel).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  describe('form validation & submission', () => {
+    const receiptDate = '2020-10-01';
+    const fillForm = async () => {
+      //   Set receipt date
+      await fireEvent.change(screen.getByLabelText(/receipt date/i), { target: { value: receiptDate } });
+
+      //   Enter context/instructions
+      await userEvent.type(screen.getByRole('textbox', { name: /context/i }), instructions);
+    };
+
+    it('disables submit until all fields valid', async () => {
+      render(<DocketSwitchDenialForm {...defaults} />);
+
+      const submit = screen.getByRole('button', { name: /confirm/i });
+
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      await fillForm();
+
+      await userEvent.click(submit);
+      expect(onSubmit).not.toHaveBeenCalled();
+
+      // We need to wrap this in waitFor due to async nature of form validation
+      await waitFor(() => {
+        expect(submit).toBeDisabled();
+      });
+
+      await waitFor(() => {
+        expect(submit).toBeEnabled();
+      });
+
+      await userEvent.click(submit);
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+    });
+
+    it('fires onSubmit with correct values', async () => {
+
+      render(<DocketSwitchDenialForm {...defaults} />);
+
+      const submit = screen.getByRole('button', { name: /confirm/i });
+
+      await fillForm();
+
+      await userEvent.click(submit);
+
+      waitFor(() => {
+        expect(onSubmit).toHaveBeenCalledWith({
+          receiptDate,
+          context,
+
+        });
+      });
+    });
+  });
+});

--- a/client/test/app/queue/docketSwitch/__snapshots__/DocketSwitchDenialForm.test.js.snap
+++ b/client/test/app/queue/docketSwitch/__snapshots__/DocketSwitchDenialForm.test.js.snap
@@ -16,7 +16,7 @@ exports[`DocketSwitchDenialForm renders correctly 1`] = `
       <div
         data-css-1sbm5ab=""
       >
-        Add the date and add any context for the denial of this switch
+        Add the date and add any context for the denial of this switch.
       </div>
       <div
         class="cf-form-textinput   "

--- a/client/test/app/queue/docketSwitch/__snapshots__/DocketSwitchDenialForm.test.js.snap
+++ b/client/test/app/queue/docketSwitch/__snapshots__/DocketSwitchDenialForm.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DocketSwitchDenialForm renders correctly 1`] = `
+<div>
+  <form
+    aria-label="Deny Docket Switch"
+    class="docket-switch-denial"
+  >
+    <section
+      class="cf-app-segment cf-app-segment--alt"
+      role="main"
+    >
+      <h1>
+        Switch Docket: Deny Claimant 1's Request
+      </h1>
+      <div
+        data-css-1sbm5ab=""
+      >
+        Add the date and add any context for the denial of this switch
+      </div>
+      <div
+        class="cf-form-textinput   "
+      >
+        <label
+          for="receiptDate"
+        >
+          <strong>
+            <span>
+              What is the Receipt Date of the docket switch request?
+            </span>
+          </strong>
+        </label>
+        <input
+          class="cf-form-textinput"
+          id="receiptDate"
+          max="9999-12-31"
+          name="receiptDate"
+          placeholder="mm/dd/yyyy"
+          type="date"
+          value=""
+        />
+      </div>
+      <div
+        class="cf-form-textarea"
+      >
+        <label
+          class="question-label"
+          for="context"
+        >
+          <strong>
+            <span>
+              Provide context for this denial (this will be visible in the Case Timeline)
+            </span>
+          </strong>
+        </label>
+        <textarea
+          id="context"
+          name="context"
+        />
+      </div>
+    </section>
+    <div
+      class="controls cf-app-segment"
+    >
+      <span>
+        <button
+          class="cf-right-side usa-button"
+          id="submit-submit"
+          type="submit"
+        >
+          Confirm
+        </button>
+      </span>
+      <span>
+        <button
+          class="cf-right-side usa-button-secondary usa-button"
+          id="button-Cancel"
+          style="margin-right: 1rem;"
+          type="button"
+        >
+          Cancel
+        </button>
+      </span>
+    </div>
+  </form>
+</div>
+`;

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -499,6 +499,10 @@ FactoryBot.define do
         parent { create(:docket_switch_mail_task, appeal: appeal) }
       end
 
+      factory :docket_switch_denied_task, class: DocketSwitchDeniedTask do
+        parent { create(:docket_switch_ruling_task, appeal: appeal) }
+      end
+
       factory :congressional_interest_mail_task, class: CongressionalInterestMailTask do
         parent { create(:root_task, appeal: appeal) }
         assigned_to { MailTeam.singleton }

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -157,4 +157,40 @@ RSpec.feature "Docket Switch", :all_dbs do
       end
     end
   end
+
+  describe "COTB attorney completes docket switch denial" do
+    let!(:docket_switch_denied_task) do
+      create(
+        :docket_switch_denied_task,
+        appeal: appeal,
+        # parent: root_task,
+        assigned_to: cotb_attorney,
+        assigned_by: judge
+      )
+    end
+    let(:receipt_date) { Time.zone.today - 5.days }
+    let(:context) { "Lorem ipsum dolor sit amet, consectetur adipiscing elit" }
+
+    it "allows attorney to complete the docket switch denial" do
+      User.authenticate!(user: cotb_attorney)
+      visit "/queue/appeals/#{appeal.uuid}"
+      find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+      find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.DOCKET_SWITCH_DENIED.label).click
+
+      expect(page).to have_content(format(COPY::DOCKET_SWITCH_DENIAL_TITLE, appeal.claimant.name))
+      expect(page).to have_content(COPY::DOCKET_SWITCH_DENIAL_INSTRUCTIONS)
+
+      fill_in "What is the Receipt Date of the docket switch request?", with: receipt_date
+      fill_in("context", with: context)
+
+      click_button(text: "Continue")
+
+      # Return back to user's queue
+      expect(page).to have_current_path("/queue")
+
+      # Verify correct success alert
+
+      # Verify that denial completed correctly
+    end
+  end
 end

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -183,7 +183,7 @@ RSpec.feature "Docket Switch", :all_dbs do
       fill_in "What is the Receipt Date of the docket switch request?", with: receipt_date
       fill_in("context", with: context)
 
-      click_button(text: "Continue")
+      click_button(text: "Confirm")
 
       # Return back to user's queue
       expect(page).to have_current_path("/queue")


### PR DESCRIPTION
Connects #15470

### Description
This adds the view for the denial of a docket switch request

### Acceptance Criteria
- [x] Code compiles correctly
- [x] When a user selects "deny docket switch" in their action drop-down, they are taken to the denial screen
- [x] The user should see the denial screen based on the designs below
- [x] Both the date and context fields are required
- [x] Include screenshot(s) in the Github issue if there are front-end changes
- [x] Add Jest test
- [x] Add Storybook story