### PR TITLE
Add storybook entries for remaining form fields

### DIFF
--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -34,15 +34,15 @@ const EditableField = (props) => {
     startEditing();
   }
 
-  const saveOnEnter = (event) => {
-    if (event.key === 'Enter') {
-      onSave(value);
-    }
-  };
-
   const onSaveClick = () => {
     stopEditing();
     onSave(value);
+  };
+
+  const saveOnEnter = (event) => {
+    if (event.key === 'Enter') {
+      onSaveClick();
+    }
   };
 
   const onCancelClick = () => {

--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -10,6 +10,7 @@ export const EditableField = (props) => {
   const {
     className,
     errorMessage,
+    inputProps,
     inputRef,
     label,
     maxLength,
@@ -74,6 +75,7 @@ export const EditableField = (props) => {
       placeholder={placeholder}
       title={title}
       maxLength={maxLength}
+      {...inputProps}
     />;
   } else {
     actionLinks = <span>
@@ -110,6 +112,11 @@ EditableField.propTypes = {
    * Error string to show. Will style entire component as invalid if defined
    */
   errorMessage: PropTypes.string,
+
+  /**
+   * Props to be applied to the `input` element
+   */
+  inputProps: PropTypes.object,
 
   /**
    * Pass a ref to the `input` element

--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -36,7 +36,7 @@ const EditableField = (props) => {
 
   const saveOnEnter = (event) => {
     if (event.key === 'Enter') {
-      onSave();
+      onSave(value);
     }
   };
 

--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -1,94 +1,94 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from './Button';
 
-export default class EditableField extends React.Component {
-  constructor(props) {
-    super(props);
+const EditableField = (props) => {
+  const {
+    errorMessage,
+    className,
+    label,
+    name,
+    type,
+    value: initialValue,
+    onChange,
+    onCancel,
+    onSave,
+    placeholder,
+    title,
+    maxLength
+  } = props;
+  const buttonClasses = ['cf-btn-link', 'editable-field-btn-link'];
+  let actionLinks, textDisplay;
 
-    this.state = {
-      editing: false
-    };
+  const [editing, setEditing] = useState(false);
+  const [value, setvalue] = useState(initialValue);
+
+  const startEditing = () => setEditing(true);
+  const stopEditing = () => setEditing(false);
+
+  if (errorMessage && !editing) {
+    startEditing();
   }
 
-  startEditing = () => this.setState({ editing: true });
-  stopEditing = () => this.setState({ editing: false });
-
-  saveOnEnter = (event) => {
+  const saveOnEnter = (event) => {
     if (event.key === 'Enter') {
-      this.onSave();
+      onSave();
     }
-  }
-  onSave = () => {
-    this.props.onSave(this.props.value);
-    this.stopEditing();
-  }
-  onCancel = () => {
-    this.props.onCancel();
-    this.stopEditing();
-  }
-  onChange = (event) => this.props.onChange(event.target.value);
+  };
 
-  componentDidUpdate = () => {
-    if (this.props.errorMessage && !this.state.editing) {
-      this.setState({ editing: true });
-    }
+  const onSaveClick = () => {
+    stopEditing();
+    onSave(value);
+  };
+
+  const onCancelClick = () => {
+    stopEditing();
+    onCancel();
+  };
+
+  const onValueChange = (event) => {
+    setvalue(event.target.value);
+    onChange(event.target.value);
+  };
+
+  if (editing) {
+    actionLinks = <span>
+      <Button onClick={onCancelClick} id={`${name}-cancel`} classNames={buttonClasses}>
+        Cancel
+      </Button>&nbsp;|&nbsp;
+      <Button onClick={onSaveClick} id={`${name}-save`} classNames={buttonClasses}>
+        Save
+      </Button>
+    </span>;
+    textDisplay = <input
+      className={className}
+      name={name}
+      id={name}
+      onChange={onValueChange}
+      onKeyDown={saveOnEnter}
+      type={type}
+      value={value}
+      placeholder={placeholder}
+      title={title}
+      maxLength={maxLength}
+    />;
+  } else {
+    actionLinks = <span>
+      <Button onClick={startEditing} id={`${name}-edit`} classNames={buttonClasses}>
+        Edit
+      </Button>
+    </span>;
+    textDisplay = <span id={name}>{value}</span>;
   }
 
-  render() {
-    const {
-      errorMessage,
-      className,
-      label,
-      name,
-      type,
-      value,
-      placeholder,
-      title,
-      maxLength
-    } = this.props;
-    const buttonClasses = ['cf-btn-link', 'editable-field-btn-link'];
-    let actionLinks, textDisplay;
-
-    if (this.state.editing) {
-      actionLinks = <span>
-        <Button onClick={this.onCancel} id={`${name}-cancel`} classNames={buttonClasses}>
-          Cancel
-        </Button>&nbsp;|&nbsp;
-        <Button onClick={this.onSave} id={`${name}-save`} classNames={buttonClasses}>
-          Save
-        </Button>
-      </span>;
-      textDisplay = <input
-        className={className}
-        name={name}
-        id={name}
-        onChange={this.onChange}
-        onKeyDown={this.saveOnEnter}
-        type={type}
-        value={value}
-        placeholder={placeholder}
-        title={title}
-        maxLength={maxLength}
-      />;
-    } else {
-      actionLinks = <span>
-        <Button onClick={this.startEditing} id={`${name}-edit`} classNames={buttonClasses}>
-          Edit
-        </Button>
-      </span>;
-      textDisplay = <span id={name}>{value}</span>;
-    }
-
-    return <div className={classNames(className, { 'usa-input-error': errorMessage })}>
-      <strong>{label}</strong>
-      {actionLinks}<br />
-      {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
-      {textDisplay}
-    </div>;
-  }
-}
+  return <div className={classNames(className, { 'usa-input-error': errorMessage })}>
+    <strong>{label}</strong>
+    {actionLinks}<br />
+    {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
+    {textDisplay}
+  </div>;
+};
 
 EditableField.defaultProps = {
   type: 'text',
@@ -96,15 +96,66 @@ EditableField.defaultProps = {
 };
 
 EditableField.propTypes = {
-  name: PropTypes.string,
-  onSave: PropTypes.func.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  errorMessage: PropTypes.string,
+
+  /**
+   * Class to apply to the wrapping div and input field of the component
+   */
   className: PropTypes.string,
+
+  /**
+   * Error string to show. Will style entire component as invalid if defined
+   */
+  errorMessage: PropTypes.string,
+
+  /**
+   * Text (or other node) to display in associated `label` element
+   */
   label: PropTypes.string,
-  type: PropTypes.string,
-  value: PropTypes.string,
+
+  /**
+   * The maximum number of characters allowed in the `input` element. Default value is 524288.
+   */
+  maxLength: PropTypes.number,
+
+  /**
+   * String to be applied to the `name` attribute of the `input` element
+   */
+  name: PropTypes.string,
+
+  /**
+   * Callback fired when the cancel button is clicked
+   */
+  onCancel: PropTypes.func.isRequired,
+
+  /**
+   * Callback fired when value in the text field is changed
+   */
+  onChange: PropTypes.func,
+
+  /**
+   * Callback fired when the cancel button is clicked
+   */
+  onSave: PropTypes.func.isRequired,
+
+  /**
+   * Text to display when `value` is empty
+   */
   placeholder: PropTypes.string,
+
+  /**
+   * String to be applied to the `title` attribute of the `input` element
+   */
   title: PropTypes.string,
-  maxLength: PropTypes.number
+
+  /**
+   * String to be applied to the `type` attribute of the `input` element
+   */
+  type: PropTypes.string,
+
+  /**
+   * The value of the `input` element
+   */
+  value: PropTypes.string
 };
+
+export default EditableField;

--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Button from './Button';
 
+/**
+ * A field that displays a value that can be edited and saved
+ */
 const EditableField = (props) => {
   const {
     errorMessage,

--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -6,33 +6,31 @@ import Button from './Button';
 /**
  * A field that displays a value that can be edited and saved
  */
-const EditableField = (props) => {
+export const EditableField = (props) => {
   const {
-    errorMessage,
     className,
+    errorMessage,
+    inputRef,
     label,
+    maxLength,
     name,
-    type,
-    value: initialValue,
-    onChange,
     onCancel,
+    onChange,
     onSave,
     placeholder,
     title,
-    maxLength
+    type,
+    value: initialValue
   } = props;
   const buttonClasses = ['cf-btn-link', 'editable-field-btn-link'];
   let actionLinks, textDisplay;
 
-  const [editing, setEditing] = useState(false);
+  // Initialize with the editable field displayed if these is an error
+  const [editing, setEditing] = useState(errorMessage && errorMessage.length);
   const [value, setvalue] = useState(initialValue);
 
   const startEditing = () => setEditing(true);
   const stopEditing = () => setEditing(false);
-
-  if (errorMessage && !editing) {
-    startEditing();
-  }
 
   const onSaveClick = () => {
     stopEditing();
@@ -65,6 +63,7 @@ const EditableField = (props) => {
       </Button>
     </span>;
     textDisplay = <input
+      ref={inputRef}
       className={className}
       name={name}
       id={name}
@@ -85,12 +84,14 @@ const EditableField = (props) => {
     textDisplay = <span id={name}>{value}</span>;
   }
 
-  return <div className={classNames(className, { 'usa-input-error': errorMessage })}>
-    <strong>{label}</strong>
-    {actionLinks}<br />
-    {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
-    {textDisplay}
-  </div>;
+  return (
+    <div className={classNames(className, { 'usa-input-error': errorMessage })}>
+      <strong>{label}</strong>
+      {actionLinks}<br />
+      {errorMessage && <span className="usa-input-error-message">{errorMessage}</span>}
+      {textDisplay}
+    </div>
+  );
 };
 
 EditableField.defaultProps = {
@@ -109,6 +110,16 @@ EditableField.propTypes = {
    * Error string to show. Will style entire component as invalid if defined
    */
   errorMessage: PropTypes.string,
+
+  /**
+   * Pass a ref to the `input` element
+   */
+  inputRef: PropTypes.oneOfType([
+    // Either a function
+    PropTypes.func,
+    // Or the instance of a DOM native element (see the note about SSR)
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
 
   /**
    * Text (or other node) to display in associated `label` element

--- a/client/app/components/EditableField.stories.js
+++ b/client/app/components/EditableField.stories.js
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import EditableField from './EditableField';
+
+const Template = (args) => <EditableField {...args} />;
+
+export const Default = Template.bind({});
+Default.args = { label: 'Click "Edit" to change the value below' };
+
+export const Error = Template.bind({});
+Error.args = { errorMessage: 'This is invalid' };
+
+export const Label = Template.bind({});
+Label.args = { label: 'This is a new label' };
+
+export const MaxLength = Template.bind({});
+MaxLength.args = { maxLength: 30, label: 'Enter more text below (max 30)', value: 'This is exactly 29 characters' };
+
+export const Placeholder = Template.bind({});
+Placeholder.args = { placeholder: 'This is a placeholder', value: '', label: 'Click "Edit" to see placeholder text' };
+
+export const Title = Template.bind({});
+Title.args = { label: 'Click "Edit" and hover over the input field', title: 'This is the title text' };
+
+export const Type = Template.bind({});
+Type.args = { type: 'date', value: '2020-12-22', label: 'Click "Edit" to select a new date' };
+

--- a/client/app/components/EditableField.stories.mdx
+++ b/client/app/components/EditableField.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as Stories from './EditableField.stories';
 
@@ -65,38 +65,50 @@ done editing the field, they can cancel or save their changes.
 
 When an error message is provided, the field will be stylized as invalid.
 
-<Story story={Stories.Error} />
+<Canvas>
+  <Story story={Stories.Error} />
+</Canvas>
 
 ## Label
 
 Labels can be set with the `label` property.
 
-<Story story={Stories.Label} />
+<Canvas>
+  <Story story={Stories.Label} />
+</Canvas>
 
 ## Max Length
 
 The length of the string input into the text field can be restricted. The default for this is 524288.
 
-<Story story={Stories.MaxLength} />
+<Canvas>
+  <Story story={Stories.MaxLength} />
+</Canvas>
 
 ## Placeholder
 
 Placeholder text can be set to display when the input is empty. This can be used to provide the user with additional
 context or instructions.
 
-<Story story={Stories.Placeholder} />
+<Canvas>
+  <Story story={Stories.Placeholder} />
+</Canvas>
 
 ## Title
 
 A title can be set to provide extra information to the user when they hover over the label or input field
 
-<Story story={Stories.Title} />
+<Canvas>
+  <Story story={Stories.Title} />
+</Canvas>
 
 ## Type
 
 Type can be used to control the type of data to input
 
-<Story story={Stories.Type} />
+<Canvas>
+  <Story story={Stories.Type} />
+</Canvas>
 
 ## Args
 

--- a/client/app/components/EditableField.stories.mdx
+++ b/client/app/components/EditableField.stories.mdx
@@ -1,0 +1,103 @@
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+
+import * as Stories from './EditableField.stories';
+
+import EditableField from './EditableField';
+
+<Meta
+  title='Commons/Components/Form Fields/EditableField'
+  component={EditableField}
+  parameters={{
+    controls: { expanded: true }
+  }}
+  args={{
+    label: 'Label',
+    value: 'Value'
+  }}
+  argTypes={{
+    errorMessage: { control: { type: 'text' } },
+    label: { control: { type: 'text' } },
+    maxLength: { control: { type: 'number' } },
+    placeholder: { control: { type: 'text' } },
+    title: { control: { type: 'text' } },
+    type: {
+      control: {
+        type: 'select',
+        options: [
+          'button',
+          'checkbox',
+          'color',
+          'date',
+          'datetime-local',
+          'email',
+          'file',
+          'hidden',
+          'image',
+          'month',
+          'number',
+          'password',
+          'radio',
+          'range',
+          'reset',
+          'search',
+          'submit',
+          'tel',
+          'text',
+          'time',
+          'url',
+          'week',
+        ]
+      }
+    },
+  }}
+/>
+
+# Editable Field
+
+An editable field shows the current value of a field. The value can be changed by clicking "Edit". After the user is
+done editing the field, they can cancel or save their changes.
+
+## Default
+
+<Story story={Stories.Default} />
+
+## Error
+
+When an error message is provided, the field will be stylized as invalid.
+
+<Story story={Stories.Error} />
+
+## Label
+
+Labels can be set with the `label` property.
+
+<Story story={Stories.Label} />
+
+## Max Length
+
+The length of the string input into the text field can be restricted. The default for this is 524288.
+
+<Story story={Stories.MaxLength} />
+
+## Placeholder
+
+Placeholder text can be set to display when the input is empty. This can be used to provide the user with additional
+context or instructions.
+
+<Story story={Stories.Placeholder} />
+
+## Title
+
+A title can be set to provide extra information to the user when they hover over the label or input field
+
+<Story story={Stories.Title} />
+
+## Type
+
+Type can be used to control the type of data to input
+
+<Story story={Stories.Type} />
+
+## Args
+
+<ArgsTable of={EditableField} />

--- a/client/app/components/InlineForm.jsx
+++ b/client/app/components/InlineForm.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 /**
  * Wrapper to display both labels and input fields inline
  */
-const InlineForm = ({ children }) => (
+export const InlineForm = ({ children }) => (
   <div className="usa-grid-half cf-inline-form">
     {Children.map(children, (child) => {
       return (<div className="cf-push-left">

--- a/client/app/components/InlineForm.jsx
+++ b/client/app/components/InlineForm.jsx
@@ -1,12 +1,25 @@
 import React, { Children } from 'react';
+import PropTypes from 'prop-types';
 
-export default function InlineForm({ children }) {
-
-  return (<div className="usa-grid-half cf-inline-form">
+/**
+ * Wrapper to display both labels and input fields inline
+ */
+const InlineForm = ({ children }) => (
+  <div className="usa-grid-half cf-inline-form">
     {Children.map(children, (child) => {
       return (<div className="cf-push-left">
         {child}
       </div>);
     })}
-  </div>);
-}
+  </div>
+);
+
+InlineForm.propTypes = {
+
+  /**
+   * The form fields to display inline
+   */
+  children: PropTypes.node
+};
+
+export default InlineForm;

--- a/client/app/components/InlineForm.stories.js
+++ b/client/app/components/InlineForm.stories.js
@@ -5,13 +5,15 @@ import InlineForm from './InlineForm';
 import NumberField from './NumberField';
 import Button from './Button';
 
-const Template = (args) => <InlineForm {...args}>
-  <NumberField
-    label="Enter the number of people working today"
-    name="employeeCount"
-    isInteger
-  />
-  <Button name="Update" />
-</InlineForm>;
+const Template = (args) => (
+  <InlineForm {...args}>
+    <NumberField
+      label="Enter the number of people working today"
+      name="employeeCount"
+      isInteger
+    />
+    <Button name="Update" />
+  </InlineForm>
+);
 
 export const Default = Template.bind({});

--- a/client/app/components/InlineForm.stories.js
+++ b/client/app/components/InlineForm.stories.js
@@ -1,0 +1,17 @@
+import React from 'react';
+
+import InlineForm from './InlineForm';
+
+import NumberField from './NumberField';
+import Button from './Button';
+
+const Template = (args) => <InlineForm {...args}>
+  <NumberField
+    label="Enter the number of people working today"
+    name="employeeCount"
+    isInteger
+  />
+  <Button name="Update" />
+</InlineForm>;
+
+export const Default = Template.bind({});

--- a/client/app/components/InlineForm.stories.mdx
+++ b/client/app/components/InlineForm.stories.mdx
@@ -1,0 +1,21 @@
+import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+
+import * as Stories from './InlineForm.stories';
+
+import InlineForm from './InlineForm';
+
+<Meta
+  title='Commons/Components/Form Fields/InlineForm'
+  component={InlineForm}
+/>
+
+# Inline Form
+
+Inline forms give designers and developers the liberty to customize the width and spacing of each field in a row.
+Input fields can be found placed after labels and descriptions to provide users context and actionable steps.
+
+<Story story={Stories.Default} />
+
+## Args
+
+<ArgsTable of={InlineForm} />

--- a/client/app/components/InlineForm.stories.mdx
+++ b/client/app/components/InlineForm.stories.mdx
@@ -1,4 +1,4 @@
-import { Meta, Story, ArgsTable } from '@storybook/addon-docs/blocks';
+import { Meta, Story, ArgsTable, Canvas } from '@storybook/addon-docs/blocks';
 
 import * as Stories from './InlineForm.stories';
 
@@ -14,7 +14,9 @@ import InlineForm from './InlineForm';
 Inline forms give designers and developers the liberty to customize the width and spacing of each field in a row.
 Input fields can be found placed after labels and descriptions to provide users context and actionable steps.
 
-<Story story={Stories.Default} />
+<Canvas>
+  <Story story={Stories.Default} />
+</Canvas>
 
 ## Args
 

--- a/client/app/components/SaveableTextArea.jsx
+++ b/client/app/components/SaveableTextArea.jsx
@@ -4,59 +4,93 @@ import PropTypes from 'prop-types';
 import Button from './Button';
 import TextareaField from './TextareaField';
 
-export default class SaveableTextArea extends React.PureComponent {
-  render() {
-    const {
-      disabled,
-      hideLabel,
-      id,
-      name,
-      onChange,
-      onCancelClick,
-      onKeyDown,
-      onSaveClick,
-      value
-    } = this.props;
+/**
+ * A long text field with accompanying save and cancel buttons. Props 'name' and 'onChange' are required
+ */
+const SaveableTextArea = (props) => {
+  const { disabled, hideLabel, id, label, name, onChange, onCancelClick, onKeyDown, onSaveClick, value } = props;
 
-    return <div className="comment-size-container">
-      <TextareaField
-        name={name}
-        hideLabel={hideLabel}
-        aria-label={name}
-        onChange={onChange}
-        onKeyDown={onKeyDown}
-        id={id || name}
-        value={value}
-      />
-      <div className="comment-save-button-container">
-        <span className="cf-right-side">
-          <Button
-            name="cancel"
-            classNames={['cf-btn-link']}
-            onClick={onCancelClick}>
-              Cancel
-          </Button>
-          <Button
-            disabled={disabled}
-            name="save"
-            onClick={onSaveClick}>
-              Save
-          </Button>
-        </span>
-      </div>
-    </div>;
-  }
-}
+  return <div className="comment-size-container">
+    <TextareaField
+      label={label}
+      name={name}
+      hideLabel={hideLabel}
+      aria-label={name}
+      onChange={onChange}
+      onKeyDown={onKeyDown}
+      id={id || name}
+      value={value}
+    />
+    <div className="comment-save-button-container">
+      <span className="cf-right-side">
+        <Button
+          name="cancel"
+          classNames={['cf-btn-link']}
+          onClick={onCancelClick}>
+            Cancel
+        </Button>
+        <Button
+          disabled={disabled}
+          name="save"
+          onClick={onSaveClick}>
+            Save
+        </Button>
+      </span>
+    </div>
+  </div>;
+};
 
-// Both name and onChange are required because of TextareaField
 SaveableTextArea.propTypes = {
+
+  /**
+   * Whether or not the save button is disabled
+   */
   disabled: PropTypes.bool,
+
+  /**
+   * Whether or not to show the label above the text field
+   */
+  hideLabel: PropTypes.bool,
+
+  /**
+   * Sets the `id` attribute on the `input` element; defaults to value of `name` prop
+   */
   id: PropTypes.string,
+
+  /**
+   * Text (or other node) to display in associated `label` element
+   */
   label: PropTypes.string,
+
+  /**
+   * String to be applied to the `name` attribute of the `input` element. Required
+   */
   name: PropTypes.string.isRequired,
-  onChange: PropTypes.func.isRequired,
+
+  /**
+   * Callback to perform when the cancel button is clicked
+   */
   onCancelClick: PropTypes.func,
+
+  /**
+   * Callback fired when value in the text field is changed
+   */
+  onChange: PropTypes.func.isRequired,
+
+  /**
+   * Callback fired when a key is pressed while the text field is in focus
+   */
   onKeyDown: PropTypes.func,
+
+  /**
+   * Callback to perform when the save button is clicked
+   */
   onSaveClick: PropTypes.func,
+
+  /**
+   * Value of the `input` element
+   */
   value: PropTypes.string
 };
+
+export default SaveableTextArea;

--- a/client/app/components/SaveableTextArea.jsx
+++ b/client/app/components/SaveableTextArea.jsx
@@ -7,19 +7,15 @@ import TextareaField from './TextareaField';
 /**
  * A long text field with accompanying save and cancel buttons. Props 'name' and 'onChange' are required
  */
-const SaveableTextArea = (props) => {
-  const { disabled, hideLabel, id, label, name, onChange, onCancelClick, onKeyDown, onSaveClick, value } = props;
+export const SaveableTextArea = (props) => {
+  const { disabled, id, name, onCancelClick, onSaveClick, ...textAreaProps } = props;
 
   return <div className="comment-size-container">
     <TextareaField
-      label={label}
       name={name}
-      hideLabel={hideLabel}
       aria-label={name}
-      onChange={onChange}
-      onKeyDown={onKeyDown}
       id={id || name}
-      value={value}
+      {...textAreaProps}
     />
     <div className="comment-save-button-container">
       <span className="cf-right-side">

--- a/client/app/components/SaveableTextArea.jsx
+++ b/client/app/components/SaveableTextArea.jsx
@@ -68,7 +68,7 @@ SaveableTextArea.propTypes = {
   name: PropTypes.string.isRequired,
 
   /**
-   * Callback to perform when the cancel button is clicked
+   * Callback fired when the cancel button is clicked
    */
   onCancelClick: PropTypes.func,
 

--- a/client/app/components/SaveableTextArea.stories.js
+++ b/client/app/components/SaveableTextArea.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import SaveableTextArea from './SaveableTextArea';
+
+export default {
+  title: 'Commons/Components/Form Fields/SaveableTextArea',
+  component: SaveableTextArea,
+  parameters: {
+    controls: { expanded: true },
+  },
+  args: {
+    disabled: false,
+    hideLabel: false,
+    label: 'Label'
+  },
+  argTypes: {
+    disabled: { control: 'boolean' },
+    hideLabel: { control: 'boolean' },
+    label: { control: 'text' }
+  }
+};
+
+const Template = (args) => <SaveableTextArea {...args} />;
+
+export const Default = Template.bind({});
+
+export const Disabled = Template.bind({});
+Disabled.args = { disabled: true };
+
+export const HiddenLabel = Template.bind({});
+HiddenLabel.args = { hideLabel: true };

--- a/client/app/components/SaveableTextArea.stories.js
+++ b/client/app/components/SaveableTextArea.stories.js
@@ -14,9 +14,9 @@ export default {
     label: 'Label'
   },
   argTypes: {
-    disabled: { control: 'boolean' },
-    hideLabel: { control: 'boolean' },
-    label: { control: 'text' }
+    disabled: { control: { type: 'boolean' } },
+    hideLabel: { control: { type: 'boolean' } },
+    label: { control: { type: 'text' } }
   }
 };
 


### PR DESCRIPTION
Bumps #15646

### Description
Creates a storybook entry for , `SaveableTextArea`, and `EditableField`. Refactored all from class to functional components.  Added documentation of each.

### Acceptance Criteria
- [ ] Stories exist for the following
    - [ ] [Inline Form](https://www.caseflowdemo.com/styleguide#inline-form)
    - [ ] [Save Long Text](https://www.caseflowdemo.com/styleguide#save-long-text)
    - [ ] [Save Short Text](https://www.caseflowdemo.com/styleguide#save-short-text)
- [ ] Story _AT LEAST_ includes same [documentation](https://storybook.js.org/docs/react/writing-docs/introduction) as the style guide (look for ways to add more!)
- [ ] Story _AT LEAST_ includes same examples ([stories](https://storybook.js.org/docs/react/writing-stories/introduction#how-to-write-stories)) as the style guide (look for ways to add more!)
- [ ] Add proptype documentation via js docstrings to components that are missing them ([these will be automatically pulled by storybook](https://storybook.js.org/docs/react/writing-docs/doc-blocks#argstable))
- [ ] Add [controls](https://storybook.js.org/docs/react/essentials/controls) for args that will change the display of the component

### Testing Plan
1. Run `make storybook` and navigate to http://localhost:6006/?path=/docs/commons-components-searchbar--big-story

### User Facing Changes

 COMPONENT|BEFORE|AFTER|AFTER 2
---| ---|---|---
`InlineForm`|![Screen Shot 2020-12-02 at 9 20 54 AM](https://user-images.githubusercontent.com/45575454/100898527-da747e00-348e-11eb-8814-67178f5a4cd2.png)|![Screen Shot 2020-12-02 at 9 25 57 AM](https://user-images.githubusercontent.com/45575454/100898525-da747e00-348e-11eb-9022-854b12b8e7bc.png)
`SaveableTextArea`|![Screen Shot 2020-12-02 at 9 54 02 AM](https://user-images.githubusercontent.com/45575454/100898598-ee1fe480-348e-11eb-8d00-cd4b7810edc4.png)|![Screen Shot 2020-12-02 at 9 53 08 AM](https://user-images.githubusercontent.com/45575454/100898602-eeb87b00-348e-11eb-9d15-c782d73922dd.png)|![Screen Shot 2020-12-02 at 9 53 15 AM](https://user-images.githubusercontent.com/45575454/100898600-ee1fe480-348e-11eb-9b31-6e78c3502975.png)
`EditableField`|![Screen Shot 2020-12-02 at 9 54 10 AM](https://user-images.githubusercontent.com/45575454/100898654-fbd56a00-348e-11eb-8233-4f8293fbf69d.png)|![Screen Shot 2020-12-02 at 11 02 40 AM](https://user-images.githubusercontent.com/45575454/100898650-fb3cd380-348e-11eb-9ee7-c4f9f1dbaf62.png)|![Screen Shot 2020-12-02 at 11 03 19 AM](https://user-images.githubusercontent.com/45575454/100898645-fb3cd380-348e-11eb-9026-9e664ba0afc3.png)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component