### PR TITLE
Add one more fake room to allocate all necessary days for Q3 FY21

### DIFF
--- a/client/constants/HEARING_ROOMS_LIST.json
+++ b/client/constants/HEARING_ROOMS_LIST.json
@@ -100,5 +100,8 @@
   },
   "34" : {
     "label": "Fallujah"
+  },
+  "35" : {
+    "label": "Yorktown"
   }
 }

--- a/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
@@ -2873,6 +2873,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                     "label": "Fallujah",
                     "value": "34",
                   },
+                  Object {
+                    "label": "Yorktown",
+                    "value": "35",
+                  },
                 ]
               }
               strongLabel={true}
@@ -3055,6 +3059,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                           Object {
                             "label": "Fallujah",
                             "value": "34",
+                          },
+                          Object {
+                            "label": "Yorktown",
+                            "value": "35",
                           },
                         ]
                       }
@@ -3252,6 +3260,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                               "label": "Fallujah",
                               "value": "34",
                             },
+                            Object {
+                              "label": "Yorktown",
+                              "value": "35",
+                            },
                           ]
                         }
                         pageSize={5}
@@ -3429,6 +3441,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                               Object {
                                 "label": "Fallujah",
                                 "value": "34",
+                              },
+                              Object {
+                                "label": "Yorktown",
+                                "value": "35",
                               },
                             ]
                           }
@@ -3616,6 +3632,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                 Object {
                                   "label": "Fallujah",
                                   "value": "34",
+                                },
+                                Object {
+                                  "label": "Yorktown",
+                                  "value": "35",
                                 },
                               ],
                               "pageSize": 5,
@@ -3844,6 +3864,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                       "label": "Fallujah",
                                       "value": "34",
                                     },
+                                    Object {
+                                      "label": "Yorktown",
+                                      "value": "35",
+                                    },
                                   ]
                                 }
                                 selectOption={[Function]}
@@ -4030,6 +4054,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                       Object {
                                         "label": "Fallujah",
                                         "value": "34",
+                                      },
+                                      Object {
+                                        "label": "Yorktown",
+                                        "value": "35",
                                       },
                                     ],
                                     "pageSize": 5,
@@ -4266,6 +4294,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -4452,6 +4484,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -4679,6 +4715,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -4865,6 +4905,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -5139,6 +5183,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -5443,6 +5491,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -5629,6 +5681,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -5847,6 +5903,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -6033,6 +6093,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -6262,6 +6326,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -6448,6 +6516,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -13598,6 +13670,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                     "label": "Fallujah",
                     "value": "34",
                   },
+                  Object {
+                    "label": "Yorktown",
+                    "value": "35",
+                  },
                 ]
               }
               strongLabel={true}
@@ -13780,6 +13856,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                           Object {
                             "label": "Fallujah",
                             "value": "34",
+                          },
+                          Object {
+                            "label": "Yorktown",
+                            "value": "35",
                           },
                         ]
                       }
@@ -13977,6 +14057,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                               "label": "Fallujah",
                               "value": "34",
                             },
+                            Object {
+                              "label": "Yorktown",
+                              "value": "35",
+                            },
                           ]
                         }
                         pageSize={5}
@@ -14154,6 +14238,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                               Object {
                                 "label": "Fallujah",
                                 "value": "34",
+                              },
+                              Object {
+                                "label": "Yorktown",
+                                "value": "35",
                               },
                             ]
                           }
@@ -14341,6 +14429,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                 Object {
                                   "label": "Fallujah",
                                   "value": "34",
+                                },
+                                Object {
+                                  "label": "Yorktown",
+                                  "value": "35",
                                 },
                               ],
                               "pageSize": 5,
@@ -14569,6 +14661,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                       "label": "Fallujah",
                                       "value": "34",
                                     },
+                                    Object {
+                                      "label": "Yorktown",
+                                      "value": "35",
+                                    },
                                   ]
                                 }
                                 selectOption={[Function]}
@@ -14755,6 +14851,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                       Object {
                                         "label": "Fallujah",
                                         "value": "34",
+                                      },
+                                      Object {
+                                        "label": "Yorktown",
+                                        "value": "35",
                                       },
                                     ],
                                     "pageSize": 5,
