### PR TITLE
Allow appeals to be searched by their stream docket number

### DIFF
--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -19,23 +19,7 @@ class AppealFinder
     end
 
     def find_appeals_by_docket_number(docket_number)
-      return [] unless docket_number
-
-      # Take the first six digits as date, remaining as ID
-      parsed = docket_number.split("-")
-
-      # If we can't parse a valid date from search, return no results
-      begin
-        receipt_date = Date.strptime(parsed[0], "%y%m%d")
-
-        id = parsed[1]
-        Appeal.where(
-          "(receipt_date = ? AND id = ?) OR stream_docket_number = ?",
-          receipt_date, id, docket_number
-        )
-      rescue ArgumentError
-        []
-      end
+      Appeal.where(stream_docket_number: docket_number)
     end
   end
 

--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -34,7 +34,7 @@ class AppealFinder
           receipt_date, id, docket_number
         )
       rescue ArgumentError
-        nil
+        []
       end
     end
   end

--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -54,12 +54,4 @@ class AppealFinder
       end
     end
   end
-
-  def filter_appeals_for_vso_user(appeals:, veterans:)
-    allowed_appeal_ids = find_appeals_for_vso_user(veterans: veterans).map(&:id)
-
-    appeals.select do |appeal|
-      allowed_appeal_ids.include?(appeal.id)
-    end
-  end
 end

--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -18,6 +18,11 @@ class AppealFinder
       end
     end
 
+    # All Appeals have stream_docket_number populated either with their own
+    # docket number (original appeals), or with the original appeal's docket
+    # number (new appeal streams). This will thus return both the original
+    # and all appeal streams off of it. Docket number of appeal streams is
+    # never shown and thus the inability to search for it is OK.
     def find_appeals_by_docket_number(docket_number)
       Appeal.where(stream_docket_number: docket_number)
     end

--- a/app/services/appeal_finder.rb
+++ b/app/services/appeal_finder.rb
@@ -18,7 +18,7 @@ class AppealFinder
       end
     end
 
-    def find_appeal_by_docket_number(docket_number)
+    def find_appeals_by_docket_number(docket_number)
       return [] unless docket_number
 
       # Take the first six digits as date, remaining as ID
@@ -29,9 +29,10 @@ class AppealFinder
         receipt_date = Date.strptime(parsed[0], "%y%m%d")
 
         id = parsed[1]
-        appeal = Appeal.find_by(id: id, receipt_date: receipt_date)
-
-        appeal
+        Appeal.where(
+          "(receipt_date = ? AND id = ?) OR stream_docket_number = ?",
+          receipt_date, id, docket_number
+        )
       rescue ArgumentError
         nil
       end

--- a/app/workflows/case_search_results_for_docket_number.rb
+++ b/app/workflows/case_search_results_for_docket_number.rb
@@ -15,7 +15,7 @@ class CaseSearchResultsForDocketNumber < ::CaseSearchResultsBase
   end
 
   def appeals
-    Array.wrap(AppealFinder.find_appeal_by_docket_number(docket_number))
+    AppealFinder.find_appeals_by_docket_number(docket_number)
   end
 
   private

--- a/spec/services/appeal_finder_spec.rb
+++ b/spec/services/appeal_finder_spec.rb
@@ -7,15 +7,17 @@ describe AppealFinder, :all_dbs do
   let(:invalid_veteran_id) { "obviouslyinvalidveteranid" }
   let(:invalid_docket_number) { "invaliddocket-number" }
   let!(:legacy_appeal) { create(:legacy_appeal, :with_veteran, vacols_case: create(:case)) }
+  let(:second_appeal) { create(:appeal, veteran: veteran, stream_docket_number: appeal.stream_docket_number) }
 
-  describe ".find_appeal_by_docket_number" do
-    subject { described_class.find_appeal_by_docket_number(docket_number) }
+  describe ".find_appeals_by_docket_number" do
+    subject { described_class.find_appeals_by_docket_number(docket_number) }
 
     context "valid docket number" do
       let(:docket_number) { appeal.docket_number }
 
-      it "returns results upon valid input" do
-        expect(subject.id).to eq(appeal.id)
+      it "returns a result upon valid input" do
+        expect(subject.count).to eq(1)
+        expect(subject.first.id).to eq(appeal.id)
       end
     end
 
@@ -34,6 +36,19 @@ describe AppealFinder, :all_dbs do
         expect(subject).to be_nil
       end
     end
