### PR TITLE
Prevent tasks from being assigned to COB

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -10,6 +10,7 @@ class Api::V1::JobsController < Api::ApplicationController
     "delete_conferences_job" => VirtualHearings::DeleteConferencesJob,
     "dependencies_check" => DependenciesCheckJob,
     "dependencies_report_service_log" => DependenciesReportServiceLogJob,
+    "docket_range_job" => DocketRangeJob,
     "etl_builder" => ETLBuilderJob,
     "heartbeat" => HeartbeatTasksJob,
     "missed_job_sweeper" => MissedJobSweeperJob,

--- a/app/models/organizations/clerk_of_the_board.rb
+++ b/app/models/organizations/clerk_of_the_board.rb
@@ -5,6 +5,10 @@ class ClerkOfTheBoard < Organization
     ClerkOfTheBoard.first || ClerkOfTheBoard.create(name: "Clerk of the Board", url: "clerk-of-the-board")
   end
 
+  def can_receive_task?(_task)
+    false
+  end
+
   def users_can_create_mail_task?
     true
   end

--- a/spec/models/organizations/clerk_of_the_board_spec.rb
+++ b/spec/models/organizations/clerk_of_the_board_spec.rb
@@ -15,7 +15,7 @@ describe ClerkOfTheBoard do
 
   describe ".can_receive_task?" do
     it "returns false because the COB hasn't started using Queue yet" do
-      expect(dvc_team.can_receive_task?(nil)).to eq(false)
+      expect(ClerkOfTheBoard.singleton.can_receive_task?(nil)).to eq(false)
     end
   end
 end

--- a/spec/models/organizations/clerk_of_the_board_spec.rb
+++ b/spec/models/organizations/clerk_of_the_board_spec.rb
@@ -12,4 +12,10 @@ describe ClerkOfTheBoard do
       expect(ClerkOfTheBoard.singleton.users_can_create_mail_task?).to eq(true)
     end
   end
+
+  describe ".can_receive_task?" do
+    it "returns false because the COB hasn't started using Queue yet" do
+      expect(dvc_team.can_receive_task?(nil)).to eq(false)
+    end
+  end
 end


### PR DESCRIPTION
### Description
The Clerk of the Board is available for task assignments, but they haven't started using Queue yet so we want to prevent this.

[Slack thread for background](https://dsva.slack.com/archives/C54QCEHAL/p1609868022296200)

### Acceptance Criteria
- [x] Users cannot assign tasks to the Clerk of the Board organization

### Testing Plan
1. Automated test

