### PR TITLE
Change withdrawn back to cancelled

### DIFF
--- a/client/app/hearings/constants.js
+++ b/client/app/hearings/constants.js
@@ -107,7 +107,7 @@ export const DISPOSITION_OPTIONS = [{ value: 'held',
 { value: 'no_show',
   label: 'No Show' },
 { value: 'cancelled',
-  label: 'Withdrawn' },
+  label: 'Cancelled' },
 { value: 'postponed',
   label: 'Postponed' }];
 

--- a/client/constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP.json
+++ b/client/constants/HEARING_DISPOSITION_TYPE_TO_LABEL_MAP.json
@@ -2,5 +2,5 @@
   "postponed": "Postponed",
   "no_show": "No Show",
   "held": "Held",
-  "cancelled": "Withdrawn"
+  "cancelled": "Cancelled"
 }


### PR DESCRIPTION
Related to #https://vajira.max.gov/browse/CASEFLOW-443
Reverts the core change of https://github.com/department-of-veterans-affairs/caseflow/pull/15831
Related Slack conversation: https://dsva.slack.com/archives/C3EAF3Q15/p1612460935070300

### Testing Plan
#### Updating disposition from daily docket
1. Login as `BVASYELLOW`
2. Go to hearing schedule and click on any day with hearings to go to daily docket
3. on daily docket, ensure disposition dropdown shows `Cancelled` as opposed to `Withdrawn`
4. Select `Cancelled` disposition and ensure that a modal pops open to display the new disposition as `Cancelled` as opposed to `Withdrawn`
5. Click confirm and ensure that the disposition has been modified to `Cancelled` on the UI
6. Go to case details page for this appellant, and ensure that the disposition is displayed as `Cancelled`
7. Go to hearing details page for this hearing, and ensure that the disposition is displayed as `Cancelled`
8. Go to hearings worksheet for this hearing and ensure that the disposition is displayed as `Cancelled`

#### Updating disposition via Change Hearing Disposition Task
1. Login as `BVATWARNER`
2. Go to hearing admin queue and pick a case with `Change hearing disposition`
3. go to case details and click on action `Change Hearing Disposition`
4. ensure dropdown displays `Cancelled` as opposed to `Withdrawn`
5. select `Cancelled` and hit confirm