### PR TITLE
Add link to CAVC Remand wiki page

### DIFF
--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -2,7 +2,7 @@
 
 # Model to store information captured when processing a form for an appeal remanded by CAVC
 #
-# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
+# CAVC Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcRemand < CaseflowRecord
   include UpdatedByUserConcern

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 # Model to store information captured when processing a form for an appeal remanded by CAVC
+#
+# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcRemand < CaseflowRecord
   include UpdatedByUserConcern

--- a/app/models/tasks/cavc_correspondence_mail_task.rb
+++ b/app/models/tasks/cavc_correspondence_mail_task.rb
@@ -8,7 +8,7 @@
 #
 # Expected Child Task: CavcCorrespondenceMailTask
 #
-# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
+# CAVC Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcCorrespondenceMailTask < MailTask
   validate :cavc_appeal_stream, on: :create

--- a/app/models/tasks/cavc_correspondence_mail_task.rb
+++ b/app/models/tasks/cavc_correspondence_mail_task.rb
@@ -7,6 +7,8 @@
 # Expected Parent Task: RootTask
 #
 # Expected Child Task: CavcCorrespondenceMailTask
+#
+# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcCorrespondenceMailTask < MailTask
   validate :cavc_appeal_stream, on: :create

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -10,7 +10,7 @@
 # Expected parent: CavcTask
 # Expected assigned_to.type: CavcLitigationSupport
 #
-# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
+# CAVC Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcRemandProcessedLetterResponseWindowTask < Task
   VALID_PARENT_TYPES = [

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -9,6 +9,8 @@
 # to be assigned and acted upon.
 # Expected parent: CavcTask
 # Expected assigned_to.type: CavcLitigationSupport
+#
+# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcRemandProcessedLetterResponseWindowTask < Task
   VALID_PARENT_TYPES = [

--- a/app/models/tasks/cavc_task.rb
+++ b/app/models/tasks/cavc_task.rb
@@ -5,6 +5,8 @@
 # If this task is still open, there is still more CAVC-specific work to be done of this appeal.
 # This task should be a child of DistributionTask, and so it blocks distribution until all its children are closed.
 # There are no actions available to any user for this task.
+#
+# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcTask < Task
   validates :parent, presence: true, parentTask: { task_type: DistributionTask }, on: :create

--- a/app/models/tasks/cavc_task.rb
+++ b/app/models/tasks/cavc_task.rb
@@ -6,7 +6,7 @@
 # This task should be a child of DistributionTask, and so it blocks distribution until all its children are closed.
 # There are no actions available to any user for this task.
 #
-# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
+# CAVC Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class CavcTask < Task
   validates :parent, presence: true, parentTask: { task_type: DistributionTask }, on: :create

--- a/app/models/tasks/send_cavc_remand_processed_letter_task.rb
+++ b/app/models/tasks/send_cavc_remand_processed_letter_task.rb
@@ -10,7 +10,7 @@
 # - Expected parent: SendCavcRemandProcessedLetterTask that is assigned to CavcLitigationSupport
 # - Expected assigned_to.type: User
 #
-# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
+# CAVC Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class SendCavcRemandProcessedLetterTask < Task
   validates :parent, presence: true,

--- a/app/models/tasks/send_cavc_remand_processed_letter_task.rb
+++ b/app/models/tasks/send_cavc_remand_processed_letter_task.rb
@@ -9,6 +9,8 @@
 # If this task is assigned to a user (i.e., a member of CavcLitigationSupport), then:
 # - Expected parent: SendCavcRemandProcessedLetterTask that is assigned to CavcLitigationSupport
 # - Expected assigned_to.type: User
+#
+# Cavc Remands Overview: https://github.com/department-of-veterans-affairs/caseflow/wiki/CAVC-Remands
 
 class SendCavcRemandProcessedLetterTask < Task
   validates :parent, presence: true,


### PR DESCRIPTION
### Description
Adds link to the CAVC Remand wiki page as code comments in relevant classes.

### Acceptance Criteria
- [ ] Code compiles correctly


