### PR TITLE
Selectively show cavc decision types and remand subtypes based on feature toggles

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -21,6 +21,9 @@
       special_issues_revamp: FeatureToggle.enabled?(:special_issues_revamp, user: current_user),
       overtime_revamp: FeatureToggle.enabled?(:overtime_revamp, user: current_user),
       cavc_remand: FeatureToggle.enabled?(:cavc_remand, user: current_user),
+      mdr_cavc_remand: FeatureToggle.enabled?(:mdr_cavc_remand, user: current_user),
+      reversal_cavc_remand: FeatureToggle.enabled?(:reversal_cavc_remand, user: current_user),
+      dismissal_cavc_remand: FeatureToggle.enabled?(:dismissal_cavc_remand, user: current_user),
       editNodDate: FeatureToggle.enabled?(:edit_nod_date, user: current_user)
     }
   }) %>

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -56,9 +56,10 @@ const subTypeOptions = _.map(_.keys(CAVC_REMAND_SUBTYPE_NAMES), (key) => ({
  *  - @param {Object}   error            Error sent from the back end upon submit to be displayed rather than submitting
  *  - @param {boolean}  highlightInvalid Whether or not to show field validation, set to true upon submit
  *  - @param {Object}   history          Provided with react router to be able to route to another page upon success
+ *  - @param {Object}   featureToggles   Which cavc decision types and remand subtypes are supported
  */
 const AddCavcRemandView = (props) => {
-  const { appealId, decisionIssues, error, highlightInvalid, history, ...otherProps } = props;
+  const { appealId, decisionIssues, error, highlightInvalid, history, featureToggles, ...otherProps } = props;
 
   const [docketNumber, setDocketNumber] = useState(null);
   const [attorney, setAttorney] = useState('1');
@@ -70,6 +71,20 @@ const AddCavcRemandView = (props) => {
   const [mandateDate, setMandateDate] = useState(null);
   const [issues, setIssues] = useState({});
   const [instructions, setInstructions] = useState(null);
+
+  const supportedDecisionTypes = {
+    [CAVC_DECISION_TYPES.remand]: featureToggles.cavc_remand,
+    [CAVC_DECISION_TYPES.straight_reversal]: featureToggles.reversal_cavc_remand,
+    [CAVC_DECISION_TYPES.death_dismissal]: featureToggles.dismissal_cavc_remand
+  };
+  const filteredDecisionTypes = typeOptions.filter((typeOption) => supportedDecisionTypes[typeOption.value]);
+
+  const supportedRemandTypes = {
+    [CAVC_REMAND_SUBTYPES.jmr]: featureToggles.cavc_remand,
+    [CAVC_REMAND_SUBTYPES.jmpr]: featureToggles.cavc_remand,
+    [CAVC_REMAND_SUBTYPES.mdr]: featureToggles.mdr_cavc_remand
+  };
+  const filteredRemandTypes = subTypeOptions.filter((subTypeOption) => supportedRemandTypes[subTypeOption.value]);
 
   const issueOptions = () => decisionIssues.map((decisionIssue) => ({
     id: decisionIssue.id,
@@ -170,7 +185,7 @@ const AddCavcRemandView = (props) => {
     styling={radioLabelStyling}
     label={COPY.CAVC_TYPE_LABEL}
     name="type-options"
-    options={typeOptions}
+    options={filteredDecisionTypes}
     value={type}
     onChange={(val) => setType(val)}
     strongLabel
@@ -180,7 +195,7 @@ const AddCavcRemandView = (props) => {
     styling={radioLabelStyling}
     label={COPY.CAVC_SUB_TYPE_LABEL}
     name="sub-type-options"
-    options={subTypeOptions}
+    options={filteredRemandTypes}
     value={subType}
     onChange={(val) => setSubType(val)}
     strongLabel
@@ -272,6 +287,12 @@ AddCavcRemandView.propTypes = {
   requestSave: PropTypes.func,
   showErrorMessage: PropTypes.func,
   error: PropTypes.object,
+  featureToggles: PropTypes.shape({
+    cavc_remand: PropTypes.bool,
+    mdr_cavc_remand: PropTypes.bool,
+    reversal_cavc_remand: PropTypes.bool,
+    dismissal_cavc_remand: PropTypes.bool
+  }),
   highlightInvalid: PropTypes.bool,
   history: PropTypes.object
 };
@@ -279,7 +300,8 @@ AddCavcRemandView.propTypes = {
 const mapStateToProps = (state, ownProps) => ({
   decisionIssues: state.queue.appealDetails[ownProps.appealId].decisionIssues,
   highlightInvalid: state.ui.highlightFormItems,
-  error: state.ui.messages.error
+  error: state.ui.messages.error,
+  featureToggles: state.ui.featureToggles
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/AddCavcRemandView.stories.js
+++ b/client/app/queue/AddCavcRemandView.stories.js
@@ -7,13 +7,40 @@ import AddCavcRemandView from './AddCavcRemandView';
 
 export default {
   title: 'Queue/AddCavcRemandView',
-  component: AddCavcRemandView
+  component: AddCavcRemandView,
+  parameters: { controls: { expanded: true } },
+  args: {
+    cavcRemandToggled: true,
+    mdrToggled: false,
+    reversalToggled: false,
+    dismissalToggled: false,
+  },
+  argTypes: {
+    cavcRemandToggled: { control: { type: 'boolean' } },
+    mdrToggled: { control: { type: 'boolean' } },
+    reversalToggled: { control: { type: 'boolean' } },
+    dismissalToggled: { control: { type: 'boolean' } },
+  }
 };
 
 const appealId = amaAppeal.externalId;
 
-const Template = (args) => (<Wrapper>
-  <AddCavcRemandView appealId={appealId} {...args} />
-</Wrapper>);
+const Template = ({ cavcRemandToggled, mdrToggled, reversalToggled, dismissalToggled, ...componentArgs }) => {
+  const storeArgs = {
+    ui: {
+      featureToggles: {
+        cavc_remand: cavcRemandToggled,
+        mdr_cavc_remand: mdrToggled,
+        reversal_cavc_remand: reversalToggled,
+        dismissal_cavc_remand: dismissalToggled
+      }
+    }
+  };
+
+  return <Wrapper {...storeArgs}>
+    <AddCavcRemandView appealId={appealId} {...componentArgs} />
+  </Wrapper>;
+};
 
 export const Default = Template.bind({});
+Default.args = { cavcRemandToggled: true };

--- a/client/test/data/stores/queueStore.js
+++ b/client/test/data/stores/queueStore.js
@@ -42,7 +42,8 @@ export const initialState = {
   ui: {
     messages: {},
     saveState: {},
-    modals: {}
+    modals: {},
+    featureToggles: {}
   }
 };
 


### PR DESCRIPTION


### Description
Does not show options for mdr, death dismissal, or straight reversal unless those features are enabled.

### Acceptance Criteria
- [ ] MDR can only be selected if the feature toggle is on (mdr_cavc_remand)
- [ ] Death dismissal can only be selected if the feature toggle is on (dismissal_cavc_remand)
- [ ] Straight reversal can only be selected if the feature toggle is on (reversal_cavc_remand)

### Testing Plan
1. Enable cavc_remand feature toggle
1. Find a dispatched appeal (search for vet 500000000)
1. Click "+ Add CAVC Remand"

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|mdr_cavc_remand enabled|dismissal_cavc_remand enabled|reversal_cavc_remand enabled
 ---|---|---|---
![Screen Shot 2020-12-07 at 11 37 19 AM](https://user-images.githubusercontent.com/45575454/101378050-98797c80-3880-11eb-8b1f-0ab70cc11abf.png)|![Screen Shot 2020-12-07 at 11 38 33 AM](https://user-images.githubusercontent.com/45575454/101378201-cd85cf00-3880-11eb-9cdf-2bcda3d310e6.png)|![Screen Shot 2020-12-07 at 11 38 49 AM](https://user-images.githubusercontent.com/45575454/101378209-d1195600-3880-11eb-95b8-6fdcfc4ca1fc.png)|![Screen Shot 2020-12-07 at 11 38 43 AM](https://user-images.githubusercontent.com/45575454/101378205-cf4f9280-3880-11eb-9f02-492478fc7bfa.png)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component