### PR TITLE
Add pre-AMA date error validation to Edit NOD Date Modal

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -155,7 +155,8 @@
   "EDIT_NOD_DATE_LABEL": "NOD Date",
   "EDIT_NOD_DATE_SUCCESS_ALERT_TITLE": "NOD date has been updated",
   "EDIT_NOD_DATE_SUCCESS_ALERT_MESSAGE": "You have successfully updated the NOD date",
-  "EDIT_NOD_DATE_ERROR_ALERT_MESSAGE": "The new NOD date cannot be after today's date",
+  "EDIT_NOD_DATE_FUTURE_DATE_ERROR_MESSAGE": "The new NOD date cannot be after today's date",
+  "EDIT_NOD_DATE_PRE_AMA_DATE_ERROR_MESSAGE": "New NOD date cannot be before 02/19/2019",
 
   "DROPDOWN_LABEL_JUDGE": "VLJ",
   "DROPDOWN_LABEL_HEARING_COORDINATOR": "Hearing Coordinator",

--- a/client/app/queue/components/EditNodDateModal.jsx
+++ b/client/app/queue/components/EditNodDateModal.jsx
@@ -44,8 +44,8 @@ export const EditNodDateModalContainer = ({ onCancel, onSubmit, nodDate, appealI
 
 export const EditNodDateModal = ({ onCancel, onSubmit, nodDate }) => {
   const [receiptDate, setReceiptDate] = useState(nodDate);
-  const [futureDate, setFutureDate] = useState(false);
   const [disableButton, setDisableButton] = useState(false);
+  const [errorMessage, setErrorMessage] = useState(null);
 
   const buttons = [
     {
@@ -70,15 +70,26 @@ export const EditNodDateModal = ({ onCancel, onSubmit, nodDate }) => {
     return (date > todaysDate);
   };
 
+  const isPreAmaDate = (newDate) => {
+    const formattedNewDate = moment(newDate);
+    const amaDate = moment('2019-02-19');
+
+    return (formattedNewDate < amaDate);
+  };
+
   const handleDateChange = (value) => {
     if (isFutureDate(value)) {
-      setFutureDate(true);
+      setErrorMessage(COPY.EDIT_NOD_DATE_FUTURE_DATE_ERROR_MESSAGE);
+      setDisableButton(true);
+      setReceiptDate(value);
+    } else if (isPreAmaDate(value)) {
+      setErrorMessage(COPY.EDIT_NOD_DATE_PRE_AMA_DATE_ERROR_MESSAGE);
       setDisableButton(true);
       setReceiptDate(value);
     } else {
+      setErrorMessage(null);
       setReceiptDate(value);
       setDisableButton(false);
-      setFutureDate(false);
     }
   };
 
@@ -94,7 +105,7 @@ export const EditNodDateModal = ({ onCancel, onSubmit, nodDate }) => {
       </div>
       <DateSelector
         name="nodDate"
-        errorMessage={futureDate ? COPY.EDIT_NOD_DATE_ERROR_ALERT_MESSAGE : null}
+        errorMessage={errorMessage}
         label={COPY.EDIT_NOD_DATE_LABEL}
         strongLabel
         type="date"

--- a/client/test/app/queue/components/EditNodDateModal.test.js
+++ b/client/test/app/queue/components/EditNodDateModal.test.js
@@ -1,7 +1,8 @@
 import React from 'react';
-import { EditNodDateModal } from 'app/queue/components/EditNodDateModal';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import { EditNodDateModal } from 'app/queue/components/EditNodDateModal';
+import COPY from 'app/../COPY';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -56,7 +57,6 @@ describe('EditNodDateModal', () => {
   it('should give error when future date is given', () => {
     const component = setupEditNodDateModal();
     const dateInput = component.find('input[type="date"]');
-    const errorMsg = "The new NOD date cannot be after today's date";
 
     dateInput.simulate('change', { target: { value: futureDate } });
     component.update();
@@ -65,7 +65,20 @@ describe('EditNodDateModal', () => {
     expect(component.find('input[type="date"]').props().value).
       toEqual(futureDate);
 
-    component.setProps({ errorMessage: errorMsg });
-    expect(component.props().errorMessage).toEqual(errorMsg);
+    const errorMessage = component.find('.usa-input-error-message');
+
+    expect(errorMessage.text()).toEqual(COPY.EDIT_NOD_DATE_FUTURE_DATE_ERROR_MESSAGE);
+  });
+
+  it('should show error when date before 2019-02-19 is given', () => {
+    const component = setupEditNodDateModal();
+    const dateInput = component.find('input[type="date"]');
+    const preAmaDate = '2018-01-01';
+
+    dateInput.simulate('change', { target: { value: preAmaDate } });
+    component.update();
+    const errorMessage = component.find('.usa-input-error-message');
+
+    expect(errorMessage.text()).toEqual(COPY.EDIT_NOD_DATE_PRE_AMA_DATE_ERROR_MESSAGE);
   });
 });


### PR DESCRIPTION
Resolves [CASEFLOW-198](https://vajira.max.gov/browse/CASEFLOW-198)

### Description
Add pre-AMA date error validation to Edit NOD Date Modal

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Error message appears when new NOD date entered into date selector

### Testing Plan
1. Select user with access to Edit NOD link e.g. BVAISHAW (VACO)
2. Go to **Queue** and search for a veteran id like '701305078'
3. Go to Case Details page for for an appeal
4. Select Edit NOD link
5. Enter date before 02-19-2019
6. Verify error message appears

### User Facing Changes

 BEFORE|AFTER
 ---|---
<> |<img width="951" alt="Screen Shot 2020-12-21 at 6 53 57 PM" src="https://user-images.githubusercontent.com/68879427/102847271-d6b98480-43c6-11eb-9548-1b19f5d64fc5.png">
