### PR TITLE
CASEFLOW-126 #done Copy AOD state to CAVC Remand Appeal

### DIFF
--- a/app/models/advance_on_docket_motion.rb
+++ b/app/models/advance_on_docket_motion.rb
@@ -60,11 +60,11 @@ class AdvanceOnDocketMotion < CaseflowRecord
       end
     end
 
-    def copy_to_appeal(src_appeal, dst_appeal)
+    def copy_granted_motions_to_appeal(src_appeal, dst_appeal)
       person = src_appeal.claimant.person
       fail "Claimants on appeals are expected to be the same" unless person == dst_appeal.claimant.person
 
-      where(person_id: person, appeal: src_appeal).map do |aod_motion|
+      where(person_id: person, appeal: src_appeal).granted.map do |aod_motion|
         aod_motion.dup.tap do |motion_copy|
           motion_copy.appeal_id = dst_appeal.id
           motion_copy.save!

--- a/app/models/advance_on_docket_motion.rb
+++ b/app/models/advance_on_docket_motion.rb
@@ -65,10 +65,10 @@ class AdvanceOnDocketMotion < CaseflowRecord
       fail "Claimants on appeals are expected to be the same" unless person == dst_appeal.claimant.person
 
       where(person_id: person, appeal: src_appeal).map do |aod_motion|
-        aod_motion.dup.tap { |motion_copy|
+        aod_motion.dup.tap do |motion_copy|
           motion_copy.appeal_id = dst_appeal.id
           motion_copy.save!
-        }
+        end
       end
     end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -115,7 +115,6 @@ class Appeal < DecisionReview
           payee_code: claimant.payee_code,
           type: claimant.type
         )
-        stream.conditionally_set_aod_based_on_age
       end
     end
   end
@@ -270,6 +269,8 @@ class Appeal < DecisionReview
   end
 
   def conditionally_set_aod_based_on_age
+    return unless claimant # do not update if claimant is not yet set, i.e., when create_stream is called
+
     updated_aod_based_on_age = claimant&.advanced_on_docket_based_on_age?
     update(aod_based_on_age: updated_aod_based_on_age) if aod_based_on_age != updated_aod_based_on_age
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -115,6 +115,7 @@ class Appeal < DecisionReview
           payee_code: claimant.payee_code,
           type: claimant.type
         )
+        stream.conditionally_set_aod_based_on_age
       end
     end
   end

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -49,6 +49,7 @@ class CavcRemand < CaseflowRecord
       DecisionIssue.find(decision_issue_ids).map do |cavc_remanded_issue|
         cavc_remanded_issue.create_contesting_request_issue!(cavc_appeal)
       end
+      AdvanceOnDocketMotion.copy_to_appeal(appeal, cavc_appeal)
       InitialTasksFactory.new(cavc_appeal).create_root_and_sub_tasks!
     end
   end

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -49,7 +49,7 @@ class CavcRemand < CaseflowRecord
       DecisionIssue.find(decision_issue_ids).map do |cavc_remanded_issue|
         cavc_remanded_issue.create_contesting_request_issue!(cavc_appeal)
       end
-      AdvanceOnDocketMotion.copy_to_appeal(appeal, cavc_appeal)
+      AdvanceOnDocketMotion.copy_granted_motions_to_appeal(appeal, cavc_appeal)
       InitialTasksFactory.new(cavc_appeal).create_root_and_sub_tasks!
     end
   end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -153,7 +153,8 @@ FactoryBot.define do
     end
 
     trait :advanced_on_docket_due_to_age do
-      claimants { [create(:claimant, :advanced_on_docket_due_to_age)] }
+      # set claimant.decision_review to nil so that it isn't created by the Claimant factorybot
+      claimants { [create(:claimant, :advanced_on_docket_due_to_age, decision_review: nil)] }
     end
 
     trait :advanced_on_docket_due_to_motion do

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -157,6 +157,12 @@ FactoryBot.define do
       claimants { [create(:claimant, :advanced_on_docket_due_to_age, decision_review: nil)] }
     end
 
