### PR TITLE
Create virtual hearing url service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ client/junit.xml
 /coverage
 /reports/*
 !/reports/.keep
+credstash.log
 
 # Ignore vim swap and tag files
 *.swp

--- a/app/services/virtual_hearings/link_service.rb
+++ b/app/services/virtual_hearings/link_service.rb
@@ -47,7 +47,8 @@ class VirtualHearings::LinkService
   end
 
   def conference_id
-    @conference_id.presence ||= VirtualHearings::SequenceConferenceId.next
+    @conference_id = VirtualHearings::SequenceConferenceId.next if @conference_id.blank?
+    @conference_id
   end
 
   def base_url

--- a/app/services/virtual_hearings/link_service.rb
+++ b/app/services/virtual_hearings/link_service.rb
@@ -7,6 +7,8 @@ require "digest"
 ##
 class VirtualHearings::LinkService
   class PINKeyMissingError < StandardError; end
+  class URLHostMissingError < StandardError; end
+  class URLPathMissingError < StandardError; end
   class PINMustBePresentError < StandardError; end
   class NameMustBePresentError < StandardError; end
 
@@ -42,8 +44,8 @@ class VirtualHearings::LinkService
     "0x#{Digest::SHA256.hexdigest(seed)}".to_i(16).to_s
   end
 
-  def pin_key
-    ENV["VIRTUAL_HEARING_PIN_KEY"] || fail(PINKeyMissingError, message: COPY::PIN_KEY_MISSING_ERROR_MESSAGE)
+  def base_url
+    "https://#{host}#{path}"
   end
 
   def conference_id
@@ -51,15 +53,15 @@ class VirtualHearings::LinkService
     @conference_id
   end
 
-  def base_url
-    "https://#{host}#{path}"
+  def pin_key
+    ENV["VIRTUAL_HEARING_PIN_KEY"] || fail(PINKeyMissingError, message: COPY::PIN_KEY_MISSING_ERROR_MESSAGE)
   end
 
   def host
-    ENV["VIRTUAL_HEARING_URL_HOST"] || "vc.va.gov"
+    ENV["VIRTUAL_HEARING_URL_HOST"] || fail(URLHostMissingError, COPY::URL_HOST_MISSING_ERROR_MESSAGE)
   end
 
   def path
-    ENV["VIRTUAL_HEARING_URL_PATH"] || "/webapp"
+    ENV["VIRTUAL_HEARING_URL_PATH"] || fail(URLPathMissingError, COPY::URL_PATH_MISSING_ERROR_MESSAGE)
   end
 end

--- a/app/services/virtual_hearings/link_service.rb
+++ b/app/services/virtual_hearings/link_service.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require "digest"
+
+##
+# Service for generating new guest and host virtual hearings links
+##
+class VirtualHearings::LinkService
+  class PINKeyMissingError < StandardError; end
+  class PINMustBePresentError < StandardError; end
+  class NameMustBePresentError < StandardError; end
+
+  JUDGE_NAME = "Judge"
+  GUEST_NAME = "Guest"
+
+  def host_link
+    link(host_pin, JUDGE_NAME)
+  end
+
+  def guest_link
+    link(guest_pin, GUEST_NAME)
+  end
+
+  def host_pin
+    pin_hash("#{pin_key}#{conference_id}")[0..6]
+  end
+
+  def guest_pin
+    pin_hash("#{conference_id}#{pin_key}")[0..9]
+  end
+
+  private
+
+  def link(pin, name)
+    fail PINMustBePresentError if pin.blank?
+    fail NameMustBePresentError if name.blank?
+
+    "#{base_url}/?conference=BVA#{conference_id}@#{host}&name=#{name}&pin=#{pin}&callType=video&join=1"
+  end
+
+  def pin_hash(seed)
+    "0x#{Digest::SHA256.hexdigest(seed)}".to_i(16).to_s
+  end
+
+  def pin_key
+    ENV["VIRTUAL_HEARING_PIN_KEY"] || fail(PINKeyMissingError, message: COPY::PIN_KEY_MISSING_ERROR_MESSAGE)
+  end
+
+  def conference_id
+    @conference_id.presence ||= VirtualHearings::SequenceConferenceId.next
+  end
+
+  def base_url
+    "https://#{host}#{path}"
+  end
+
+  def host
+    ENV["VIRTUAL_HEARING_URL_HOST"] || "vc.va.gov"
+  end
+
+  def path
+    ENV["VIRTUAL_HEARING_URL_PATH"] || "/webapp"
+  end
+end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -944,6 +944,7 @@
   "REPRESENTATIVE_VIRTUAL_HEARING_LINK_LABEL": "Virtual Hearing Link",
   "VLJ_VIRTUAL_HEARINGS_LINK_TEXT": "Start Virtual Hearing",
   "GUEST_VIRTUAL_HEARINGS_LINK_TEXT": "Join Virtual Hearing",
+  "PIN_KEY_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid PIN key",
 
   "BULK_REASSIGN_INSTRUCTIONS": "This task has been %s due to the reassignment of all tasks previously assigned to %s.",
 

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -946,6 +946,8 @@
   "VLJ_VIRTUAL_HEARINGS_LINK_TEXT": "Start Virtual Hearing",
   "GUEST_VIRTUAL_HEARINGS_LINK_TEXT": "Join Virtual Hearing",
   "PIN_KEY_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid PIN key",
+  "URL_HOST_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid URL host",
+  "URL_PATH_MISSING_ERROR_MESSAGE": "Cannot generate a virtual hearing URL without a valid URL path",
 
   "BULK_REASSIGN_INSTRUCTIONS": "This task has been %s due to the reassignment of all tasks previously assigned to %s.",
 

--- a/spec/services/virtual_hearings/link_service_spec.rb
+++ b/spec/services/virtual_hearings/link_service_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+describe VirtualHearings::LinkService do
+  URL_HOST = "example.va.gov"
+  URL_PATH = "/sample"
+  PIN_KEY = "mysecretkey"
+
+  before do
+    allow(ENV).to receive(:[]).and_call_original
+    allow(ENV).to receive(:fetch).and_call_original
+  end
+
+  describe ".host_link" do
+    context "pin key env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+      end
+
+      it "raises the missing PIN key error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::PINKeyMissingError
+      end
+    end
+
+    context "url host env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+      end
+
+      it "raises the missing host error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::URLHostMissingError
+      end
+    end
+
+    context "url path env variable is missing" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+      end
+
+      it "raises the missing path error" do
+        expect { described_class.new.host_link }.to raise_error VirtualHearings::LinkService::URLPathMissingError
+      end
+    end
+
+    context "all env variables are present" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+        allow(VirtualHearings::SequenceConferenceId).to receive(:next).and_return "0000001"
+      end
+
+      it "returns the expected URL", :aggregate_failures do
+        uri = URI(described_class.new.host_link)
+        expect(uri.scheme).to eq "https"
+        expect(uri.host).to eq URL_HOST
+        expect(uri.path).to eq "#{URL_PATH}/"
+
+        query = Hash[*uri.query.split(/&|=/)]
+        expect(query["conference"]).to eq "BVA0000001@#{URL_HOST}"
+        expect(query["name"]).to eq VirtualHearings::LinkService::JUDGE_NAME
+        expect(query["pin"]).to eq "3998472"
+        expect(query["callType"]).to eq "video"
+        expect(query["join"]).to eq "1"
+      end
+    end
+  end
+
+  describe ".guest_link" do
+    context "all env variables are present" do
+      before do
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_PIN_KEY").and_return PIN_KEY
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_HOST").and_return URL_HOST
+        allow(ENV).to receive(:[]).with("VIRTUAL_HEARING_URL_PATH").and_return URL_PATH
+        allow(VirtualHearings::SequenceConferenceId).to receive(:next).and_return "0000001"
+      end
+
+      it "returns the expected URL", :aggregate_failures do
+        uri = URI(described_class.new.guest_link)
+        expect(uri.scheme).to eq "https"
+        expect(uri.host).to eq URL_HOST
+        expect(uri.path).to eq "#{URL_PATH}/"
+
+        query = Hash[*uri.query.split(/&|=/)]
+        expect(query["conference"]).to eq "BVA0000001@#{URL_HOST}"
+        expect(query["name"]).to eq VirtualHearings::LinkService::GUEST_NAME
+        expect(query["pin"]).to eq "7470125694"
+        expect(query["callType"]).to eq "video"
+        expect(query["join"]).to eq "1"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Connects [CASEFLOW-269](https://vajira.max.gov/browse/CASEFLOW-269)

Part 2 of stack
Part 1: #15713 

### Description
Creates a new `VirtualHearings::LinkService` class that generates the new style of virtual hearing links.

### Testing Plan
1. Run the migration
  ```bash
  bundle exec rails db:migrate
  ```
2. Start a rails console
  ```bash
  bundle exec rails c
  ```
3. Set some values for the required `ENV` variables. If you want to generate valid URLs, use the values found in [credstash](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Credstash), under the keys listed in the jira ticket linked above.
  ```ruby
  ENV["VIRTUAL_HEARING_PIN_KEY"] = "mysecretkey"
  ENV["VIRTUAL_HEARING_URL_HOST"] = "example.va.gov"
  ENV["VIRTUAL_HEARING_URL_PATH"] = "/sample"
  ```
4. Use the service to generate links
  ```ruby
  vhls = VirtualHearings::LinkService.new
  vhls.guest_link
  => "https://example.va.gov/sample/?conference=BVA0000001@example.va.gov&name=Guest&pin=7470125694&callType=video&join=1"
  vhls.host_link
  => "https://example.va.gov/sample/?conference=BVA0000001@example.va.gov&name=Judge&pin=3998472&callType=video&join=1"
  ```
