### PR TITLE
Bulk upsert in DocumentFetcher with duplicate detection

### DIFF
--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -17,7 +17,7 @@ class DocumentFetcher
     documents.size
   end
 
-  # Fetch documents, then updates or creates them
+  # Fetch documents, then update and/or create them in the DB
   def find_or_create_documents!
     @find_or_create_documents ||= save!
   end
@@ -120,6 +120,7 @@ class DocumentFetcher
     extra = { application: "reader",
               docs_duplicated: dups_hash.count,
               docs_as_csv: docs_as_csv.join("") }
-    Raven.capture_exception(RuntimeError.new("Warning: Unexpected duplicate document records: #{warning_message}"), extra: extra)
+    Raven.capture_exception(RuntimeError.new("Warning: Unexpected duplicate document records: #{warning_message}"),
+                            extra: extra)
   end
 end

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -17,6 +17,7 @@ class DocumentFetcher
     documents.size
   end
 
+  # Fetch documents, then updates or creates them
   def find_or_create_documents!
     @find_or_create_documents ||= save!
   end
@@ -37,40 +38,56 @@ class DocumentFetcher
   end
 
   def save!
+    # Calls out to VBMSService.fetch_document_series_for(appeal)
     DocumentSeriesIdAssigner.new(appeal).call
 
-    ids = documents.map(&:vbms_document_id)
-    existing_documents = Document.where(vbms_document_id: ids)
-      .includes(:annotations, :tags).each_with_object({}) do |document, accumulator|
-      accumulator[document.vbms_document_id] = document
-    end
+    # Each document has a series_id and a version_id
+    # (unfortunately we refer to version_id as vbms_document_id in most of the code)
+    # See https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Reader#vbms
+    vbms_doc_ver_ids = documents.map(&:vbms_document_id)
 
-    documents.map do |document|
-      if existing_documents[document.vbms_document_id]
-        document.merge_into(existing_documents[document.vbms_document_id]).save!
-        existing_documents[document.vbms_document_id]
-      else
-        create_new_document!(document, ids)
-      end
-    rescue ActiveRecord::RecordNotUnique
-      Document.find_by_vbms_document_id(document.vbms_document_id)
+    existing_vbms_doc_ver_ids = Document.where(vbms_document_id: vbms_doc_ver_ids).pluck(:vbms_document_id)
+    docs_to_update, docs_to_create = split_docs(documents, existing_vbms_doc_ver_ids)
+
+    # Update existing docs
+    updated_docs = Document.bulk_merge_and_save(docs_to_update)
+
+    # Create new docs that don't exist
+    Document.import(docs_to_create)
+    # For newly created documents that have a series_id, copy over the metadata (annotations, tags, category labels)
+    # from the latest version of the document (i.e., the latest id having the same series_id) in Caseflow.
+    # The created document then becomes the latest version among the documents with the same series_id.
+    series_id_docs = Document.where(vbms_document_id: docs_to_create.select(&:series_id).pluck(:vbms_document_id))
+    copy_metadata_from_document(series_id_docs, vbms_doc_ver_ids)
+    created_docs = retrieve_created_docs_including_nondb_attributes(docs_to_create)
+
+    updated_docs + created_docs
+  end
+
+  def split_docs(documents, vbms_doc_ver_ids)
+    documents.partition { |doc| vbms_doc_ver_ids.include?(doc.vbms_document_id) }
+  end
+
+  def copy_metadata_from_document(created_docs_with_series_id, vbms_doc_ver_ids)
+    # Find the most recent saved document with the given series_id that is not in the list of vbms_doc_ver_ids passed
+    # since vbms_doc_ver_ids have already been updated
+    series_id_hash = Document.includes(:annotations, :tags)
+      .where(series_id: created_docs_with_series_id.pluck(:series_id))
+      .where.not(vbms_document_id: vbms_doc_ver_ids).group_by(&:series_id)
+    created_docs_with_series_id.map do |document|
+      # update the DB for each doc individually; this could be optimized if needed
+      previous_documents = series_id_hash[document.series_id]&.sort_by(&:id)
+      document.copy_metadata_from_document(previous_documents.last) if previous_documents.present?
     end
   end
 
-  def create_new_document!(document, ids)
-    document.save!
-
-    if document.series_id
-      # Find the most recent saved document with the given series_id that is not in the list of ids passed.
-      previous_documents = Document.where(series_id: document.series_id).order(:id)
-        .where.not(vbms_document_id: ids)
-
-      if previous_documents.any?
-        document.copy_metadata_from_document(previous_documents.last)
-      end
+  def retrieve_created_docs_including_nondb_attributes(docs_to_create)
+    docs_to_create_hash = docs_to_create.index_by(&:vbms_document_id)
+    created_docs = Document.where(vbms_document_id: docs_to_create.pluck(:vbms_document_id))
+    created_docs.map do |doc|
+      fetched_doc = docs_to_create_hash[doc.vbms_document_id]
+      doc.assign_nondatabase_attributes(fetched_doc)
     end
-
-    document
   end
 
   def document_service

--- a/app/services/document_series_id_assigner.rb
+++ b/app/services/document_series_id_assigner.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+##
+# The series_id is the series_id provided by VBMS;
+# otherwise, it is the document.vbms_document_id
+# (aka `external_document_id` or `version_id` from eFolder;
+#  aka `document_id` from VBMS).
+
 class DocumentSeriesIdAssigner
   def initialize(appeal)
     @appeal = appeal

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -80,6 +80,7 @@ describe DocumentFetcher, :postgres do
   NONDB_ATTRIBUTES = [:efolder_id, :alt_types, :filename].freeze
 
   context "#find_or_create_documents!" do
+    # documents returned by document_fetcher
     let(:documents) do
       [
         Generators::Document.build(id: 201, type: "NOD", series_id: series_id),
@@ -314,8 +315,8 @@ describe DocumentFetcher, :postgres do
           # Uncomment the following to see a count of SQL queries
           # pp query_data.values.pluck(:sql, :count)
           doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
-          # This expected count of 25 is bad and will be fixed in another PR
-          expect(doc_insert_queries.pluck(:count).max).to eq 25
+          expect(doc_insert_queries.pluck(:count).max).to eq 1
+          expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE") }).to be_empty
         end
       end
     end

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -112,7 +112,7 @@ describe DocumentFetcher, :postgres do
     context "when there is no existing document" do
       it "saves retrieved documents" do
         returned_documents = document_fetcher.find_or_create_documents!
-        expect(returned_documents.map(&:type)).to eq(documents.map(&:type))
+        expect(returned_documents.map(&:type)).to match_array(documents.map(&:type))
 
         expect(Document.count).to eq(documents.count)
         expect(Document.first.type).to eq(documents[0].type)
@@ -179,7 +179,7 @@ describe DocumentFetcher, :postgres do
         expect(returned_documents.count).to eq(2)
         expect(Document.count).to eq(4)
 
-        expect(returned_documents.map(&:type)).to eq(documents.map(&:type))
+        expect(returned_documents.map(&:type)).to match_array(documents.map(&:type))
 
         expect(Document.first.type).to eq(saved_documents.first.type)
         expect(Document.second.type).to eq(saved_documents.second.type)


### PR DESCRIPTION
Addresses problems when deploying #15707 on real documents.

### Description
Sends warnings about duplicates and removes duplicates so that bulk upsert doesn't fail.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Deploy during low-user activity
2. Run Reader tests
3. Check Sentry for warnings to diagnose cause for duplication
