### PR TITLE
Added support for `inputProps` to `SearchBar`

### DIFF
--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -10,25 +10,25 @@ import uuid from 'uuid';
 export default class SearchBar extends React.Component {
   onChange = (event) => {
     this.props.onChange(event.target.value);
-  }
+  };
 
   onSearch = () => {
     if (this.props.value && this.props.recordSearch) {
       this.props.recordSearch(this.props.value);
     }
-  }
+  };
 
   onSubmit = () => {
     if (this.props.onSubmit) {
       this.props.onSubmit(this.props.value);
     }
-  }
+  };
 
   handleKeyPress = (event) => {
     if (event.key === 'Enter') {
       this.onSubmit();
     }
-  }
+  };
 
   clearSearchCallback() {
     if (this.searchTimeout) {
@@ -56,34 +56,40 @@ export default class SearchBar extends React.Component {
     if (this.clearSearchCallback()) {
       this.onSearch();
     }
-  }
+  };
 
-  setInputRef = (node) => this.input = node
+  setInputRef = (node) => (this.input = node);
 
-  setInputFocus = () => this.input.focus()
+  setInputFocus = () => this.input.focus();
   releaseInputFocus = () => this.input.blur();
 
-  clearInput = () => this.input.value = '';
+  clearInput = () => (this.input.value = '');
 
   getInternalField = (spinnerColor) => {
     if (this.props.loading) {
-      return <div className="search-text-spinner">
-        { loadingSymbolHtml('', '25px', spinnerColor) }
-      </div>;
+      return (
+        <div className="search-text-spinner">
+          {loadingSymbolHtml('', '25px', spinnerColor)}
+        </div>
+      );
     }
 
-    return <input
-      id="search-internal-text"
-      type="text"
-      value={this.props.internalText}
-      onClick={this.setInputFocus}
-      className="cf-search-internal-text"
-      readOnly />;
-  }
+    return (
+      <input
+        id="search-internal-text"
+        type="text"
+        value={this.props.internalText}
+        onClick={this.setInputFocus}
+        className="cf-search-internal-text"
+        readOnly
+        {...this.props.inputProps}
+      />
+    );
+  };
 
   render() {
-    let {
-      id,
+    const {
+      id = uuid.v4(),
       value,
       loading,
       onClearSearch,
@@ -95,10 +101,8 @@ export default class SearchBar extends React.Component {
       submitUsingEnterKey,
       placeholder,
       internalText,
-      spinnerColor
+      spinnerColor,
     } = this.props;
-
-    id = id || uuid.v4();
 
     const hasInternalText = !_.isUndefined(internalText);
 
@@ -106,58 +110,75 @@ export default class SearchBar extends React.Component {
       'usa-search-big': size === 'big',
       'usa-search-small': size === 'small',
       'cf-search-ahead': isSearchAhead,
-      'cf-has-internal-text': hasInternalText
+      'cf-has-internal-text': hasInternalText,
     });
 
     const buttonClassNames = classnames({
-      'usa-sr-only': size === 'small'
+      'usa-sr-only': size === 'small',
     });
 
     const label = classnames({
       'usa-search-big': size === 'big',
-      'usa-search-small': size === 'small'
+      'usa-search-small': size === 'small',
     });
 
     const searchClasses = classnames('cf-search-input-with-close', {
-      'cf-search-with-internal-text': hasInternalText
+      'cf-search-with-internal-text': hasInternalText,
     });
 
-    return <span className={searchTypeClasses} role="search">
-      <label className={title ? label : 'usa-sr-only'} htmlFor={id}>
-        {title || 'Search'}
-      </label>
-      <input
-        ref={this.setInputRef}
-        className={searchClasses}
-        id={id}
-        onChange={this.onChange}
-        onBlur={this.onBlur}
-        type="search"
-        name="search"
-        onKeyPress={submitUsingEnterKey && !searchDisabled ? this.handleKeyPress : this.props.onKeyPress}
-        placeholder={placeholder}
-        value={value} />
-      { hasInternalText &&
-      <div>
-        <label className="usa-sr-only" htmlFor="search-internal-text">
-          Search Result Count
+    return (
+      <span className={searchTypeClasses} role="search">
+        <label className={title ? label : 'usa-sr-only'} htmlFor={id}>
+          {title || 'Search'}
         </label>
-        { this.getInternalField(spinnerColor) }
-      </div>}
-      {_.size(value) > 0 &&
-        <Button
-          ariaLabel="clear search"
-          name="clear search"
-          classNames={['cf-pdf-button cf-search-close-icon']}
-          onClick={onClearSearch}>
-          {closeIcon()}
-        </Button>}
-      { !isSearchAhead && <Button name={`search-${id}`}
-        disabled={searchDisabled}
-        onClick={onSubmit ? this.onSubmit : null} on type="submit" loading={loading}>
-        <span className={buttonClassNames}>Search</span>
-      </Button> }
-    </span>;
+        <input
+          ref={this.setInputRef}
+          className={searchClasses}
+          id={id}
+          onChange={this.onChange}
+          onBlur={this.onBlur}
+          type="search"
+          name="search"
+          onKeyPress={
+            submitUsingEnterKey && !searchDisabled ?
+              this.handleKeyPress :
+              this.props.onKeyPress
+          }
+          placeholder={placeholder}
+          value={value}
+        />
+        {hasInternalText && (
+          <div>
+            <label className="usa-sr-only" htmlFor="search-internal-text">
+              Search Result Count
+            </label>
+            {this.getInternalField(spinnerColor)}
+          </div>
+        )}
+        {_.size(value) > 0 && (
+          <Button
+            ariaLabel="clear search"
+            name="clear search"
+            classNames={['cf-pdf-button cf-search-close-icon']}
+            onClick={onClearSearch}
+          >
+            {closeIcon()}
+          </Button>
+        )}
+        {!isSearchAhead && (
+          <Button
+            name={`search-${id}`}
+            disabled={searchDisabled}
+            onClick={onSubmit ? this.onSubmit : null}
+            on
+            type="submit"
+            loading={loading}
+          >
+            <span className={buttonClassNames}>Search</span>
+          </Button>
+        )}
+      </span>
+    );
   }
 }
 
