### PR TITLE
Remove Slack notifications to appeals-delta channel

### DIFF
--- a/app/jobs/etl_builder_job.rb
+++ b/app/jobs/etl_builder_job.rb
@@ -6,8 +6,6 @@ class ETLBuilderJob < CaseflowJob
   queue_with_priority :low_priority
   application_attr :etl
 
-  SLACK_CHANNEL = "#appeals-delta"
-
   def perform
     RequestStore.store[:current_user] = User.system_user
 
@@ -26,7 +24,7 @@ class ETLBuilderJob < CaseflowJob
     return unless swept > 20 # big enough to warrant reality check
 
     msg = "[INFO] ETL swept up #{swept} deleted records -- see logs for details"
-    slack_service.send_notification(msg, "ETL::Sweeper", SLACK_CHANNEL)
+    slack_service.send_notification(msg, "ETL::Sweeper")
   end
 
   def build_etl
@@ -37,6 +35,6 @@ class ETLBuilderJob < CaseflowJob
     return unless etl_build.built == 0
 
     msg = "[WARN] ETL failed to sync any records"
-    slack_service.send_notification(msg, self.class.to_s, SLACK_CHANNEL)
+    slack_service.send_notification(msg, self.class.to_s)
   end
 end


### PR DESCRIPTION
The appeals-delta Slack channel is being deprecated -- [Slack thread](https://dsva.slack.com/archives/CPEMQPVKR/p1610385691011200)

### Description
Remove Slack notifications that go to appeals-delta channel.
Notifications will be sent to the default channel: 
https://github.com/department-of-veterans-affairs/caseflow/blob/892aa6c3f05b8c0e7b044af6023a6c2e5e0ad259/app/services/slack_service.rb#L4

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] There are no references to the appeals-delta Slack channel

### Testing Plan
Not needed.
If desired, keep an eye on the appeals-delta channel for Sentry messages.