+
+    context "stream docket number is provided" do
+      let(:docket_number) { second_appeal.stream_docket_number }
+
+      it "returns two object" do
+        expect(subject.count).to eq(2)
+        expect(subject.first.id).to eq(appeal.id)
+        expect(subject.second.id).to eq(second_appeal.id)
+        expect(subject.first.id).to_not eq(subject.second.id)
+        expect(subject.second.stream_docket_number).to eq(subject.first.stream_docket_number)
+      end
+    end
+
   end
 
   describe ".find_appeals_with_file_numbers" do

--- a/spec/services/appeal_finder_spec.rb
+++ b/spec/services/appeal_finder_spec.rb
@@ -40,7 +40,7 @@ describe AppealFinder, :all_dbs do
     context "stream docket number is provided" do
       let(:docket_number) { second_appeal.stream_docket_number }
 
-      it "returns two object" do
+      it "returns two appeals" do
         expect(subject.count).to eq(2)
         expect(subject.first.id).to eq(appeal.id)
         expect(subject.second.id).to eq(second_appeal.id)

--- a/spec/services/appeal_finder_spec.rb
+++ b/spec/services/appeal_finder_spec.rb
@@ -15,7 +15,7 @@ describe AppealFinder, :all_dbs do
     context "valid docket number" do
       let(:docket_number) { appeal.docket_number }
 
-      it "returns a result upon valid input" do
+      it "returns only the matching appeal" do
         expect(subject.count).to eq(1)
         expect(subject.first.id).to eq(appeal.id)
       end
@@ -24,7 +24,7 @@ describe AppealFinder, :all_dbs do
     context "docket number cannot be found" do
       let(:docket_number) { unknown_docket_number }
 
-      it "returns nil" do
+      it "returns an empty array" do
         expect(subject).to eq([])
       end
     end

--- a/spec/services/appeal_finder_spec.rb
+++ b/spec/services/appeal_finder_spec.rb
@@ -25,7 +25,7 @@ describe AppealFinder, :all_dbs do
       let(:docket_number) { invalid_docket_number }
 
       it "returns nil" do
-        expect(subject).to be_nil
+        expect(subject).to eq([])
       end
     end
 
@@ -33,7 +33,7 @@ describe AppealFinder, :all_dbs do
       let(:docket_number) { unknown_docket_number }
 
       it "returns nil" do
-        expect(subject).to be_nil
+        expect(subject).to eq([])
       end
     end
 
@@ -48,7 +48,6 @@ describe AppealFinder, :all_dbs do
         expect(subject.second.stream_docket_number).to eq(subject.first.stream_docket_number)
       end
     end
-
   end
 
   describe ".find_appeals_with_file_numbers" do

--- a/spec/services/appeal_finder_spec.rb
+++ b/spec/services/appeal_finder_spec.rb
@@ -21,14 +21,6 @@ describe AppealFinder, :all_dbs do
       end
     end
 
-    context "docket number is invalid format" do
-      let(:docket_number) { invalid_docket_number }
-
-      it "returns nil" do
-        expect(subject).to eq([])
-      end
-    end
-
     context "docket number cannot be found" do
       let(:docket_number) { unknown_docket_number }
 
@@ -37,7 +29,7 @@ describe AppealFinder, :all_dbs do
       end
     end
 
-    context "stream docket number is provided" do
+    context "stream docket number matches two appeals" do
       let(:docket_number) { second_appeal.stream_docket_number }
 
       it "returns two appeals" do


### PR DESCRIPTION
Resolves #15535

### Description
`AppealFinder.find_appeals_by_docket_number` now also searches for appeals with a matching `stream_docket_number`.

### Acceptance Criteria
(I copied these verbatim. I think we only care about the last one.)

- [ ] Please put this work behind the feature toggle: NONE
- [ ] This feature should be accessible to the following user groups: ALL
- [ ] Include screenshot(s) in the Github issue if there are front-end changes
- [ ] Update documentation:
- [ ] As a user, I can find all appeal streams by searching for the original appeal's docket number

### Testing Plan
1. Find an appeal whose `stream_docket_number` references something other than itself. With the default DB seed, `Appeal.last.stream_docket_number` was such a case, with its id (1037) being different from the referenced one (201105-1035, your date prefix will probably vary).
2. Without these changes applied, searching (at /search/ in Caseflow) for that should return only one result.
3. With the changes applied, it should find multiple results.
4. Searching on other fields should not change in behavior.


### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

We might be able to just describe this, but:

#### Before

![Screen Shot 2020-11-17 at 5 04 54 PM](https://user-images.githubusercontent.com/314663/99456464-7763e280-28f7-11eb-9274-b54770586cbc.png)

#### After

![Screen Shot 2020-11-17 at 5 05 49 PM](https://user-images.githubusercontent.com/314663/99456484-7d59c380-28f7-11eb-83cc-ffc5f5041235.png)