### PR TITLE
Use find_by_css_id for faster lookup using the index

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -125,3 +125,15 @@ if contains_new_index.any?
     "See https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations#index-creation-should-go-in-its-own-migration-file"
   )
 end
+
+# Check for `User.find_by(css_id:`
+result = git.diff.flat_map do |chunk|
+  chunk.patch.lines.grep(/^\+\s*\w/).select { |added_line| added_line.match?(/User.find_by\(css_id:/) }
+end
+
+if !result.empty?
+  warn(
+    "This PR uses `User.find_by(css_id:`, which uses a sequential scan on the DB. " \
+    "Instead, use `User.find_by_css_id` to use the `index_users_unique_css_id` index."
+  )
+end

--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -44,7 +44,7 @@ class Idt::Api::V1::BaseController < ActionController::Base
 
   def user
     @user ||= begin
-      user = User.find_by(css_id: css_id)
+      user = User.find_by_css_id(css_id)
       RequestStore.store[:current_user] = user
       user
     end

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -360,7 +360,7 @@ class LegacyHearing < CaseflowRecord
       if user_nil_or_assigned_to_another_judge?(hearing.user, vacols_record.css_id)
         hearing.update(
           appeal: LegacyAppeal.find_or_create_by(vacols_id: vacols_record.folder_nr),
-          user: User.find_by(css_id: vacols_record.css_id)
+          user: User.find_by_css_id(vacols_record.css_id)
         )
       end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -519,6 +519,8 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
 
     # case-insensitive search
     def find_by_css_id(css_id)
+      # this query uses the index_users_unique_css_id
+      # find_by(css_id: css_id) does a slower seq scan
       find_by("UPPER(css_id)=UPPER(?)", css_id)
     end
 

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -177,9 +177,9 @@ class QueueRepository
       records.group_by(&:vacols_id).each_with_object([]) do |(_k, v), result|
         next result << v.first if v.size == 1
 
-        user = User.find_by(css_id: css_id, station_id: User::BOARD_STATION_ID) if css_id
+        user = User.find_by_css_id(css_id) if css_id
         # If user is an attorney, find all associated with the user's attorney_id
-        if user && attorney_id_match_found?(v, user)
+        if user&.station_id == User::BOARD_STATION_ID && attorney_id_match_found?(v, user)
           v.select! { |task| task.attorney_id == user.vacols_attorney_id }
         end
         # If DAS record doesn't have updated_at date, put it at the beginning of the list

--- a/app/services/user_reporter.rb
+++ b/app/services/user_reporter.rb
@@ -86,11 +86,13 @@ class UserReporter
     related_records
   end
 
+  # UPPER(css_id) is unique, so this should always return 1 or 0 records
   def all_users_for_css_id
     User.where("UPPER(css_id)=UPPER(?)", css_id)
   end
 
+  # Where is this used?
   def uppercase_user
-    User.find_by(css_id: css_id.upcase)
+    User.find_by_css_id(css_id)
   end
 end

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -151,7 +151,7 @@ module Seeds
         )
       )
 
