### PR TITLE
Optimize query in Reader::DocumentsController

### DIFF
--- a/app/controllers/reader/documents_controller.rb
+++ b/app/controllers/reader/documents_controller.rb
@@ -62,7 +62,7 @@ class Reader::DocumentsController < Reader::ApplicationController
 
   def load_tags_by_doc_id
     tags_by_doc_id = Hash[document_ids.map { |key, _| [key, Set[]] }]
-    Tag.joins(:documents_tags).where(documents_tags: { document_id: document_ids }).each do |tag|
+    Tag.includes(:documents_tags).where(documents_tags: { document_id: document_ids }).each do |tag|
       # tag.documents_tags returns extraneous documents outside document_ids, so
       # only capture tags associated with docs associated with document_ids
       (tag.documents_tags.pluck(:document_id) & document_ids).each do |doc_id|

--- a/app/controllers/reader/documents_controller.rb
+++ b/app/controllers/reader/documents_controller.rb
@@ -34,26 +34,42 @@ class Reader::DocumentsController < Reader::ApplicationController
   helper_method :appeal
 
   def annotations
-    appeal.document_fetcher.find_or_create_documents!.flat_map(&:annotations).map(&:to_hash)
+    Annotation.where(document_id: document_ids).map(&:to_hash)
+  end
+
+  def document_ids
+    @document_ids ||= appeal.document_fetcher.find_or_create_documents!.pluck(:id)
   end
 
   delegate :manifest_vbms_fetched_at, :manifest_vva_fetched_at, to: :appeal
 
   def documents
-    document_ids = appeal.document_fetcher.find_or_create_documents!.map(&:id)
-
     # Create a hash mapping each document_id that has been read to true
     read_documents_hash = current_user.document_views.where(document_id: document_ids)
       .each_with_object({}) do |document_view, object|
       object[document_view.document_id] = true
     end
 
+    tags_by_doc_id = load_tags_by_doc_id
+
     @documents = appeal.document_fetcher.find_or_create_documents!.map do |document|
       document.to_hash.tap do |object|
         object[:opened_by_current_user] = read_documents_hash[document.id] || false
-        object[:tags] = document.tags
+        object[:tags] = tags_by_doc_id[document.id].to_a
       end
     end
+  end
+
+  def load_tags_by_doc_id
+    tags_by_doc_id = Hash[document_ids.map { |key, _| [key, Set[]] }]
+    Tag.joins(:documents_tags).where(documents_tags: { document_id: document_ids }).each do |tag|
+      # tag.documents_tags returns extraneous documents outside document_ids, so
+      # only capture tags associated with docs associated with document_ids
+      (tag.documents_tags.pluck(:document_id) & document_ids).each do |doc_id|
+        tags_by_doc_id[doc_id].add(tag)
+      end
+    end
+    tags_by_doc_id
   end
 
   def appeal_id

