### PR TITLE
create a virtual hearing conference id sequence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ client/junit.xml
 /coverage
 /reports/*
 !/reports/.keep
+credstash.log
 
 # Ignore vim swap and tag files
 *.swp

--- a/app/services/virtual_hearings/link_service.rb
+++ b/app/services/virtual_hearings/link_service.rb
@@ -15,6 +15,10 @@ class VirtualHearings::LinkService
   JUDGE_NAME = "Judge"
   GUEST_NAME = "Guest"
 
+  def initialize
+    @conference_id = nil
+  end
+
   def host_link
     link(host_pin, JUDGE_NAME)
   end

--- a/app/services/virtual_hearings/link_service.rb
+++ b/app/services/virtual_hearings/link_service.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require "digest"
+
+##
+# Service for generating new guest and host virtual hearings links
+##
+class VirtualHearings::LinkService
+  class PINKeyMissingError < StandardError; end
+  class URLHostMissingError < StandardError; end
+  class URLPathMissingError < StandardError; end
+  class PINMustBePresentError < StandardError; end
+  class NameMustBePresentError < StandardError; end
+
+  JUDGE_NAME = "Judge"
+  GUEST_NAME = "Guest"
+
+  def host_link
+    link(host_pin, JUDGE_NAME)
+  end
+
+  def guest_link
+    link(guest_pin, GUEST_NAME)
+  end
+
+  def host_pin
+    pin_hash("#{pin_key}#{conference_id}")[0..6]
+  end
+
+  def guest_pin
+    pin_hash("#{conference_id}#{pin_key}")[0..9]
+  end
+
+  private
+
+  def link(pin, name)
+    fail PINMustBePresentError if pin.blank?
+    fail NameMustBePresentError if name.blank?
+
+    "#{base_url}/?conference=BVA#{conference_id}@#{host}&name=#{name}&pin=#{pin}&callType=video&join=1"
+  end
+
+  def pin_hash(seed)
+    "0x#{Digest::SHA256.hexdigest(seed)}".to_i(16).to_s
+  end
+
+  def base_url
+    "https://#{host}#{path}"
+  end
+
+  def conference_id
+    @conference_id = VirtualHearings::SequenceConferenceId.next if @conference_id.blank?
+    @conference_id
+  end
+
+  def pin_key
+    ENV["VIRTUAL_HEARING_PIN_KEY"] || fail(PINKeyMissingError, message: COPY::PIN_KEY_MISSING_ERROR_MESSAGE)
+  end
+
+  def host
+    ENV["VIRTUAL_HEARING_URL_HOST"] || fail(URLHostMissingError, COPY::URL_HOST_MISSING_ERROR_MESSAGE)
+  end
+
+  def path
+    ENV["VIRTUAL_HEARING_URL_PATH"] || fail(URLPathMissingError, COPY::URL_PATH_MISSING_ERROR_MESSAGE)
+  end
+end

--- a/app/services/virtual_hearings/sequence_conference_id.rb
+++ b/app/services/virtual_hearings/sequence_conference_id.rb
@@ -8,11 +8,33 @@
 ##
 module VirtualHearings::SequenceConferenceId
   SEQUENCE_NAME = "virtual_hearing_conference_id_seq"
+  MAXIMUM_VALUE = 9_999_999
 
   class << self
     def next
-      result = ActiveRecord::Base.connection.execute "SELECT nextval('#{SEQUENCE_NAME}')"
+      create_sequence_if_not_exists
+      result = ActiveRecord::Base.connection.execute("SELECT nextval('#{SEQUENCE_NAME}')")
       format("%07<id>d", id: result.first["nextval"])
+    end
+
+    private
+
+    # The sequence is created by a migration, but it isn't recorded in
+    # the schema. This means that databases created with db:schema:load
+    # won't include the sequence. We call this method before accessing
+    # the sequence to make sure it exists.
+    def create_sequence_if_not_exists
+      ActiveRecord::Base.connection.execute(create_sequence_sql)
+    end
+
+    def create_sequence_sql
+      "CREATE SEQUENCE IF NOT EXISTS #{SEQUENCE_NAME} "\
+        "START WITH 1 "\
+        "INCREMENT BY 1 "\
+        "MINVALUE 1 "\
+        "MAXVALUE #{MAXIMUM_VALUE} "\
+        "CYCLE "\
+        "CACHE 1;"
     end
   end
 end

--- a/app/services/virtual_hearings/sequence_conference_id.rb
+++ b/app/services/virtual_hearings/sequence_conference_id.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+##
+# Call VirtualHearings::SequenceConferenceId.next to get a number as a
+# string between "0000001" and "9999999" for use as a virtual hearing
+# conference ID. When the sequence hits its maximum value of "9999999",
+# it will loop back to "0000001".
+##
+module VirtualHearings::SequenceConferenceId
+  SEQUENCE_NAME = "virtual_hearing_conference_id_seq"
+
+  class << self
+    def next
+      result = ActiveRecord::Base.connection.execute "SELECT nextval('#{SEQUENCE_NAME}')"
+      format("%07<id>d", id: result.first["nextval"])
+    end
+  end
+end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -945,6 +945,9 @@
   "REPRESENTATIVE_VIRTUAL_HEARING_LINK_LABEL": "Virtual Hearing Link",
   "VLJ_VIRTUAL_HEARINGS_LINK_TEXT": "Start Virtual Hearing",
   "GUEST_VIRTUAL_HEARINGS_LINK_TEXT": "Join Virtual Hearing",
+  "PIN_KEY_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid PIN key",
+  "URL_HOST_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid URL host",
+  "URL_PATH_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid URL path",
 
   "BULK_REASSIGN_INSTRUCTIONS": "This task has been %s due to the reassignment of all tasks previously assigned to %s.",
 

--- a/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
+++ b/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
@@ -20,7 +20,7 @@ class AddVirtualHearingConferenceIdSequence < Caseflow::Migration
   def down
     safety_assured do
       execute <<-SQL
-        DROP SEQUENCE virtual_hearing_conference_id_seq;
+        DROP SEQUENCE IF EXISTS virtual_hearing_conference_id_seq;
       SQL
     end
   end

--- a/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
+++ b/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
@@ -1,0 +1,27 @@
+##
+# Creates a sequence for virtual hearing conference IDs. The sequence
+# will go from 1 to 9999999 and then start again at 1.
+##
+class AddVirtualHearingConferenceIdSequence < Caseflow::Migration
+  def up
+    safety_assured do
+      execute <<-SQL
+        CREATE SEQUENCE virtual_hearing_conference_id_seq
+          START WITH 1
+          INCREMENT BY 1
+          MINVALUE 1
+          MAXVALUE 9999999
+          CYCLE
+          CACHE 1;
+      SQL
+    end
+  end
+
+  def down
+    safety_assured do
+      execute <<-SQL
+        DROP SEQUENCE virtual_hearing_conference_id_seq;
+      SQL
+    end
+  end
+end

--- a/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
+++ b/db/migrate/20201221063738_add_virtual_hearing_conference_id_sequence.rb
@@ -6,7 +6,7 @@ class AddVirtualHearingConferenceIdSequence < Caseflow::Migration
   def up
     safety_assured do
       execute <<-SQL
-        CREATE SEQUENCE virtual_hearing_conference_id_seq
+        CREATE SEQUENCE IF NOT EXISTS virtual_hearing_conference_id_seq
           START WITH 1
           INCREMENT BY 1
           MINVALUE 1

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_11_10_021033) do
+ActiveRecord::Schema.define(version: 2020_12_21_063738) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -350,23 +350,23 @@ distributions,started_at,datetime,,,,,,when the Distribution job commenced
 distributions,statistics,json,,,,,,
 distributions,status,string,,,,,,
 distributions,updated_at,datetime ∗,x,,,,x,
-docket_changes,,,,,,,,Stores the disposition and associated data for Docket Change motions
-docket_changes,created_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
-docket_changes,disposition,string ∗,x,,,,,"Possible options are granted, partially_granted, and denied"
-docket_changes,docket_type,string,,,,,,The new docket
-docket_changes,granted_request_issue_ids,integer,,,,,,"When a docket change is partially granted, this includes an array of the appeal's request issue IDs that were selected for the new docket. For full grant, this includes all prior request issue IDs."
-docket_changes,id,integer (8) PK,x,x,,,,
-docket_changes,new_docket_stream_id,integer (8) FK,,,x,,x,References the new appeal stream with the updated docket; initially null until created by workflow
-docket_changes,old_docket_stream_id,integer (8) ∗ FK,x,,x,,x,References the original appeal stream with old docket
-docket_changes,receipt_date,datetime ∗,x,,,,,
-docket_changes,task_id,integer (8) ∗ FK,x,,x,,x,The task that triggered the switch
-docket_changes,updated_at,datetime ∗,x,,,,,Standard created_at/updated_at timestamps
 docket_snapshots,,,,,,,,
 docket_snapshots,created_at,datetime,,,,,,
 docket_snapshots,docket_count,integer,,,,,,
 docket_snapshots,id,integer PK,x,x,,,,
 docket_snapshots,latest_docket_month,date,,,,,,
 docket_snapshots,updated_at,datetime,,,,,x,
+docket_switches,,,,,,,,Stores the disposition and associated data for Docket Switch motions.
+docket_switches,created_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
+docket_switches,disposition,string ∗,x,,,,,"Possible options are granted, partially_granted, and denied"
+docket_switches,docket_type,string,,,,,,The new docket
+docket_switches,granted_request_issue_ids,integer,,,,,,"When a docket switch is partially granted, this includes an array of the appeal's request issue IDs that were selected for the new docket. For full grant, this includes all prior request issue IDs."
+docket_switches,id,integer (8) PK,x,x,,,,
+docket_switches,new_docket_stream_id,integer (8) FK,,,x,,x,References the new appeal stream with the updated docket; initially null until created by workflow
+docket_switches,old_docket_stream_id,integer (8) ∗ FK,x,,x,,x,References the original appeal stream with old docket
+docket_switches,receipt_date,datetime ∗,x,,,,,
+docket_switches,task_id,integer (8) ∗ FK,x,,x,,x,The task that triggered the switch
+docket_switches,updated_at,datetime ∗,x,,,,,Standard created_at/updated_at timestamps
 docket_tracers,,,,,,,,
 docket_tracers,ahead_and_ready_count,integer,,,,,,
 docket_tracers,ahead_count,integer,,,,,,

--- a/spec/services/virtual_hearings/link_service_spec.rb
+++ b/spec/services/virtual_hearings/link_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+describe VirtualHearings::LinkService do
+  URL_HOST = "example.va.gov"
+  URL_PATH = "/sample"
+  PIN_KEY = "mysecretkey"
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:fetch).and_call_original
+  end
+
+  describe ".host_link" do
+    context "pin key env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+      end
+
+      it "raises the missing PIN key error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::PINKeyMissingError
+      end
+    end
+
+    context "url host env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+      end
+
+      it "raises the missing host error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::URLHostMissingError
+      end
+    end
+
+    context "url path env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+      end
+
+      it "raises the missing path error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::URLPathMissingError
+      end
+    end
+
+    context "all env variables are present" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+        allow(VirtualHearings::SequenceConferenceId).to receive(:next).and_return "0000001"
+      end
+
+      it "returns the expected URL", :aggregate_failures do
+        uri = URI(described_class.new.host_link)
+        expect(uri.scheme).to eq "https"
+        expect(uri.host).to eq URL_HOST
+        expect(uri.path).to eq "#{URL_PATH}/"
+
+        query = Hash[*uri.query.split(/&|=/)]
+        expect(query["conference"]).to eq "BVA0000001@#{URL_HOST}"
+        expect(query["name"]).to eq VirtualHearings::LinkService::JUDGE_NAME
+        expect(query["pin"]).to eq "3998472"
+        expect(query["callType"]).to eq "video"
+        expect(query["join"]).to eq "1"
+      end
+    end
+  end
+
+  describe ".guest_link" do
+    context "all env variables are present" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+        allow(VirtualHearings::SequenceConferenceId).to receive(:next).and_return "0000001"
+      end
+
+      it "returns the expected URL", :aggregate_failures do
+        uri = URI(described_class.new.guest_link)
+        expect(uri.scheme).to eq "https"
+        expect(uri.host).to eq URL_HOST
+        expect(uri.path).to eq "#{URL_PATH}/"
+
+        query = Hash[*uri.query.split(/&|=/)]
+        expect(query["conference"]).to eq "BVA0000001@#{URL_HOST}"
+        expect(query["name"]).to eq VirtualHearings::LinkService::GUEST_NAME
+        expect(query["pin"]).to eq "7470125694"
+        expect(query["callType"]).to eq "video"
+        expect(query["join"]).to eq "1"
+      end
+    end
+  end
+end

--- a/spec/services/virtual_hearings/sequence_conference_id_spec.rb
+++ b/spec/services/virtual_hearings/sequence_conference_id_spec.rb
@@ -2,16 +2,14 @@
 
 describe VirtualHearings::SequenceConferenceId do
   context ".next" do
-    subject { described_class.next }
-
     it "returns values in sequence" do
-      first_value = subject
-      second_value = subject
+      first_value = described_class.next
+      second_value = described_class.next
       expect(first_value.to_i).to eq(second_value.to_i - 1)
     end
 
     it "returns a seven character string starting with '0'" do
-      check_value = subject
+      check_value = described_class.next
       expect(check_value.class).to eq String
       expect(check_value.length).to eq 7
       expect(check_value[0]).to eq "0"

--- a/spec/services/virtual_hearings/sequence_conference_id_spec.rb
+++ b/spec/services/virtual_hearings/sequence_conference_id_spec.rb
@@ -17,9 +17,10 @@ describe VirtualHearings::SequenceConferenceId do
 
     it "cycles when the last number is reached" do
       sequence_name = VirtualHearings::SequenceConferenceId::SEQUENCE_NAME
-      ActiveRecord::Base.connection.execute "SELECT setval('#{sequence_name}', 9999998)"
+      max_value = VirtualHearings::SequenceConferenceId::MAXIMUM_VALUE
+      ActiveRecord::Base.connection.execute "SELECT setval('#{sequence_name}', #{max_value - 1})"
       first_value = described_class.next
-      expect(first_value).to eq "9999999"
+      expect(first_value).to eq max_value.to_s
       second_value = described_class.next
       expect(second_value).to eq "0000001"
     end

--- a/spec/services/virtual_hearings/sequence_conference_id_spec.rb
+++ b/spec/services/virtual_hearings/sequence_conference_id_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe VirtualHearings::SequenceConferenceId do
+  context ".next" do
+    subject { described_class.next }
+
+    it "returns values in sequence" do
+      first_value = subject
+      second_value = subject
+      expect(first_value.to_i).to eq(second_value.to_i - 1)
+    end
+
+    it "returns a seven character string starting with '0'" do
+      check_value = subject
+      expect(check_value.class).to eq String
+      expect(check_value.length).to eq 7
+      expect(check_value[0]).to eq "0"
+    end
+  end
+end

--- a/spec/services/virtual_hearings/sequence_conference_id_spec.rb
+++ b/spec/services/virtual_hearings/sequence_conference_id_spec.rb
@@ -14,5 +14,14 @@ describe VirtualHearings::SequenceConferenceId do
       expect(check_value.length).to eq 7
       expect(check_value[0]).to eq "0"
     end
+
+    it "cycles when the last number is reached" do
+      sequence_name = VirtualHearings::SequenceConferenceId::SEQUENCE_NAME
+      ActiveRecord::Base.connection.execute "SELECT setval('#{sequence_name}', 9999998)"
+      first_value = described_class.next
+      expect(first_value).to eq "9999999"
+      second_value = described_class.next
+      expect(second_value).to eq "0000001"
+    end
   end
 end


### PR DESCRIPTION
Connects [CASEFLOW-269](https://vajira.max.gov/browse/CASEFLOW-269)

### Description
Creates a new sequence for generating virtual hearing conference IDs, and adds a module for retrieving them.

Part 1 of stack
Part 2: #15714

### Testing Plan
1. Run the migration
  ```bash
  bundle exec rails db:migrate
  ```
2. Start a rails console
  ```bash
  bundle exec rails c
  ```
3. Use the service to generate new IDs
  ```ruby
  VirtualHearings::SequenceConferenceId.next
  => "0000001"
  VirtualHearings::SequenceConferenceId.next
  => "0000002"
  VirtualHearings::SequenceConferenceId.next
  => "0000003"
  ```

If you'd like to test that the cycle works correctly...
1. In the console, set the value of the sequence near its maximum value
  ```ruby
  ActiveRecord::Base.connection.execute "SELECT setval('virtual_hearing_conference_id_seq', 9999997)"
  ```
2. Use the service to generate new IDs
  ```ruby
  VirtualHearings::SequenceConferenceId.next
  => "9999998"
  VirtualHearings::SequenceConferenceId.next
  => "9999999"
  VirtualHearings::SequenceConferenceId.next
  => "0000001"
  ```

### Database Changes
*Only for Schema Changes*

* ~Timestamps (created_at, updated_at) for new tables~
* ~Column comments updated~
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* ~Query profiling performed (eyeball Rails log, check bullet and fasterer output)~
* ~Appropriate indexes added (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)~
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
* ~Any non-obvious semantics or logic useful for interpreting database data is documented at Caseflow Data Model and Dictionary~
