### PR TITLE
Remove PaperTrail versioning from Document model

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,12 +5,6 @@ class Document < CaseflowRecord
   has_many :document_views
   has_many :documents_tags
   has_many :tags, through: :documents_tags
-  has_paper_trail only: [:description,
-                         :category_case_summary,
-                         :category_medical,
-                         :category_other,
-                         :category_procedural],
-                  on: [:update, :destroy], save_changes: false
 
   self.inheritance_column = nil
 

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -310,18 +310,4 @@ describe Document, :postgres do
       expect(document.default_path).to match(%r{.*\/tmp\/pdfs\/.*123})
     end
   end
-
-  context "versioning" do
-    it "saves new version on update description" do
-      document.save
-      expect(document.versions.length).to eq 0
-      expect(document.description).to eq("Document description")
-
-      document.description = "Updated description"
-      document.save
-
-      expect(document.versions.length).to eq 1
-      expect(document.reload.description).to eq("Updated description")
-    end
-  end
 end


### PR DESCRIPTION
### Description
This PR is to test the effect of disabling PaperTrail from the Document Model to see if it impacts performance. We tripe-checked to ensure that the versions are being used anywhere. 
[Relevant Slack](https://dsva.slack.com/archives/CHD7QU4L8/p1608079039186400)
### Testing Plan
- Open rails console and make updates making a to any of these fields: : `[:description, :category_case_summary,	 :category_medical, :category_other, :category_procedural]`  for a an existing document: `Document.last.update!(description: "new description")`
-  Ensure that no paper trail version is created for above action
