### PR TITLE
Edit Claim Label Confirmation modal

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -717,6 +717,9 @@
   "EDIT_CLAIM_LABEL_MODAL_SUBHEAD": "You are editing a %s claim",
   "EDIT_CLAIM_LABEL_MODAL_NOTE": "Please note: you will only be able to select claim labels within the same EP family (e.g. 040, 030). If you need to switch to another EP family, please cancel and re-establish the claim.",
 
+  "CONFIRM_CLAIM_LABEL_MODAL_TITLE": "Confirm new claim label",
+  "CONFIRM_CLAIM_LABEL_MODAL_BODY": "Select \"confirm\" to save and complete editing this claim label. If the claim label is not updated in VBMS in 24 hours, please submit a YourIT ticket.",
+
   "INTAKE_CORRECTION_TYPE_MODAL_TITLE": "Set Correction Type",
   "INTAKE_CORRECTION_TYPE_MODAL_COPY": "This issue will be added to a 930 EP for correction. If a mistake was found during quality review, please select whether it was discovered by the local or national quality review team. Otherwise, select control.",
   "INTAKE_LEGACY_OPT_IN_MESSAGE": "Did the Veteran check the \"OPT-IN from SOC/SSOC\" box on the form?",

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -158,7 +158,6 @@ class AddIssuesPage extends React.Component {
     });
   }
 