+    trait :active do
+      before(:create) do |appeal, _evaluator|
+        RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
+      end
+    end
+
     trait :advanced_on_docket_due_to_motion do
       # the appeal has to be established before the motion is created to apply to it.
       established_at { Time.zone.now - 1 }

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -153,9 +153,7 @@ FactoryBot.define do
     end
 
     trait :advanced_on_docket_due_to_age do
-      after(:create) do |appeal, _evaluator|
-        appeal.claimants = [create(:claimant, :advanced_on_docket_due_to_age, decision_review: appeal)]
-      end
+      claimants { [create(:claimant, :advanced_on_docket_due_to_age)] }
     end
 
     trait :advanced_on_docket_due_to_motion do

--- a/spec/jobs/set_appeal_age_aod_job_spec.rb
+++ b/spec/jobs/set_appeal_age_aod_job_spec.rb
@@ -35,13 +35,14 @@ describe SetAppealAgeAodJob, :postgres do
 
       expect(age_aod_appeal_wrong_dob.aod_based_on_age).to eq(true)
 
+      inactive_age_aod_appeal__aod_based_on_age = inactive_age_aod_appeal.aod_based_on_age
       described_class.perform_now
       expect(@slack_title).to include("[INFO] SetAppealAgeAodJob completed after running for less than a minute.")
 
-      # `aod_based_on_age` will be nil
+      # `aod_based_on_age` will be nil or the same as it was before the job
       # `aod_based_on_age` being false means that it was once true (in the case where the claimant's DOB was updated)
       expect(non_aod_appeal.reload.aod_based_on_age).not_to eq(true)
-      expect(inactive_age_aod_appeal.reload.aod_based_on_age).not_to eq(true)
+      expect(inactive_age_aod_appeal.reload.aod_based_on_age).to eq(inactive_age_aod_appeal__aod_based_on_age)
 
       expect(age_aod_appeal.reload.aod_based_on_age).to eq(true)
       expect(motion_aod_appeal.reload.aod_based_on_age).not_to eq(true)

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -67,22 +67,24 @@ describe CavcRemand do
     end
 
     context "when source appeal is AOD" do
-      context "source appeal is AOD due to veteran's age" do
-        let(:appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age) }
-        it "new CAVC remand appeal is AOD due to age" do
+      context "source appeal is AOD due to claimant's age" do
+        let(:appeal) { create(:appeal, :active, :advanced_on_docket_due_to_age) }
+        it "creates new CAVC remand appeal with AOD due to age" do
           expect(appeal.aod_based_on_age).to be true
+
           cavc_remand = subject
           cavc_appeal = last_cavc_appeal(cavc_remand)
           expect(cavc_appeal.aod_based_on_age).to eq cavc_remand.appeal.aod_based_on_age
         end
       end
       context "source appeal has non-age-related AOD Motion" do
-        let(:appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_motion) }
+        let(:appeal) { create(:appeal, :active, :advanced_on_docket_due_to_motion) }
         it "copies AOD motions to new CAVC remand appeal" do
-          expect(appeal.aod?).to be true
           person = appeal.claimant.person
           expect(AdvanceOnDocketMotion.granted_for_person?(person, appeal)).to be true
           aod_motions_count = AdvanceOnDocketMotion.for_appeal_and_person(appeal, person).count
+          expect(appeal.aod?).to be true
+
           cavc_remand = subject
           cavc_appeal = last_cavc_appeal(cavc_remand)
           expect(cavc_remand.appeal.claimant.person).to eq person
@@ -90,9 +92,8 @@ describe CavcRemand do
           expect(AdvanceOnDocketMotion.for_appeal_and_person(appeal, person).count).to eq aod_motions_count
           expect(AdvanceOnDocketMotion.for_appeal_and_person(cavc_appeal, person).count).to eq aod_motions_count
 
-          pp [cavc_appeal.aod?, cavc_remand.appeal.aod?] # not sure why this is needed
           expect(AdvanceOnDocketMotion.granted_for_person?(cavc_appeal.claimant.person, cavc_appeal)).to be true
-          expect(cavc_appeal.aod?).to eq cavc_remand.appeal.aod?
+          expect(cavc_appeal.aod?).to be true
         end
       end
     end

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -27,7 +27,7 @@ describe CavcRemand do
       )
     end
     let(:decision_issue_ids) { decision_issues.map(&:id) }
