### PR TITLE
Add docket_range_job mapping to JobsController

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::JobsController < Api::ApplicationController
     "delete_conferences_job" => VirtualHearings::DeleteConferencesJob,
     "dependencies_check" => DependenciesCheckJob,
     "dependencies_report_service_log" => DependenciesReportServiceLogJob,
+    "docket_range_job" => DocketRangeJob,
     "etl_builder" => ETLBuilderJob,
     "heartbeat" => HeartbeatTasksJob,
     "missed_job_sweeper" => MissedJobSweeperJob,


### PR DESCRIPTION
### Description

Adds `docket_range_job` mapping to `JobsController` to resolve an issue with the AWS lambda not being able to invoke the `DocketRangeJob`.
