### PR TITLE
Fix flake in DocumentFetcher

### DIFF
--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -404,7 +404,7 @@ describe DocumentFetcher, :postgres do
         expect(Document.first.series_id).to eq(nil)
 
         returned_documents = document_fetcher.find_or_create_documents!
-        expect(returned_documents.map(&:type)).to eq(documents.map(&:type))
+        expect(returned_documents.map(&:type)).to match_array(documents.map(&:type))
 
         # Adds series id to existing document
         expect(Document.first.series_id).to eq(series_id)

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -282,7 +282,7 @@ describe DocumentFetcher, :postgres do
           expect(Document.first.type).to eq(saved_documents.type)
 
           returned_documents = document_fetcher.find_or_create_documents!
-          expect(returned_documents.map(&:type)).to eq(documents.map(&:type))
+          expect(returned_documents.map(&:type)).to match_array(documents.map(&:type))
 
           expect(Document.count).to eq(2)
           expect(Document.first.type).to eq("NOD")

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -154,7 +154,9 @@ describe DocumentFetcher, :postgres do
         expect(Document.first.type).to eq(saved_documents[0].type)
 
         returned_documents = document_fetcher.find_or_create_documents!
+        expect(returned_documents.count).to eq(2)
         expect(returned_documents.first.reload.annotations.count).to eq(0)
+        expect(returned_documents.second.reload.annotations.count).to eq(0)
       end
 
       include_examples "has non-database attributes"
@@ -183,8 +185,6 @@ describe DocumentFetcher, :postgres do
 
         expect(Document.first.type).to eq(saved_documents.first.type)
         expect(Document.second.type).to eq(saved_documents.second.type)
-        expect(Document.third.type).to eq(returned_documents.first.type)
-        expect(Document.fourth.type).to eq(returned_documents.second.type)
 
         # According to DocumentFetcher.create_new_document!,
         # since returned_documents.first has the same series_id as the 2 saved_documents,

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -185,6 +185,7 @@ describe DocumentFetcher, :postgres do
 
         expect(Document.first.type).to eq(saved_documents.first.type)
         expect(Document.second.type).to eq(saved_documents.second.type)
+        expect([Document.third.type, Document.fourth.type]).to match_array(returned_documents.map(&:type))
 
         # According to DocumentFetcher.create_new_document!,
         # since returned_documents.first has the same series_id as the 2 saved_documents,


### PR DESCRIPTION
Use match_array, not eq

I've tripped over this several times. :( Credit to @yoomlam on identifying the cause.