@@ -171,6 +192,11 @@ SearchBar.propTypes = {
    * Id of the `input` element
    */
   id: PropTypes.string,
+
+  /**
+   * Props that will be passed along to the `input` element
+   */
+  inputProps: PropTypes.object,
 
   /**
    * Label to display above the search bar, defaults to "Search"
@@ -247,5 +273,5 @@ SearchBar.propTypes = {
   /**
    * Text to display when there is no search term in the `input`
    */
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 };

--- a/client/app/components/SearchBar.jsx
+++ b/client/app/components/SearchBar.jsx
@@ -90,6 +90,7 @@ export default class SearchBar extends React.Component {
   render() {
     const {
       id = uuid.v4(),
+      inputProps,
       value,
       loading,
       onClearSearch,
@@ -146,6 +147,7 @@ export default class SearchBar extends React.Component {
           }
           placeholder={placeholder}
           value={value}
+          {...inputProps}
         />
         {hasInternalText && (
           <div>

--- a/client/test/app/queue/components/__snapshots__/EditNodDateModal.test.js.snap
+++ b/client/test/app/queue/components/__snapshots__/EditNodDateModal.test.js.snap
@@ -109,19 +109,80 @@ exports[`EditNodDateModal renders correctly 1`] = `
             >
               <div>
                 <ReactMarkdown
-                  astPlugins={Array []}
-                  escapeHtml={true}
-                  parserOptions={Object {}}
-                  plugins={Array []}
-                  rawSourcePos={false}
-                  renderers={Object {}}
-                  skipHtml={false}
                   source="**Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.**"
-                  sourcePos={false}
                   transformLinkUri={[Function]}
                 >
                   <Root
                     key="root-1-1-0"
+                    node={
+                      Object {
+                        "children": Array [
+                          Object {
+                            "children": Array [
+                              Object {
+                                "children": Array [
+                                  Object {
+                                    "position": Object {
+                                      "end": Object {
+                                        "column": 102,
+                                        "line": 1,
+                                        "offset": 101,
+                                      },
+                                      "start": Object {
+                                        "column": 3,
+                                        "line": 1,
+                                        "offset": 2,
+                                      },
+                                    },
+                                    "type": "text",
+                                    "value": "Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.",
+                                  },
+                                ],
+                                "position": Object {
+                                  "end": Object {
+                                    "column": 104,
+                                    "line": 1,
+                                    "offset": 103,
+                                  },
+                                  "start": Object {
+                                    "column": 1,
+                                    "line": 1,
+                                    "offset": 0,
+                                  },
+                                },
+                                "type": "strong",
+                              },
+                            ],
+                            "position": Object {
+                              "end": Object {
+                                "column": 104,
+                                "line": 1,
+                                "offset": 103,
+                              },
+                              "start": Object {
+                                "column": 1,
+                                "line": 1,
+                                "offset": 0,
+                              },
+                            },
+                            "type": "paragraph",
+                          },
+                        ],
+                        "position": Object {
+                          "end": Object {
+                            "column": 104,
+                            "line": 1,
+                            "offset": 103,
+                          },
+                          "start": Object {
+                            "column": 1,
+                            "line": 1,
+                            "offset": 0,
+                          },
+                        },
+                        "type": "root",
+                      }
+                    }
                   >
                     <p
                       key="paragraph-1-1-0"
@@ -131,6 +192,24 @@ exports[`EditNodDateModal renders correctly 1`] = `
                       >
                         <TextRenderer
                           key="text-1-3-0"
+                          node={
+                            Object {
+                              "position": Object {
+                                "end": Object {
+                                  "column": 102,
+                                  "line": 1,
+                                  "offset": 101,
+                                },
+                                "start": Object {
+                                  "column": 3,
+                                  "line": 1,
+                                  "offset": 2,
+                                },
+                              },
+                              "type": "text",
+                              "value": "Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.",
+                            }
+                          }
                           nodeKey="text-1-3-0"
                           value="Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal."
                         >

--- a/client/test/app/queue/components/__snapshots__/EditNodDateModal.test.js.snap
+++ b/client/test/app/queue/components/__snapshots__/EditNodDateModal.test.js.snap
@@ -109,80 +109,19 @@ exports[`EditNodDateModal renders correctly 1`] = `
             >
               <div>
                 <ReactMarkdown
+                  astPlugins={Array []}
+                  escapeHtml={true}
+                  parserOptions={Object {}}
+                  plugins={Array []}
+                  rawSourcePos={false}
+                  renderers={Object {}}
+                  skipHtml={false}
                   source="**Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.**"
+                  sourcePos={false}
                   transformLinkUri={[Function]}
                 >
                   <Root
                     key="root-1-1-0"
-                    node={
-                      Object {
-                        "children": Array [
-                          Object {
-                            "children": Array [
-                              Object {
-                                "children": Array [
-                                  Object {
-                                    "position": Object {
-                                      "end": Object {
-                                        "column": 102,
-                                        "line": 1,
-                                        "offset": 101,
-                                      },
-                                      "start": Object {
-                                        "column": 3,
-                                        "line": 1,
-                                        "offset": 2,
-                                      },
-                                    },
-                                    "type": "text",
-                                    "value": "Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.",
-                                  },
-                                ],
-                                "position": Object {
-                                  "end": Object {
-                                    "column": 104,
-                                    "line": 1,
-                                    "offset": 103,
-                                  },
-                                  "start": Object {
-                                    "column": 1,
-                                    "line": 1,
-                                    "offset": 0,
-                                  },
-                                },
-                                "type": "strong",
-                              },
-                            ],
-                            "position": Object {
-                              "end": Object {
-                                "column": 104,
-                                "line": 1,
-                                "offset": 103,
-                              },
-                              "start": Object {
-                                "column": 1,
-                                "line": 1,
-                                "offset": 0,
-                              },
-                            },
-                            "type": "paragraph",
-                          },
-                        ],
-                        "position": Object {
-                          "end": Object {
-                            "column": 104,
-                            "line": 1,
-                            "offset": 103,
-                          },
-                          "start": Object {
-                            "column": 1,
-                            "line": 1,
-                            "offset": 0,
-                          },
-                        },
-                        "type": "root",
-                      }
-                    }
                   >
                     <p
                       key="paragraph-1-1-0"
@@ -192,24 +131,6 @@ exports[`EditNodDateModal renders correctly 1`] = `
                       >
                         <TextRenderer
                           key="text-1-3-0"
-                          node={
-                            Object {
-                              "position": Object {
-                                "end": Object {
-                                  "column": 102,
-                                  "line": 1,
-                                  "offset": 101,
-                                },
-                                "start": Object {
-                                  "column": 3,
-                                  "line": 1,
-                                  "offset": 2,
-                                },
-                              },
-                              "type": "text",
-                              "value": "Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal.",
-                            }
-                          }
                           nodeKey="text-1-3-0"
                           value="Editing the NOD date affects the time it takes for a Veteran to receive a response to their appeal."
                         >


### PR DESCRIPTION
### Description
Adds support for passing `inputProps` to underlying `input` element in `SearchBar`

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
You can test this out in Storybook by adding something for `inputProps` control
