### PR TITLE
CASEFLOW-108 #resolve Create CavcRemandProcessedLetterResponseWindowTask

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,20 +9,20 @@ class TasksController < ApplicationController
   before_action :verify_task_access, only: [:create]
   skip_before_action :deny_vso_access, only: [:create, :index, :update, :for_appeal]
 
-  # for user-created tasks -- see taskactionrepository
+  # Tasks that are allowed to be created by a user.
+  # If a task type is not sent to the frontend via TaskActionRepository's `type` or `options` parameters,
+  # then it doesn't need to be included here.
   TASK_CLASSES_LOOKUP = {
     AttorneyDispatchReturnTask: AttorneyDispatchReturnTask,
     AttorneyQualityReviewTask: AttorneyQualityReviewTask,
     AttorneyRewriteTask: AttorneyRewriteTask,
     AttorneyTask: AttorneyTask,
     BlockedSpecialCaseMovementTask: BlockedSpecialCaseMovementTask,
-    # CavcRemandProcessedLetterResponseWindowTask: CavcRemandProcessedLetterResponseWindowTask,
     ChangeHearingDispositionTask: ChangeHearingDispositionTask,
     ColocatedTask: ColocatedTask,
     DocketSwitchRulingTask: DocketSwitchRulingTask,
     DocketSwitchDeniedTask: DocketSwitchDeniedTask,
     DocketSwitchGrantedTask: DocketSwitchGrantedTask,
-    # TODO check creation: EvidenceSubmissionWindowTask: EvidenceSubmissionWindowTask, 
     FoiaTask: FoiaTask,
     HearingAdminActionTask: HearingAdminActionTask,
     InformalHearingPresentationTask: InformalHearingPresentationTask,
@@ -37,8 +37,7 @@ class TasksController < ApplicationController
     ScheduleHearingTask: ScheduleHearingTask,
     SendCavcRemandProcessedLetterTask: SendCavcRemandProcessedLetterTask,
     SpecialCaseMovementTask: SpecialCaseMovementTask,
-    # Investigate prod first; TODO check creation `type:` and `options:`: 
-    Task: Task,
+    Task: Task, # Consider for removal, after cleaning up occurrences in prod
     TranslationTask: TranslationTask
   }.freeze
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -9,18 +9,20 @@ class TasksController < ApplicationController
   before_action :verify_task_access, only: [:create]
   skip_before_action :deny_vso_access, only: [:create, :index, :update, :for_appeal]
 
+  # for user-created tasks -- see taskactionrepository
   TASK_CLASSES_LOOKUP = {
     AttorneyDispatchReturnTask: AttorneyDispatchReturnTask,
     AttorneyQualityReviewTask: AttorneyQualityReviewTask,
     AttorneyRewriteTask: AttorneyRewriteTask,
     AttorneyTask: AttorneyTask,
     BlockedSpecialCaseMovementTask: BlockedSpecialCaseMovementTask,
+    # CavcRemandProcessedLetterResponseWindowTask: CavcRemandProcessedLetterResponseWindowTask,
     ChangeHearingDispositionTask: ChangeHearingDispositionTask,
     ColocatedTask: ColocatedTask,
     DocketSwitchRulingTask: DocketSwitchRulingTask,
     DocketSwitchDeniedTask: DocketSwitchDeniedTask,
     DocketSwitchGrantedTask: DocketSwitchGrantedTask,
-    EvidenceSubmissionWindowTask: EvidenceSubmissionWindowTask,
+    # TODO check creation: EvidenceSubmissionWindowTask: EvidenceSubmissionWindowTask, 
     FoiaTask: FoiaTask,
     HearingAdminActionTask: HearingAdminActionTask,
     InformalHearingPresentationTask: InformalHearingPresentationTask,
@@ -35,6 +37,7 @@ class TasksController < ApplicationController
     ScheduleHearingTask: ScheduleHearingTask,
     SendCavcRemandProcessedLetterTask: SendCavcRemandProcessedLetterTask,
     SpecialCaseMovementTask: SpecialCaseMovementTask,
+    # Investigate prod first; TODO check creation `type:` and `options:`: 
     Task: Task,
     TranslationTask: TranslationTask
   }.freeze

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -21,7 +21,7 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
         TimedHoldTask.create_from_parent(
           window_task,
           days_on_hold: 90,
-          instructions: ["This case is on hold for 90 days to allow the appellant to respond."]
+          instructions: [COPY::CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS]
         )
       end
     end

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -39,8 +39,8 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
     Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
   ].freeze
 
-  def available_actions(_user)
-    USER_ACTIONS
+  def available_actions(user)
+    assigned_to.user_has_access?(user) ? USER_ACTIONS : []
   end
 
   private

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+##
+# Task to indicate that Litigation Support is awaiting a response from the appellant,
+# after sending the CAVC-remand-processed letter to an appellant (SendCavcRemandProcessedLetterTask).
+# This task is for CAVC Remand appeal streams.
+# The appeal is put on hold for 90 days, with the option of ending the hold early.
+# After 90 days, the task comes off hold and show up in the CavcLitigationSupport team's unassigned tab
+# to be assigned and acted upon.
+# Expected parent: CavcTask
+# Expected assigned_to.type: CavcLitigationSupport
+
+class CavcRemandProcessedLetterResponseWindowTask < Task
+  validates :parent, presence: true,
+                     parentTask: { task_type: CavcTask },
+                     on: :create
+
+  before_validation :set_assignee
+
+  def self.create_with_hold(parent_task)
+    multi_transaction do
+      create!(parent: parent_task, appeal: parent_task.appeal).tap do |window_task|
+        TimedHoldTask.create_from_parent(
+          window_task,
+          days_on_hold: 90,
+          instructions: ["This case is on hold for 90 days to allow the appellant to respond."]
+        )
+      end
+    end
+  end
+
+  USER_ACTIONS = [
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
+  ].freeze
+
+  def self.label
+    COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
+  end
+
+  def available_actions(user)
+    return USER_ACTIONS
+  end
+
+  private
+
+  def set_assignee
+    self.assigned_to = CavcLitigationSupport.singleton if assigned_to.nil?
+  end
+
+end

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -11,9 +11,7 @@
 # Expected assigned_to.type: CavcLitigationSupport
 
 class CavcRemandProcessedLetterResponseWindowTask < Task
