### PR TITLE
Task sorter fix for sort by task label

### DIFF
--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -68,8 +68,8 @@ class TaskSorter
   # Sort tasks by their labels, rather than by type. Constructs a string of all task types sorted by their labels for
   # postgres to use as a reference for sorting as a task's label is not stored in the database.
   def task_type_order_clause
-    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name).to_json.tr('"', "'")
-    task_types_sql_array = "array#{task_types_sorted_by_label}::varchar[]"
+    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name)
+    task_types_sql_array = "array#{task_types_sorted_by_label}::varchar[]".tr('"', "'")
     task_type_sort_position = "#{task_types_sql_array}, tasks.type"
     "array_position(#{task_type_sort_position}) #{sort_order}"
   end

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -68,7 +68,7 @@ class TaskSorter
   # Sort tasks by their labels, rather than by type. Constructs a string of all task types sorted by their labels for
   # postgres to use as a reference for sorting as a task's label is not stored in the database.
   def task_type_order_clause
-    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name).to_json.gsub(/"/,"'")
+    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name).to_json.tr('"', "'")
     task_types_sql_array = "array#{task_types_sorted_by_label}::varchar[]"
     task_type_sort_position = "#{task_types_sql_array}, tasks.type"
     "array_position(#{task_type_sort_position}) #{sort_order}"

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -68,9 +68,10 @@ class TaskSorter
   # Sort tasks by their labels, rather than by type. Constructs a string of all task types sorted by their labels for
   # postgres to use as a reference for sorting as a task's label is not stored in the database.
   def task_type_order_clause
-    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name)
-    task_type_sort_position = "tasks.type in '#{task_types_sorted_by_label.join(',')}'"
-    "position(#{task_type_sort_position}) #{sort_order}"
+    task_types_sorted_by_label = Task.descendants.sort_by(&:label).map(&:name).to_json.gsub(/"/,"'")
+    task_types_sql_array = "array#{task_types_sorted_by_label}::varchar[]"
+    task_type_sort_position = "#{task_types_sql_array}, tasks.type"
+    "array_position(#{task_type_sort_position}) #{sort_order}"
   end
 
   def assigner_order_clause

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -362,7 +362,8 @@ feature "Intake Add Issues Page", :all_dbs do
       add_untimely_exemption_response("No")
       expect(page).to have_content("Unidentified issue")
       click_on "Establish EP"
-      expect(page).to have_content("Unidentified issue")
+
+      expect(page).to have_content(RequestIssue::UNIDENTIFIED_ISSUE_MSG)
 
       unidentified_issue = RequestIssue.where(
         unidentified_issue_text: "Unidentified issue",

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -159,6 +159,13 @@ describe TaskSorter, :all_dbs do
         before do
           Colocated.singleton.add_user(create(:user))
           tasks.each_with_index { |task, index| task.update!(type: task_types[index].name) }
+
+          # Used to ensure sort by label still works when a task name contain another task name as a substring
+          class TestAttorneyTask < AttorneyTask
+            def self.label
+              "Alphabetically superior to AttorneyTask"
+            end
+          end
         end
 
         it "sorts ColocatedTasks by label" do

--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -163,7 +163,7 @@ describe TaskSorter, :all_dbs do
           # Used to ensure sort by label still works when a task name contain another task name as a substring
           class TestAttorneyTask < AttorneyTask
             def self.label
-              "Alphabetically superior to AttorneyTask"
+              "Alphabetically superior to Draft decision (label for Attorney Task)"
             end
           end
         end


### PR DESCRIPTION
resolves #15636

### Description
Defines sort position by finding task type in a SQL array, instead of matching task type as substring in a string.

Note: This was noticed during [another PR](https://github.com/department-of-veterans-affairs/caseflow/pull/15622) that JC is able to fix by changing his task's label - so we're not aware of this being a prod bug.  It seems like a task's name could easily be a substring in another task's name, and so this is to prevent potential future easy-to-miss occurrences.

### Acceptance criteria
- [x] `TaskSorter` will not fail if two tasks that share a type substring, regardless of output of their `label` method