### PR TITLE
Always return cached date of death for VSOs

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -272,7 +272,7 @@ class Veteran < CaseflowRecord
 
   def date_of_death
     cached_date_of_death = super
-    return cached_date_of_death if cached_date_of_death.present? || RequestStore.store[:current_user].vso_employee?
+    return cached_date_of_death if cached_date_of_death.present? || RequestStore.store[:current_user]&.vso_employee?
 
     dod = bgs_record[:date_of_death] if bgs_record_found?
     dod && Date.strptime(dod, "%m/%d/%Y")

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -273,7 +273,6 @@ class Veteran < CaseflowRecord
   def date_of_death
     cached_date_of_death = super
     return cached_date_of_death if cached_date_of_death.present? || RequestStore.store[:current_user].vso_employee?
-  
     dod = bgs_record[:date_of_death] if bgs_record_found?
     dod && Date.strptime(dod, "%m/%d/%Y")
   rescue ArgumentError

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -271,12 +271,13 @@ class Veteran < CaseflowRecord
   end
 
   def date_of_death
-    super || begin
-               dod = bgs_record[:date_of_death] if bgs_record_found?
-               dod && Date.strptime(dod, "%m/%d/%Y")
-             rescue ArgumentError
-               nil
-             end
+    cached_date_of_death = super
+    return cached_date_of_death if cached_date_of_death.present? || RequestStore.store[:current_user].vso_employee?
+  
+    dod = bgs_record[:date_of_death] if bgs_record_found?
+    dod && Date.strptime(dod, "%m/%d/%Y")
+  rescue ArgumentError
+    nil
   end
 
   def address

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -273,6 +273,7 @@ class Veteran < CaseflowRecord
   def date_of_death
     cached_date_of_death = super
     return cached_date_of_death if cached_date_of_death.present? || RequestStore.store[:current_user].vso_employee?
+
     dod = bgs_record[:date_of_death] if bgs_record_found?
     dod && Date.strptime(dod, "%m/%d/%Y")
   rescue ArgumentError

--- a/spec/workflows/docket_switch_task_handler_spec.rb
+++ b/spec/workflows/docket_switch_task_handler_spec.rb
@@ -92,7 +92,7 @@ describe DocketSwitchTaskHandler, :all_dbs do
         expect(docket_task.reload).to be_cancelled
 
         new_docket_task = new_docket_stream.reload.tasks.find { |task| task.type == "ScheduleHearingTask" }
-        persistent_task_copy = new_docket_stream.tasks.find { |task| task.type == "TranslationTask" }
+        persistent_task_copy = new_docket_stream.tasks.find_by(type: "TranslationTask", assigned_to_type: "User")
         new_admin_action = new_docket_stream.tasks.find do |task|
           task.type == "AojColocatedTask" && task.assigned_to_type == "User"
         end
@@ -121,7 +121,7 @@ describe DocketSwitchTaskHandler, :all_dbs do
         expect(docket_task.reload).to be_active
 
         new_docket_task = new_docket_stream.reload.tasks.find { |task| task.type == "ScheduleHearingTask" }
-        persistent_task_copy = new_docket_stream.tasks.find { |task| task.type == "TranslationTask" }
+        persistent_task_copy = new_docket_stream.tasks.find_by(type: "TranslationTask", assigned_to_type: "User")
         new_admin_action = new_docket_stream.tasks.find do |task|
           task.type == "AojColocatedTask" && task.assigned_to_type == "User"
         end


### PR DESCRIPTION
Related to #appeals-batteam [slack discussion](https://dsva.slack.com/archives/CHX8FMP28/p1611245229027400?thread_ts=1611244230.025200&cid=CHX8FMP28)

### Description
Currently, VSOs don't have permission to refresh veteran info from BGS. As a result, if `date_of_death` isn't already cached, case details and queue will error for VSOs. This makes it so VSOs will not trigger a call to BGS to refresh `date_of_death` and the cached value (or nil in the absence of a cached date) will always be returned for those users.

### Acceptance Criteria
- [ ] Code compiles correctly

### Manual Testing Plan

1. Switch to a `VSO` user (ex: `BILLIE_VSO`) and ensure that `fnod_badge` feature toggle is on.
2. Modify `Veteran#date_of_death` to start with `return Time.zone.today`
3. Verify that the FNOD badge shows in `/queue`.
4. Add `fail BGS::PowerOfAttorneyFolderDenied.new("test")` to `Veteran#date_of_death` after `cached_date_of_death` and ensure the queue loads without error and you can visit a case details page.