-    let(:instructions) { "Intructions!" }
+    let(:instructions) { "Instructions!" }
 
     let(:params) do
       {

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -63,18 +63,16 @@ describe CavcRemand do
       expect(appeal.aod_based_on_age).not_to be true
       expect { subject }.not_to raise_error
       expect(Appeal.court_remand.where(stream_docket_number: appeal.docket_number).count).to eq(1)
-      expect(last_cavc_appeal(subject).aod_based_on_age).to eq subject.appeal.aod_based_on_age
+      expect(last_cavc_appeal(subject).aod_based_on_age).not_to be true
     end
 
     context "when source appeal is AOD" do
       context "source appeal is AOD due to veteran's age" do
         let(:appeal) { create(:appeal, :with_schedule_hearing_tasks, :advanced_on_docket_due_to_age) }
         it "new CAVC remand appeal is AOD due to age" do
-          appeal.aod? # not sure why this is needed
-          expect(appeal.reload.aod_based_on_age).to be true # reload may not be needed
+          expect(appeal.aod_based_on_age).to be true
           cavc_remand = subject
           cavc_appeal = last_cavc_appeal(cavc_remand)
-          cavc_appeal.aod? # not sure why this is needed
           expect(cavc_appeal.aod_based_on_age).to eq cavc_remand.appeal.aod_based_on_age
         end
       end


### PR DESCRIPTION
Resolves [CASEFLOW-126](https://vajira.max.gov/browse/CASEFLOW-126)

### Description

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Verify the CAVC Remand is AOD if the original appeal was AOD
How we determine AOD:
- [ ] `aod_based_on_age` is true on the appeal (set by a job, should be set automatically upon creation)
- [ ] The claimant's dob is over 75 years ago (should have the same claimant, automatically checked in the code)
- [ ] The claimant has a granted age base aod motion (AOD currently only applies at the combined claimant and appeal level; create a new aod motion for this appeal if one existed for the OG)

### Testing Plan
Refer to Rails commands provided in #15469.

```ruby
# Create an active "source appeal" with AOD due to age
# Also try this with another appeal that is not AOD (leave out `:advanced_on_docket_due_to_age`).
appeal = FactoryBot.create(:appeal, :active, :advanced_on_docket_due_to_age)
appeal.aod_based_on_age
=> true
appeal.aod?
=> true

decision_issues = FactoryBot.create_list(
        :decision_issue,
        3,
        :rating,
        decision_review: appeal,
        disposition: "denied",
        description: "Decision issue description",
        decision_text: "decision issue"
      )
params = {
        created_by: User.last,
        updated_by: User.last,
        appeal: appeal,
        cavc_docket_number: "123-1234567",
        represented_by_attorney: true,
        cavc_judge_full_name: Constants::CAVC_JUDGE_FULL_NAMES.first,
        cavc_decision_type: Constants::CAVC_DECISION_TYPES.keys.first,
        remand_subtype: Constants::CAVC_REMAND_SUBTYPES.keys.first,
        decision_date: 5.days.ago.to_date,
        judgement_date: 4.days.ago.to_date,
        mandate_date: 3.days.ago.to_date,
        decision_issue_ids: decision_issues.map(&:id),
        instructions: "Instructions!"
      }
cavc_remand = CavcRemand.create!(params)
cavc_appeal = Appeal.court_remand.where(stream_docket_number: cavc_remand.appeal.docket_number).order(:id).last
cavc_appeal.aod_based_on_age
=> true
cavc_appeal.aod?
=> true
```

```ruby
# Create an active "source appeal" with AOD due to AOD motion
appeal = FactoryBot.create(:appeal, :active, :advanced_on_docket_due_to_motion)
appeal.aod?
=> true

decision_issues = ... # same as above
params  = ... # same as above
cavc_remand = CavcRemand.create!(params)
cavc_appeal = Appeal.court_remand.where(stream_docket_number: cavc_remand.appeal.docket_number).order(:id).last
cavc_appeal.aod?
=> true
cavc_appeal.aod_based_on_age
=> false

# Verify that there are new AdvanceOnDocketMotion -- see code in RSpec tests
```