-  validates :parent, presence: true,
-                     parentTask: { task_type: CavcTask },
-                     on: :create
+  validates :parent, presence: true, parentTask: { task_type: CavcTask }, on: :create
 
   before_validation :set_assignee
 
@@ -25,9 +23,11 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
           days_on_hold: 90,
           instructions: ["This case is on hold for 90 days to allow the appellant to respond."]
         )
-      end
     end
+  rescue ActiveRecord::RecordInvalid
+    errors.add(:parent, "should be a CavcTask")
   end
+end
 
   USER_ACTIONS = [
     Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
@@ -37,8 +37,12 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
     COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
   end
 
-  def available_actions(user)
-    return USER_ACTIONS
+  def default_instructions
+    [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+  end
+
+  def available_actions(_user)
+    USER_ACTIONS
   end
 
   private
@@ -46,5 +50,4 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
   def set_assignee
     self.assigned_to = CavcLitigationSupport.singleton if assigned_to.nil?
   end
-
 end

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -23,15 +23,9 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
           days_on_hold: 90,
           instructions: ["This case is on hold for 90 days to allow the appellant to respond."]
         )
+      end
     end
-  rescue ActiveRecord::RecordInvalid
-    errors.add(:parent, "should be a CavcTask")
   end
-end
-
-  USER_ACTIONS = [
-    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
-  ].freeze
 
   def self.label
     COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
@@ -40,6 +34,10 @@ end
   def default_instructions
     [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
   end
+
+  USER_ACTIONS = [
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
+  ].freeze
 
   def available_actions(_user)
     USER_ACTIONS

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -28,11 +28,11 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
   end
 
   def self.label
-    COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
+    COPY::CRP_LETTER_RESP_WINDOW_TASK_LABEL
   end
 
   def default_instructions
-    [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+    [COPY::CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS]
   end
 
   USER_ACTIONS = [

--- a/app/models/tasks/send_cavc_remand_processed_letter_task.rb
+++ b/app/models/tasks/send_cavc_remand_processed_letter_task.rb
@@ -3,8 +3,12 @@
 ##
 # Task for Litigation Support to take necessary action before sending the CAVC-remand-processed letter to an appellant.
 # This task is for CAVC Remand appeal streams.
-# Expected parent: CavcTask
-# Expected assigned_to.type: User
+# If this task is assigned to an org (i.e., CavcLitigationSupport), then:
+# - Expected parent: CavcTask
+# - Expected assigned_to: CavcLitigationSupport
+# If this task is assigned to a user (i.e., a member of CavcLitigationSupport), then:
+# - Expected parent: SendCavcRemandProcessedLetterTask that is assigned to CavcLitigationSupport
+# - Expected assigned_to.type: User
 
 class SendCavcRemandProcessedLetterTask < Task
   validates :parent, presence: true,
@@ -34,6 +38,18 @@ class SendCavcRemandProcessedLetterTask < Task
     return USER_ACTIONS if assigned_to == user
 
     []
+  end
+  
+  def update_from_params(params, current_user)
+    if params[:status] == "completed"
+      # Create ResponseWindowTask before completing this task so that parent CavcTask is remains on-hold
+      cavc_task = ancestor_task_of_type(CavcTask) # TODO: test for error when cavc_task=nil
+      CavcRemandProcessedLetterResponseWindowTask.create_with_hold(cavc_task)
+    end
+
+    super(params, current_user)
+
+    [self]
   end
 
   private

--- a/app/models/tasks/send_cavc_remand_processed_letter_task.rb
+++ b/app/models/tasks/send_cavc_remand_processed_letter_task.rb
@@ -43,8 +43,7 @@ class SendCavcRemandProcessedLetterTask < Task
   def update_from_params(params, current_user)
     if params[:status] == "completed"
       # Create ResponseWindowTask before completing this task so that parent CavcTask is remains on-hold
-      cavc_task = ancestor_task_of_type(CavcTask) # TODO: test for error when cavc_task=nil
-      CavcRemandProcessedLetterResponseWindowTask.create_with_hold(cavc_task)
+      CavcRemandProcessedLetterResponseWindowTask.create_with_hold(ancestor_task_of_type(CavcTask))
     end
 
     super(params, current_user)

--- a/app/models/tasks/send_cavc_remand_processed_letter_task.rb
+++ b/app/models/tasks/send_cavc_remand_processed_letter_task.rb
@@ -39,7 +39,7 @@ class SendCavcRemandProcessedLetterTask < Task
 
     []
   end
-  
+
   def update_from_params(params, current_user)
     if params[:status] == "completed"
       # Create ResponseWindowTask before completing this task so that parent CavcTask is remains on-hold

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -272,6 +272,8 @@ class TaskActionRepository
                               COPY::NO_SHOW_HEARING_TASK_COMPLETE_MODAL_BODY
                             elsif task.is_a? HearingAdminActionTask
                               COPY::HEARING_SCHEDULE_COMPLETE_ADMIN_MODAL
+                            elsif task.is_a? SendCavcRemandProcessedLetterTask
+                              COPY::SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY
                             else
                               COPY::MARK_TASK_COMPLETE_COPY
                             end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -266,17 +266,15 @@ class TaskActionRepository
       end
     end
 
+    COMPLETE_TASK_MODAL_BODY_HASH = {
+      NoShowHearingTask: COPY::NO_SHOW_HEARING_TASK_COMPLETE_MODAL_BODY,
+      HearingAdminActionTask: COPY::HEARING_SCHEDULE_COMPLETE_ADMIN_MODAL,
+      SendCavcRemandProcessedLetterTask: COPY::SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY
+    }.freeze
+
     def complete_data(task, _user = nil)
-      params = {}
-      params[:modal_body] = if task.is_a? NoShowHearingTask
-                              COPY::NO_SHOW_HEARING_TASK_COMPLETE_MODAL_BODY
-                            elsif task.is_a? HearingAdminActionTask
-                              COPY::HEARING_SCHEDULE_COMPLETE_ADMIN_MODAL
-                            elsif task.is_a? SendCavcRemandProcessedLetterTask
-                              COPY::SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY
-                            else
-                              COPY::MARK_TASK_COMPLETE_COPY
-                            end
+      params = { modal_body: COMPLETE_TASK_MODAL_BODY_HASH[task.type.to_sym] }
+      params[:modal_body] = COPY::MARK_TASK_COMPLETE_COPY if params[:modal_body].nil?
 
       if defined? task.completion_contact
         params[:contact] = task.completion_contact

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -375,6 +375,7 @@
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY": "Marking this task complete will put this case on hold for 90 days to allow the appellant to respond.",
 
   "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed Letter Response Window Task",
+  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "This response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
 
   "ASSIGN_HEARING_DISPOSITION_TASK_DEFAULT_INSTRUCTIONS": "Postpone or cancel a hearing prior to the hearing date. This task will be auto-completed after the hearing's scheduled date.",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -374,8 +374,8 @@
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_LABEL": "Send CAVC-Remand-Processed Letter Task",
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY": "Marking this task complete will put this case on hold for 90 days to allow the appellant to respond.",
 
-  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed-Letter Response Window Task",
-  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "This response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
+  "CRP_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed-Letter Response Window Task",
+  "CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "This response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
 
   "ASSIGN_HEARING_DISPOSITION_TASK_DEFAULT_INSTRUCTIONS": "Postpone or cancel a hearing prior to the hearing date. This task will be auto-completed after the hearing's scheduled date.",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -372,6 +372,9 @@
   "CAVC_TASK_DEFAULT_INSTRUCTIONS": "This task will be auto-completed when all CAVC-related tasks have been closed.",
 
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_LABEL": "Send CAVC-Remand-Processed Letter Task",
+  "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY": "Marking this task complete will put this case on hold for 90 days to allow the appellant to respond.",
+
+  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed Letter Response Window Task",
 
   "ASSIGN_HEARING_DISPOSITION_TASK_DEFAULT_INSTRUCTIONS": "Postpone or cancel a hearing prior to the hearing date. This task will be auto-completed after the hearing's scheduled date.",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -375,7 +375,7 @@
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY": "Marking this task complete will put this case on hold for 90 days to allow the appellant to respond.",
 
   "CRP_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed-Letter Response Window Task",
-  "CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "This response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
+  "CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "The response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
 
   "ASSIGN_HEARING_DISPOSITION_TASK_DEFAULT_INSTRUCTIONS": "Postpone or cancel a hearing prior to the hearing date. This task will be auto-completed after the hearing's scheduled date.",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -374,7 +374,7 @@
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_LABEL": "Send CAVC-Remand-Processed Letter Task",
   "SEND_CAVC_REMAND_PROCESSED_LETTER_TASK_COMPLETE_MODAL_BODY": "Marking this task complete will put this case on hold for 90 days to allow the appellant to respond.",
 
-  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed Letter Response Window Task",
+  "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL": "CAVC-Remand-Processed-Letter Response Window Task",
   "CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS": "This response window task will return to the CAVC Teams queue after 90 days or when manually ended early.",
 
   "ASSIGN_HEARING_DISPOSITION_TASK_DEFAULT_INSTRUCTIONS": "Postpone or cancel a hearing prior to the hearing date. This task will be auto-completed after the hearing's scheduled date.",

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -10,47 +10,113 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
   let!(:org_nonadmin2) { create(:user, full_name: "Tooey Remandy") { |u| CavcLitigationSupport.singleton.add_user(u) } }
   let!(:other_user) { create(:user, full_name: "Othery Usery") }
 
-  context "when CAVC Lit Support is assigned SendCavcRemandProcessedLetterTask" do
+  describe "when CAVC Lit Support is assigned SendCavcRemandProcessedLetterTask" do
     let!(:send_task) { create(:send_cavc_remand_processed_letter_task) }
+    let(:vet_name) { send_task.appeal.veteran_full_name }
 
-    it "allows admin to assign SendCavcRemandProcessedLetterTask to user" do
-      # Logged in as CAVC Lit Support admin
-      User.authenticate!(user: org_admin)
-      visit "queue/appeals/#{send_task.appeal.external_id}"
+    it "allows users to assign and process tasks" do
+      step "allows admin to assign SendCavcRemandProcessedLetterTask to user" do
+        # Logged in as CAVC Lit Support admin
+        User.authenticate!(user: org_admin)
+        visit "queue/appeals/#{send_task.appeal.external_id}"
 
-      find(".cf-select__control", text: "Select an action").click
-      find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.label).click
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.ASSIGN_TO_PERSON.label).click
 
-      find(".cf-select__control", text: org_admin.full_name).click
-      find("div", class: "cf-select__option", text: org_nonadmin.full_name).click
-      fill_in "taskInstructions", with: "Confirm info and send letter to Veteran."
-      click_on "Submit"
-      expect(page).to have_content COPY::ASSIGN_TASK_SUCCESS_MESSAGE % org_nonadmin.full_name
+        find(".cf-select__control", text: org_admin.full_name).click
+        find("div", class: "cf-select__option", text: org_nonadmin.full_name).click
+        fill_in "taskInstructions", with: "Confirm info and send letter to Veteran."
+        click_on "Submit"
+        expect(page).to have_content COPY::ASSIGN_TASK_SUCCESS_MESSAGE % org_nonadmin.full_name
 
-      # Logged in as first user assignee
-      User.authenticate!(user: org_nonadmin)
-      visit "queue/appeals/#{send_task.appeal.external_id}"
+        # Logged in as first user assignee
+        User.authenticate!(user: org_nonadmin)
+        visit "queue/appeals/#{send_task.appeal.external_id}"
 
-      find(".cf-select__control", text: "Select an action").click
-      expect(page).to have_content Constants.TASK_ACTIONS.MARK_COMPLETE.label
-      expect(page).to have_content Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.label
+        find(".cf-select__control", text: "Select an action").click
+        expect(page).to have_content Constants.TASK_ACTIONS.MARK_COMPLETE.label
+        expect(page).to have_content Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.label
 
-      find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.label).click
-      find(".cf-select__control", text: COPY::ASSIGN_WIDGET_DROPDOWN_PLACEHOLDER).click
-      find("div", class: "cf-select__option", text: org_nonadmin2.full_name).click
-      fill_in "taskInstructions", with: "Going fishing. Handing off to you."
-      click_on "Submit"
-      expect(page).to have_content COPY::REASSIGN_TASK_SUCCESS_MESSAGE % org_nonadmin2.full_name
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.label).click
+        find(".cf-select__control", text: COPY::ASSIGN_WIDGET_DROPDOWN_PLACEHOLDER).click
+        find("div", class: "cf-select__option", text: org_nonadmin2.full_name).click
+        fill_in "taskInstructions", with: "Going fishing. Handing off to you."
+        click_on "Submit"
+        expect(page).to have_content COPY::REASSIGN_TASK_SUCCESS_MESSAGE % org_nonadmin2.full_name
+      end
 
