### PR TITLE
CASEFLOW-106 #done Allow CAVC Litigation Support Users to Correct Issues

### DIFF
--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -40,6 +40,7 @@ class AppealRequestIssuesPolicy
   end
 
   def cavc_task_open?
-    appeal.tasks.open.where(type: :CavcTask).count > 0
+    CavcLitigationSupport.singleton.users.include?(user) &&
+      appeal.tasks.open.where(type: :CavcTask).any?
   end
 end

--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -8,7 +8,7 @@ class AppealRequestIssuesPolicy
 
   def editable?
     editable_by_case_review_team_member? || case_is_in_active_review_by_current_user? ||
-      hearing_is_assigned_to_judge_user
+      hearing_is_assigned_to_judge_user? || cavc_task_open?
   end
 
   private
@@ -27,7 +27,7 @@ class AppealRequestIssuesPolicy
     Task.where(appeal: appeal, type: "AttorneyTask").empty?
   end
 
-  def hearing_is_assigned_to_judge_user
+  def hearing_is_assigned_to_judge_user?
     appeal.hearings.last&.judge == user
   end
 
@@ -37,5 +37,9 @@ class AppealRequestIssuesPolicy
       assigned_to: user,
       status: [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.in_progress]
     ).select { |task| task.is_a?(JudgeTask) || task.is_a?(AttorneyTask) }.any?
