### PR TITLE
Moves feature toggle to the frontend and makes fnod badge a connected component

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -352,9 +352,7 @@ class Appeal < DecisionReview
   end
 
   def veteran_appellant_deceased?
-    return (veteran_is_deceased && appellant_is_veteran) if FeatureToggle.enabled?(:fnod_badge, user: self)
-
-    false
+    veteran_is_deceased && appellant_is_veteran
   end
 
   # matches Legacy behavior

--- a/client/app/queue/components/FnodBadge.jsx
+++ b/client/app/queue/components/FnodBadge.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
+import { connect } from 'react-redux';
 
 import { COLORS } from '../../constants/AppConstants';
 import Badge from './Badge';
@@ -10,9 +11,9 @@ import Badge from './Badge';
  */
 
 const FnodBadge = (props) => {
-  const { appeal } = props;
+  const { appeal, featureToggles } = props;
 
-  if (!appeal.veteranAppellantDeceased) {
+  if (!appeal.veteranAppellantDeceased || !featureToggles.fnod_badge) {
     return null;
   }
 
@@ -22,7 +23,10 @@ const FnodBadge = (props) => {
 };
 
 FnodBadge.propTypes = {
-  appeal: PropTypes.object
+  appeal: PropTypes.object,
+  featureToggles: PropTypes.object
 };
 
-export default FnodBadge;
+const mapStateToProps = (state) => ({ featureToggles: state.ui.featureToggles });
+
+export default connect(mapStateToProps)(FnodBadge);

--- a/client/app/queue/components/FnodBadge.test.js
+++ b/client/app/queue/components/FnodBadge.test.js
@@ -1,6 +1,10 @@
 import React from 'react';
+import { createStore, applyMiddleware } from 'redux';
+import rootReducer from '../../../app/queue/reducers';
+import thunk from 'redux-thunk';
 import FnodBadge from 'app/queue/components/FnodBadge';
 import { mount } from 'enzyme';
+import { Provider } from 'react-redux';
 
 describe('FnodBadge', () => {
   const defaultAppeal = {
@@ -8,16 +12,21 @@ describe('FnodBadge', () => {
     date_of_death: '2019-03-17'
   };
 
-  const setupFnodBadge = () => {
+  const getStore = () => createStore(rootReducer, applyMiddleware(thunk));
+
+  const setupFnodBadge = (store) => {
     return mount(
-      <FnodBadge
-        appeal={defaultAppeal}
-      />
+      <Provider store={store}>
+        <FnodBadge
+          appeal={defaultAppeal}
+        />
+      </Provider> 
     );
   };
 
   it('renders correctly', () => {
-    const component = setupFnodBadge();
+    const store = getStore();
+    const component = setupFnodBadge(store);
 
     expect(component).toMatchSnapshot();
   });

--- a/client/app/queue/components/__snapshots__/FnodBadge.test.js.snap
+++ b/client/app/queue/components/__snapshots__/FnodBadge.test.js.snap
@@ -1,12 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`FnodBadge renders correctly 1`] = `
-<FnodBadge
-  appeal={
+<Provider
+  store={
     Object {
-      "date_of_death": "2019-03-17",
-      "veteran_appellant_deceased": true,
+      "dispatch": [Function],
+      "getState": [Function],
+      "replaceReducer": [Function],
+      "subscribe": [Function],
+      Symbol(observable): [Function],
     }
   }
-/>
+>
+  <Connect(FnodBadge)
+    appeal={
+      Object {
+        "date_of_death": "2019-03-17",
+        "veteran_appellant_deceased": true,
+      }
+    }
+  >
+    <FnodBadge
+      appeal={
+        Object {
+          "date_of_death": "2019-03-17",
+          "veteran_appellant_deceased": true,
+        }
+      }
+      dispatch={[Function]}
+      featureToggles={Object {}}
+    />
+  </Connect(FnodBadge)>
+</Provider>
 `;


### PR DESCRIPTION
Replacement for #15784 (reverted by #15794)

### Description
Moves the feature toggle for FNOD badge out of the appeal model so that `veteran_appellant_deceased` isn't tied to the FNOD badge and can be used elsewhere.

### Acceptance Criteria
- [x] Code compiles correctly
