### PR TITLE
Remove 3 day window constraint when assigning judges to hearing days

### DIFF
--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -109,7 +109,7 @@ class HearingSchedule::AssignJudgesToHearingDays
     # hearing_day is a CO docket and judge was already assigned to one CO hearing day
     problems = @judges[css_id][:non_availabilities].include?(scheduled_for) ||
                hearing_day_already_assigned?(current_hearing_day.id) ||
-               judge_already_assigned_on_date?(judge_id, current_hearing_day) ||
+               judge_already_assigned_on_date?(judge_id, scheduled_for) ||
                (current_hearing_day.central_office? && judge_already_assigned_to_co?(judge_id))
 
     !problems
@@ -121,7 +121,7 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def judge_already_assigned_on_date?(judge_id, date)
     @assigned_hearing_days.any? do |day|
-      day.judge_id.to_s == judge_id.to_s && day.scheduled_for_as_date == date.scheduled_for_as_date
+      day.judge_id.to_s == judge_id.to_s && day.scheduled_for_as_date == date
     end
   end
 

--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -16,7 +16,6 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   TB_ADDITIONAL_NA_DAYS = 3
   CO_ROOM_NUM = "2"
-  DAYS_OF_SEPARATION = 3
 
   class HearingDaysNotAllocated < StandardError; end
   class NoJudgesProvided < StandardError; end
@@ -122,12 +121,7 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def judge_already_assigned_on_date?(judge_id, date)
     @assigned_hearing_days.any? do |day|
-      # IF judge is assigned to a hearing day AND
-      # the unassigned hearing day falls within 3 day before or after the assigned hearing day THEN
-      # don't assign this judge to this unassigned hearing day
-      # Note: i think this is meant to prevent assigning the same judge to more than half of the available
-      # hearing days for a week
-      day.judge_id.to_s == judge_id.to_s && (day.scheduled_for_as_date - date).abs <= DAYS_OF_SEPARATION
+      day.judge_id.to_s == judge_id.to_s
     end
   end
 

--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -109,6 +109,7 @@ class HearingSchedule::AssignJudgesToHearingDays
     # hearing_day is a CO docket and judge was already assigned to one CO hearing day
     problems = @judges[css_id][:non_availabilities].include?(scheduled_for) ||
                hearing_day_already_assigned?(current_hearing_day.id) ||
+               judge_already_assigned_on_date?(judge_id, current_hearing_day) ||
                (current_hearing_day.central_office? && judge_already_assigned_to_co?(judge_id))
 
     !problems
@@ -116,6 +117,12 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def hearing_day_already_assigned?(id)
     @assigned_hearing_days.any? { |day| day.id == id }
+  end
+
+  def judge_already_assigned_on_date?(judge_id, date)
+    @assigned_hearing_days.any? do |day|
+      day.judge_id.to_s == judge_id.to_s && day.scheduled_for_as_date == date
+    end
   end
 
   def judge_already_assigned_to_co?(judge_id)

--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -109,7 +109,6 @@ class HearingSchedule::AssignJudgesToHearingDays
     # hearing_day is a CO docket and judge was already assigned to one CO hearing day
     problems = @judges[css_id][:non_availabilities].include?(scheduled_for) ||
                hearing_day_already_assigned?(current_hearing_day.id) ||
-               judge_already_assigned_on_date?(judge_id, scheduled_for) ||
                (current_hearing_day.central_office? && judge_already_assigned_to_co?(judge_id))
 
     !problems
@@ -117,12 +116,6 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def hearing_day_already_assigned?(id)
     @assigned_hearing_days.any? { |day| day.id == id }
-  end
-
-  def judge_already_assigned_on_date?(judge_id, date)
-    @assigned_hearing_days.any? do |day|
-      day.judge_id.to_s == judge_id.to_s
-    end
   end
 
   def judge_already_assigned_to_co?(judge_id)

--- a/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
+++ b/app/services/hearing_schedule/assign_judges_to_hearing_days.rb
@@ -121,7 +121,7 @@ class HearingSchedule::AssignJudgesToHearingDays
 
   def judge_already_assigned_on_date?(judge_id, date)
     @assigned_hearing_days.any? do |day|
-      day.judge_id.to_s == judge_id.to_s && day.scheduled_for_as_date == date
+      day.judge_id.to_s == judge_id.to_s && day.scheduled_for_as_date == date.scheduled_for_as_date
     end
   end
 


### PR DESCRIPTION
### Description
We had placed a 3 day window constraint when assigning in this [PR](https://github.com/department-of-veterans-affairs/caseflow/pull/6859#discussion_r215948158). This pr removes this constraint to test to see if the judge assignment algorithm works now that we have a lot more hearings days and lot more non-available days for judges.

[Relevant Slack Thread](https://dsva.slack.com/archives/C01155MJGF2/p1607971420005100)
### Testing plan
Before anything set travel board hearings days to `[]` [here](https://github.com/department-of-veterans-affairs/caseflow/blob/f6df286d06066e6dea8b9e11ea77d24e624d2e85/app/services/hearing_schedule/assign_judges_to_hearing_days.rb#L243) to replicate PROD
- upload blackout sheet here: http://localhost:3000/hearings/schedule/build