### PR TITLE
Resolve double reminder bug

### DIFF
--- a/app/services/virtual_hearings/reminder_service.rb
+++ b/app/services/virtual_hearings/reminder_service.rb
@@ -44,17 +44,17 @@ class VirtualHearings::ReminderService
   # If the virtual hearing was scheduled within a reminder period, we skip sending the reminder for that period
   # because the confirmation will have redundant information.
   def days_between_hearing_and_created_at
-    (virtual_hearing.hearing.scheduled_for - virtual_hearing.created_at) / 1.day
+    ((virtual_hearing.hearing.scheduled_for - virtual_hearing.created_at) / 1.day).floor
   end
 
   def days_until_hearing
-    ((virtual_hearing.hearing.scheduled_for - Time.zone.now.utc) / 1.day).round
+    ((virtual_hearing.hearing.scheduled_for - Time.zone.now.utc) / 1.day).floor
   end
 
   def days_from_hearing_day_to_last_sent_reminder
     # Pick arbitrarily big value if the reminder has never been sent.
     return Float::INFINITY if last_sent_reminder.nil?
 
-    (virtual_hearing.hearing.scheduled_for - last_sent_reminder) / 1.day
+    ((virtual_hearing.hearing.scheduled_for - last_sent_reminder) / 1.day).floor
   end
 end


### PR DESCRIPTION
https://vajira.max.gov/browse/CASEFLOW-194

### Description

- Fixes a rounding bug that caused emails to double send
- Adds test for double sending emails