--- a/spec/controllers/reader/documents_controller_spec.rb
+++ b/spec/controllers/reader/documents_controller_spec.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+describe Reader::DocumentsController, :postgres, type: :controller do
+  let(:attorney_user) { create(:user, roles: ["Reader"]) }
+  let!(:vacols_atty) { create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
+  let(:params) { { format: :json, appeal_id: appeal.uuid } }
+
+  before { User.authenticate!(user: attorney_user) }
+  after { User.unauthenticate! }
+
+  let!(:appeal) { create(:appeal) }
+  let(:document_fetcher) { DocumentFetcher.new(appeal: appeal, use_efolder: true) }
+  let!(:documents) do
+    [
+      Generators::Document.build(id: 201, type: "NOD", series_id: "TEST_SERIES_ID"),
+      Generators::Document.build(id: 202, type: "SOC")
+    ]
+  end
+
+  before do
+    fetched_doc_struct = {
+      # create duplicate documents so as not to modify the original documents used in expect statements
+      documents: documents.map(&:dup),
+      manifest_vbms_fetched_at: Time.zone.local(1989, "nov", 23, 8, 2, 55).utc.strftime("%FT%T.%LZ"),
+      manifest_vva_fetched_at: Time.zone.local(1989, "dec", 13, 20, 15, 1).utc.strftime("%FT%T.%LZ")
+    }
+    expect(EFolderService).to receive(:fetch_documents_for).and_return(fetched_doc_struct).once
+  end
+
+  describe "#index" do
+    context "when API returns many documents" do
+      # Increase the size of the array to test scalability; 20000 works but takes a minute or so
+      let(:documents) { Array.new(50) { Generators::Document.build }.uniq(&:vbms_document_id) }
+      let!(:saved_documents) do
+        Array.new(20) do |i|
+          # have every other document already exists to test that all CREATEs and UPDATEs are each done at most once
+          fetched_document = documents[i * 2]
+          Generators::Document.create(
+            type: "Form 9",
+            series_id: fetched_document.series_id,
+            vbms_document_id: fetched_document.vbms_document_id
+          )
+        end
+      end
+      let(:doc_tag) { Generators::Tag.create(text: "existing tag") }
+      let!(:older_documents_with_metadata) do
+        Array.new(13) do |i|
+          fetched_document = documents[(i * 2) + 1]
+          # same series_id but different vbms_document_id indicate different versions of same document
+          doc = Generators::Document.create(
+            type: "Form 9",
+            series_id: fetched_document.series_id,
+            vbms_document_id: fetched_document.vbms_document_id + ".old",
+            category_medical: true
+          )
+          Generators::Annotation.create(document_id: doc.id, comment: "existing comment", x: rand(100), y: rand(100))
+          DocumentsTag.create(document_id: doc.id, tag_id: doc_tag.id)
+          doc
+        end
+      end
+      it "DocumentsController" do
+        annotations = []
+        tags = []
+        ActiveRecord::Base.logger = Logger.new(STDOUT)
+        controller_query_data = SqlTracker.track do
+          get :index, params: params
+        end
+
+        response_body = JSON.parse(response.body)
+        response_body_keys = %w[appealDocuments annotations manifestVbmsFetchedAt manifestVvaFetchedAt].freeze
+        expect(response_body.keys).to match_array(response_body_keys)
+        expect(response_body["manifestVbmsFetchedAt"]).to_not be_nil
+        expect(response_body["manifestVvaFetchedAt"]).to_not be_nil
+        expect(response_body["appealDocuments"].size).to eq documents.count
+
+        # Check that annotations and tags from older_documents_with_metadata are included in response
+        expect(response_body["annotations"].size).to eq older_documents_with_metadata.count
+        nonempty_tags = response_body["appealDocuments"].pluck("tags").reject(&:empty?)
+        expect(nonempty_tags.count).to eq older_documents_with_metadata.count
+
+        # All annotations have the same comment
+        expect(response_body["annotations"].pluck("comment").uniq).to eq ["existing comment"]
+        # All tags have the same tag
+        expect(nonempty_tags.flatten.pluck("text").uniq).to eq ["existing tag"]
+        # older_documents_with_metadata have category_medical==true
+        docs_with_metadata = response_body["appealDocuments"].reject { |doc| doc["category_medical"].nil? }
+        expect(docs_with_metadata.count).to eq older_documents_with_metadata.count
+
+        # 20 saved_documents are updated and should be returned
+        returned_doc_ids = response_body["appealDocuments"].pluck("id")
+        expect(returned_doc_ids).to include(*saved_documents.pluck(:id))
+
+        # 30 remaining_returned documents are newly created; 13 new versions of known docs + 17 new docs
+        remaining_returned_doc_ids = returned_doc_ids - saved_documents.pluck(:id)
+        remaining_returned_docs = Document.where(id: remaining_returned_doc_ids)
+        returned_docs_with_prev_version = remaining_returned_docs.where.not(previous_document_version_id: nil)
+        expect(returned_docs_with_prev_version.count).to eq 13
+        expect(remaining_returned_doc_ids).to_not include(*older_documents_with_metadata.pluck(:id))
+        expect(remaining_returned_docs.where(previous_document_version_id: nil).count).to eq 17
+
+        # All returned_docs_with_prev_version have annotations, so check that annotations were copied to new docs
+        doc_ids_with_annotations = response_body["annotations"].pluck("document_id")
+        expect(doc_ids_with_annotations).to match_array(returned_docs_with_prev_version.pluck(:id))
+        expect(doc_ids_with_annotations).to match_array(docs_with_metadata.pluck("id"))
+
+        # The following queries will be made efficient in a subsequent commit
+        single_annot_query = "SELECT \"annotations\".* FROM \"annotations\" WHERE \"annotations\".\"document_id\" = xxx"
+        annotation_select_queries = controller_query_data.values.select { |o| o[:sql].start_with?(single_annot_query) }
+        expect(annotation_select_queries.pluck(:count).max).to eq documents.count
+
+        single_tags_query = /SELECT \"tags\".* FROM \"tags\" .* WHERE \"documents_tags\".\"document_id\" = xxx/
+        tag_select_queries = controller_query_data.values.select { |o| o[:sql].start_with?(single_tags_query) }
+        expect(tag_select_queries.pluck(:count).max).to eq documents.count
+      end
+    end
+  end
+end

--- a/spec/controllers/reader/documents_controller_spec.rb
+++ b/spec/controllers/reader/documents_controller_spec.rb
@@ -29,14 +29,14 @@ describe Reader::DocumentsController, :postgres, type: :controller do
 
   describe "#index" do
     context "when API returns many documents" do
-      # Increase the size of the array to test scalability; 20000 works but takes a minute or so
       let(:documents) { Array.new(50) { Generators::Document.build }.uniq(&:vbms_document_id) }
       let!(:saved_documents) do
         Array.new(20) do |i|
-          # have every other document already exists to test that all CREATEs and UPDATEs are each done at most once
+          # to test that all CREATEs and UPDATEs are each done at most once,
+          # have every other document already exists (up to 20 records)
           fetched_document = documents[i * 2]
           Generators::Document.create(
-            type: "Form 9",
+            type: "SOC",
             series_id: fetched_document.series_id,
             vbms_document_id: fetched_document.vbms_document_id
           )
@@ -48,7 +48,7 @@ describe Reader::DocumentsController, :postgres, type: :controller do
           fetched_document = documents[(i * 2) + 1]
           # same series_id but different vbms_document_id indicate different versions of same document
           doc = Generators::Document.create(
-            type: "Form 9",
+            type: "SOC",
             series_id: fetched_document.series_id,
             vbms_document_id: fetched_document.vbms_document_id + ".old",
             category_medical: true
@@ -59,8 +59,6 @@ describe Reader::DocumentsController, :postgres, type: :controller do
         end
       end
       it "DocumentsController" do
-        annotations = []
-        tags = []
         ActiveRecord::Base.logger = Logger.new(STDOUT)
         controller_query_data = SqlTracker.track do
           get :index, params: params

--- a/spec/controllers/reader/documents_controller_spec.rb
+++ b/spec/controllers/reader/documents_controller_spec.rb
@@ -59,7 +59,7 @@ describe Reader::DocumentsController, :postgres, type: :controller do
         end
       end
       it "efficiently queries and returns correct response" do
-        # ActiveRecord::Base.logger = Logger.new(STDOUT)
+        ActiveRecord::Base.logger = Logger.new(STDOUT)
         controller_query_data = SqlTracker.track do
           get :index, params: params
         end

--- a/spec/controllers/reader/documents_controller_spec.rb
+++ b/spec/controllers/reader/documents_controller_spec.rb
@@ -3,19 +3,11 @@
 describe Reader::DocumentsController, :postgres, type: :controller do
   let(:attorney_user) { create(:user, roles: ["Reader"]) }
   let!(:vacols_atty) { create(:staff, :attorney_role, sdomainid: attorney_user.css_id) }
+  let!(:appeal) { create(:appeal) }
   let(:params) { { format: :json, appeal_id: appeal.uuid } }
 
   before { User.authenticate!(user: attorney_user) }
   after { User.unauthenticate! }
-
-  let!(:appeal) { create(:appeal) }
-  let(:document_fetcher) { DocumentFetcher.new(appeal: appeal, use_efolder: true) }
-  let!(:documents) do
-    [
-      Generators::Document.build(id: 201, type: "NOD", series_id: "TEST_SERIES_ID"),
-      Generators::Document.build(id: 202, type: "SOC")
-    ]
-  end
 
   before do
     fetched_doc_struct = {

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -305,6 +305,20 @@ describe DocumentFetcher, :postgres do
             )
           end
         end
+        let(:doc_tag) { Generators::Tag.create(text: "existing tag") }
+        let!(:older_documents_with_metadata) do
+          Array.new(13) do |i|
+            fetched_document = documents[(i * 2) + 1]
+            # same series_id but different vbms_document_id indicate different versions of same document
+            doc = Generators::Document.create(
+              type: "Form 9",
+              series_id: fetched_document.series_id,
+              vbms_document_id: fetched_document.vbms_document_id + ".old"
+            )
+            Generators::Annotation.create(document_id: doc.id, comment: "existing comment", x: rand(100), y: rand(100))
+            DocumentsTag.create(document_id: doc.id, tag_id: doc_tag.id)
+          end
+        end
         it "efficiently creates and updates documents" do
           expect(Document.distinct.pluck(:type)).to eq(["Form 9"])
 
@@ -318,7 +332,16 @@ describe DocumentFetcher, :postgres do
           # pp query_data.values.pluck(:sql, :count)
           doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
           expect(doc_insert_queries.pluck(:count).max).to eq 1
-          expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE") }).to be_empty
+
+          # When metadata exists for a previous version of a document, queries remain inefficient
+          annotns_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"annotations\"") }
+          expect(annotns_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+
+          doctags_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents_tags\"") }
+          expect(doctags_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+
+          doc_update_queries = query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }
+          expect(doc_update_queries.pluck(:count).max).to eq older_documents_with_metadata.count
         end
 
         context "when there are duplicate documents returned from document_service" do
