### PR TITLE
Check feature toggle on user who updated virtual hearing

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -128,7 +128,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
   end
 
   def create_conference
-    if FeatureToggle.enabled?(:virtual_hearings_use_new_links, user: RequestStore.store[:current_user])
+    if FeatureToggle.enabled?(:virtual_hearings_use_new_links, user: virtual_hearing.updated_by)
       generate_links_and_pins
     else
       assign_virtual_hearing_alias_and_pins if should_initialize_alias_and_pins?


### PR DESCRIPTION
Connects [CASEFLOW-269](https://vajira.max.gov/browse/CASEFLOW-269)
Follows: https://github.com/department-of-veterans-affairs/caseflow/pull/15732

### Testing Plan
#### Feature toggle is enabled
1. Go to http://localhost:3000/test/users and login as `BVASYELLOW` 
2. Enable feature flag for user in Rails console
```ruby
 FeatureToggle.enable!(:virtual_hearings_use_new_links, users: ["BVASYELLOW"])
```
##### Converting a video/central video to virtual and back
3. go to http://localhost:3000/hearings/schedule
3. pick any central or video hearings go go the details page
4. click on the hearing type dropdown and convert to virtual hearing
5. Ensure that the new pins and links are as expected
6. You can also try switching back to video/central to ensure that works as expected

##### Scheduling directly to Virtual
3. go to http://localhost:3000/hearings/schedule/assign
4. pick a RO that has veterans waiting 
5. pick a veteran to schedule hearing for and go to case details page
6. on case details, click on action `Schedule Veteran`
7. schedule veteran directly to virtual
8. you can directly go to hearing details page to ensure that the links and pins were generated correctly

#### Feature toggle is disabled
1. Go to http://localhost:3000/test/users and login as `BVASYELLOW` 
2. Disable feature flag for user in Rails console
```ruby
 FeatureToggle.disable!(:virtual_hearings_use_new_links, users: ["BVASYELLOW"])
```
##### Converting a video/central video to virtual and back
3. go to http://localhost:3000/hearings/schedule
3. pick any central or video hearings go go the details page
4. click on the hearing type dropdown and convert to virtual hearing
5. Ensure conference was created old way
6. You can also try switching back to video/central to ensure that works as expected

##### Scheduling directly to Virtual
3. go to http://localhost:3000/hearings/schedule/assign
4. pick a RO that has veterans waiting 
5. pick a veteran to schedule hearing for and go to case details page
6. on case details, click on action `Schedule Veteran`
7. schedule veteran directly to virtual
8. you can directly go to hearing details page to ensure that conference was created old way

