### PR TITLE
Add Nod Date Update Timeline Component to Case Timeline #2

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -24,7 +24,7 @@ class Appeal < DecisionReview
   has_many :vbms_uploaded_documents
   has_many :remand_supplemental_claims, as: :decision_review_remanded, class_name: "SupplementalClaim"
 
-  has_many :nod_date_updates, as: :appeal
+  has_many :nod_date_updates
 
   has_one :special_issue_list
   has_one :post_decision_motion

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -37,6 +37,19 @@ class WorkQueue::AppealSerializer
     end
   end
 
+  attribute :nod_date_updates do |object|
+    object.nod_date_updates.map do |nod_date_update|
+      updated_by = nod_date_update.user
+      {
+        old_date: nod_date_update.old_date,
+        new_date: nod_date_update.new_date,
+        change_reason: nod_date_update.change_reason,
+        closed_at: nod_date_update.updated_at, # alias to sort updates with tasks
+        updated_by: updated_by.full_name
+      }
+    end
+  end
+
   attribute :can_edit_request_issues do |object, params|
     AppealRequestIssuesPolicy.new(user: params[:user], appeal: object).editable?
   end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -541,6 +541,7 @@
   "CASE_TIMELINE_FORM_9_PENDING": "Form 9 pending",
   "CASE_TIMELINE_NOD_RECEIVED": "Notice of disagreement received",
   "CASE_TIMELINE_NOD_PENDING": "Notice of disagreement pending",
+  "CASE_TIMELINE_NOD_DATE_UPDATE": "Notice of disagreement edited",
   "CASE_TIMELINE_JUDGE_TASK": "Decision signed by judge",
   "CASE_TIMELINE_ATTORNEY_TASK": "Decision drafted by attorney",
   "CASE_TIMELINE_ATTORNEY_DISPATCH_RETURN_TASK": "Decision revised for dispatch by attorney",

--- a/client/app/queue/components/EditNodDateModal.jsx
+++ b/client/app/queue/components/EditNodDateModal.jsx
@@ -22,7 +22,7 @@ const alertStyling = css({
   '& .usa-alert-text': { lineHeight: '1' }
 });
 
