### PR TITLE
Update hearings seed script to create "former travel, virtual" data

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,8 +268,8 @@ GEM
     factory_bot_rails (5.2.0)
       factory_bot (~> 5.2.0)
       railties (>= 4.2.0)
-    faker (2.1.2)
-      i18n (>= 0.8)
+    faker (2.15.1)
+      i18n (>= 1.6, < 2)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.2.0)
@@ -321,7 +321,7 @@ GEM
     httpi (2.4.4)
       rack
       socksify
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     i18n_data (0.10.0)
     icalendar (2.6.1)

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -176,7 +176,8 @@ module Seeds
     end
 
     def create_virtual_hearing_day
-      # Take an existing hearing day for st. petes and change it to a Virtual hearing day
+      # Take an existing hearing day change it to a Virtual hearing day to get around
+      # validations
       HearingDay.last.dup.update!(request_type: "R", regional_office: nil)
     end
 

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -187,6 +187,8 @@ module Seeds
           :schedule_hearing_task,
           appeal: create(
             :legacy_appeal,
+            :with_veteran,
+            :with_veteran_address,
             vacols_case: create(
               :case,
               :travel_board_hearing,

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -187,7 +187,6 @@ module Seeds
         first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name,
         file_number: veteran_file_number,
-        email_address: Faker::Internet.email,
         bgs_veteran_record: {
           date_of_birth: Faker::Date.birthday(min_age: 35, max_age: 80).strftime("%m/%d/%Y"),
           date_of_death: nil,

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -176,7 +176,7 @@ module Seeds
 
     def create_former_travel_currently_virtual_requested_legacy_appeals
       closest_regional_office = "RO17"
-      16.times.each do |i|
+      [1..16].each do |id|
         create(
           :schedule_hearing_task,
           appeal: create(
@@ -184,9 +184,9 @@ module Seeds
             vacols_case: create(
               :case,
               :travel_board_hearing,
-              bfkey: "1234#{i+1}",
-              bfcorkey: "1234#{i+1}",
-              correspondent: create(:correspondent, stafkey: "1234#{i+1}")
+              bfkey: "1234#{id}",
+              bfcorkey: "5678#{id}",
+              correspondent: create(:correspondent, stafkey: "5678#{id}")
             ),
             closest_regional_office: closest_regional_office,
             changed_request_type: "R"

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -9,6 +9,7 @@ module Seeds
       RequestStore[:current_user] = created_by_user
       create_hearing_days
       create_ama_hearing_appeals
+      create_virtual_hearing_day
       create_former_travel_currently_virtual_requested_legacy_appeals
       RequestStore[:current_user] = prev_user
     end
@@ -174,8 +175,13 @@ module Seeds
       create(:case_hearing, :disposition_held, user: user, folder_nr: appeal.vacols_id)
     end
 
+    def create_virtual_hearing_day
+      # Take an existing hearing day for st. petes and change it to a Virtual hearing day
+      HearingDay.last.dup.update!(request_type: "R", regional_office: nil)
+    end
+
     def create_former_travel_currently_virtual_requested_legacy_appeals
-      closest_regional_office = "RO17"
+      ro_key = "R" # virtual
       (1..16).each do |id|
         create(
           :schedule_hearing_task,
@@ -188,7 +194,7 @@ module Seeds
               bfcorkey: "5678#{id}",
               correspondent: create(:correspondent, stafkey: "5678#{id}")
             ),
-            closest_regional_office: closest_regional_office,
+            closest_regional_office: ro_key,
             changed_request_type: "R"
           )
         )

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -176,7 +176,7 @@ module Seeds
 
     def create_former_travel_currently_virtual_requested_legacy_appeals
       closest_regional_office = "RO17"
-      [1..16].each do |id|
+      (1..16).each do |id|
         create(
           :schedule_hearing_task,
           appeal: create(

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -180,22 +180,51 @@ module Seeds
       HearingDay.last.dup.update!(request_type: "R", regional_office: nil)
     end
 
+    # creates fake veteran given a file number
+    def create_veteran(veteran_file_number)
+      create(
+        :veteran,
+        first_name: Faker::Name.first_name,
+        last_name: Faker::Name.last_name,
+        file_number: veteran_file_number,
+        email_address: Faker::Internet.email,
+        bgs_veteran_record: {
+          date_of_birth: Faker::Date.birthday(min_age: 35, max_age: 80).strftime("%m/%d/%Y"),
+          date_of_death: nil,
+          name_suffix: nil,
+          sex: Faker::Gender.binary_type[0],
+          address_line1: Faker::Address.street_address,
+          country: "USA",
+          zip_code: Faker::Address.zip_code,
+          state: Faker::Address.state_abbr,
+          city: Faker::Address.city
+        }
+      )
+    end
+
+    def create_travel_board_vacols_case(id)
+      create(
+        :case,
+        :travel_board_hearing,
+        bfkey: "1234#{id}",
+        bfcorkey: "5678#{id}",
+        correspondent: create(:correspondent, stafkey: "5678#{id}")
+      )
+    end
+
     def create_former_travel_currently_virtual_requested_legacy_appeals
       ro_key = "R" # virtual
       (1..16).each do |id|
+        vacols_case = create_travel_board_vacols_case(id)
+
+        create_veteran(LegacyAppeal.veteran_file_number_from_bfcorlid(vacols_case.bfcorlid))
+
         create(
           :schedule_hearing_task,
           appeal: create(
             :legacy_appeal,
             :with_veteran,
-            :with_veteran_address,
-            vacols_case: create(
-              :case,
-              :travel_board_hearing,
-              bfkey: "1234#{id}",
-              bfcorkey: "5678#{id}",
-              correspondent: create(:correspondent, stafkey: "5678#{id}")
-            ),
+            vacols_case: vacols_case,
             closest_regional_office: ro_key,
             changed_request_type: "R"
           )

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -9,6 +9,7 @@ module Seeds
       RequestStore[:current_user] = created_by_user
       create_hearing_days
       create_ama_hearing_appeals
+      create_former_travel_currently_virtual_requested_legacy_appeals
       RequestStore[:current_user] = prev_user
     end
 
@@ -171,6 +172,27 @@ module Seeds
                 appeal.hearings.map(&:disposition).include?(:held)
 
       create(:case_hearing, :disposition_held, user: user, folder_nr: appeal.vacols_id)
+    end
+
+    def create_former_travel_currently_virtual_requested_legacy_appeals
+      closest_regional_office = "RO17"
+      16.times.each do |i|
+        create(
+          :schedule_hearing_task,
+          appeal: create(
+            :legacy_appeal,
+            vacols_case: create(
+              :case,
+              :travel_board_hearing,
+              bfkey: "1234#{i+1}",
+              bfcorkey: "1234#{i+1}",
+              correspondent: create(:correspondent, stafkey: "1234#{i+1}")
+            ),
+            closest_regional_office: closest_regional_office,
+            changed_request_type: "R"
+          )
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Connects https://vajira.max.gov/browse/CASEFLOW-407

### Description
- create some appeals which are former traval and currently virtual along with open ScheduleHearingTask for them
### Testing Plan
2. Login as `BVASYELLOW`
1. On console run `make reset`
2. Enable Feature toggle: `FeatureToggle.enable!(:national_vh_queue, users: ["BVASYELLOW"])`
1. Go to http://localhost:3000/hearings/schedule/assign?tab=legacyAssignHearingsTab&regional_office_key=R&page=1
2. Click on `Legacy Veterans Waiting Tab` and ensure that 16 items display with hearing request type `former travel, virtual`