-      # Logged in as second user assignee (due to reassignment)
-      User.authenticate!(user: org_nonadmin2)
-      visit "queue/appeals/#{send_task.appeal.external_id}"
+      step "assigned user completes task" do
+        # Logged in as second user assignee (due to reassignment)
+        User.authenticate!(user: org_nonadmin2)
+        visit "queue/appeals/#{send_task.appeal.external_id}"
 
-      find(".cf-select__control", text: "Select an action").click
-      find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.label).click
-      fill_in "completeTaskInstructions", with: "Letter sent."
-      click_on COPY::MARK_TASK_COMPLETE_BUTTON
-      expect(page).to have_content COPY::MARK_TASK_COMPLETE_CONFIRMATION % send_task.appeal.veteran_full_name
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.label).click
+        fill_in "completeTaskInstructions", with: "Letter sent."
+        click_on COPY::MARK_TASK_COMPLETE_BUTTON
+        expect(page).to have_content COPY::MARK_TASK_COMPLETE_CONFIRMATION % vet_name
+
+        # Check that appeal is in correct tab in user's queue
+        find(".cf-tab", text: "Completed").click
+        expect(page).to have_content send_task.appeal.docket_number
+
+        # Check that appeal is in correct tab in Team view
+        User.authenticate!(user: org_admin)
+        visit "organizations/cavc-lit-support"
+        find(".cf-tab", text: "Assigned").click
+        expect(page).to have_content send_task.appeal.docket_number
+        # Check that org_admin has option to End hold early
+        visit "queue/appeals/#{send_task.appeal.external_id}"
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label).click
+        click_on "Cancel"
+      end
+
+      step "end timed hold early" do
+        # Actually "End hold early" as org_nonadmin this time
+        User.authenticate!(user: org_nonadmin2)
+        visit "queue/appeals/#{send_task.appeal.external_id}"
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label).click
+        click_on "Submit"
+        expect(page).to have_content COPY::END_HOLD_SUCCESS_MESSAGE_TITLE
+      end
+
+      step "resume hold" do
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label).click
+        find(".cf-select__control", text: "Select number of days").click
+        find("div", class: "cf-select__option", text: "90 days").click
+        fill_in "instructions", with: "Put it back on hold. Wait for more Veteran responses."
+        click_on "Submit"
+        expect(page).to have_content(format(COPY::COLOCATED_ACTION_PLACE_HOLD_CONFIRMATION, vet_name, 90))
+
+        # Check that appeal is back in correct tab in user's queue
+        visit "/queue"
+        find(".cf-tab", text: "Completed").click
+        expect(page).to have_content send_task.appeal.docket_number
+
+        # Check that appeal is back in correct tab in Team view
+        User.authenticate!(user: org_admin)
+        visit "organizations/cavc-lit-support"
+        find(".cf-tab", text: "Assigned").click
+        expect(page).to have_content send_task.appeal.docket_number
+      end
+
+      step "travel 90+ days into the future to trigger TimedHoldTask to expire" do
+        Timecop.travel(Time.zone.now + 90.days + 1.hour)
+        TaskTimerJob.perform_now
+
+        visit "organizations/cavc-lit-support"
+        find(".cf-tab", text: "Unassigned").click
+        expect(page).to have_content send_task.appeal.docket_number
+
+        # Check case details page has action to place on hold
+        visit "queue/appeals/#{send_task.appeal.external_id}"
+        find(".cf-select__control", text: "Select an action").click
+        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label).click
+        click_on "Cancel"
+      end
     end
   end
 end

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -50,8 +50,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         User.authenticate!(user: org_nonadmin2)
         visit "queue/appeals/#{send_task.appeal.external_id}"
 
