### PR TITLE
Add FNOD Banner feature toggle

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -73,6 +73,8 @@ class WorkQueue::AppealSerializer
 
   attribute :cavc_remand
 
+  attribute :veteran_death_date
+
   attribute :veteran_file_number
 
   attribute :veteran_full_name do |object|

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -26,7 +26,8 @@
       reversal_cavc_remand: FeatureToggle.enabled?(:reversal_cavc_remand, user: current_user),
       dismissal_cavc_remand: FeatureToggle.enabled?(:dismissal_cavc_remand, user: current_user),
       editNodDate: FeatureToggle.enabled?(:edit_nod_date, user: current_user),
-      fnod_badge: FeatureToggle.enabled?(:fnod_badge, user: current_user)
+      fnod_badge: FeatureToggle.enabled?(:fnod_badge, user: current_user),
+      fnod_banner: FeatureToggle.enabled?(:fnod_banner, user: current_user)
     }
   }) %>
 <% end %>

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -118,7 +118,7 @@ export const CaseDetailsView = (props) => {
       {(!modalIsOpen || props.userCanScheduleVirtualHearings) && <UserAlerts />}
       <AppSegment filledBackground>
         <CaseTitle appeal={appeal} />
-        { appeal.veteran_appellant_deceased && props.featureToggles.fnod_banner && <FnodBanner appeal={appeal} /> }
+        { appeal.veteranDateOfDeath && props.featureToggles.fnod_banner && <FnodBanner appeal={appeal} /> }
         <CaseTitleDetails
           appealId={appealId}
           redirectUrl={window.location.pathname}

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -118,7 +118,7 @@ export const CaseDetailsView = (props) => {
       {(!modalIsOpen || props.userCanScheduleVirtualHearings) && <UserAlerts />}
       <AppSegment filledBackground>
         <CaseTitle appeal={appeal} />
-        { appeal.veteranAppellantDeceased && <FnodBanner appeal={appeal} /> }
+        { appeal.veteran_appellant_deceased && props.featureToggles.fnod_banner && <FnodBanner appeal={appeal} /> }
         <CaseTitleDetails
           appealId={appealId}
           redirectUrl={window.location.pathname}

--- a/client/app/queue/components/FnodBanner.jsx
+++ b/client/app/queue/components/FnodBanner.jsx
@@ -2,11 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import COPY from 'app/../COPY';
-import moment from 'moment';
 import Alert from 'app/components/Alert';
+import { formatDateStr } from 'app/util/DateUtil';
 
 const FnodBanner = ({ appeal }) => {
-  const formattedDeathDate = moment(appeal.date_of_death).format('MM/DD/YYYY');
+  const formattedDeathDate = formatDateStr(appeal.veteranDateOfDeath);
   const fnodBannerInfoPadding = css({
     padding: '5px',
   });

--- a/client/app/queue/components/FnodBanner.stories.js
+++ b/client/app/queue/components/FnodBanner.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { FnodBanner } from './FnodBanner';
+import FnodBanner from './FnodBanner';
 
 export default {
   title: 'Queue/FNOD Banner',

--- a/client/app/queue/components/FnodBanner.test.js
+++ b/client/app/queue/components/FnodBanner.test.js
@@ -36,7 +36,6 @@ describe('FnodBanner', () => {
     const component = setupFnodBanner();
 
     const alertText = component.find('.usa-alert-text');
-    // console.log(alertText.text());
 
     expect(alertText.text()).toContain(defaultAppeal.veteranFullName);
   });

--- a/client/app/queue/components/FnodBanner.test.js
+++ b/client/app/queue/components/FnodBanner.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import FnodBanner from 'app/queue/components/FnodBanner';
 import { mount } from 'enzyme';
-import moment from 'moment';
+import { formatDateStr } from 'app/util/DateUtil';
 
 describe('FnodBanner', () => {
   const defaultAppeal = {
     veteran_appellant_deceased: true,
-    date_of_death: '2019-03-17',
+    veteranDateOfDeath: '2019-03-17',
     veteranFullName: 'Jane Doe'
   };
 
@@ -29,14 +29,15 @@ describe('FnodBanner', () => {
 
     const alertText = component.find('.usa-alert-text');
 
-    expect(alertText.html()).toContain(moment(defaultAppeal.date_of_death).format('MM/DD/YYYY'));
+    expect(alertText.html()).toContain(formatDateStr(defaultAppeal.veteranDateOfDeath));
   });
 
   it('displays Veteran appellant\'s full name', () => {
     const component = setupFnodBanner();
 
     const alertText = component.find('.usa-alert-text');
+    // console.log(alertText.text());
 
-    expect(alertText.html()).toContain(defaultAppeal.veteranFullName);
+    expect(alertText.text()).toContain(defaultAppeal.veteranFullName);
   });
 });

--- a/client/app/queue/components/__snapshots__/FnodBanner.test.js.snap
+++ b/client/app/queue/components/__snapshots__/FnodBanner.test.js.snap
@@ -4,7 +4,7 @@ exports[`FnodBanner renders correctly 1`] = `
 <FnodBanner
   appeal={
     Object {
-      "date_of_death": "2019-03-17",
+      "veteranDateOfDeath": "2019-03-17",
       "veteranFullName": "Jane Doe",
       "veteran_appellant_deceased": true,
     }

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -344,7 +344,7 @@ export const prepareAppealForStore = (appeals) => {
       appellantRelationship: appeal.attributes.appellant_relationship,
       assignedToLocation: appeal.attributes.assigned_to_location,
       veteranDateOfBirth: appeal.attributes.veteran_date_of_birth,
-      veteranDateOfDeath: appeal.attributes.veteran_date_of_death,
+      veteranDateOfDeath: appeal.attributes.veteran_death_date,
       veteranGender: appeal.attributes.veteran_gender,
       veteranAddress: appeal.attributes.veteran_address,
       closestRegionalOffice: appeal.attributes.closest_regional_office,


### PR DESCRIPTION
Resolves [CASEFLOW-703](https://vajira.max.gov/browse/CASEFLOW-703)

### Description
Add FNOD Banner Feature Toggle

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] FNOD Banner appears if feature toggle is enabled
- [ ] Veteran date of death is date of death on appeal object and not today's date 

### Testing Plan
1. Go to Queue and search for Veteran with date of death e.g. 500000000. 
If the date of death does not appear, enter a date of death for the`date_of_death` column for the Veteran in the `veterans` table
2. Verify that the FNOD banner does not appear
3. Enable `fnod_banner` feature toggle
5. Go to Queue and search for Veteran with date of death e.g. 500000000. If the date of death does not appear, enter a date_of_death manually for the Veteran in the `veterans` table
6. Verify that banner appears
7. Verify that date of death is the current day's date

