### PR TITLE
Don't warn about exact duplicates in DocumentFetcher

### DIFF
--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -121,21 +121,12 @@ class DocumentFetcher
   end
 
   # identify hash entries with an array consisting of the exact same document
-  # :reek:FeatureEnvy
   def split_exact_dups(dups_hash)
-    dups_hash.partition do |_id, array|
-      first_doc = array.first
-      array.drop(1).reject { |doc| same_attributes?(first_doc, doc) }.empty?
-    end
+    dups_hash.partition { |_id, docs| docs.map(&:to_hash).uniq.size == 1 }
   end
 
-  def same_attributes?(first_doc, doc)
-    first_doc.to_hash == doc.to_hash
-  end
-
-  # :reek:FeatureEnvy
   def warn_about_same_vbms_document_id(warning_message, nonexact_dups_hash)
-    docs_as_csv = nonexact_dups_hash.map { |_id, array| array.map { |doc| doc.to_hash.values.to_csv } }.flatten
+    docs_as_csv = nonexact_dups_hash.map { |_id, docs| docs.map { |doc| doc.to_hash.values.to_csv } }.flatten
     extra = { application: "reader",
               nonexact_dup_docs_count: nonexact_dups_hash.count,
               nonexact_dups_hash: nonexact_dups_hash,

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -132,6 +132,9 @@ class DocumentFetcher
               nonexact_dup_docs_count: nonexact_dups_hash.count,
               nonexact_dups_hash: nonexact_dups_hash,
               docs_as_csv: docs_as_csv.join("") }
-    Raven.capture_message("Document records with duplicate vbms_document_id: #{warning_message}", extra: extra)
+    Raven.capture_exception(DuplicateVbmsDocumentIdError.new("Document records with duplicate vbms_document_id: #{warning_message}"), 
+                            extra: extra)
   end
+
+  class DuplicateVbmsDocumentIdError < RuntimeError; end
 end

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -128,10 +128,10 @@ class DocumentFetcher
   def warn_about_same_vbms_document_id(warning_message, nonexact_dups_hash)
     docs_as_csv = nonexact_dups_hash.map { |_id, docs| docs.map { |doc| doc.to_hash.values.to_csv } }.flatten
     extra = { application: "reader",
+              backtrace: caller,
               nonexact_dup_docs_count: nonexact_dups_hash.count,
               nonexact_dups_hash: nonexact_dups_hash,
               docs_as_csv: docs_as_csv.join("") }
-    Raven.capture_exception(RuntimeError.new("Document records with duplicate vbms_document_id: #{warning_message}"),
-                            extra: extra)
+    Raven.capture_message("Document records with duplicate vbms_document_id: #{warning_message}", extra: extra)
   end
 end

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -125,6 +125,7 @@ class DocumentFetcher
     dups_hash.partition { |_id, docs| docs.map(&:to_hash).uniq.size == 1 }
   end
 
+  # :reek:FeatureEnvy
   def warn_about_same_vbms_document_id(warning_message, nonexact_dups_hash)
     docs_as_csv = nonexact_dups_hash.map { |_id, docs| docs.map { |doc| doc.to_hash.values.to_csv } }.flatten
     extra = { application: "reader",

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -132,8 +132,8 @@ class DocumentFetcher
               nonexact_dup_docs_count: nonexact_dups_hash.count,
               nonexact_dups_hash: nonexact_dups_hash,
               docs_as_csv: docs_as_csv.join("") }
-    Raven.capture_exception(DuplicateVbmsDocumentIdError.new("Document records with duplicate vbms_document_id: #{warning_message}"), 
-                            extra: extra)
+    error_message = "Document records with duplicate vbms_document_id: #{warning_message}"
+    Raven.capture_exception(DuplicateVbmsDocumentIdError.new(error_message), extra: extra)
   end
 
   class DuplicateVbmsDocumentIdError < RuntimeError; end

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -337,9 +337,9 @@ describe DocumentFetcher, :postgres do
             expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
             expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
 
-            error_msg = "Document records with duplicate vbms_document_id: fetched_documents"
+            expected_error_message = "Document records with duplicate vbms_document_id: fetched_documents"
             expect(Raven).to receive(:capture_exception).with(
-              DocumentFetcher::DuplicateVbmsDocumentIdError.new(error_msg),
+              DocumentFetcher::DuplicateVbmsDocumentIdError.new(expected_error_message),
               hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
             )
 

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -337,8 +337,8 @@ describe DocumentFetcher, :postgres do
             expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
             expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
 
-            expect(Raven).to receive(:capture_exception).with(
-              RuntimeError.new("Document records with duplicate vbms_document_id: fetched_documents"),
+            expect(Raven).to receive(:capture_message).with(
+              "Document records with duplicate vbms_document_id: fetched_documents",
               hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
             )
 

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -337,8 +337,9 @@ describe DocumentFetcher, :postgres do
             expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
             expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
 
-            expect(Raven).to receive(:capture_message).with(
-              "Document records with duplicate vbms_document_id: fetched_documents",
+            error_msg = "Document records with duplicate vbms_document_id: fetched_documents"
+            expect(Raven).to receive(:capture_exception).with(
+              DocumentFetcher::DuplicateVbmsDocumentIdError.new(error_msg),
               hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
             )
 


### PR DESCRIPTION
Follow-on to #15787 
 
### Description
After [investigation](https://github.com/department-of-veterans-affairs/caseflow/pull/15787#issuecomment-761266148), we don't need to submit warnings for every duplicate document (8k new alerts popped up over 4 days over the weekend!). This PR reduces the warning verbosity and only sends a Sentry alert when there are non-exact-duplicates with the same `vbms_document_id`.

Further investigation is needed to explain why the `document_service` is returning records with the same `vbms_document_id`.

### Acceptance Criteria
- [ ] Code compiles correctly