@@ -14991,6 +15091,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -15177,6 +15281,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -15404,6 +15512,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -15590,6 +15702,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -15864,6 +15980,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -16168,6 +16288,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -16354,6 +16478,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -16572,6 +16700,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -16758,6 +16890,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -16987,6 +17123,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -17173,6 +17313,10 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -24345,6 +24489,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                     "label": "Fallujah",
                     "value": "34",
                   },
+                  Object {
+                    "label": "Yorktown",
+                    "value": "35",
+                  },
                 ]
               }
               strongLabel={true}
@@ -24527,6 +24675,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                           Object {
                             "label": "Fallujah",
                             "value": "34",
+                          },
+                          Object {
+                            "label": "Yorktown",
+                            "value": "35",
                           },
                         ]
                       }
@@ -24724,6 +24876,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                               "label": "Fallujah",
                               "value": "34",
                             },
+                            Object {
+                              "label": "Yorktown",
+                              "value": "35",
+                            },
                           ]
                         }
                         pageSize={5}
@@ -24901,6 +25057,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                               Object {
                                 "label": "Fallujah",
                                 "value": "34",
+                              },
+                              Object {
+                                "label": "Yorktown",
+                                "value": "35",
                               },
                             ]
                           }
@@ -25088,6 +25248,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                 Object {
                                   "label": "Fallujah",
                                   "value": "34",
+                                },
+                                Object {
+                                  "label": "Yorktown",
+                                  "value": "35",
                                 },
                               ],
                               "pageSize": 5,
@@ -25316,6 +25480,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                       "label": "Fallujah",
                                       "value": "34",
                                     },
+                                    Object {
+                                      "label": "Yorktown",
+                                      "value": "35",
+                                    },
                                   ]
                                 }
                                 selectOption={[Function]}
@@ -25502,6 +25670,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                       Object {
                                         "label": "Fallujah",
                                         "value": "34",
+                                      },
+                                      Object {
+                                        "label": "Yorktown",
+                                        "value": "35",
                                       },
                                     ],
                                     "pageSize": 5,
@@ -25738,6 +25910,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -25924,6 +26100,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -26151,6 +26331,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -26337,6 +26521,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -26611,6 +26799,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -26915,6 +27107,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -27101,6 +27297,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -27319,6 +27519,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -27505,6 +27709,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -27734,6 +27942,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -27920,6 +28132,10 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -36513,6 +36729,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                     "label": "Fallujah",
                     "value": "34",
                   },
+                  Object {
+                    "label": "Yorktown",
+                    "value": "35",
+                  },
                 ]
               }
               strongLabel={true}
@@ -36695,6 +36915,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                           Object {
                             "label": "Fallujah",
                             "value": "34",
+                          },
+                          Object {
+                            "label": "Yorktown",
+                            "value": "35",
                           },
                         ]
                       }
@@ -36892,6 +37116,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                               "label": "Fallujah",
                               "value": "34",
                             },
+                            Object {
+                              "label": "Yorktown",
+                              "value": "35",
+                            },
                           ]
                         }
                         pageSize={5}
@@ -37069,6 +37297,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                               Object {
                                 "label": "Fallujah",
                                 "value": "34",
+                              },
+                              Object {
+                                "label": "Yorktown",
+                                "value": "35",
                               },
                             ]
                           }
@@ -37256,6 +37488,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                 Object {
                                   "label": "Fallujah",
                                   "value": "34",
+                                },
+                                Object {
+                                  "label": "Yorktown",
+                                  "value": "35",
                                 },
                               ],
                               "pageSize": 5,
@@ -37484,6 +37720,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                       "label": "Fallujah",
                                       "value": "34",
                                     },
+                                    Object {
+                                      "label": "Yorktown",
+                                      "value": "35",
+                                    },
                                   ]
                                 }
                                 selectOption={[Function]}
@@ -37670,6 +37910,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                       Object {
                                         "label": "Fallujah",
                                         "value": "34",
+                                      },
+                                      Object {
+                                        "label": "Yorktown",
+                                        "value": "35",
                                       },
                                     ],
                                     "pageSize": 5,
