### PR TITLE
Adjustments to Stories for EditableField

### DIFF
--- a/client/app/components/EditableField.jsx
+++ b/client/app/components/EditableField.jsx
@@ -34,7 +34,7 @@ export const EditableField = (props) => {
 
   const onSaveClick = () => {
     stopEditing();
-    onSave(value);
+    onSave?.(value);
   };
 
   const saveOnEnter = (event) => {
@@ -45,12 +45,10 @@ export const EditableField = (props) => {
 
   const onCancelClick = () => {
     stopEditing();
-    onCancel();
+    onCancel?.();
   };
 
-  const onValueChange = (event) => {
-    onChange(event.target.value);
-  };
+  const onValueChange = (event) => onChange?.(event.target.value);
 
   if (editing) {
     actionLinks = <span>

--- a/client/app/components/EditableField.stories.js
+++ b/client/app/components/EditableField.stories.js
@@ -2,10 +2,18 @@ import React from 'react';
 
 import EditableField from './EditableField';
 
-const Template = (args) => <EditableField {...args} />;
+const Template = (args) => {
+  const [value, setValue] = React.useState(args.value || '');
+
+  React.useEffect(() => setValue(args.value), [args.value]);
+
+  return <EditableField {...args} value={value} onChange={setValue} />;
+};
 
 export const Default = Template.bind({});
-Default.args = { label: 'Click "Edit" to change the value below' };
+Default.args = {
+  label: 'Click "Edit" to change the value below',
+};
 
 export const Error = Template.bind({});
 Error.args = { errorMessage: 'This is invalid' };
@@ -14,14 +22,28 @@ export const Label = Template.bind({});
 Label.args = { label: 'This is a new label' };
 
 export const MaxLength = Template.bind({});
-MaxLength.args = { maxLength: 30, label: 'Enter more text below (max 30)', value: 'This is exactly 29 characters' };
+MaxLength.args = {
+  maxLength: 30,
+  label: 'Enter more text below (max 30)',
+  value: 'This is exactly 29 characters',
+};
 
 export const Placeholder = Template.bind({});
-Placeholder.args = { placeholder: 'This is a placeholder', value: '', label: 'Click "Edit" to see placeholder text' };
+Placeholder.args = {
+  placeholder: 'This is a placeholder',
+  value: '',
+  label: 'Click "Edit" to see placeholder text',
+};
 
 export const Title = Template.bind({});
-Title.args = { label: 'Click "Edit" and hover over the input field', title: 'This is the title text' };
+Title.args = {
+  label: 'Click "Edit" and hover over the input field',
+  title: 'This is the title text',
+};
 
 export const Type = Template.bind({});
-Type.args = { type: 'date', value: '2020-12-22', label: 'Click "Edit" to select a new date' };
-
+Type.args = {
+  type: 'date',
+  value: '2020-12-22',
+  label: 'Click "Edit" to select a new date',
+};

--- a/client/app/components/EditableField.stories.mdx
+++ b/client/app/components/EditableField.stories.mdx
@@ -5,14 +5,14 @@ import * as Stories from './EditableField.stories';
 import EditableField from './EditableField';
 
 <Meta
-  title='Commons/Components/Form Fields/EditableField'
+  title="Commons/Components/Form Fields/EditableField"
   component={EditableField}
   parameters={{
-    controls: { expanded: true }
+    controls: { expanded: true },
   }}
   args={{
     label: 'Label',
-    value: 'Value'
+    value: 'Value',
   }}
   argTypes={{
     errorMessage: { control: { type: 'text' } },
@@ -20,6 +20,7 @@ import EditableField from './EditableField';
     maxLength: { control: { type: 'number' } },
     placeholder: { control: { type: 'text' } },
     title: { control: { type: 'text' } },
+    onSave: { action: 'onSave' },
     type: {
       control: {
         type: 'select',
@@ -46,8 +47,8 @@ import EditableField from './EditableField';
           'time',
           'url',
           'week',
-        ]
-      }
+        ],
+      },
     },
   }}
 />
@@ -59,7 +60,9 @@ done editing the field, they can cancel or save their changes.
 
 ## Default
 
-<Story story={Stories.Default} />
+<Canvas>
+  <Story story={Stories.Default} />
+</Canvas>
 
 ## Error
 


### PR DESCRIPTION


### Description
This makes some minor changes to `EditableField` to better account for the callback functions being optional, and adjusts the stories for `EditableField` to use it as a controlled component with `value` prop handled in the outer scope of the story.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Stories for `EditableField` all work
