### PR TITLE
Adds "make jest" command to run jest tests locally

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -172,6 +172,9 @@ client-build-demo client-demo: ## Builds webpack for local server
 
 client-build-all client-all: client-test client-demo ## Builds webpack for both tests and local server
 
+jest: ## Run jest tests
+	cd client && yarn jest
+
 one-test:  ## run the test passed in
 	bundle exec rspec $$T
 

--- a/Makefile.example
+++ b/Makefile.example
@@ -42,6 +42,15 @@
 #
 .DEFAULT_GOAL := help
 
+# https://stackoverflow.com/a/14061796/2237879
+#
+# This hack allows you to run make commands with any set of arguments.
+#
+# For example, these lines are the same:
+#   > make one-test spec/path/here.rb
+#   > bundle exec rspec spec/path/here.rb
+RUN_ARGS := $(wordlist 2, $(words $(MAKECMDGOALS)), $(MAKECMDGOALS))
+
 whats-next:  ## TODO
 	scripts/whats-next
 
@@ -172,11 +181,14 @@ client-build-demo client-demo: ## Builds webpack for local server
 
 client-build-all client-all: client-test client-demo ## Builds webpack for both tests and local server
 
+one-test:  ## run the rspec test passed in
+	bundle exec rspec $(RUN_ARGS)
+
 jest: ## Run jest tests
 	cd client && yarn jest
 
-one-test:  ## run the test passed in
-	bundle exec rspec $$T
+one-jest:  ## run the jest test passed in (leave off client/)
+	cd client && yarn jest $(RUN_ARGS)
 
 unsafe:  ## TODO
 	mv .git/hooks/pre-commit .git/hooks/pre-commit-linter


### PR DESCRIPTION
I was trying to figure out how to run jest locally and didn't see anything in the Makefile.

Note that this PR is both an attempt to be helpful _and_ an "am I invoking this correctly?" question all bundled into one. I get a few failing tests locally and am not sure if it's a problem with my environment or a problem with me invoking jest incorrectly.

### Testing Plan
1. Running `make jest` should trigger a run of jest tests
2. There is no step 2.