+  end
+
+  def cavc_task_open?
+    appeal.tasks.open.where(type: :CavcTask).count > 0
   end
 end

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -136,8 +136,12 @@ class AddIssuesPage extends React.Component {
 
   establishmentCredits() {
     return <div className="cf-intake-establish-credits">
-      Established {this.establishmentCreditsTimestamp()}
-      <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
+      Established at {this.establishmentCreditsTimestamp()}
+      { this.props.intakeUser &&
+        <span>
+          by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a>
+        </span>
+      }
     </div>;
   }
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -136,11 +136,9 @@ class AddIssuesPage extends React.Component {
 
   establishmentCredits() {
     return <div className="cf-intake-establish-credits">
-      Established at {this.establishmentCreditsTimestamp()}
+      Established {this.establishmentCreditsTimestamp()}
       { this.props.intakeUser &&
-        <span>
-          by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a>
-        </span>
+        <span> by <a href={`/intake/manager?user_css_id=${this.props.intakeUser}`}>{this.props.intakeUser}</a></span>
       }
     </div>;
   }

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -10,6 +10,14 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
   let!(:org_nonadmin2) { create(:user, full_name: "Tooey Remandy") { |u| CavcLitigationSupport.singleton.add_user(u) } }
   let!(:other_user) { create(:user, full_name: "Othery Usery") }
 
+  describe "when CAVC Lit Support has a CAVC Remand case" do
+    it "allows CAVC Team users to correct issues" do
+      step "check 'Correct issues' link appears" do
+
+      end
+    end
+  end
+
   describe "when CAVC Lit Support is assigned SendCavcRemandProcessedLetterTask" do
     let!(:send_task) { create(:send_cavc_remand_processed_letter_task) }
     let(:vet_name) { send_task.appeal.veteran_full_name }

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -12,7 +12,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
 
   include IntakeHelpers
   describe "when CAVC Lit Support has a CAVC Remand case" do
-    let!(:cavc_task) { create(:cavc_task) }
+    let(:cavc_task) { create(:cavc_task) }
     let!(:appeal) { cavc_task.appeal }
     let(:decision_issue) { create(:decision_issue, description: "decision 1", decision_review: appeal) }
     let!(:request_issue) do

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -11,9 +11,16 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
   let!(:other_user) { create(:user, full_name: "Othery Usery") }
 
   describe "when CAVC Lit Support has a CAVC Remand case" do
+    let!(:cavc_task) { create(:cavc_task) }
     it "allows CAVC Team users to correct issues" do
       step "check 'Correct issues' link appears" do
+        User.authenticate!(user: org_nonadmin)
+        visit "queue/appeals/#{cavc_task.appeal.external_id}"
+        expect(page).to have_content "Correct issues"
 
+        User.authenticate!(user: other_user)
+        visit "queue/appeals/#{cavc_task.appeal.external_id}"
+        expect(page).to_not have_content "Correct issues"
       end
     end
   end

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -10,17 +10,55 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
   let!(:org_nonadmin2) { create(:user, full_name: "Tooey Remandy") { |u| CavcLitigationSupport.singleton.add_user(u) } }
   let!(:other_user) { create(:user, full_name: "Othery Usery") }
 
+  include IntakeHelpers
   describe "when CAVC Lit Support has a CAVC Remand case" do
     let!(:cavc_task) { create(:cavc_task) }
+    let!(:appeal) { cavc_task.appeal }
+    let(:decision_issue) { create(:decision_issue, description: "decision 1", decision_review: appeal) }
+    let!(:request_issue) do
+      create(:request_issue, :rating, decision_review: appeal,
+                                      contested_issue_description: "issue description",
+                                      notes: "notes from NOD",
+                                      decision_issues: [decision_issue])
+    end
+
+    let!(:new_issue_description) { "Some description for new issue" }
+
     it "allows CAVC Team users to correct issues" do
+      step "check 'Correct issues' link does not appear for users not in the CAVC Team" do
+        User.authenticate!(user: other_user)
+        visit "queue/appeals/#{appeal.external_id}"
+        expect(page).to_not have_content "Correct issues"
+      end
+
       step "check 'Correct issues' link appears" do
         User.authenticate!(user: org_nonadmin)
-        visit "queue/appeals/#{cavc_task.appeal.external_id}"
+        visit "queue/appeals/#{appeal.external_id}"
         expect(page).to have_content "Correct issues"
+      end
 
-        User.authenticate!(user: other_user)
-        visit "queue/appeals/#{cavc_task.appeal.external_id}"
-        expect(page).to_not have_content "Correct issues"
+      step "add an issue" do
+        click_on "Correct issues"
+        expect(appeal.request_issues.count).to eq 1
+        click_on "+ Add issue"
+        add_intake_nonrating_issue(
+          category: "Unknown issue category",
+          description: new_issue_description,
+          date: (Time.zone.now - 100.days).mdY
+        )
+        click_edit_submit_and_confirm
+        expect(page).to have_content "Edit Completed"
+        expect(page).to have_content "You have successfully added 1 issue."
+        expect(appeal.request_issues.count).to eq 2
+      end
+
+      step "remove an issue" do
+        click_link "Correct issues"
+        click_remove_intake_issue_dropdown(new_issue_description)
+        click_edit_submit_and_confirm
+        expect(page).to have_content "Edit Completed"
+        expect(page).to have_content "You have successfully removed 1 issue."
+        expect(appeal.request_issues.where(closed_status: nil).count).to eq 1
       end
     end
   end

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -49,6 +49,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         click_edit_submit_and_confirm
         expect(page).to have_content "Edit Completed"
         expect(page).to have_content "You have successfully added 1 issue."
+        expect(page).to have_content new_issue_description
         expect(appeal.request_issues.count).to eq 2
       end
 
@@ -58,6 +59,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         click_edit_submit_and_confirm
         expect(page).to have_content "Edit Completed"
         expect(page).to have_content "You have successfully removed 1 issue."
+        expect(page).to_not have_content new_issue_description
         expect(appeal.request_issues.where(closed_status: nil).count).to eq 1
       end
     end


### PR DESCRIPTION
Resolves #15289 aka [CASEFLOW-106](https://vajira.max.gov/browse/CASEFLOW-106)

### Description
As a CAVC Litigation Support user, I need the ability to add issues on a CAVC case that the Board may not have captured in the original decision, so that the new issue can be decided on.

### Acceptance Criteria
- [ ] Verify the user has the ability to add issues on the front end after appeal is created
- [ ] Verify the link only appears to CAVC Litigation Support user if there is an active CavcTask
- [ ] Verify the user is routed to the Edit Issues page in Caseflow intake
- [ ] ~Verify VBMS records are created as needed~ (UPDATE: Sally says, "Since appeals are processed in Caseflow, nothing is updated in VBMS when someone adds a new issue to an appeal. A VBMS update happens for Comp/Pension/Fiduciary HLRs and SCs" -- [Slack](https://dsva.slack.com/archives/C54QCEHAL/p1606323959368000?thread_ts=1606319918.367400&cid=C54QCEHAL).

### Testing Plan
1. Log in as CAVC_LIT_SUPPORT_ADMIN (VACO)
1. Go to http://localhost:3000/organizations/cavc-lit-support?tab=unassignedTab&page=1
1. Assign a case to yourself
1. Open the case details page for the case (under the Assigned tab of the Team view -- same URL above)
1. Click the "Correct issues" link 
1. Add issue(s) via the "Add issue" button. In the modal, click "None of these match, see more options" to add an entirely new issue (that is eligible). Optionally, remove issue(s).
1. Click "Save" and confirm.
1. Back in the case details page, eligible issues are shown, and removed or ineligible issues are not shown.
1. Bonus: Check associated `RequestIssuesUpdate` records for appropriate modifications.
1. Bonus: Repeat the steps above. May have to `riu.perform!` if you get an error message after trying to save subsequent edits. See [VBMS investigation comment below](https://github.com/department-of-veterans-affairs/caseflow/pull/15631#issuecomment-733774776).

### User Facing Changes
 - [x] Screenshots of UI changes added 

New "Correct Issues" link for CAVC Litigation Support users
![image](https://user-images.githubusercontent.com/55255674/100134714-3e26f780-2e4e-11eb-840d-0002d188720f.png)

After adding 2 new issues:
![image](https://user-images.githubusercontent.com/55255674/100160017-75a89a80-2e74-11eb-9609-e620641071c7.png)

Clicking "Save" brings up confirmation:
![image](https://user-images.githubusercontent.com/55255674/100160074-8ce78800-2e74-11eb-97ba-a81221da2c03.png)

After saving, case details shows success banner (and new issues if they were eligible):
![image](https://user-images.githubusercontent.com/55255674/100160209-bc969000-2e74-11eb-978c-72882457cd94.png)

Removing an issue shows confirmation modal:
![image](https://user-images.githubusercontent.com/55255674/100160306-ebad0180-2e74-11eb-9032-fd2cfed1d606.png)

Removing last issue shows case-will-be-closed warning modal:
![image](https://user-images.githubusercontent.com/55255674/100160336-01bac200-2e75-11eb-8952-1c69f2fa844e.png)