-const changeReasons = [
+export const changeReasons = [
   { label: 'New Form/Information Received', value: 'new_info' },
   { label: 'Data Entry Error', value: 'entry_error' },
 ];

--- a/client/app/queue/components/NodDateUpdateTimeline.jsx
+++ b/client/app/queue/components/NodDateUpdateTimeline.jsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import moment from 'moment-timezone';
+import { formatDateStr } from '../../util/DateUtil';
+import { changeReasons } from './EditNodDateModal';
+
+import COPY from 'app/../COPY';
+import { GreenCheckmark } from '../../components/RenderFunctions';
+import { COLORS } from '../../constants/AppConstants';
+import { grayLineTimelineStyling } from './TaskRows';
+
+const nodDateUpdateTimelineTimeStyling = css({
+  color: COLORS.GREY_MEDIUM,
+  fontSize: '15px'
+});
+
+const nodDateUpdateTimelineInfoStyling = css({
+  display: 'flex',
+  flexWrap: 'wrap',
+  '& *': {
+    whiteSpace: 'nowrap',
+    marginRight: '1rem',
+  },
+  '& span': {
+    color: COLORS.GREY_MEDIUM,
+    fontSize: '1.5rem',
+    marginRight: '0.5rem',
+    textTransform: 'uppercase'
+  }
+});
+
+export const NodDateUpdateTimeline = (props) => {
+  const { nodDateUpdate, timeline } = props;
+  const changeReason = changeReasons.find((reason) => reason.value === nodDateUpdate.changeReason).label;
+
+  return <React.Fragment>
+    {timeline && <tr>
+      <td className="taskContainerStyling taskTimeTimelineContainerStyling">
+        <div>{ moment(nodDateUpdate.closedAt).format('MM/DD/YYYY') }</div>
+        <div {...nodDateUpdateTimelineTimeStyling}>
+          { moment(nodDateUpdate.closedAt).tz('America/New_York').
+            format('HH:mm:ss') } EST
+        </div>
+      </td>
+      <td className="taskInfoWithIconContainer taskInfoWithIconTimelineContainer">
+        <GreenCheckmark />
+        <div {...grayLineTimelineStyling} />
+      </td>
+      <td className="taskContainerStyling taskInformationTimelineContainerStyling">
+        { COPY.CASE_TIMELINE_NOD_DATE_UPDATE }
+        <div {...nodDateUpdateTimelineInfoStyling}>
+          <div><span>Edited:</span>{nodDateUpdate.userFirstName.split('')[0]}. {nodDateUpdate.userLastName}</div>
+          <div><span>Old Nod:</span>{formatDateStr(nodDateUpdate.oldDate)}</div>
+          <div><span>New Nod:</span>{formatDateStr(nodDateUpdate.newDate)}</div>
+          <div><span>Reason:</span>{changeReason}</div>
+        </div>
+      </td>
+    </tr>
+    }
+  </React.Fragment>;
+};
+
+NodDateUpdateTimeline.propTypes = {
+  nodDateUpdate: PropTypes.shape({
+    appealId: PropTypes.number,
+    changeReason: PropTypes.string,
+    closedAt: PropTypes.string,
+    newDate: PropTypes.string,
+    oldDate: PropTypes.string,
+    userFirstName: PropTypes.string,
+    userLastName: PropTypes.string
+  }),
+  timeline: PropTypes.bool
+};

--- a/client/app/queue/components/NodDateUpdateTimeline.test.js
+++ b/client/app/queue/components/NodDateUpdateTimeline.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { NodDateUpdateTimeline } from 'app/queue/components/NodDateUpdateTimeline';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('NodDateUpdateTimeline', () => {
+  const nodDateUpdate = {
+    appealId: 1,
+    changeReason: 'entry_error',
+    newDate: '2021-01-12',
+    oldDate: '2021-01-05',
+    closedAt: '2021-01-25T15:10:29.033-05:00',
+    userFirstName: 'Jane',
+    userLastName: 'Doe'
+  };
+
+  const setupNodDateUpdateTimeline = (timeline) => {
+    return shallow(
+      <NodDateUpdateTimeline
+        nodDateUpdate={nodDateUpdate}
+        timeline={timeline}
+      />
+    );
+  };
+
+  it('renders correctly', () => {
+    const component = setupNodDateUpdateTimeline(true);
+
+    expect(component).toMatchSnapshot();
+  });
+
+  it('should show update details', () => {
+    const component = setupNodDateUpdateTimeline(true);
+    console.log(component.debug())
+
+    expect(component.text()).toContain('01/05/2021');
+    expect(component.text()).toContain('01/12/2021');
+    expect(component.text()).toContain('J. Doe');
+    expect(component.text()).toContain('Data Entry Error');
+  });
+
+  it('should not render if Task Rows is in Task Snapshot', () => {
+    const component = setupNodDateUpdateTimeline(false);
+
+    expect(component.find('tr').exists()).toEqual(false);
+  });
+});

--- a/client/app/queue/components/NodDateUpdateTimline.stories.js
+++ b/client/app/queue/components/NodDateUpdateTimline.stories.js
@@ -1,0 +1,36 @@
+import React from 'react';
+
+import { NodDateUpdateTimeline } from './NodDateUpdateTimeline';
+
+export default {
+  title: 'Queue/CaseTimeline/NODDateUpdateTimeline',
+  component: NodDateUpdateTimeline,
+  parameters: {
+    docs: {
+      inlineStories: false
+    },
+  },
+  args: {
+    nodDateUpdate: {
+      appealId: 1,
+      changeReason: 'entry_error',
+      newDate: '2021-01-12',
+      oldDate: '2021-01-05',
+      closedAt: '2021-01-25T15:10:29.033-05:00',
+      userFirstName: 'Jane',
+      userLastName: 'Doe'
+    },
+    timeline: true
+  }
+};
+
+const Template = (args) => (
+  <table>
+    <tbody>
+      <NodDateUpdateTimeline {...args} />
+    </tbody>
+  </table>
+);
+
+export const NODDateUpdateTimeline = Template.bind({});
+

--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -6,7 +6,7 @@ import Button from '../../components/Button';
 import COPY from '../../../COPY';
 import { GrayDot, GreenCheckmark, CancelIcon } from '../../components/RenderFunctions';
 import { COLORS } from '../../constants/AppConstants';
-import { taskIsOnHold, sortCaseTimelineEntries } from '../utils';
+import { taskIsOnHold, sortCaseTimelineEvents } from '../utils';
 import CaseDetailsDescriptionList from '../components/CaseDetailsDescriptionList';
 import ActionsDropdown from '../components/ActionsDropdown';
 import OnHoldLabel from '../components/OnHoldLabel';
@@ -337,29 +337,29 @@ class TaskRows extends React.PureComponent {
     } = this.props;
     const nodDateUpdates = appeal.nodDateUpdates;
 
-    const sortedTimelineEvents = sortCaseTimelineEntries(taskList, nodDateUpdates);
+    const sortedTimelineEvents = sortCaseTimelineEvents(taskList, nodDateUpdates);
 
     return <React.Fragment key={appeal.externalId}>
 
-      { sortedTimelineEvents.map((timelineEntry, index) => {
+      { sortedTimelineEvents.map((timelineEvent, index) => {
         const templateConfig = {
-          task: timelineEntry,
+          task: timelineEvent,
           index,
           timeline,
           sortedTimelineEvents,
           appeal
         };
 
-        if (timelineEntry.isDecisionDate) {
+        if (timelineEvent.isDecisionDate) {
           return <DecisionDateTimeLine
             appeal = {appeal}
             timeline = {timeline}
             taskList = {taskList} />;
         }
 
-        if (timelineEntry.changeReason) {
+        if (timelineEvent.changeReason) {
           return <NodDateUpdateTimeline
-            nodDateUpdate = {timelineEntry}
+            nodDateUpdate = {timelineEvent}
             timeline = {timeline}
           />;
         }

--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -6,7 +6,7 @@ import Button from '../../components/Button';
 import COPY from '../../../COPY';
 import { GrayDot, GreenCheckmark, CancelIcon } from '../../components/RenderFunctions';
 import { COLORS } from '../../constants/AppConstants';
-import { taskIsOnHold, sortTaskList } from '../utils';
+import { taskIsOnHold, sortCaseTimelineEntries } from '../utils';
 import CaseDetailsDescriptionList from '../components/CaseDetailsDescriptionList';
 import ActionsDropdown from '../components/ActionsDropdown';
 import OnHoldLabel from '../components/OnHoldLabel';
@@ -14,6 +14,7 @@ import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import DecisionDateTimeLine from '../components/DecisionDateTimeLine';
 import ReactMarkdown from 'react-markdown';
 import { EditNodDateModalContainer } from './EditNodDateModal';
+import { NodDateUpdateTimeline } from './NodDateUpdateTimeline';
 
 export const grayLineStyling = css({
   width: '5px',
@@ -21,11 +22,11 @@ export const grayLineStyling = css({
   margin: 'auto',
   position: 'absolute',
   top: '30px',
-  left: '49.5%',
+  left: '45.5%',
   bottom: 0
 });
 
-const grayLineTimelineStyling = css(grayLineStyling, { left: '9%',
+export const grayLineTimelineStyling = css(grayLineStyling, { left: '9%',
   marginLeft: '12px',
   top: '39px' });
 
@@ -291,7 +292,7 @@ class TaskRows extends React.PureComponent {
   }
 
   taskTemplate = (templateConfig) => {
-    const { task, taskList, index, timeline, appeal } = templateConfig;
+    const { task, sortedTimelineEvents, index, timeline, appeal } = templateConfig;
 
     const timelineTitle = isCancelled(task) ? `${task.type} cancelled` : task.timelineTitle;
 
@@ -305,7 +306,8 @@ class TaskRows extends React.PureComponent {
       </td>
       <td {...taskInfoWithIconContainer} className={tdClassNames(timeline, task)}>
         { isCancelled(task) ? <CancelIcon /> : closedAtIcon(task, timeline) }
-        { (((index < taskList.length) && timeline) || (index < taskList.length - 1 && !timeline)) &&
+        { (((index < sortedTimelineEvents.length) && timeline) ||
+          (index < sortedTimelineEvents.length - 1 && !timeline)) &&
               <div {...grayLineStyling} className={[cancelGrayTimeLineStyle(timeline),
                 task.closedAt ? '' : greyDotAndlineStyling].join(' ')} /> }
       </td>
@@ -333,29 +335,39 @@ class TaskRows extends React.PureComponent {
       taskList,
       timeline
     } = this.props;
+    const nodDateUpdates = appeal.nodDateUpdates;
+
+    const sortedTimelineEvents = sortCaseTimelineEntries(taskList, nodDateUpdates);
 
     return <React.Fragment key={appeal.externalId}>
 
-      { sortTaskList(taskList, appeal).map((task, index) => {
+      { sortedTimelineEvents.map((timelineEntry, index) => {
         const templateConfig = {
-          task,
+          task: timelineEntry,
           index,
           timeline,
-          taskList,
+          sortedTimelineEvents,
           appeal
         };
 
-        if (!task.isDecisionDate) {
-          return this.taskTemplate(templateConfig);
+        if (timelineEntry.isDecisionDate) {
+          return <DecisionDateTimeLine
+            appeal = {appeal}
+            timeline = {timeline}
+            taskList = {taskList} />;
         }
 
-        return <DecisionDateTimeLine
-          appeal = {appeal}
-          timeline ={timeline}
-          taskList = {taskList} />;
+        if (timelineEntry.changeReason) {
+          return <NodDateUpdateTimeline
+            nodDateUpdate = {timelineEntry}
+            timeline = {timeline}
+          />;
+        }
+
+        return this.taskTemplate(templateConfig);
       }) }
 
-      {/* everything below here will not be in chronological order unless it's added to the task list on line 287*/}
+      {/* Everything below won't be in chronological order unless added to task list to return under render function*/}
       { timeline && appeal.isLegacyAppeal && <tr>
         <td className="taskContainerStyling taskTimeTimelineContainerStyling">
           { appeal.form9Date ? moment(appeal.form9Date).format('MM/DD/YYYY') : null }
@@ -381,7 +393,7 @@ class TaskRows extends React.PureComponent {
                 <Button
                   type="button"
                   linkStyling
-                  styling={css({ 'padding-left': '0' })}
+                  styling={css({ paddingLeft: '0' })}
                   onClick={this.toggleEditNodDateModal}>
                   {COPY.CASE_DETAILS_EDIT_NOD_DATE_LINK_COPY}
                 </Button>

--- a/client/app/queue/components/__snapshots__/NodDateUpdateTimeline.test.js.snap
+++ b/client/app/queue/components/__snapshots__/NodDateUpdateTimeline.test.js.snap
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NodDateUpdateTimeline renders correctly 1`] = `
+<Fragment>
+  <tr>
+    <td
+      className="taskContainerStyling taskTimeTimelineContainerStyling"
+    >
+      <div>
+        01/25/2021
+      </div>
+      <div
+        data-css-1e14v4t=""
+      >
+        15:10:29
+         EST
+      </div>
+    </td>
+    <td
+      className="taskInfoWithIconContainer taskInfoWithIconTimelineContainer"
+    >
+      <GreenCheckmark />
+      <div
+        data-css-78t0uq=""
+      />
+    </td>
+    <td
+      className="taskContainerStyling taskInformationTimelineContainerStyling"
+    >
+      Notice of disagreement edited
+      <div
+        data-css-qgrw5t=""
+      >
+        <div>
+          <span>
+            Edited:
+          </span>
+          J
+          . 
+          Doe
+        </div>
+        <div>
+          <span>
+            Old Nod:
+          </span>
+          01/05/2021
+        </div>
+        <div>
+          <span>
+            New Nod:
+          </span>
+          01/12/2021
+        </div>
+        <div>
+          <span>
+            Reason:
+          </span>
+          Data Entry Error
+        </div>
+      </div>
+    </td>
+  </tr>
+</Fragment>
+`;

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -620,15 +620,15 @@ export const nullToFalse = (key, obj) => {
   return obj;
 };
 
-export const sortCaseTimelineEntries = (taskList, nodDateUpdates) => {
-  const timelineEntries = [...taskList, ...nodDateUpdates];
+export const sortCaseTimelineEvents = (taskList, nodDateUpdates) => {
+  const timelineEvents = [...taskList, ...nodDateUpdates];
 
-  const sortedTimelineEntries = timelineEntries.sort((prev, next) => {
+  const sortedTimelineEvents = timelineEvents.sort((prev, next) => {
     return new Date(next.closedAt || next.createdAt).getTime() -
            new Date(prev.closedAt || prev.createdAt).getTime();
   });
 
-  return sortedTimelineEntries;
+  return sortedTimelineEvents;
 };
 
 export const regionalOfficeCity = (objWithLocation, defaultToUnknown) => {

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -299,6 +299,20 @@ const prepareAppealAvailableHearingLocationsForStore = (appeal) =>
     zipCode: ahl.zip_code
   }));
 
+const prepareNodDateUpdatesForStore = (appeal) => {
+  const nodDateUpdates = appeal.attributes.nod_date_updates.map((nodDateUpdate) => ({
+    appealId: appeal.id,
+    changeReason: nodDateUpdate.change_reason,
+    newDate: nodDateUpdate.new_date,
+    oldDate: nodDateUpdate.old_date,
+    closedAt: nodDateUpdate.closed_at,
+    userFirstName: nodDateUpdate.updated_by.split(' ')[0],
+    userLastName: nodDateUpdate.updated_by.split(' ')[nodDateUpdate.updated_by.split(' ').length - 1]
+  }));
+
+  return nodDateUpdates;
+};
+
 export const prepareAppealForStore = (appeals) => {
   const appealHash = appeals.reduce((accumulator, appeal) => {
     const {
@@ -356,6 +370,7 @@ export const prepareAppealForStore = (appeals) => {
       decisionDate: appeal.attributes.decision_date,
       form9Date: appeal.attributes.form9_date,
       nodDate: appeal.attributes.nod_date,
+      nodDateUpdates: prepareNodDateUpdatesForStore(appeal),
       certificationDate: appeal.attributes.certification_date,
       powerOfAttorney: appeal.attributes.power_of_attorney,
       cavcRemand: appeal.attributes.cavc_remand,
@@ -605,10 +620,15 @@ export const nullToFalse = (key, obj) => {
   return obj;
 };
 
-export const sortTaskList = (taskList) => {
-  return taskList.sort((prev, next) => {
-    return new Date(next.closedAt || next.createdAt).getTime() - new Date(prev.closedAt || prev.createdAt).getTime();
+export const sortCaseTimelineEntries = (taskList, nodDateUpdates) => {
+  const timelineEntries = [...taskList, ...nodDateUpdates];
+
+  const sortedTimelineEntries = timelineEntries.sort((prev, next) => {
+    return new Date(next.closedAt || next.createdAt).getTime() -
+           new Date(prev.closedAt || prev.createdAt).getTime();
   });
+
+  return sortedTimelineEntries;
 };
 
 export const regionalOfficeCity = (objWithLocation, defaultToUnknown) => {

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -892,7 +892,8 @@ RSpec.feature "Case details", :all_dbs do
 
     describe "CaseTimeline shows judge & attorney tasks" do
       let!(:user) { create(:user) }
-      let!(:appeal) { create(:appeal) }
+      let!(:nod_date_update) { create(:nod_date_update) }
+      let!(:appeal) { create(:appeal, nod_date_updates: [nod_date_update]) }
       let!(:appeal2) { create(:appeal) }
       let!(:root_task) { create(:root_task, appeal: appeal, assigned_to: user) }
       let!(:assign_task) { create(:ama_judge_assign_task, assigned_to: user, parent: root_task) }
@@ -913,6 +914,7 @@ RSpec.feature "Case details", :all_dbs do
         attorney_task.update!(status: Constants.TASK_STATUSES.completed, closed_at: "2019-02-01")
         attorney_task2.update!(status: Constants.TASK_STATUSES.completed, closed_at: "2019-03-01")
         judge_task.update!(status: Constants.TASK_STATUSES.completed, closed_at: Time.zone.now)
+        nod_date_update.update!(updated_at: "2019-01-05")
       end
 
       it "should display judge & attorney tasks, but not judge assign tasks" do
@@ -921,15 +923,18 @@ RSpec.feature "Case details", :all_dbs do
         expect(page.find_all("dl", text: COPY::CASE_TIMELINE_JUDGE_TASK).length).to eq 1
       end
 
-      it "should sort tasks properly" do
+      it "should sort tasks and nod date updates properly" do
         visit "/queue/appeals/#{appeal.uuid}"
         case_timeline_rows = page.find_all("table#case-timeline-table tbody tr")
+        puts(case_timeline_rows)
         first_row_with_date = case_timeline_rows[1]
         second_row_with_date = case_timeline_rows[2]
         third_row_with_date = case_timeline_rows[3]
+        foruth_row_with_date = case_timeline_rows[4]
         expect(first_row_with_date).to have_content("01/01/2020")
         expect(second_row_with_date).to have_content("03/01/2019")
         expect(third_row_with_date).to have_content("02/01/2019")
+        expect(foruth_row_with_date).to have_content("01/05/2019")
       end
 
       it "should NOT display judge & attorney tasks" do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -926,7 +926,6 @@ RSpec.feature "Case details", :all_dbs do
       it "should sort tasks and nod date updates properly" do
         visit "/queue/appeals/#{appeal.uuid}"
         case_timeline_rows = page.find_all("table#case-timeline-table tbody tr")
-        puts(case_timeline_rows)
         first_row_with_date = case_timeline_rows[1]
         second_row_with_date = case_timeline_rows[2]
         third_row_with_date = case_timeline_rows[3]

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -930,11 +930,11 @@ RSpec.feature "Case details", :all_dbs do
         first_row_with_date = case_timeline_rows[1]
         second_row_with_date = case_timeline_rows[2]
         third_row_with_date = case_timeline_rows[3]
-        foruth_row_with_date = case_timeline_rows[4]
+        fourth_row_with_date = case_timeline_rows[4]
         expect(first_row_with_date).to have_content("01/01/2020")
         expect(second_row_with_date).to have_content("03/01/2019")
         expect(third_row_with_date).to have_content("02/01/2019")
-        expect(foruth_row_with_date).to have_content("01/05/2019")
+        expect(fourth_row_with_date).to have_content("01/05/2019")
       end
 
       it "should NOT display judge & attorney tasks" do


### PR DESCRIPTION
Resolves [CASEFLOW-201](https://vajira.max.gov/browse/CASEFLOW-201)

### Description
Add NOD Date Update Component to Case Timeline

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Nod Date Update details display in timeline (user, old NOD, new NOD, change reason) in correctly sorted order

### Testing Plan
- Switch to a used that can edit nod date such as 
- Go to an AMA appeal e.g. 000100013
- Edit the NOD Date if no update exists in the timeline
- Verify that the update appears in the timeline after reloading the page

### User Facing Changes

 BEFORE|AFTER
 ---|---
<img width="860" alt="Screen Shot 2021-02-02 at 4 27 15 PM" src="https://user-images.githubusercontent.com/68879427/106816998-1660c680-662b-11eb-8f6b-fac4b7056bcc.png">|<img width="1183" alt="Screen Shot 2021-02-02 at 3 46 16 PM" src="https://user-images.githubusercontent.com/68879427/106817011-1b257a80-662b-11eb-9052-d1f8d1a53379.png">

### Storybook Story
*For Frontend (Presentational) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file