@@ -333,7 +356,7 @@ describe DocumentFetcher, :postgres do
           it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
             expect(documents.map(&:vbms_document_id).count).to eq(53)
             expect(documents.map(&:vbms_document_id).uniq.count).to eq(50)
-            expect(Document.count).to eq 20
+            expect(Document.count).to eq (saved_documents.count + older_documents_with_metadata.count)
             expect(Document.find_by(vbms_document_id: documents.first.vbms_document_id)).not_to be_nil
             expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
             expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
@@ -351,7 +374,8 @@ describe DocumentFetcher, :postgres do
             # pp query_data.values.pluck(:sql, :count)
             doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
             expect(doc_insert_queries.pluck(:count).max).to eq 1
-            expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE") }).to be_empty
+            expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }.pluck(:count).max)
+              .to eq(older_documents_with_metadata.count)
           end
         end
       end

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -337,7 +337,7 @@ describe DocumentFetcher, :postgres do
           annotns_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"annotations\"") }
           expect(annotns_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
 
-          doctags_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents_tags\"") }
+          doctags_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents_tags") }
           expect(doctags_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
 
           doc_update_queries = query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }
@@ -356,7 +356,7 @@ describe DocumentFetcher, :postgres do
           it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
             expect(documents.map(&:vbms_document_id).count).to eq(53)
             expect(documents.map(&:vbms_document_id).uniq.count).to eq(50)
-            expect(Document.count).to eq (saved_documents.count + older_documents_with_metadata.count)
+            expect(Document.count).to eq(saved_documents.count + older_documents_with_metadata.count)
             expect(Document.find_by(vbms_document_id: documents.first.vbms_document_id)).not_to be_nil
             expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
             expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil


### PR DESCRIPTION
Follow-up to #15787

The optimization in DocumentFetcher revealed a slowdown in DocumentsController when loading `Annotation` and `Tag` records. See comment https://github.com/department-of-veterans-affairs/caseflow/pull/15792#issuecomment-766090169.

### Description
Bulk load `Annotation` and `Tag` records instead of query for them individually in Reader::DocumentsController.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Checkout git commit with hash `98e23f6` of this PR: `git checkout 98e23f6`
2. Run `bundle exec rspec spec/controllers/reader/documents_controller_spec.rb`. Notice all the individual queries for `Annotation Load` and `Tag Load`. This is the problem being solved.
3. Checkout this PR
4. Rerun the test. Notice the individual queries are gone.