-        find(".cf-select__control", text: "Select an action").click
-        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.MARK_COMPLETE.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.MARK_COMPLETE.label)
         fill_in "completeTaskInstructions", with: "Letter sent."
         click_on COPY::MARK_TASK_COMPLETE_BUTTON
         expect(page).to have_content COPY::MARK_TASK_COMPLETE_CONFIRMATION % vet_name
@@ -67,8 +66,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         expect(page).to have_content send_task.appeal.docket_number
         # Check that org_admin has option to End hold early
         visit "queue/appeals/#{send_task.appeal.external_id}"
-        find(".cf-select__control", text: "Select an action").click
-        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label)
         click_on "Cancel"
       end
 
@@ -76,8 +74,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         # Actually "End hold early" as org_nonadmin this time
         User.authenticate!(user: org_nonadmin2)
         visit "queue/appeals/#{send_task.appeal.external_id}"
-        find(".cf-select__control", text: "Select an action").click
-        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.END_TIMED_HOLD.label)
         click_on "Submit"
         expect(page).to have_content COPY::END_HOLD_SUCCESS_MESSAGE_TITLE
       end
@@ -113,8 +110,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
 
         # Check case details page has action to place on hold
         visit "queue/appeals/#{send_task.appeal.external_id}"
-        find(".cf-select__control", text: "Select an action").click
-        find("div", class: "cf-select__option", text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label).click
+        click_dropdown(text: Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.label)
         click_on "Cancel"
       end
     end

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
+  require_relative "task_shared_examples.rb"
+
+  describe ".create" do
+    subject { described_class.create(parent: parent_task, appeal: appeal) }
+    let(:appeal) { create(:appeal) }
+    let!(:parent_task) { create(:cavc_task, appeal: appeal) }
+    let(:parent_task_class) { CavcTask }
+
+    it_behaves_like "task requiring specific parent"
+
+    it "has expected defaults" do
+      new_task = subject
+      expect(new_task.assigned_to).to eq CavcLitigationSupport.singleton
+      expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
+      expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+    end
+    describe ".create_with_hold" do
+      subject { described_class.create_with_hold(parent_task) }
+
+      it "creates task with child TimedHoldTask" do
+        new_task = subject
+        expect(new_task.valid?)
+        expect(new_task.assigned_to).to eq CavcLitigationSupport.singleton
+
+        expect(appeal.tasks).to include new_task
+        expect(parent_task.children).to include new_task
+        child_tasks = new_task.children.where(type: :TimedHoldTask)
+        expect(child_tasks.count).to eq 1
+        expect(child_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
+
+        expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
+        expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+      end
+    end
+  end
+
+  # describe "FactoryBot.create(:send_cavc_remand_processed_letter_task) with different arguments" do
+  #   context "appeal is provided" do
+  #     let(:appeal) { create(:appeal) }
+  #     let!(:cavc_task) { create(:cavc_task, appeal: appeal) }
+  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task, appeal: appeal) }
+  #     it "finds existing parent_task to use as parent" do
+  #       expect(Appeal.count).to eq 1
+  #       expect(RootTask.count).to eq 1
+  #       expect(DistributionTask.count).to eq 1
+  #       expect(CavcTask.count).to eq 1
+  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
+  #       expect(send_task.parent).to eq cavc_task
+  #     end
+  #   end
+  #   context "parent task is provided" do
+  #     let!(:parent_task) { create(:cavc_task) }
+  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task, parent: parent_task) }
+  #     it "uses existing parent_task" do
+  #       expect(Appeal.count).to eq 1
+  #       expect(RootTask.count).to eq 1
+  #       expect(DistributionTask.count).to eq 1
+  #       expect(CavcTask.count).to eq 1
+  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
+  #       expect(send_task.parent).to eq parent_task
+  #     end
+  #   end
+  #   context "nothing is provided" do
+  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task) }
+  #     it "creates realistic task tree" do
+  #       expect(Appeal.count).to eq 1
+  #       expect(RootTask.count).to eq 1
+  #       expect(DistributionTask.count).to eq 1
+  #       expect(CavcTask.count).to eq 1
+  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
+  #       expect(send_task.parent).to eq CavcTask.first
+  #     end
+  #   end
+  # end
+
+  SendCRPLetterTask = SendCavcRemandProcessedLetterTask
+  CRPLRWindowTask = CavcRemandProcessedLetterResponseWindowTask
+  describe "#available_actions" do
+    let(:org_admin) do
+      create(:user) do |u|
+        OrganizationsUser.make_user_admin(u, CavcLitigationSupport.singleton)
+      end
+    end
+    let(:org_nonadmin) { create(:user) { |u| CavcLitigationSupport.singleton.add_user(u) } }
+    let(:other_user) { create(:user) }
+    let(:send_task) { create(:send_cavc_remand_processed_letter_task) }
+    # context "task assigned to CavcLitigationSupport admin" do
+    #   it "returns admin actions" do
+    #     expect(send_task.available_actions(org_admin)).to match_array SendCRPLetterTask::ADMIN_ACTIONS
+    #     expect(send_task.available_actions(other_user)).to be_empty
+    #   end
+    # end
+    context "task assigned to CavcLitigationSupport non-admin" do
+      let(:user_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
+      let(:window_task) do
+        user_task.update_from_params({ status: "completed" }, org_nonadmin)
+        user_task.appeal.tasks.where(type: CRPLRWindowTask.name).first
+      end
+      it "returns non-admin actions" do
+        expect(user_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
+        expect(window_task.available_actions(org_nonadmin)).to match_array CRPLRWindowTask::USER_ACTIONS
+      end
+    end
+  end
+end

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -17,6 +17,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
       expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
       expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
     end
+
     describe ".create_with_hold" do
       subject { described_class.create_with_hold(parent_task) }
 
@@ -24,12 +25,14 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
         new_task = subject
         expect(new_task.valid?)
         expect(new_task.assigned_to).to eq CavcLitigationSupport.singleton
+        expect(new_task.status).to eq "on_hold"
 
         expect(appeal.tasks).to include new_task
         expect(parent_task.children).to include new_task
         child_tasks = new_task.children.where(type: :TimedHoldTask)
         expect(child_tasks.count).to eq 1
         expect(child_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
+        expect(child_tasks.first.status).to eq "assigned"
 
         expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
         expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
@@ -87,21 +90,16 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     let(:org_nonadmin) { create(:user) { |u| CavcLitigationSupport.singleton.add_user(u) } }
     let(:other_user) { create(:user) }
     let(:send_task) { create(:send_cavc_remand_processed_letter_task) }
-    # context "task assigned to CavcLitigationSupport admin" do
-    #   it "returns admin actions" do
-    #     expect(send_task.available_actions(org_admin)).to match_array SendCRPLetterTask::ADMIN_ACTIONS
-    #     expect(send_task.available_actions(other_user)).to be_empty
-    #   end
-    # end
-    context "task assigned to CavcLitigationSupport non-admin" do
+
+    context "window task created after SendCRPLetterTask completed" do
       let(:user_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
       let(:window_task) do
         user_task.update_from_params({ status: "completed" }, org_nonadmin)
         user_task.appeal.tasks.where(type: CRPLRWindowTask.name).first
       end
-      it "returns non-admin actions" do
+      it "returns available actions" do
         expect(user_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
-        expect(window_task.available_actions(org_nonadmin)).to match_array CRPLRWindowTask::USER_ACTIONS
+        expect(window_task.available_actions(org_nonadmin)).to include Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
       end
     end
   end

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -40,45 +40,6 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     end
   end
 
-  # describe "FactoryBot.create(:send_cavc_remand_processed_letter_task) with different arguments" do
-  #   context "appeal is provided" do
-  #     let(:appeal) { create(:appeal) }
-  #     let!(:cavc_task) { create(:cavc_task, appeal: appeal) }
-  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task, appeal: appeal) }
-  #     it "finds existing parent_task to use as parent" do
-  #       expect(Appeal.count).to eq 1
-  #       expect(RootTask.count).to eq 1
-  #       expect(DistributionTask.count).to eq 1
-  #       expect(CavcTask.count).to eq 1
-  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
-  #       expect(send_task.parent).to eq cavc_task
-  #     end
-  #   end
-  #   context "parent task is provided" do
-  #     let!(:parent_task) { create(:cavc_task) }
-  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task, parent: parent_task) }
-  #     it "uses existing parent_task" do
-  #       expect(Appeal.count).to eq 1
-  #       expect(RootTask.count).to eq 1
-  #       expect(DistributionTask.count).to eq 1
-  #       expect(CavcTask.count).to eq 1
-  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
-  #       expect(send_task.parent).to eq parent_task
-  #     end
-  #   end
-  #   context "nothing is provided" do
-  #     let!(:send_task) { create(:send_cavc_remand_processed_letter_task) }
-  #     it "creates realistic task tree" do
-  #       expect(Appeal.count).to eq 1
-  #       expect(RootTask.count).to eq 1
-  #       expect(DistributionTask.count).to eq 1
-  #       expect(CavcTask.count).to eq 1
-  #       expect(SendCavcRemandProcessedLetterTask.count).to eq 1
-  #       expect(send_task.parent).to eq CavcTask.first
-  #     end
-  #   end
-  # end
-
   SendCRPLetterTask = SendCavcRemandProcessedLetterTask
   CRPLRWindowTask = CavcRemandProcessedLetterResponseWindowTask
   describe "#available_actions" do

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -25,14 +25,14 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
         new_task = subject
         expect(new_task.valid?)
         expect(new_task.assigned_to).to eq CavcLitigationSupport.singleton
-        expect(new_task.status).to eq "on_hold"
+        expect(new_task.status).to eq Constants.TASK_STATUSES.on_hold
 
         expect(appeal.tasks).to include new_task
         expect(parent_task.children).to include new_task
-        child_tasks = new_task.children.where(type: :TimedHoldTask)
-        expect(child_tasks.count).to eq 1
-        expect(child_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
-        expect(child_tasks.first.status).to eq "assigned"
+        child_timed_hold_tasks = new_task.children.where(type: :TimedHoldTask)
+        expect(child_timed_hold_tasks.count).to eq 1
+        expect(child_timed_hold_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
+        expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
 
         expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
         expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
@@ -82,6 +82,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
   SendCRPLetterTask = SendCavcRemandProcessedLetterTask
   CRPLRWindowTask = CavcRemandProcessedLetterResponseWindowTask
   describe "#available_actions" do
+    Timecop.travel(17.days.ago)
     let(:org_admin) do
       create(:user) do |u|
         OrganizationsUser.make_user_admin(u, CavcLitigationSupport.singleton)
@@ -94,12 +95,29 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     context "window task created after SendCRPLetterTask completed" do
       let(:user_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
       let(:window_task) do
-        user_task.update_from_params({ status: "completed" }, org_nonadmin)
+        user_task.update_from_params({ status: Constants.TASK_STATUSES.completed }, org_nonadmin)
         user_task.appeal.tasks.where(type: CRPLRWindowTask.name).first
       end
       it "returns available actions" do
         expect(user_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
         expect(window_task.available_actions(org_nonadmin)).to include Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
+        expect(window_task.reload.status).to eq Constants.TASK_STATUSES.on_hold
+
+        Timecop.travel(Time.zone.now + 90.days + 1.hour)
+        TaskTimerJob.perform_now
+        child_timed_hold_tasks = window_task.children.where(type: :TimedHoldTask)
+        expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.completed
+        expect(window_task.reload.status).to eq Constants.TASK_STATUSES.assigned
+      end
+
+      context "when user_task cannot be marked complete" do
+        before { allow(user_task).to receive(:update_from_params).and_raise(StandardError) }
+        it "does not create window_task" do
+          expect(user_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
+          expect { window_task }.to raise_error(StandardError)
+          expect(user_task.appeal.tasks.where(type: CRPLRWindowTask.name).count).to eq 0
+          expect(user_task.status).to eq Constants.TASK_STATUSES.assigned
+        end
       end
     end
   end

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -36,6 +36,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
         expect(child_timed_hold_tasks.count).to eq 1
         expect(child_timed_hold_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
+        expect(child_timed_hold_tasks.first.timer_end_time.to_date).to eq(Time.zone.now.to_date + 90.days)
 
         expect(new_task.label).to eq COPY::CRP_LETTER_RESP_WINDOW_TASK_LABEL
         expect(new_task.default_instructions).to eq [COPY::CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS]

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -17,8 +17,8 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     it "has expected defaults" do
       new_task = subject
       expect(new_task.assigned_to).to eq CavcLitigationSupport.singleton
-      expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
-      expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+      expect(new_task.label).to eq COPY::CRP_LETTER_RESP_WINDOW_TASK_LABEL
+      expect(new_task.default_instructions).to eq [COPY::CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS]
     end
 
     describe ".create_with_hold" do
@@ -37,8 +37,8 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
         expect(child_timed_hold_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
 
-        expect(new_task.label).to eq COPY::CAVC_REMAND_PROCESSED_LETTER_RESP_WINDOW_TASK_LABEL
-        expect(new_task.default_instructions).to eq [COPY::CAVC_TASK_DEFAULT_INSTRUCTIONS]
+        expect(new_task.label).to eq COPY::CRP_LETTER_RESP_WINDOW_TASK_LABEL
+        expect(new_task.default_instructions).to eq [COPY::CRP_LETTER_RESP_WINDOW_TASK_DEFAULT_INSTRUCTIONS]
       end
     end
   end

--- a/spec/models/tasks/send_cavc_remand_processed_letter_task_spec.rb
+++ b/spec/models/tasks/send_cavc_remand_processed_letter_task_spec.rb
@@ -18,9 +18,9 @@ describe SendCavcRemandProcessedLetterTask, :postgres do
       expect(new_task.default_instructions).to be_empty
     end
 
-    context "create child task assigned to user" do
+    context "creation of child task assigned to user" do
       let!(:parent_task) { create(:send_cavc_remand_processed_letter_task, appeal: appeal) }
-      it "returns non-admin actions" do
+      it "creates child task with defaults" do
         new_task = subject
         expect(new_task.valid?)
         expect(new_task.errors.messages[:parent]).to be_empty
@@ -93,7 +93,7 @@ describe SendCavcRemandProcessedLetterTask, :postgres do
       let(:child_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
       it "returns non-admin actions" do
         expect(child_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
-        expect(send_task.available_actions(other_user)).to be_empty
+        expect(child_task.available_actions(other_user)).to be_empty
       end
     end
   end

--- a/spec/models/tasks/send_cavc_remand_processed_letter_task_spec.rb
+++ b/spec/models/tasks/send_cavc_remand_processed_letter_task_spec.rb
@@ -2,6 +2,11 @@
 
 describe SendCavcRemandProcessedLetterTask, :postgres do
   require_relative "task_shared_examples.rb"
+  SendCRPLetterTask = SendCavcRemandProcessedLetterTask
+
+  let(:org_admin) { create(:user) { |u| OrganizationsUser.make_user_admin(u, CavcLitigationSupport.singleton) } }
+  let(:org_nonadmin) { create(:user) { |u| CavcLitigationSupport.singleton.add_user(u) } }
+  let(:other_user) { create(:user) }
 
   describe ".create" do
     subject { described_class.create(appeal: appeal, parent: parent_task) }
@@ -73,27 +78,42 @@ describe SendCavcRemandProcessedLetterTask, :postgres do
     end
   end
 
-  SendCRPLetterTask = SendCavcRemandProcessedLetterTask
   describe "#available_actions" do
-    let(:org_admin) do
-      create(:user) do |u|
-        OrganizationsUser.make_user_admin(u, CavcLitigationSupport.singleton)
-      end
-    end
-    let(:org_nonadmin) { create(:user) { |u| CavcLitigationSupport.singleton.add_user(u) } }
-    let(:other_user) { create(:user) }
     let(:send_task) { create(:send_cavc_remand_processed_letter_task) }
-    context "task assigned to CavcLitigationSupport admin" do
+    let(:child_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
+
+    context "task assigned to CavcLitigationSupport (aka org-task)" do
       it "returns admin actions" do
+        expect(send_task.assigned_to).to eq CavcLitigationSupport.singleton
         expect(send_task.available_actions(org_admin)).to match_array SendCRPLetterTask::ADMIN_ACTIONS
         expect(send_task.available_actions(other_user)).to be_empty
       end
     end
-    context "task assigned to CavcLitigationSupport non-admin" do
-      let(:child_task) { create(:send_cavc_remand_processed_letter_task, parent: send_task, assigned_to: org_nonadmin) }
+
+    context "task assigned to CavcLitigationSupport non-admin (aka user-task)" do
       it "returns non-admin actions" do
+        expect(child_task.assigned_to).to eq org_nonadmin
         expect(child_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
         expect(child_task.available_actions(other_user)).to be_empty
+      end
+    end
+
+    context "when SendCRPLetterTask completed" do
+      let(:user_task) { child_task }
+      subject { user_task.update_from_params({ status: Constants.TASK_STATUSES.completed }, org_nonadmin) }
+
+      it "status is updated to be completed" do
+        expect { subject }.to_not raise_error(StandardError)
+        expect(user_task.status).to eq Constants.TASK_STATUSES.completed
+      end
+
+      context "when user_task cannot be marked complete" do
+        before { allow(user_task).to receive(:update_from_params).and_raise(StandardError) }
+        it "does not create CavcRemandProcessedLetterResponseWindowTask" do
+          expect(user_task.available_actions(org_nonadmin)).to match_array SendCRPLetterTask::USER_ACTIONS
+          expect { subject }.to raise_error(StandardError)
+          expect(user_task.status).to eq Constants.TASK_STATUSES.assigned
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #15309 (aka [CASEFLOW-108](https://vajira.max.gov/browse/CASEFLOW-108))

### Description
Create new CavcRemandProcessedLetterResponseWindowTask for 90-day duration with ability to "end hold early".

Also included the action to place task back on hold -- see  [Slack](https://dsva.slack.com/archives/C01BKL4CCRL/p1605913943002800?thread_ts=1605913086.002300&cid=C01BKL4CCRL).

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Verify when a SendCavcRemandProcessedLetterTask is completed, a CavcRemandProcessedLetterResponseWindowTask is created
   - [ ] As a child of the CavcTask
   - [ ] Assigned to the CavcLitigationSupportTeam
   - [ ] Is put on hold for 90 days by creating a child timed hold task
   - [ ] Give task action of "End hold early" while task is on hold
   - [ ] After 90 days, the task should come off hold and show up in the CAVC teams unassigned tab to be assigned/acted upon

### Testing Plan
Log in as CAVC_LIT_SUPPORT_ADMIN (VACO)
1. Go to the team view of Queue: http://localhost:3000/organizations/cavc-lit-support?tab=unassignedTab&page=1
1. Click on a case in Unassigned tab; note the case docket number
1. "Assign to person" and check that case is now under the "Assigned tab" in the team view (note the task type)
1. Check task tree in the Rails console

Log in as the assignee (in an incognito window)
1.  go to their queue: http://localhost:3000/queue?tab=assigned_person&page=1
1. Click on the assigned case and "Mark task complete"; not that case is in the Completed tab in the user's queue
1. Click on the case, note the user as the action to "End hold early". (You can test it now or later.)
1. Check task tree in the Rails console

Log in as CAVC_LIT_SUPPORT_ADMIN (VACO)
1. check that case is still under the "Assigned tab" in the team view (with the Window Task type)
1. Click on the case, note the user as the action to "End hold early". (You can test it now or later.)
1. Check task tree in the Rails console

Ending and restoring hold:
1. When you "End hold early", the case shows in the Unassigned tab  in the team view.
1. When you "Put task on hold", the case shows in the "Assigned tab" in the team view.
1. Check task tree in the Rails console

Hold ends due to time passing:
1. Travel 90+ days into the future
   ```ruby
   Timecop.travel(Time.zone.now + 90.days + 1.hour)
   TaskTimerJob.perform_now
   ```
1. The case shows in the Unassigned tab  in the team view.
1. Check task tree in the Rails console

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

Note window task instructions and "End hold early" action:
![image](https://user-images.githubusercontent.com/55255674/99857353-ad4fd380-2b50-11eb-88fe-1c533ff10add.png)
Case Timeline shows completed send letter task:
![image](https://user-images.githubusercontent.com/55255674/99857432-da03eb00-2b50-11eb-8292-6eaaf3ffc90e.png)

After clicking on "End hold early" action:
![image](https://user-images.githubusercontent.com/55255674/99857496-facc4080-2b50-11eb-963d-68e3db0bc31f.png)
and after clicking Submit, user can "Put task on hold" (do we want this action to be available?):
![image](https://user-images.githubusercontent.com/55255674/99857586-251dfe00-2b51-11eb-8895-b7f12a4e1ef2.png)



### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

