### PR TITLE
Allow 5 minutes for Reader page to load documents

### DIFF
--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -17,11 +17,11 @@ export class ReaderLoadingScreen extends React.Component {
       return Promise.resolve();
     }
 
-    const requestOptions = {
+    const reqOptions = {
       timeout: { response: getMinutesToMilliseconds(5) }
     };
 
-    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents?json`, requestOptions, ENDPOINT_NAMES.DOCUMENTS).
+    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents?json`, reqOptions, ENDPOINT_NAMES.DOCUMENTS).
       then((response) => {
         const returnedObject = response.body;
         const documents = returnedObject.appealDocuments;

--- a/client/app/reader/ReaderLoadingScreen.jsx
+++ b/client/app/reader/ReaderLoadingScreen.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { ENDPOINT_NAMES } from './analytics';
 import ApiUtil from '../util/ApiUtil';
+import { getMinutesToMilliseconds } from '../util/DateUtil';
 import { onReceiveManifests } from './DocumentList/DocumentListActions';
 import { onReceiveDocs } from '../reader/Documents/DocumentsActions';
 import { onReceiveAnnotations } from './AnnotationLayer/AnnotationActions';
@@ -16,7 +17,11 @@ export class ReaderLoadingScreen extends React.Component {
       return Promise.resolve();
     }
 
-    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents?json`, {}, ENDPOINT_NAMES.DOCUMENTS).
+    const requestOptions = {
+      timeout: { response: getMinutesToMilliseconds(5) }
+    };
+
+    return ApiUtil.get(`/reader/appeal/${this.props.vacolsId}/documents?json`, requestOptions, ENDPOINT_NAMES.DOCUMENTS).
       then((response) => {
         const returnedObject = response.body;
         const documents = returnedObject.appealDocuments;


### PR DESCRIPTION
Resolves [Sentry alert](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/13952)

[All relevant Sentry alerts](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/?query=url%3A%22https%3A%2F%2Fappeals.cf.ds.va.gov%2Freader%2Fappeal%2F4035313%2Fdocuments%22)

### Description
Increase ApiUtils timeout for the `ReaderLoadingScreen` component to allow `https://appeals.cf.ds.va.gov/reader/appeal/4035313/documents` to load 54k documents.

The current timeout is 60s: https://github.com/department-of-veterans-affairs/caseflow/blob/d035e3b9db1cd5e26c81aa2497c6a1aa6aeee423/client/app/util/ApiUtil.js#L8
which causes this:
![image](https://user-images.githubusercontent.com/55255674/106802072-14493880-6628-11eb-9c3a-6206124d49f5.png)

Other similar components use a 5 minute timeout, e.g.:
* https://github.com/department-of-veterans-affairs/caseflow/blob/28d5b669ce036ab555199e80ad7a39fdcb89179b/client/app/queue/AppealDocumentCount.jsx#L34
* https://github.com/department-of-veterans-affairs/caseflow/blob/e44bfbc0db616dd7fa5dd7608d26bf0e643c98f3/client/app/queue/OrganizationQueueLoadingScreen.jsx#L24

### Acceptance Criteria
- [ ] Code compiles correctly and tests pass

### Testing Plan
1. Deploy
2. Check if https://appeals.cf.ds.va.gov/reader/appeal/4035313/documents loads
3. Record the time it takes to load.
