### PR TITLE
Added condition to remove bullets for new virtual hearing links

### DIFF
--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -133,7 +133,7 @@ class VirtualHearing < CaseflowRecord
   end
 
   def test_link(title)
-    if guest_hearing_link.present? && host_hearing_link.present?
+    if use_vc_test_link?
       "https://vc.va.gov/webapp2/conference/test_call?name=#{email_recipient_name(title)}&join=1"
     else
       "https://care.va.gov/webapp2/conference/test_call?name=#{email_recipient_name(title)}&join=1"
@@ -203,6 +203,10 @@ class VirtualHearing < CaseflowRecord
   # checks if emails were sent to appellant and reps
   def cancellation_emails_sent?
     appellant_email_sent && (representative_email.nil? || representative_email_sent)
+  end
+
+  def use_vc_test_link?
+    guest_hearing_link.present? && host_hearing_link.present?
   end
 
   private

--- a/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
+++ b/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
@@ -13,6 +13,7 @@
   you plan to use for your hearing</strong>: <%= external_link @test_link %>
 </p>
 <% end %>
+<% if @virtual_hearing&.use_vc_test_link? %>
 <ul>
   <li>
     If you are using an Apple mobile device, such as an iPhone or iPad, you
@@ -24,6 +25,7 @@
     no application download is required. The hearing will launch automatically in your web browser after you click the link.
   </li>
 </ul>
+<% end %>
 <p>
   Want to learn more about Virtual Tele-hearings? Watch this video at <%= external_link "https://www.youtube.com/watch?v=UDI3C_ytJt8" %>.
 </p>

--- a/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
+++ b/app/views/virtual_hearing_mailer/sections/_test_your_connection.html.erb
@@ -13,7 +13,7 @@
   you plan to use for your hearing</strong>: <%= external_link @test_link %>
 </p>
 <% end %>
-<% if @virtual_hearing&.use_vc_test_link? %>
+<% if !@virtual_hearing&.use_vc_test_link? %>
 <ul>
   <li>
     If you are using an Apple mobile device, such as an iPhone or iPad, you


### PR DESCRIPTION
Resolves [CASEFLOW-853](https://vajira.max.gov/browse/CASEFLOW-853)

### Description
Removes the test your connection section for the new vc.va.gov links

### Acceptance Criteria
- [ ] When a confirmation or reminder email is sent for a virtual hearing with a URL on vc.va.gov, then
the following text should be removed from the "Test Your Connection" section
```
<ul>
  <li>
    If you are using an Apple mobile device, such as an iPhone or iPad, you
    will need to download the free VA Video Connect app from the App Store:
    <%= external_link "https://itunes.apple.com/us/app/va-video-connect/id1224250949?mt=8" %>
  </li>
  <li>
    If you are using an Apple computer, such as a Mac, or any Windows or Android device,
    no application download is required. The hearing will launch automatically in your web browser after you click the link.
  </li>
</ul>
```
 - [ ] the test link should be https://vc.va.gov/bva-app/conference/test_call?name=Veteran&join=1 

### Testing Plan