-      user = User.find_by(css_id: "BVATWARNER")
+      user = User.find_by_css_id("BVATWARNER")
       HearingDay.create(
         regional_office: "RO17",
         request_type: "V",

--- a/db/seeds/mtv.rb
+++ b/db/seeds/mtv.rb
@@ -55,8 +55,8 @@ module Seeds
     end
 
     def create_motion_to_vacate_mail_task(appeal)
-      lit_support_user = User.find_by(css_id: "LIT_SUPPORT_USER")
-      mail_user = User.find_by(css_id: "JOLLY_POSTMAN")
+      lit_support_user = User.find_by_css_id("LIT_SUPPORT_USER")
+      mail_user = User.find_by_css_id("JOLLY_POSTMAN")
       mail_team_task = create(
         :vacate_motion_mail_task,
         :on_hold,
@@ -98,10 +98,10 @@ module Seeds
 
     # rubocop:disable Metrics/AbcSize
     def setup_motion_to_vacate
-      lit_support_user = User.find_by(css_id: "LIT_SUPPORT_USER")
-      mtv_judge = User.find_by(css_id: "BVAAABSHIRE")
-      drafting_attorney = User.find_by(css_id: "BVAEERDMAN")
-      u = User.find_by(css_id: "BVAGWHITE")
+      lit_support_user = User.find_by_css_id("LIT_SUPPORT_USER")
+      mtv_judge = User.find_by_css_id("BVAAABSHIRE")
+      drafting_attorney = User.find_by_css_id("BVAEERDMAN")
+      u = User.find_by_css_id("BVAGWHITE")
       BvaDispatch.singleton.add_user(u) unless BvaDispatch.singleton.users.include? u
 
       # MTV file numbers with a decided appeal

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -210,7 +210,7 @@ module Seeds
       )
 
       root_task = appeal.root_task
-      judge = User.find_by(css_id: "BVAAWAKEFIELD")
+      judge = User.find_by_css_id("BVAAWAKEFIELD")
       judge_task = create(
         :ama_judge_decision_review_task,
         assigned_to: judge,
@@ -218,7 +218,7 @@ module Seeds
         parent: root_task
       )
 
-      atty = User.find_by(css_id: "BVAABELANGER")
+      atty = User.find_by_css_id("BVAABELANGER")
       atty_task = create(
         :ama_attorney_task,
         :in_progress,
@@ -257,8 +257,8 @@ module Seeds
           last_name: Faker::Name.last_name
         )
 
-        attorney = User.find_by(css_id: "BVASCASPER1")
-        judge = User.find_by(css_id: "BVAAABSHIRE")
+        attorney = User.find_by_css_id("BVASCASPER1")
+        judge = User.find_by_css_id("BVAAABSHIRE")
 
         appeal = create(
           :appeal,
@@ -299,8 +299,8 @@ module Seeds
           last_name: Faker::Name.last_name
         )
 
-        attorney = User.find_by(css_id: "BVASCASPER1")
-        judge = User.find_by(css_id: "BVAAABSHIRE")
+        attorney = User.find_by_css_id("BVASCASPER1")
+        judge = User.find_by_css_id("BVAAABSHIRE")
 
         appeal = create(
           :appeal,
@@ -558,8 +558,8 @@ module Seeds
     end
 
     def create_ama_tasks
-      attorney = User.find_by(css_id: "BVASCASPER1")
-      judge = User.find_by(css_id: "BVAAABSHIRE")
+      attorney = User.find_by_css_id("BVASCASPER1")
+      judge = User.find_by_css_id("BVAAABSHIRE")
 
       # At Judge Assignment
       # evidence submission docket
@@ -599,7 +599,7 @@ module Seeds
         create(
           :ama_judge_assign_task,
           :in_progress,
-          assigned_to: User.find_by(css_id: "BVAEBECKER"),
+          assigned_to: User.find_by_css_id("BVAEBECKER"),
           appeal: create(:appeal)
         )
       end
@@ -615,8 +615,8 @@ module Seeds
     end
 
     def create_tasks_at_acting_judge
-      attorney = User.find_by(css_id: "BVASCASPER1")
-      judge = User.find_by(css_id: "BVAAABSHIRE")
+      attorney = User.find_by_css_id("BVASCASPER1")
+      judge = User.find_by_css_id("BVAAABSHIRE")
 
       acting_judge = create(:user, css_id: "BVAACTING", station_id: 101, full_name: "Kris ActingVLJ_AVLJ Merle")
       create(:staff, :attorney_judge_role, user: acting_judge)

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       end
 
       context "and user is a mail intake" do
-        let(:user) { User.find_by(css_id: "ID1234") }
+        let(:user) { User.find_by_css_id("ID1234") }
         before do
           User.authenticate!(roles: ["Mail Intake"], css_id: "ID1234")
           request.headers["TOKEN"] = token
@@ -77,7 +77,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       end
 
       context "and the user is intake" do
-        let(:user) { User.find_by(css_id: "ID1234") }
+        let(:user) { User.find_by_css_id("ID1234") }
         let(:appeal) { create(:appeal, number_of_claimants: 1) }
         let(:params) { { appeal_id: appeal.uuid } }
 

--- a/spec/models/tasks/colocated_task_spec.rb
+++ b/spec/models/tasks/colocated_task_spec.rb
@@ -51,7 +51,7 @@ describe ColocatedTask, :all_dbs do
           expect(user_task.assigned_at).to_not eq nil
           expect(user_task.assigned_by).to eq attorney
           expect(user_task).to be_a(AojColocatedTask)
-          expect(user_task.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+          expect(user_task.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
           expect(vacols_case.reload.bfcurloc).to eq LegacyAppeal::LOCATION_CODES[:caseflow]
           expect(ColocatedTask.count).to eq(2)
           expect(AojColocatedTask.count).to eq(2)
@@ -63,38 +63,38 @@ describe ColocatedTask, :all_dbs do
         expect(user_tasks.first.valid?).to be true
         expect(user_tasks.first.status).to eq "assigned"
         expect(user_tasks.first).to be_a(AojColocatedTask)
-        expect(user_tasks.first.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+        expect(user_tasks.first.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
 
         expect(user_tasks.second.valid?).to be true
         expect(user_tasks.second.status).to eq "assigned"
         expect(user_tasks.second).to be_a(PoaClarificationColocatedTask)
-        expect(user_tasks.second.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+        expect(user_tasks.second.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
       end
 
       it "assigns tasks on the same appeal to the same user when they're not the next assignee" do
         user_tasks = subject.select { |t| t.assigned_to.is_a?(User) }
-        expect(user_tasks.first.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
-        expect(user_tasks.second.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+        expect(user_tasks.first.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
+        expect(user_tasks.second.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
 
         record = ColocatedTask.create_many_from_params(
           [{ assigned_by: attorney, type: AojColocatedTask.name, appeal: appeal_2 }], attorney
         )
-        expect(record.second.assigned_to).to eq User.find_by(css_id: colocated_members[1].css_id)
+        expect(record.second.assigned_to).to eq User.find_by_css_id(colocated_members[1].css_id)
 
         record = ColocatedTask.create_many_from_params(
           [{ assigned_by: attorney, type: AojColocatedTask.name, appeal: appeal_3 }], attorney
         )
-        expect(record.second.assigned_to).to eq User.find_by(css_id: colocated_members[2].css_id)
+        expect(record.second.assigned_to).to eq User.find_by_css_id(colocated_members[2].css_id)
 
         record = ColocatedTask.create_many_from_params(
           [{ assigned_by: attorney, type: AojColocatedTask.name, appeal: appeal_4 }], attorney
         )
-        expect(record.second.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+        expect(record.second.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
 
         record = ColocatedTask.create_many_from_params(
           [{ assigned_by: attorney, type: PoaClarificationColocatedTask.name, appeal: appeal_3 }], attorney
         )
-        expect(record.second.assigned_to).to eq User.find_by(css_id: colocated_members[2].css_id)
+        expect(record.second.assigned_to).to eq User.find_by_css_id(colocated_members[2].css_id)
       end
     end
 
@@ -121,7 +121,7 @@ describe ColocatedTask, :all_dbs do
         expect(subject.second.assigned_at).to_not eq nil
         expect(subject.second.assigned_by).to eq attorney
         expect(subject.second).to be_a(AojColocatedTask)
-        expect(subject.second.assigned_to).to eq User.find_by(css_id: colocated_members[0].css_id)
+        expect(subject.second.assigned_to).to eq User.find_by_css_id(colocated_members[0].css_id)
 
         expect(AppealRepository).to_not receive(:update_location!)
       end


### PR DESCRIPTION
### Description
DataDog triggered a [Caseflow DB CPU Load is High alert](https://dsva.slack.com/archives/C4JECDLSE/p1608142277160400).
A possible contributor to the high CPU is https://github.com/department-of-veterans-affairs/caseflow/blob/30b4a2a263dace8b1b88beeb0c8542b70afc38ce/app/models/legacy_hearing.rb#L363
which uses `User.find_by(css_id:` instead of the more efficient manual implementation of `User.find_by_css_id`.

`User.find`  ramped up at this time:
![image](https://user-images.githubusercontent.com/55255674/102403691-4507dc80-3fac-11eb-9e4f-bd27375f544f.png)

When searching by `css_id` ([link](https://one.newrelic.com/launcher/nr1-core.explorer?pane=eyJzcGFQYXRoIjpudWxsLCJtZXRyaWMiOm51bGwsIm5lcmRsZXRJZCI6ImFwbS1uZXJkbGV0cy5kYXRhYmFzZXMiLCJlbnRpdHlJZCI6Ik1UYzRPRFExT0h4QlVFMThRVkJRVEVsRFFWUkpUMDU4T0RBMk1EZzFORFEiLCJkcmlsbGRvd24iOnsibWV0cmljVGltZXNsaWNlTmFtZSI6IkRhdGFzdG9yZS9zdGF0ZW1lbnQvUG9zdGdyZXMvVXNlci9maW5kIn0sImxlZ2FjeURhdGFiYXNlcyI6ZmFsc2UsInNlbGVjdGVkRGF0YXN0b3JlVHlwZSI6IlBvc3RncmVzIiwic2VsZG9uRGF0YXN0b3JlVHlwZSI6bnVsbCwic2hvd0RhdGFiYXNlVGFibGUiOmZhbHNlLCJzZWxlY3RlZFNlcmllcyI6ImE4NDU0NjdkZDhhOGU0ODhkZTQyNmQxNDNhNTMwMDI4ZWYxYTYzMDYifQ==&cards[0]=eyJuZXJkbGV0SWQiOiJhcG0tbmVyZGxldHMuc3FsLXRyYWNlIiwiZW50aXR5SWQiOiJNVGM0T0RRMU9IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE9EQTJNRGcxTkRRIiwiZW50aXR5R3VpZCI6Ik1UYzRPRFExT0h4QlVFMThRVkJRVEVsRFFWUkpUMDU4T0RBMk1EZzFORFEiLCJ0cmFjZUlkIjoiMjJkMDA1ZTItM2ZjYS0xMWViLWFmNWItMDI0MmFjMTEwMDA3XzBfMjk5MyJ9&sidebars[0]=eyJuZXJkbGV0SWQiOiJucjEtY29yZS5hY3Rpb25zIiwiZW50aXR5SWQiOiJNVGM0T0RRMU9IeEJVRTE4UVZCUVRFbERRVlJKVDA1OE9EQTJNRGcxTkRRIiwic2VsZWN0ZWROZXJkbGV0Ijp7Im5lcmRsZXRJZCI6ImFwbS1uZXJkbGV0cy5kYXRhYmFzZXMifX0=&platform[accountId]=1788458&platform[timeRange][duration]=1800000&platform[$isFallbackTimeRange]=false)), a sequence scan is used: 
![image](https://user-images.githubusercontent.com/55255674/102403781-649f0500-3fac-11eb-9ed3-1586c5606808.png)

(See details in the Slack thread.)

This PR changes all occurrences to the more efficient implementation.

### Acceptance Criteria
- [ ] Code compiles correctly and all tests pass.

### Testing Plan

Run the following and note the SQL as we'll use it as the `query` in the next step.
```ruby
User.find_by(css_id: "FAKE USER")
=> SELECT  "users".* FROM "users" WHERE "users"."css_id" = $1

User.find_by_css_id("FAKE USER")
=> SELECT  "users".* FROM "users" WHERE (UPPER(css_id)=UPPER('FAKE USER'))
```

Run the following:
```ruby
conn = ActiveRecord::Base.connection;
query="EXPLAIN SELECT * FROM users WHERE css_id = 'FAKE USER'"
conn.exec_query(query)

query="EXPLAIN SELECT * FROM users WHERE UPPER(css_id) = UPPER('FAKE USER')"
conn.exec_query(query)
```
Note that the query associated with `find_by_css_id` uses an `index scan`, as opposed to a `seq scan`.

You can manually run some of the changed code to ensure that `index scan` is being used.
