### PR TITLE
Parse BGS death date format and coerce to ISO 8601

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -271,7 +271,12 @@ class Veteran < CaseflowRecord
   end
 
   def date_of_death
-    super || (bgs_record_found? ? bgs_record[:date_of_death] : nil)
+    super || begin
+               dod = bgs_record[:date_of_death] if bgs_record_found?
+               dod && Date.strptime(dod, "%m/%d/%Y")
+             rescue ArgumentError
+               nil
+             end
   end
 
   def address

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -55,7 +55,7 @@ const VeteranDetail = ({ veteran, stateOnly }) => {
   if (dod) {
     details.push({
       label: 'Date of death',
-      value: <DateString date={dod} inputFormat="MM/DD/YYYY" dateFormat="M/D/YYYY" />
+      value: <DateString date={dod} inputFormat="YYYY-MM-DD" dateFormat="M/D/YYYY" />
     });
   }
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -235,7 +235,7 @@ describe Veteran, :all_dbs do
         state: "CA",
         country: "USA",
         date_of_birth: "12/21/1989",
-        date_of_death: date_of_death,
+        date_of_death: Date.new(2019, 12, 31),
         zip_code: "94117",
         military_post_office_type_code: "DPO",
         military_postal_type_code: "AE"


### PR DESCRIPTION
### Description
When a veteran has a date of death, this data may be returned to the frontend directly from a BGS call, or from the cached value in the Postgres `veterans` table. BGS uses `mm/dd/yyyy`-formatted strings, whereas ActiveRecord provides `Date` objects from Postgres which get automatically serialized in ISO-8601 `yyyy/mm/dd`.

This PR ensures that we use ISO-8601 whenever possible (including in the frontend) and parses the date format coming from BGS.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to any case details page with a veteran without a date of death
    - Normally `appeal = Appeal.last` is fine
    - Get `appeal.uuid` and point your browser to `/queue/appeals/{UUID}`
2. At `app/models/veteran.rb:130`, append `.tap { |h| h[:date_of_death] = "12/21/2020" }`
    - This ensures that the data from "BGS" comes with a DoD.
3. Refresh the page and confirm DoD shows properly
4. In Rails console, `appeal.veteran.update!(date_of_death: "2020-12-22")`
5. Refresh the page and confirm DoD shows the changed value properly

### User Facing Changes
Before, when attempting to render a date in the wrong format:
<img width="668" src="https://user-images.githubusercontent.com/282869/102925854-239e6900-4462-11eb-9c08-14813f1c7a2b.png">

After:
<img width="667" src="https://user-images.githubusercontent.com/282869/102925875-2b5e0d80-4462-11eb-835c-0151eb8fc75d.png">

