### PR TITLE
Ignore ordering of vacols_roles to determine the legacy task type

### DIFF
--- a/app/models/queues/legacy_work_queue.rb
+++ b/app/models/queues/legacy_work_queue.rb
@@ -30,7 +30,7 @@ class LegacyWorkQueue
         task_class = AttorneyLegacyTask
         # If the user is a judge they are only assigned JudgeLegacyTasks
         # If the user is an acting judge, assume any case that already has a decision doc is assigned to them as a judge
-        if user&.vacols_roles&.first&.downcase == "judge" ||
+        if user&.vacols_roles&.include?("judge") ||
            (user&.acting_judge_in_vacols? && appeal.assigned_to_acting_judge_as_judge?(user))
           task_class = JudgeLegacyTask
         end


### PR DESCRIPTION
[Bat Team Slack thread](https://dsva.slack.com/archives/CHX8FMP28/p1611864733169500)
[Echo Slack thread](https://dsva.slack.com/archives/CJL810329/p1612464153174900)

### Description
Don't rely on ordering of `vacols_roles` to determine the task type for legacy appeals.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.