@@ -37906,6 +38150,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -38092,6 +38340,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -38319,6 +38571,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -38505,6 +38761,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -38779,6 +39039,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -39083,6 +39347,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -39269,6 +39537,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -39487,6 +39759,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -39673,6 +39949,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -39902,6 +40182,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -40088,6 +40372,10 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -48681,6 +48969,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                     "label": "Fallujah",
                     "value": "34",
                   },
+                  Object {
+                    "label": "Yorktown",
+                    "value": "35",
+                  },
                 ]
               }
               strongLabel={true}
@@ -48863,6 +49155,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                           Object {
                             "label": "Fallujah",
                             "value": "34",
+                          },
+                          Object {
+                            "label": "Yorktown",
+                            "value": "35",
                           },
                         ]
                       }
@@ -49060,6 +49356,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                               "label": "Fallujah",
                               "value": "34",
                             },
+                            Object {
+                              "label": "Yorktown",
+                              "value": "35",
+                            },
                           ]
                         }
                         pageSize={5}
@@ -49237,6 +49537,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                               Object {
                                 "label": "Fallujah",
                                 "value": "34",
+                              },
+                              Object {
+                                "label": "Yorktown",
+                                "value": "35",
                               },
                             ]
                           }
@@ -49424,6 +49728,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                 Object {
                                   "label": "Fallujah",
                                   "value": "34",
+                                },
+                                Object {
+                                  "label": "Yorktown",
+                                  "value": "35",
                                 },
                               ],
                               "pageSize": 5,
@@ -49652,6 +49960,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                       "label": "Fallujah",
                                       "value": "34",
                                     },
+                                    Object {
+                                      "label": "Yorktown",
+                                      "value": "35",
+                                    },
                                   ]
                                 }
                                 selectOption={[Function]}
@@ -49838,6 +50150,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                       Object {
                                         "label": "Fallujah",
                                         "value": "34",
+                                      },
+                                      Object {
+                                        "label": "Yorktown",
+                                        "value": "35",
                                       },
                                     ],
                                     "pageSize": 5,
@@ -50074,6 +50390,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -50260,6 +50580,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -50487,6 +50811,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -50673,6 +51001,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -50947,6 +51279,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -51251,6 +51587,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                             "label": "Fallujah",
                                             "value": "34",
                                           },
+                                          Object {
+                                            "label": "Yorktown",
+                                            "value": "35",
+                                          },
                                         ]
                                       }
                                       selectOption={[Function]}
@@ -51437,6 +51777,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                             Object {
                                               "label": "Fallujah",
                                               "value": "34",
+                                            },
+                                            Object {
+                                              "label": "Yorktown",
+                                              "value": "35",
                                             },
                                           ],
                                           "pageSize": 5,
@@ -51655,6 +51999,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -51841,6 +52189,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,
@@ -52070,6 +52422,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   "label": "Fallujah",
                                                   "value": "34",
                                                 },
+                                                Object {
+                                                  "label": "Yorktown",
+                                                  "value": "35",
+                                                },
                                               ]
                                             }
                                             selectOption={[Function]}
@@ -52256,6 +52612,10 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
                                                   Object {
                                                     "label": "Fallujah",
                                                     "value": "34",
+                                                  },
+                                                  Object {
+                                                    "label": "Yorktown",
+                                                    "value": "35",
                                                   },
                                                 ],
                                                 "pageSize": 5,


### PR DESCRIPTION
Resolves CASEFLOW-658
DSVA Slack thread: https://dsva.slack.com/archives/C01155MJGF2/p1609969681023200

### Description
We added 11 more fake rooms before the Branch attempted to allocate the Q3 FY21 hearing days so they could create as many hearing days as they needed to reach their goals. Those rooms got us very close to their desired allocation, but for some reason was ending up with one day short of what was needed. Adding another fake room gives enough extra capacity for all the ROs to get the total number of days they want to allocate.

### Testing Plan
This has been tested through a monkey-patch in the console to add one more room and run the algorithm again with the Branch's Q3 FY21 allocation spreadsheet.