-  // eslint-disable-next-line no-unused-vars
   handleEditClaimLabel = (data) => {
     this.setState({
       showEditClaimLabelModal: false,

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -40,6 +40,7 @@ import {
 } from '../actions/addIssues';
 import COPY from '../../../COPY';
 import { EditClaimLabelModal } from '../../intakeEdit/components/EditClaimLabelModal';
+import { ConfirmClaimLabelModal } from '../../intakeEdit/components/ConfirmClaimLabelModal';
 
 class AddIssuesPage extends React.Component {
   constructor(props) {
@@ -145,20 +146,35 @@ class AddIssuesPage extends React.Component {
   openEditClaimLabelModal = (endProductCode) => {
     this.setState({
       showEditClaimLabelModal: true,
-      selectedEPCode: endProductCode
+      selectedEpCode: endProductCode
     });
   }
   closeEditClaimLabelModal = () => {
     this.setState({
       showEditClaimLabelModal: false,
-      selectedEPCode: null
+      showConfirmClaimLabelModal: false,
+      previousEpCode: null,
+      selectedEpCode: null
     });
   }
-  // eslint-disable-next-line no-unused-vars
-  handleEditClaimLabel = (newCode) => {
-    // TODO: save the updated code
 
-    this.closeEditClaimLabelModal();
+  // eslint-disable-next-line no-unused-vars
+  handleEditClaimLabel = (data) => {
+    this.setState({
+      showEditClaimLabelModal: false,
+      showConfirmClaimLabelModal: true,
+      previousEpCode: data.oldCode,
+      selectedEpCode: data.newCode
+    });
+  }
+
+  submitClaimLabelEdit = () => {
+    console.log(`Submitting request to switch from ${this.state.previousEpCode} to ${this.state.selectedEpCode}...`);
+    this.setState({
+      showConfirmClaimLabelModal: false,
+      previousEpCode: null,
+      selectedEpCode: null
+    });
   }
 
   render() {
@@ -370,9 +386,17 @@ class AddIssuesPage extends React.Component {
         )}
         {this.state.showEditClaimLabelModal && (
           <EditClaimLabelModal
-            existingEpCode={this.state.selectedEPCode}
+            selectedEpCode={this.state.selectedEpCode}
             onCancel={this.closeEditClaimLabelModal}
             onSubmit={this.handleEditClaimLabel}
+          />
+        )}
+        {this.state.showConfirmClaimLabelModal && (
+          <ConfirmClaimLabelModal
+            previousEpCode={this.state.previousEpCode}
+            newEpCode={this.state.selectedEpCode}
+            onCancel={this.closeEditClaimLabelModal}
+            onSubmit={this.submitClaimLabelEdit}
           />
         )}
         <h1 className="cf-txt-c">{messageHeader}</h1>

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -169,6 +169,7 @@ class AddIssuesPage extends React.Component {
   }
 
   submitClaimLabelEdit = () => {
+    // eslint-disable-next-line no-console
     console.log(`Submitting request to switch from ${this.state.previousEpCode} to ${this.state.selectedEpCode}...`);
     this.setState({
       showConfirmClaimLabelModal: false,

--- a/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
+++ b/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Modal from 'app/components/Modal';
 import {
@@ -19,12 +19,13 @@ export const ConfirmClaimLabelModal = ({ previousEpCode, newEpCode, onCancel, on
       classNames: ['usa-button', 'usa-button-primary'],
       name: 'Confirm',
       onClick: () => onSubmit?.({
-        previousEpCode: previousEpCode,
-        newEpCode: newEpCode
+        previousEpCode,
+        newEpCode
       }),
     },
   ];
 
+  /* eslint-disable camelcase */
   return (
     <Modal
       title={CONFIRM_CLAIM_LABEL_MODAL_TITLE}
@@ -32,6 +33,7 @@ export const ConfirmClaimLabelModal = ({ previousEpCode, newEpCode, onCancel, on
       closeHandler={onCancel}
       id="confirm-claim-label-modal"
     >
+
       <div style={{ marginBottom: '24px' }}>
         <strong>
           Previous label: {EP_CLAIM_TYPES[previousEpCode]?.official_label}
@@ -42,6 +44,7 @@ export const ConfirmClaimLabelModal = ({ previousEpCode, newEpCode, onCancel, on
       <p>{CONFIRM_CLAIM_LABEL_MODAL_BODY}</p>
     </Modal>
   );
+  /* eslint-enable camelcase */
 };
 
 ConfirmClaimLabelModal.propTypes = {

--- a/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
+++ b/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
@@ -47,6 +47,6 @@ export const ConfirmClaimLabelModal = ({ previousEpCode, newEpCode, onCancel, on
 ConfirmClaimLabelModal.propTypes = {
   previousEpCode: PropTypes.string.isRequired,
   newEpCode: PropTypes.string.isRequired,
-  onCancel: PropTypes.func,
+  onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
 };

--- a/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
+++ b/client/app/intakeEdit/components/ConfirmClaimLabelModal.jsx
@@ -1,0 +1,52 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'app/components/Modal';
+import {
+  CONFIRM_CLAIM_LABEL_MODAL_TITLE,
+  CONFIRM_CLAIM_LABEL_MODAL_BODY,
+} from 'app/../COPY';
+
+import EP_CLAIM_TYPES from 'constants/EP_CLAIM_TYPES';
+
+export const ConfirmClaimLabelModal = ({ previousEpCode, newEpCode, onCancel, onSubmit }) => {
+  const buttons = [
+    {
+      classNames: ['cf-modal-link', 'cf-btn-link'],
+      name: 'Cancel',
+      onClick: onCancel,
+    },
+    {
+      classNames: ['usa-button', 'usa-button-primary'],
+      name: 'Confirm',
+      onClick: () => onSubmit?.({
+        previousEpCode: previousEpCode,
+        newEpCode: newEpCode
+      }),
+    },
+  ];
+
+  return (
+    <Modal
+      title={CONFIRM_CLAIM_LABEL_MODAL_TITLE}
+      buttons={buttons}
+      closeHandler={onCancel}
+      id="confirm-claim-label-modal"
+    >
+      <div style={{ marginBottom: '24px' }}>
+        <strong>
+          Previous label: {EP_CLAIM_TYPES[previousEpCode]?.official_label}
+          <br />
+          New label: {EP_CLAIM_TYPES[newEpCode]?.official_label}
+        </strong>
+      </div>
+      <p>{CONFIRM_CLAIM_LABEL_MODAL_BODY}</p>
+    </Modal>
+  );
+};
+
+ConfirmClaimLabelModal.propTypes = {
+  previousEpCode: PropTypes.string.isRequired,
+  newEpCode: PropTypes.string.isRequired,
+  onCancel: PropTypes.func,
+  onSubmit: PropTypes.func.isRequired,
+};

--- a/client/app/intakeEdit/components/ConfirmClaimLabelModal.stories.js
+++ b/client/app/intakeEdit/components/ConfirmClaimLabelModal.stories.js
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { ConfirmClaimLabelModal } from './ConfirmClaimLabelModal';
+
+export default {
+  title: 'Intake/Edit Issues/ConfirmClaimLabelModal',
+  component: ConfirmClaimLabelModal,
+  decorators: [],
+  parameters: {
+    docs: {
+      inlineStories: false,
+      iframeHeight: 700,
+    },
+  },
+  args: {
+    previousEpCode: '030HLRR',
+    newEpCode: '030HLRNR',
+  },
+  argTypes: {
+    onCancel: { action: 'cancel' },
+    onSubmit: { action: 'submit' },
+  },
+};
+
+const Template = (args) => <ConfirmClaimLabelModal {...args} />;
+
+export const Basic = Template.bind({});
+
+Basic.parameters = {
+  docs: {
+    storyDescription:
+      'This is a confirmation modal the user sees after selecting a new claim label for an end product.',
+  },
+};

--- a/client/app/intakeEdit/components/EditClaimLabelModal.jsx
+++ b/client/app/intakeEdit/components/EditClaimLabelModal.jsx
@@ -11,13 +11,13 @@ import {
 
 import EP_CLAIM_TYPES from 'constants/EP_CLAIM_TYPES';
 
-export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
+export const EditClaimLabelModal = ({ selectedEpCode, onCancel, onSubmit }) => {
   // Only EP codes from the same family should be allowed
   const availableOptions = useMemo(() => {
     // Filter out all but the same family (040, 930, etc)
     // eslint-disable-next-line no-unused-vars
     const filtered = Object.entries(EP_CLAIM_TYPES).filter(([code, type]) => {
-      return type.family === EP_CLAIM_TYPES[existingEpCode]?.family;
+      return type.family === EP_CLAIM_TYPES[selectedEpCode]?.family;
     });
 
     // Format suitable for SearchableDropdown
@@ -25,11 +25,11 @@ export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
       label,
       value,
     }));
-  }, [EP_CLAIM_TYPES, existingEpCode]);
+  }, [EP_CLAIM_TYPES, selectedEpCode]);
 
-  const [newCode, setNewCode] = useState(availableOptions.find((item) => item.label === existingEpCode));
+  const [newCode, setNewCode] = useState(availableOptions.find((item) => item.label === selectedEpCode));
   const handleChangeLabel = (opt) => setNewCode(opt);
-  const isValid = useMemo(() => newCode?.label !== existingEpCode);
+  const isValid = useMemo(() => newCode?.label !== selectedEpCode);
 
   const buttons = [
     {
@@ -41,7 +41,7 @@ export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
       classNames: ['usa-button', 'usa-button-primary'],
       name: 'Continue',
       onClick: () => onSubmit?.({
-        oldCode: existingEpCode,
+        oldCode: selectedEpCode,
         newCode: newCode.label
       }),
       disabled: !isValid,
@@ -53,7 +53,7 @@ export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
       title={EDIT_CLAIM_LABEL_MODAL_TITLE}
       buttons={buttons}
       closeHandler={onCancel}
-      id="add_claimant_modal"
+      id="edit-claim-label-modal"
     >
       <div>
         <strong>
@@ -61,8 +61,8 @@ export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
             /* eslint-disable camelcase */
             sprintf(
               EDIT_CLAIM_LABEL_MODAL_SUBHEAD,
-            `${EP_CLAIM_TYPES[existingEpCode]?.family} ${
-              EP_CLAIM_TYPES[existingEpCode]?.official_label
+            `${EP_CLAIM_TYPES[selectedEpCode]?.family} ${
+              EP_CLAIM_TYPES[selectedEpCode]?.official_label
             }`
             )
           /* eslint-enable camelcase */
@@ -71,7 +71,7 @@ export const EditClaimLabelModal = ({ existingEpCode, onCancel, onSubmit }) => {
       </div>
       <p>{EDIT_CLAIM_LABEL_MODAL_NOTE}</p>
       <SearchableDropdown
-        name="claimLabel"
+        name="select-claim-label"
         label="Select the correct EP claim label"
         onChange={handleChangeLabel}
         value={newCode}
@@ -87,7 +87,7 @@ EditClaimLabelModal.propTypes = {
   /**
    * The claim label that the user wants to change
    */
-  existingEpCode: PropTypes.string.isRequired,
+  selectedEpCode: PropTypes.string.isRequired,
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func.isRequired,
 };

--- a/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
+++ b/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
@@ -45,6 +45,7 @@ describe('ConfirmClaimLabelModal', () => {
     // const newLabel = EP_CLAIM_TYPES[defaults.newEpCode].official_label;
     // expect(screen.queryByText(oldLabel)).toBeTruthy();
     expect(screen.getByText(COPY.EDIT_CLAIM_LABEL_MODAL_NOTE)).toBeInTheDocument();
+    expect(screen.queryByText(COPY.EDIT_CLAIM_LABEL_MODAL_NOTE)).toBeInTheDocument();
     // expect(screen.getByText('Higher')).toBeInTheDocument();
     // expect(screen.getByText(`New label: ${newLabel}`)).toBeInTheDocument();
   });

--- a/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
+++ b/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
@@ -3,16 +3,13 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 import COPY from 'COPY';
-import EP_CLAIM_TYPES from 'constants/EP_CLAIM_TYPES';
 
 import { ConfirmClaimLabelModal } from 'app/intakeEdit/components/ConfirmClaimLabelModal';
-
 
 describe('ConfirmClaimLabelModal', () => {
   const onSubmit = jest.fn();
   const onCancel = jest.fn();
   const defaults = { onCancel, onSubmit, previousEpCode: '030HLRR', newEpCode: "030HLRNR" };
-  // const oldLabel = EP_CLAIM_TYPES[defaults.previousEpCode].official_label;
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -41,13 +38,9 @@ describe('ConfirmClaimLabelModal', () => {
 
   it('shows the previous and new selected claim label', async () => {
     render(<ConfirmClaimLabelModal {...defaults} />);
-
-    // const newLabel = EP_CLAIM_TYPES[defaults.newEpCode].official_label;
-    // expect(screen.queryByText(oldLabel)).toBeTruthy();
-    expect(screen.getByText(COPY.EDIT_CLAIM_LABEL_MODAL_NOTE)).toBeInTheDocument();
-    expect(screen.queryByText(COPY.EDIT_CLAIM_LABEL_MODAL_NOTE)).toBeInTheDocument();
-    // expect(screen.getByText('Higher')).toBeInTheDocument();
-    // expect(screen.getByText(`New label: ${newLabel}`)).toBeInTheDocument();
+    expect(screen.getByText((/previous label: higher-level review rating*/i))).toBeInTheDocument();
+    expect(screen.getByText((/new label: higher-level review non-rating*/i))).toBeInTheDocument();
+    expect(screen.getByText(COPY.CONFIRM_CLAIM_LABEL_MODAL_BODY)).toBeInTheDocument();
   });
 
   describe('submission', () => {

--- a/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
+++ b/client/test/app/intake/components/ConfirmClaimLabelModal.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+import COPY from 'COPY';
+import EP_CLAIM_TYPES from 'constants/EP_CLAIM_TYPES';
+
+import { ConfirmClaimLabelModal } from 'app/intakeEdit/components/ConfirmClaimLabelModal';
+
+
+describe('ConfirmClaimLabelModal', () => {
+  const onSubmit = jest.fn();
+  const onCancel = jest.fn();
+  const defaults = { onCancel, onSubmit, previousEpCode: '030HLRR', newEpCode: "030HLRNR" };
+  // const oldLabel = EP_CLAIM_TYPES[defaults.previousEpCode].official_label;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders correctly', () => {
+    const { container } = render(<ConfirmClaimLabelModal {...defaults} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('passes a11y testing', async () => {
+    const { container } = render(<ConfirmClaimLabelModal {...defaults} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('should fire cancel event', async () => {
+    render(<ConfirmClaimLabelModal {...defaults} />);
+
+    await userEvent.click(screen.getByText('Cancel'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('shows the previous and new selected claim label', async () => {
+    render(<ConfirmClaimLabelModal {...defaults} />);
+
+    // const newLabel = EP_CLAIM_TYPES[defaults.newEpCode].official_label;
+    // expect(screen.queryByText(oldLabel)).toBeTruthy();
+    expect(screen.getByText(COPY.EDIT_CLAIM_LABEL_MODAL_NOTE)).toBeInTheDocument();
+    // expect(screen.getByText('Higher')).toBeInTheDocument();
+    // expect(screen.getByText(`New label: ${newLabel}`)).toBeInTheDocument();
+  });
+
+  describe('submission', () => {
+    it('submits the correct values', async () => {
+      render(<ConfirmClaimLabelModal {...defaults} />);
+
+      const submit = screen.getByRole('button', { name: /confirm/i });
+
+      userEvent.click(submit);
+
+      expect(onSubmit).toHaveBeenCalledWith({ previousEpCode: defaults.previousEpCode, newEpCode: defaults.newEpCode });
+    });
+  });
+
+});

--- a/client/test/app/intake/components/EditClaimLabelModal.test.js
+++ b/client/test/app/intake/components/EditClaimLabelModal.test.js
@@ -10,7 +10,7 @@ import { select } from 'glamor';
 describe('EditClaimLabelModal', () => {
   const onSubmit = jest.fn();
   const onCancel = jest.fn();
-  const defaults = { onCancel, onSubmit, existingEpCode: '040HDENR' };
+  const defaults = { onCancel, onSubmit, selectedEpCode: '040HDENR' };
 
   afterEach(() => {
     jest.clearAllMocks();
@@ -41,7 +41,7 @@ describe('EditClaimLabelModal', () => {
     render(<EditClaimLabelModal {...defaults} />);
 
     // Preselected, the code should show on screen
-    expect(screen.getByText(defaults.existingEpCode)).toBeInTheDocument();
+    expect(screen.getByText(defaults.selectedEpCode)).toBeInTheDocument();
   });
 
   describe('correctly filters by EP code family', () => {
@@ -57,7 +57,7 @@ describe('EditClaimLabelModal', () => {
     });
 
     it('displays only codes from 030 family', async () => {
-      render(<EditClaimLabelModal {...defaults} existingEpCode="030HLRFID" />);
+      render(<EditClaimLabelModal {...defaults} selectedEpCode="030HLRFID" />);
 
       const input = screen.getByLabelText(/select the correct ep claim label/i);
 
@@ -69,7 +69,7 @@ describe('EditClaimLabelModal', () => {
 
     it('displays only codes from 930 family', async () => {
       render(
-        <EditClaimLabelModal {...defaults} existingEpCode="930AHCNRLPMC" />
+        <EditClaimLabelModal {...defaults} selectedEpCode="930AHCNRLPMC" />
       );
 
       const input = screen.getByLabelText(/select the correct ep claim label/i);
@@ -115,7 +115,7 @@ describe('EditClaimLabelModal', () => {
       await selectEvent.select(dropdown, newCode);
       userEvent.click(submit);
 
-      expect(onSubmit).toHaveBeenCalledWith({ oldCode: defaults.existingEpCode, newCode });
+      expect(onSubmit).toHaveBeenCalledWith({ oldCode: defaults.selectedEpCode, newCode });
     });
   });
 

--- a/client/test/app/intake/components/__snapshots__/ConfirmClaimLabelModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/ConfirmClaimLabelModal.test.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmClaimLabelModal renders correctly 1`] = `
+<div>
+  <section
+    aria-describedby="modal_id-desc"
+    aria-labelledby="modal_id-title"
+    aria-modal="true"
+    class="cf-modal active "
+    id="modal_id"
+    role="alertdialog"
+  >
+    <div
+      class="cf-modal-body"
+      id="confirm-claim-label-modal"
+    >
+      <button
+        class="cf-modal-close"
+        id="Confirm-new-claim-label-button-id-close"
+        type="button"
+      >
+        <span
+          class="usa-sr-only"
+        >
+          Close
+        </span>
+        <svg
+          class="cf-icon-close"
+          height="55"
+          viewBox="0 0 55 55"
+          width="55"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            close
+          </title>
+          <path
+            d="M52.6 46.9l-6 6c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-13-13-13 13c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-6-6c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l13-13-13-13c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l6-6c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l13 13 13-13c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l6 6c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3l-13 13 13 13c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3z"
+          />
+        </svg>
+      </button>
+      <div
+        style="display: flex;"
+      >
+        <div
+          data-css-1gs0ko2=""
+        >
+          <h1
+            id="modal_id-title"
+          >
+            Confirm new claim label
+          </h1>
+          <div
+            data-css-o98ubo=""
+          >
+            <div
+              style="margin-bottom: 24px;"
+            >
+              <strong>
+                Previous label: 
+                Higher-Level Review Rating
+                <br />
+                New label: 
+                Higher-Level Review Non-Rating
+              </strong>
+            </div>
+            <p>
+              Select "confirm" to save and complete editing this claim label. If the claim label is not updated in VBMS in 24 hours, please submit a YourIT ticket.
+            </p>
+          </div>
+        </div>
+      </div>
+      <div
+        class="cf-modal-divider"
+      />
+      <div
+        class="cf-modal-controls"
+      >
+        <span>
+          <button
+            class="cf-modal-link cf-btn-link cf-push-left usa-button"
+            id="Confirm-new-claim-label-button-id-0"
+            type="button"
+          >
+            Cancel
+          </button>
+        </span>
+        <span>
+          <button
+            class="usa-button usa-button-primary cf-push-right usa-button"
+            id="Confirm-new-claim-label-button-id-1"
+            type="button"
+          >
+            Confirm
+          </button>
+        </span>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/client/test/app/intake/components/__snapshots__/EditClaimLabelModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/EditClaimLabelModal.test.js.snap
@@ -55,7 +55,7 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
           >
             <div>
               <strong>
-                You are editing a undefined undefined claim
+                You are editing a 040 HLR DTA Error - Non-Rating claim
               </strong>
             </div>
             <p>
@@ -87,12 +87,12 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
                       class="cf-select__control css-yk16xz-control"
                     >
                       <div
-                        class="cf-select__value-container css-g1d714-ValueContainer"
+                        class="cf-select__value-container cf-select__value-container--has-value css-g1d714-ValueContainer"
                       >
                         <div
-                          class="cf-select__placeholder css-1wa3eu0-placeholder"
+                          class="cf-select__single-value css-1uccc91-singleValue"
                         >
-                          Select...
+                          040HDENR
                         </div>
                         <div
                           class="css-81nyic-Input"

--- a/client/test/app/intake/components/__snapshots__/EditClaimLabelModal.test.js.snap
+++ b/client/test/app/intake/components/__snapshots__/EditClaimLabelModal.test.js.snap
@@ -12,7 +12,7 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
   >
     <div
       class="cf-modal-body"
-      id="add_claimant_modal"
+      id="edit-claim-label-modal"
     >
       <button
         class="cf-modal-close"
@@ -55,18 +55,18 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
           >
             <div>
               <strong>
-                You are editing a 040 HLR DTA Error - Non-Rating claim
+                You are editing a undefined undefined claim
               </strong>
             </div>
             <p>
               Please note: you will only be able to select claim labels within the same EP family (e.g. 040, 030). If you need to switch to another EP family, please cancel and re-establish the claim.
             </p>
             <div
-              class="cf-form-dropdown dropdown-claimLabel"
+              class="cf-form-dropdown dropdown-select-claim-label"
             >
               <label
                 class="question-label"
-                for="claimLabel"
+                for="select-claim-label"
               >
                 <strong>
                   <span>
@@ -87,12 +87,12 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
                       class="cf-select__control css-yk16xz-control"
                     >
                       <div
-                        class="cf-select__value-container cf-select__value-container--has-value css-g1d714-ValueContainer"
+                        class="cf-select__value-container css-g1d714-ValueContainer"
                       >
                         <div
-                          class="cf-select__single-value css-1uccc91-singleValue"
+                          class="cf-select__placeholder css-1wa3eu0-placeholder"
                         >
-                          040HDENR
+                          Select...
                         </div>
                         <div
                           class="css-81nyic-Input"
@@ -106,7 +106,7 @@ exports[`EditClaimLabelModal renders correctly 1`] = `
                               autocapitalize="none"
                               autocomplete="off"
                               autocorrect="off"
-                              id="claimLabel"
+                              id="select-claim-label"
                               spellcheck="false"
                               style="box-sizing: content-box; width: 2px; border: 0px; opacity: 1; outline: 0; padding: 0px;"
                               tabindex="0"

--- a/spec/feature/intake/edit_ep_claim_labels_spec.rb
+++ b/spec/feature/intake/edit_ep_claim_labels_spec.rb
@@ -108,13 +108,13 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
       nr_label = Constants::EP_CLAIM_TYPES[nonrating_request_issue.end_product_establishment.code]["official_label"]
       nr_row = page.find("tr", text: nr_label, match: :prefer_exact)
       expect(nr_row).to have_button("Edit claim label")
-      nr_next_row = nr_row.first(:xpath, './following-sibling::tr')
+      nr_next_row = nr_row.first(:xpath, "./following-sibling::tr")
       expect(nr_next_row).to have_content(/Requested issues\n1. #{nonrating_request_issue.description}/i)
 
       r_label = Constants::EP_CLAIM_TYPES[rating_request_issue.end_product_establishment.code]["official_label"]
       r_row = page.find("tr", text: r_label, match: :prefer_exact)
       expect(r_row).to have_button("Edit claim label")
-      r_next_row = r_row.first(:xpath, './following-sibling::tr')
+      r_next_row = r_row.first(:xpath, "./following-sibling::tr")
       expect(r_next_row).to have_content(/Requested issues\n2. #{rating_request_issue.description}/i)
 
       # Shows issues not on end products (single row)

--- a/spec/feature/intake/edit_ep_claim_labels_spec.rb
+++ b/spec/feature/intake/edit_ep_claim_labels_spec.rb
@@ -103,19 +103,19 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
     it "shows each established end product label" do
       visit "higher_level_reviews/#{higher_level_review.uuid}/edit"
 
-      # First shows issues on end products, in ascending order by EP code
-      # Note for these, there's a row for the EP, and another for the issues
-      row = find("#table-row-8")
-      label = Constants::EP_CLAIM_TYPES[nonrating_request_issue.end_product_establishment.code]["official_label"]
-      expect(row).to have_content(label)
-      expect(row).to have_button("Edit claim label")
-      expect(find("#table-row-9")).to have_content(/Requested issues\n1. #{nonrating_request_issue.description}/i)
+      # First shows issues on end products, in ascending order by EP code (nonrating before rating)
+      # Note for these, there's a row for the EP label, and a subsequent row for the issues
+      nr_label = Constants::EP_CLAIM_TYPES[nonrating_request_issue.end_product_establishment.code]["official_label"]
+      nr_row = page.find("tr", text: nr_label, match: :prefer_exact)
+      expect(nr_row).to have_button("Edit claim label")
+      nr_next_row=nr_row.first(:xpath, './following-sibling::tr')
+      expect(nr_next_row).to have_content(/Requested issues\n1. #{nonrating_request_issue.description}/i)
 
-      label = Constants::EP_CLAIM_TYPES[rating_request_issue.end_product_establishment.code]["official_label"]
-      row = find("#table-row-10")
-      expect(row).to have_content(label)
-      expect(row).to have_button("Edit claim label")
-      expect(find("#table-row-11")).to have_content(/Requested issues\n2. #{rating_request_issue.description}/i)
+      r_label = Constants::EP_CLAIM_TYPES[rating_request_issue.end_product_establishment.code]["official_label"]
+      r_row = page.find("tr", text: r_label, match: :prefer_exact)
+      expect(r_row).to have_button("Edit claim label")
+      r_next_row=r_row.first(:xpath, './following-sibling::tr')
+      expect(r_next_row).to have_content(/Requested issues\n2. #{rating_request_issue.description}/i)
 
       # Shows issues not on end products (single row)
       row = find("#table-row-12")
@@ -126,6 +126,25 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
       expect(row).to have_content(
         /Withdrawn issues\n4. #{withdrawn_request_issue.description}/i
       )
+
+      # Edit nonrating label to rating
+      nr_row.find("button", text: "Edit claim label").click
+      expect(page).to have_content(COPY::EDIT_CLAIM_LABEL_MODAL_NOTE)
+      click_on "Cancel"
+
+      expect(page).to_not have_content(COPY::EDIT_CLAIM_LABEL_MODAL_NOTE)
+
+      nr_row.find("button", text: "Edit claim label").click
+      safe_click ".cf-select"
+      fill_in "Select the correct EP claim label", with: "030HLRR"
+      find("#select-claim-label").send_keys :enter
+      find("button", text: "Continue").click
+
+      expect(page).to have_content(COPY::CONFIRM_CLAIM_LABEL_MODAL_TITLE)
+      expect(page).to have_content("Previous label: #{nr_label}")
+      expect(page).to have_content("New label: #{r_label}")
+
+      find("button", text: "Confirm").click
     end
   end
 end

--- a/spec/feature/intake/edit_ep_claim_labels_spec.rb
+++ b/spec/feature/intake/edit_ep_claim_labels_spec.rb
@@ -108,13 +108,13 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
       nr_label = Constants::EP_CLAIM_TYPES[nonrating_request_issue.end_product_establishment.code]["official_label"]
       nr_row = page.find("tr", text: nr_label, match: :prefer_exact)
       expect(nr_row).to have_button("Edit claim label")
-      nr_next_row=nr_row.first(:xpath, './following-sibling::tr')
+      nr_next_row = nr_row.first(:xpath, './following-sibling::tr')
       expect(nr_next_row).to have_content(/Requested issues\n1. #{nonrating_request_issue.description}/i)
 
       r_label = Constants::EP_CLAIM_TYPES[rating_request_issue.end_product_establishment.code]["official_label"]
       r_row = page.find("tr", text: r_label, match: :prefer_exact)
       expect(r_row).to have_button("Edit claim label")
-      r_next_row=r_row.first(:xpath, './following-sibling::tr')
+      r_next_row = r_row.first(:xpath, './following-sibling::tr')
       expect(r_next_row).to have_content(/Requested issues\n2. #{rating_request_issue.description}/i)
 
       # Shows issues not on end products (single row)


### PR DESCRIPTION
Resolves #15369

## Description
This shows a confirmation modal with the previous EP code and the new EP code for an Edit Claim Label edit.  Submitting this would submit to backend (out of scope for this ticket).

## Acceptance criteria
- [x] Please put this work behind the feature toggle: [edit_ep_claim_labels]
- [x] The user sees the confirmation modal once they click "continue" after selecting a new claim label
- [x] Please add in copy based on the attached design
- [x] The user sees the original claim label in the field "Previous label: x"
- [x] The user sees the new claim label in the field "New label: y"
- [x] If the user cancels, close the modal and clear any data related to editing the claim label
- [x] Make a storybook story for this component
- [x] Add jest test
- [x] Include screenshot(s) in the Github issue

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Automated tests


### Storybook Story
*For Frontend (Presentationa) Components*
* [x] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [x] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [x] Write a separate story (within the same file) for each discrete variation of the component


