### PR TITLE
Refactor virtual hearing repository queries

### DIFF
--- a/app/jobs/virtual_hearings/delete_conferences_job.rb
+++ b/app/jobs/virtual_hearings/delete_conferences_job.rb
@@ -36,7 +36,7 @@ class VirtualHearings::DeleteConferencesJob < VirtualHearings::ConferenceJob
     ensure_current_user_is_set
     @exception_list = {} # reset on every perform
 
-    VirtualHearingRepository.cancelled_hearings_with_pending_emails.each do |virtual_hearing|
+    VirtualHearingRepository.cancelled_with_pending_emails.each do |virtual_hearing|
       log_virtual_hearing_state(virtual_hearing)
 
       Rails.logger.info("Sending cancellation emails to recipients for hearing (#{virtual_hearing.hearing_id})")

--- a/app/repositories/virtual_hearing_repository.rb
+++ b/app/repositories/virtual_hearing_repository.rb
@@ -83,11 +83,11 @@ class VirtualHearingRepository
 
     # Returns virtual hearings joined with either the legacy hearing or hearings table,
     # and joined with the hearing day table.
-    def virtual_hearings_joined_with_hearings_and_hearing_day(appeal_type)
-      table = appeal_type.table_name
+    def virtual_hearings_joined_with_hearings_and_hearing_day(hearing_type)
+      table = hearing_type.table_name
 
       VirtualHearing
-        .where(hearing_type: appeal_type.name)
+        .where(hearing_type: hearing_type.name)
         .joins("INNER JOIN #{table} ON #{table}.id = virtual_hearings.hearing_id")
         .joins("INNER JOIN hearing_days ON hearing_days.id = #{table}.hearing_day_id")
     end

--- a/app/services/stuck_virtual_hearings_checker.rb
+++ b/app/services/stuck_virtual_hearings_checker.rb
@@ -19,7 +19,7 @@ class StuckVirtualHearingsChecker < DataIntegrityChecker
   def stuck_virtual_hearings
     rerun_jobs
 
-    VirtualHearingRepository.hearings_with_pending_conference_or_pending_emails.select do |virtual_hearing|
+    VirtualHearingRepository.with_pending_conference_or_emails.select do |virtual_hearing|
       virtual_hearing.updated_at < Time.zone.now - 2.hours
     end
   end

--- a/spec/repositories/virtual_hearing_repository_spec.rb
+++ b/spec/repositories/virtual_hearing_repository_spec.rb
@@ -145,8 +145,8 @@ describe VirtualHearingRepository, :all_dbs do
     end
   end
 
-  context ".cancelled_hearings_with_pending_emails" do
-    subject { VirtualHearingRepository.cancelled_hearings_with_pending_emails }
+  context ".cancelled_with_pending_emails" do
+    subject { VirtualHearingRepository.cancelled_with_pending_emails }
 
     let!(:cancelled_vh_with_only_pending_judge_emails) do
       create(:virtual_hearing, :all_emails_sent, status: :cancelled, hearing: hearing)
@@ -167,8 +167,8 @@ describe VirtualHearingRepository, :all_dbs do
     end
   end
 
-  context ".hearings_with_pending_conference_or_pending_emails" do
-    subject { VirtualHearingRepository.hearings_with_pending_conference_or_pending_emails }
+  context ".with_pending_conference_or_emails" do
+    subject { VirtualHearingRepository.with_pending_conference_or_emails }
 
     context "virtual hearings created with new link generation" do
       let!(:vh_with_pending_link) { create(:virtual_hearing, hearing: hearing) }


### PR DESCRIPTION
### Description
The VirtualHearingRepository `postponed_or_cancelled_vacols_ids` method queried VACOLS for all hearings with postponed or cancelled dispositions. In production, the query took more than 2m 30s to complete and returned more than 156K results.

I renamed the method `vacols_select_postponed_or_cancelled` and had it accept a list of VACOLS ids to query, then re-wrote `ready_for_deletion` and `maybe_ready_for_reminder_email` to use it in this new way: they first collect the hearings that they're interested in, then use `vacols_select_postponed_or_cancelled` to select the ones with postponed or cancelled disposition.

I verified with manual testing in production that the refactored methods return identical results. Before the changes, each method took 2.5 to 3 minutes to complete; after they take 6 to 15 seconds.
