### PR TITLE
Add red button to stories

### DIFF
--- a/client/app/components/Button.stories.js
+++ b/client/app/components/Button.stories.js
@@ -6,7 +6,7 @@ const Template = (args) => (
   <Button {...args}>
     Click Me
   </Button >
-)
+);
 
 export const Primary = Template.bind({});
 
@@ -38,3 +38,7 @@ Loading.args = {
   id: 'btn-crt',
   loadingText: 'Loading...',
 };
+
+export const Destructive = Template.bind({});
+Destructive.args = { redStyling: true };
+

--- a/client/app/components/Button.stories.js
+++ b/client/app/components/Button.stories.js
@@ -2,11 +2,7 @@ import React from 'react';
 
 import Button from './Button';
 
-const Template = (args) => (
-  <Button {...args}>
-    Click Me
-  </Button >
-);
+const Template = (args) => <Button {...args} />;
 
 export const Primary = Template.bind({});
 
@@ -40,5 +36,5 @@ Loading.args = {
 };
 
 export const Destructive = Template.bind({});
-Destructive.args = { redStyling: true };
+Destructive.args = { redStyling: true, children: 'Danger' };
 

--- a/client/app/components/Buttons.stories.mdx
+++ b/client/app/components/Buttons.stories.mdx
@@ -17,6 +17,7 @@ import Button from './Button';
     loading: false,
     type: 'button',
     name: 'myButton',
+    redStyling: false
   }}
   argTypes={{
     classNames: { control: { type: 'array' } },
@@ -24,6 +25,7 @@ import Button from './Button';
       control: { type: 'select', options: ['button', 'submit', 'reset'] },
     },
     loading: { control: { type: 'boolean' } },
+    redStyling: { control: { type: 'boolean' } },
     onClick: { action: 'clicked' },
     styling: { control: { type: 'object' } },
   }}
@@ -78,3 +80,10 @@ beside a spinning icon.
 <Canvas>
   <Story story={ButtonStories.Loading} />
 </Canvas>
+
+### Destructive
+
+<Canvas>
+  <Story story={ButtonStories.Destructive} />
+</Canvas>
+


### PR DESCRIPTION
### Description
Adds an example of a destructive button to our button stories

### Acceptance Criteria
- [ ] Example of a red destructive button exists in stories

### Testing Plan
1. run `make storybook` and go to http://localhost:6006/?path=/docs/commons-components-button--destructive

### User Facing Changes
 
![Screen Shot 2020-12-16 at 2 14 47 PM](https://user-images.githubusercontent.com/45575454/102396219-2274c400-3faa-11eb-80c4-b2f464a81b67.png)
