### PR TITLE
adds scheduled_in_error legacy hearing disposition

### DIFF
--- a/app/mappers/hearing_mapper.rb
+++ b/app/mappers/hearing_mapper.rb
@@ -42,6 +42,8 @@ module HearingMapper
         "5"
       when VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:postponed]
         nil
+      when VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:scheduled_in_error]
+        nil
       end
     end
 

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -34,7 +34,8 @@ class VACOLS::CaseHearing < VACOLS::Record
     C: Constants.HEARING_DISPOSITION_TYPES.cancelled,
     H: Constants.HEARING_DISPOSITION_TYPES.held,
     N: Constants.HEARING_DISPOSITION_TYPES.no_show,
-    P: Constants.HEARING_DISPOSITION_TYPES.postponed
+    P: Constants.HEARING_DISPOSITION_TYPES.postponed,
+    E: Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error
   }.freeze
 
   # flip {:H => "held", ...} to {:held => "H", ...}

--- a/app/models/vacols/case_hearing.rb
+++ b/app/models/vacols/case_hearing.rb
@@ -30,12 +30,16 @@ class VACOLS::CaseHearing < VACOLS::Record
 
   HEARING_TYPES = HEARING_TYPE_LOOKUP.values.freeze
 
+  # NOTE: add scheduled_in_error to Constants.HEARING_DISPOSITION_TYPES and
+  #       reference it here when we are ready to expose the new disposition
+  #       to users (the disposition dropdown in ChangeHearingDispositionModal
+  #       is populated from HEARING_DISPOSITION_TYPES)
   HEARING_DISPOSITIONS = {
     C: Constants.HEARING_DISPOSITION_TYPES.cancelled,
     H: Constants.HEARING_DISPOSITION_TYPES.held,
     N: Constants.HEARING_DISPOSITION_TYPES.no_show,
     P: Constants.HEARING_DISPOSITION_TYPES.postponed,
-    E: Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error
+    E: "scheduled_in_error"
   }.freeze
 
   # flip {:H => "held", ...} to {:held => "H", ...}

--- a/app/services/hearing_day_range.rb
+++ b/app/services/hearing_day_range.rb
@@ -150,7 +150,8 @@ class HearingDayRange
         else
           [
             VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:postponed],
-            VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:cancelled]
+            VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:cancelled],
+            VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:scheduled_in_error]
           ].exclude?(hearing.vacols_record.hearing_disp)
         end
       end

--- a/client/constants/HEARING_DISPOSITION_TYPES.json
+++ b/client/constants/HEARING_DISPOSITION_TYPES.json
@@ -2,6 +2,5 @@
   "cancelled": "cancelled",
   "held": "held",
   "no_show": "no_show",
-  "postponed": "postponed",
-  "scheduled_in_error": "scheduled_in_error"
+  "postponed": "postponed"
 }

--- a/client/constants/HEARING_DISPOSITION_TYPES.json
+++ b/client/constants/HEARING_DISPOSITION_TYPES.json
@@ -2,5 +2,6 @@
   "cancelled": "cancelled",
   "held": "held",
   "no_show": "no_show",
-  "postponed": "postponed"
+  "postponed": "postponed",
+  "scheduled_in_error": "scheduled_in_error"
 }

--- a/spec/factories/vacols/case_hearing.rb
+++ b/spec/factories/vacols/case_hearing.rb
@@ -31,6 +31,10 @@ FactoryBot.define do
       hearing_disp { VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:no_show] }
     end
 
+    trait :disposition_scheduled_in_error do
+      hearing_disp { VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:scheduled_in_error] }
+    end
+
     after(:build) do |hearing, evaluator|
       # Build Caseflow hearing day and associate with legacy hearing.
       if hearing.vdkey.nil?

--- a/spec/mappers/hearing_mapper_spec.rb
+++ b/spec/mappers/hearing_mapper_spec.rb
@@ -47,6 +47,13 @@ describe HearingMapper do
       it { is_expected.to eq nil }
     end
 
+    context "when disposition is scheduled in error" do
+      let(:hearing_disp) { VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:scheduled_in_error] }
+      let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:video] }
+
+      it { is_expected.to eq nil }
+    end
+
     context "when disposition is cancelled" do
       let(:hearing_disp) { VACOLS::CaseHearing::HEARING_DISPOSITION_CODES[:cancelled] }
       let(:hearing_type) { VACOLS::CaseHearing::HEARING_TYPE_LOOKUP[:video] }


### PR DESCRIPTION
Connects [CASEFLOW-441](https://vajira.max.gov/browse/CASEFLOW-441)

🥞  part two of two (follows #15836)

### Description
Handles the "Scheduled in Error" disposition in VACOLS/for legacy hearings without exposing it to users.