### PR TITLE
use the new syntax for brew cask installs in README & setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ brew install rbenv nodenv yarn
 brew tap ouchxp/nodenv
 brew install nodenv-nvmrc
 brew tap caskroom/cask
-brew cask install chromedriver
+brew install --cask chromedriver
 ```
 **Linux**
 
@@ -245,7 +245,7 @@ You probably have to create an Oracle account to download these.
 Install Docker on your machine via Homebrew:
 
 ```
-    brew cask install docker
+    brew install --cask docker
 ```
 
 Once Docker's installed, run the application and go into advanced preferences to limit Docker's resources in order to keep FACOLS from consuming your Macbook.  Recommended settings are 4 CPUs, 8 GiB of internal memory, and 512 MiB of swap.
@@ -289,7 +289,7 @@ Allows the feature tests to run locally.
 
 **Mac**
 ```
-brew cask install chromedriver
+brew install --cask chromedriver
 chromedriver --version
 ```
 

--- a/scripts/dev_env_setup_step1.sh
+++ b/scripts/dev_env_setup_step1.sh
@@ -48,7 +48,7 @@ brew install rbenv nodenv yarn jq
 brew tap ouchxp/nodenv
 brew install nodenv-nvmrc
 brew install postgres
-brew cask install chromedriver
+brew install --cask chromedriver
 chromedriver --version
 
 echo "==> Setting up rbenv and nodenv"
@@ -80,7 +80,7 @@ echo "==> Installing Docker"
 if which docker > /dev/null; then
   echo "Docker is already installed. Skipping installation."
 else
-  brew cask install docker
+  brew install --cask docker
 fi
 
 echo "==> Installing InstantClient"


### PR DESCRIPTION
### Description
`brew` now handles cask installs like `brew install --cask` instead of `brew cask install`