### PR TITLE
MDR, DD, SR Mandate Submission

### DIFF
--- a/app/controllers/cavc_remands_controller.rb
+++ b/app/controllers/cavc_remands_controller.rb
@@ -43,7 +43,7 @@ class CavcRemandsController < ApplicationController
   end
 
   def update
-    cavc_remand.update!(update_params)
+    cavc_remand.update(update_params)
     render json: { cavc_remand: cavc_remand, cavc_appeal: cavc_remand.remand_appeal}, status: :ok
   end
 
@@ -51,6 +51,10 @@ class CavcRemandsController < ApplicationController
 
   def source_appeal
     @source_appeal ||= Appeal.find_by_uuid(params[:source_appeal_id])
+  end
+
+  def cavc_remand
+    @cavc_remand ||= CavcRemand.find_by(remand_appeal_id: Appeal.find_by(uuid: params[:appeal_id]).id)
   end
 
   def validate_cavc_remand_access
@@ -62,17 +66,13 @@ class CavcRemandsController < ApplicationController
 
   def update_params
     params.require(UPDATE_PARAMS)
-    params.permit(UPDATE_PARAMS)
+    params.permit(UPDATE_PARAMS).reject{ |param| param == "remand_appeal_id" }
   end
 
   def create_params
     params.merge!(created_by_id: current_user.id, updated_by_id: current_user.id, source_appeal_id: source_appeal.id)
     params.require(required_params_by_decisiontype_and_subtype)
     params.permit(PERMITTED_PARAMS).merge(params.permit(decision_issue_ids: []))
-  end
-
-  def cavc_remand
-    @cavc_remand ||= CavcRemand.find_by(remand_appeal_id: params[:remand_appeal_id])
   end
 
   def required_params_by_decisiontype_and_subtype

--- a/app/controllers/cavc_remands_controller.rb
+++ b/app/controllers/cavc_remands_controller.rb
@@ -5,6 +5,13 @@
 class CavcRemandsController < ApplicationController
   before_action :validate_cavc_remand_access
 
+  UPDATE_PARAMS = [
+    :instructions,
+    :judgement_date,
+    :mandate_date,
+    :remand_appeal_id
+  ].freeze
+
   REMAND_REQUIRED_PARAMS = [
     :source_appeal_id,
     :cavc_decision_type,
@@ -30,14 +37,15 @@ class CavcRemandsController < ApplicationController
   ].flatten.freeze
 
   def create
-    cavc_remand = CavcRemand.create!(create_params)
-    cavc_appeal = cavc_remand.remand_appeal.reload
-    render json: { cavc_remand: cavc_remand, cavc_appeal: cavc_appeal }, status: :created
+    new_cavc_remand = CavcRemand.create!(create_params)
+    cavc_appeal = new_cavc_remand.remand_appeal.reload
+    render json: { cavc_remand: new_cavc_remand, cavc_appeal: cavc_appeal }, status: :created
   end
 
-  #  def update
-  # only for mdr, not yet implemented
-  #  end
+  def update
+    cavc_remand.update!(update_params)
+    render json: { cavc_remand: cavc_remand, cavc_appeal: cavc_remand.remand_appeal}, status: :ok
+  end
 
   private
 
@@ -52,10 +60,19 @@ class CavcRemandsController < ApplicationController
     end
   end
 
+  def update_params
+    params.require(UPDATE_PARAMS)
+    params.permit(UPDATE_PARAMS)
+  end
+
   def create_params
     params.merge!(created_by_id: current_user.id, updated_by_id: current_user.id, source_appeal_id: source_appeal.id)
     params.require(required_params_by_decisiontype_and_subtype)
     params.permit(PERMITTED_PARAMS).merge(params.permit(decision_issue_ids: []))
+  end
+
+  def cavc_remand
+    @cavc_remand ||= CavcRemand.find_by(remand_appeal_id: params[:remand_appeal_id])
   end
 
   def required_params_by_decisiontype_and_subtype

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -53,7 +53,7 @@ class CavcRemand < CaseflowRecord
   end
 
   def establish_appeal_stream
-    self.remand_appeal = source_appeal.create_stream(:court_remand).tap do |cavc_appeal|
+    self.remand_appeal ||= source_appeal.create_stream(:court_remand).tap do |cavc_appeal|
       DecisionIssue.find(decision_issue_ids).map do |cavc_remanded_issue|
         cavc_remanded_issue.create_contesting_request_issue!(cavc_appeal)
       end

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -20,10 +20,6 @@ class CavcRemand < CaseflowRecord
   validates :judgement_date, :mandate_date, presence: true, unless: :mandate_not_required?
   validate :decision_issue_ids_match_appeal_decision_issues, if: -> { remand? && jmr? }
 
-  def mandate_not_required?
-    straight_reversal? || death_dismissal? || (remand? && mdr?)
-  end
-
   before_save :establish_appeal_stream, if: :cavc_remand_form_complete?
 
   enum cavc_decision_type: {
@@ -42,7 +38,7 @@ class CavcRemand < CaseflowRecord
 
   def update(params)
     if(already_has_mandate?)
-      fail Caseflow::Error::MandatedRemandsNoUpdate
+      fail Caseflow::Error::CannotUpdateMandatedRemands
     end
     update!(params)
     end_mandate_hold
@@ -61,7 +57,11 @@ class CavcRemand < CaseflowRecord
   end
 
   def already_has_mandate?
-    !mandate_not_required? || (!remand? && mandate_date)
+    !!mandate_date
+  end
+
+  def mandate_not_required?
+    straight_reversal? || death_dismissal? || (remand? && mdr?)
   end
 
   def establish_appeal_stream

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -77,9 +77,9 @@ class CavcRemand < CaseflowRecord
   def end_mandate_hold
     if remand? && mdr?
       SendCavcRemandProcessedLetterTask.create!(appeal: remand_appeal, parent: cavc_task)
-      MdrTask.find_by(appeal_id: remand_appeal_id).descendants.each { |t| t.completed! }
+      MdrTask.find_by(appeal_id: remand_appeal_id).descendants.each(&:completed!)
     elsif straight_reversal? || death_dismissal?
-      CavcTask.find_by(appeal_id: remand_appeal_id).descendants.each { |t| t.completed! }
+      CavcTask.find_by(appeal_id: remand_appeal_id).descendants.each(&:completed!)
     end
   end
 

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -40,6 +40,14 @@ class CavcRemand < CaseflowRecord
     Constants.CAVC_REMAND_SUBTYPES.mdr.to_sym => Constants.CAVC_REMAND_SUBTYPES.mdr
   }
 
+  def update(params)
+    if(already_has_mandate?)
+      fail Caseflow::Error::MandatedRemandsNoUpdate
+    end
+    update!(params)
+    end_mandate_hold
+  end
+
   private
 
   def decision_issue_ids_match_appeal_decision_issues
@@ -52,6 +60,10 @@ class CavcRemand < CaseflowRecord
     valid? && (mandate_not_required? || (!mandate_date.nil? && !judgement_date.nil?))
   end
 
+  def already_has_mandate?
+    !mandate_not_required? || (!remand? && mandate_date)
+  end
+
   def establish_appeal_stream
     self.remand_appeal ||= source_appeal.create_stream(:court_remand).tap do |cavc_appeal|
       DecisionIssue.find(decision_issue_ids).map do |cavc_remanded_issue|
@@ -60,5 +72,18 @@ class CavcRemand < CaseflowRecord
       AdvanceOnDocketMotion.copy_granted_motions_to_appeal(source_appeal, cavc_appeal)
       InitialTasksFactory.new(cavc_appeal, self).create_root_and_sub_tasks!
     end
+  end
+
+  def end_mandate_hold
+    if remand? && mdr?
+      SendCavcRemandProcessedLetterTask.create!(appeal: remand_appeal, parent: cavc_task)
+      MdrTask.find_by(appeal_id: remand_appeal_id).descendants.each { |t| t.completed! }
+    elsif straight_reversal? || death_dismissal?
+      CavcTask.find_by(appeal_id: remand_appeal_id).descendants.each { |t| t.completed! }
+    end
+  end
+
+  def cavc_task
+    CavcTask.open.where(appeal_id: remand_appeal_id).first
   end
 end

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -53,6 +53,7 @@ const AddCavcDatesModal = ({ appealId, decisionType, error, highlightInvalid, hi
       if (straightReversalType() || deathDismissalType()) {
         return COPY.CAVC_REMAND_READY_FOR_DISTRIBUTION_DETAIL;
       }
+
       return COPY.CAVC_REMAND_CREATED_DETAIL;
     };
 

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-undefined */
 import React, { useState } from 'react';
 import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { withRouter } from 'react-router';
 import PropTypes from 'prop-types';
 
@@ -25,6 +25,7 @@ const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
   const [judgementDate, setJudgementDate] = useState(null);
   const [mandateDate, setMandateDate] = useState(null);
   const [instructions, setInstructions] = useState(undefined);
+  const dispatch = useDispatch();
 
   const validJudgementDate = () => Boolean(judgementDate);
   const validMandateDate = () => Boolean(mandateDate);
@@ -49,7 +50,7 @@ const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
       detail: COPY.CAVC_REMAND_CREATED_DETAIL
     };
 
-    requestPatch(`/appeals/${appealId}/cavc_remand`, payload, successMsg).
+    dispatch(requestPatch(`/appeals/${appealId}/cavc_remand`, payload, successMsg)).
       then(() => {
         history.replace('/queue');
         resolve();
@@ -103,7 +104,7 @@ const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
 
 AddCavcDatesModal.propTypes = {
   appealId: PropTypes.string,
-  requestSave: PropTypes.func,
+  requestPatch: PropTypes.func,
   showErrorMessage: PropTypes.func,
   error: PropTypes.object,
   highlightInvalid: PropTypes.bool,

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -10,6 +10,7 @@ import { requestPatch, showErrorMessage } from './uiReducer/uiActions';
 import DateSelector from '../components/DateSelector';
 import TextareaField from '../components/TextareaField';
 import Alert from '../components/Alert';
+import CAVC_DECISION_TYPES from '../../constants/CAVC_DECISION_TYPES';
 import COPY from '../../COPY';
 
 /**
@@ -20,12 +21,15 @@ import COPY from '../../COPY';
  *  - @param {Object}   history          Provided with react router to be able to route to another page upon success
  */
 
-const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
+const AddCavcDatesModal = ({ appealId, decisionType, error, highlightInvalid, history }) => {
 
   const [judgementDate, setJudgementDate] = useState(null);
   const [mandateDate, setMandateDate] = useState(null);
   const [instructions, setInstructions] = useState(undefined);
   const dispatch = useDispatch();
+
+  const straightReversalType = () => decisionType === CAVC_DECISION_TYPES.straight_reversal;
+  const deathDismissalType = () => decisionType === CAVC_DECISION_TYPES.death_dismissal;
 
   const validJudgementDate = () => Boolean(judgementDate);
   const validMandateDate = () => Boolean(mandateDate);
@@ -45,9 +49,18 @@ const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
       }
     };
 
+    const successMsgDetail = () => {
+      if (straightReversalType() || deathDismissalType()) {
+        return COPY.CAVC_REMAND_READY_FOR_DISTRIBUTION_DETAIL;
+      }
+      else {
+        return COPY.CAVC_REMAND_CREATED_DETAIL
+      }
+    };
+
     const successMsg = {
       title: COPY.CAVC_REMAND_CREATED_TITLE,
-      detail: COPY.CAVC_REMAND_CREATED_DETAIL
+      detail: successMsgDetail()
     };
 
     dispatch(requestPatch(`/appeals/${appealId}/cavc_remand`, payload, successMsg)).
@@ -104,6 +117,7 @@ const AddCavcDatesModal = ({ appealId, error, highlightInvalid, history }) => {
 
 AddCavcDatesModal.propTypes = {
   appealId: PropTypes.string,
+  decisionType: PropTypes.string,
   requestPatch: PropTypes.func,
   showErrorMessage: PropTypes.func,
   error: PropTypes.object,
@@ -111,9 +125,10 @@ AddCavcDatesModal.propTypes = {
   history: PropTypes.object
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, ownProps) => ({
   highlightInvalid: state.ui.highlightFormItems,
   error: state.ui.messages.error,
+  decisionType: state.queue.appealDetails[ownProps.appealId].cavcRemand.cavc_decision_type
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -128,7 +128,7 @@ AddCavcDatesModal.propTypes = {
 const mapStateToProps = (state, ownProps) => ({
   highlightInvalid: state.ui.highlightFormItems,
   error: state.ui.messages.error,
-  decisionType: state.queue.appealDetails[ownProps.appealId].cavcRemand.cavc_decision_type
+  decisionType: state.queue.appealDetails[ownProps.appealId].cavcRemand?.cavc_decision_type
 });
 
 const mapDispatchToProps = (dispatch) => bindActionCreators({

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -53,9 +53,7 @@ const AddCavcDatesModal = ({ appealId, decisionType, error, highlightInvalid, hi
       if (straightReversalType() || deathDismissalType()) {
         return COPY.CAVC_REMAND_READY_FOR_DISTRIBUTION_DETAIL;
       }
-      else {
-        return COPY.CAVC_REMAND_CREATED_DETAIL
-      }
+      return COPY.CAVC_REMAND_CREATED_DETAIL;
     };
 
     const successMsg = {
@@ -128,6 +126,7 @@ AddCavcDatesModal.propTypes = {
 const mapStateToProps = (state, ownProps) => ({
   highlightInvalid: state.ui.highlightFormItems,
   error: state.ui.messages.error,
+  // eslint-disable-next-line camelcase
   decisionType: state.queue.appealDetails[ownProps.appealId].cavcRemand?.cavc_decision_type
 });
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -130,6 +130,7 @@ Rails.application.routes.draw do
       get 'tasks', to: "tasks#for_appeal"
       patch 'update'
       post 'work_mode', to: "work_modes#create"
+      patch 'cavc_remand', to: "cavc_remands#update"
       post 'cavc_remand', to: "cavc_remands#create"
       patch 'nod_date_update', to: "nod_date_updates#update"
     end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -157,7 +157,7 @@ module Caseflow::Error
     end
   end
 
-  class MandatedRemandsNoUpdate < SerializableError
+  class CannotUpdateMandatedRemands < SerializableError
     def initialize
       @message = "Cavc Remands can only be updated if they did not have mandate"
     end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -157,6 +157,12 @@ module Caseflow::Error
     end
   end
 
+  class MandatedRemandsNoUpdate < SerializableError
+    def initialize
+      @message = "Cavc Remands can only be updated if they did not have mandate"
+    end
+  end
+
   class JmrAppealDecisionIssueMismatch < SerializableError
     def initialize(args)
       @code = args[:code] || 422

--- a/spec/controllers/cavc_remands_controller_spec.rb
+++ b/spec/controllers/cavc_remands_controller_spec.rb
@@ -141,15 +141,16 @@ RSpec.describe CavcRemandsController, type: :controller do
 
   describe "PATCH /appeals/:appeal_id/cavc_remands" do
     # create an existing cavc remand
-    let(:cavc_remand) { create(:cavc_remand) }
+    let(:cavc_remand) { create(:cavc_remand, :mdr) }
     let(:remand_appeal_id) { cavc_remand.remand_appeal_id  }
+    let(:remand_appeal_uuid) { Appeal.find(cavc_remand.remand_appeal_id).uuid  }
     let(:judgement_date) { 2.days.ago }
     let(:mandate_date) { 2.days.ago }
     let(:instructions) { "Do this!"  }
     let(:params) do
       {
-        remand_appeal_id: remand_appeal_id,
-        appeal_id: remand_appeal_id,
+        remand_appeal_id: remand_appeal_uuid,
+        appeal_id: remand_appeal_uuid,
         judgement_date: judgement_date,
         mandate_date: mandate_date,
         instructions: instructions
@@ -202,7 +203,6 @@ RSpec.describe CavcRemandsController, type: :controller do
           expect(response_body["cavc_remand"]["judgement_date"].to_date).to eq(judgement_date.to_date)
           expect(response_body["cavc_remand"]["mandate_date"].to_date).to eq(mandate_date.to_date)
           expect(response_body["cavc_remand"]["instructions"]).to eq(instructions)
-
         end
       end
     end

--- a/spec/controllers/cavc_remands_controller_spec.rb
+++ b/spec/controllers/cavc_remands_controller_spec.rb
@@ -11,6 +11,19 @@ RSpec.describe CavcRemandsController, type: :controller do
     CavcLitigationSupport.singleton.users.first
   end
 
+  shared_examples "required cavc lit support user" do
+    context "without a Lit Support User" do
+      it "does not create the CAVC remand" do
+        User.authenticate!(user: create(:user))
+        subject
+
+        expect(response.status).to eq(403)
+        expect(JSON.parse(response.body)["errors"][0]["title"])
+          .to eq("Only CAVC Litigation Support users can create CAVC Remands")
+      end
+    end
+  end
+
   describe "POST /appeals/:appeal_id/cavc_remands" do
     let(:source_appeal) { create(:appeal) }
     let(:source_appeal_id) { source_appeal.uuid }
@@ -119,18 +132,81 @@ RSpec.describe CavcRemandsController, type: :controller do
         let(:remand_subtype) { nil }
 
         include_examples "works without judgement and mandate date parameters"
+     end
+    end
+
+    include_examples "required cavc lit support user"
+  end
+
+
+  describe "PATCH /appeals/:appeal_id/cavc_remands" do
+    # create an existing cavc remand
+    let(:cavc_remand) { create(:cavc_remand) }
+    let(:remand_appeal_id) { cavc_remand.remand_appeal_id  }
+    let(:judgement_date) { 2.days.ago }
+    let(:mandate_date) { 2.days.ago }
+    let(:instructions) { "Do this!"  }
+    let(:params) do
+      {
+        remand_appeal_id: remand_appeal_id,
+        appeal_id: remand_appeal_id,
+        judgement_date: judgement_date,
+        mandate_date: mandate_date,
+        instructions: instructions
+      }
+    end
+
+
+    subject { patch :update, params: params }
+
+    context "with a Lit Support User" do
+      context "with insufficient parameters" do
+        let(:mandate_date) { nil }
+
+        it "does not create the CAVC remand" do
+          expect { subject }.to raise_error do |error|
+            expect(error).to be_a(ActionController::ParameterMissing)
+          end
+        end
+      end
+
+      context "with sufficient parameters" do
+        it "does not create new objects" do
+          existing_remand = Appeal.find(remand_appeal_id)
+          remand_count = CavcRemand.count
+          cavc_count = Appeal.court_remand.count
+
+          expect { subject }.not_to raise_error
+
+          expect(CavcRemand.count).to eq(remand_count)
+          expect(Appeal.court_remand.count).to eq(cavc_count)
+        end
+
+        it "does not change the Remand appeal" do
+          existing_remand = Appeal.find(remand_appeal_id)
+          expect { subject }.not_to raise_error
+          response_body = JSON.parse(response.body)
+          expect(response_body["cavc_appeal"]["id"]).to eq(existing_remand.reload.id)
+          expect(response_body["cavc_appeal"]["updated_at"].to_date).to eq(existing_remand.updated_at.to_date)
+        end
+
+        it "updates the CAVC remand" do
+          existing_remand = Appeal.find(remand_appeal_id)
+
+          expect { subject }.not_to raise_error
+
+          expect(response.status).to eq(200)
+          response_body = JSON.parse(response.body)
+
+          expect(response_body["cavc_remand"]["remand_appeal_id"]).to eq(existing_remand.reload.id)
+          expect(response_body["cavc_remand"]["judgement_date"].to_date).to eq(judgement_date.to_date)
+          expect(response_body["cavc_remand"]["mandate_date"].to_date).to eq(mandate_date.to_date)
+          expect(response_body["cavc_remand"]["instructions"]).to eq(instructions)
+
+        end
       end
     end
 
-    context "without a Lit Support User" do
-      it "does not create the CAVC remand" do
-        User.authenticate!(user: create(:user))
-        subject
-
-        expect(response.status).to eq(403)
-        expect(JSON.parse(response.body)["errors"][0]["title"])
-          .to eq("Only CAVC Litigation Support users can create CAVC Remands")
-      end
-    end
+    include_examples "required cavc lit support user"
   end
 end

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -185,7 +185,7 @@ describe CavcRemand do
     context "on a JMR appeal" do
       let(:cavc_remand) { create(:cavc_remand) }
       it "throws an error" do
-        expect { subject }.to raise_error(Caseflow::Error::MandatedRemandsNoUpdate)
+        expect { subject }.to raise_error(Caseflow::Error::CannotUpdateMandatedRemands)
       end
     end
 
@@ -207,6 +207,7 @@ describe CavcRemand do
         expect(mdr_task.reload.open?).to be(false)
         expect(hold_task.reload.open?).to be(false)
       end
+
       it "opens a CAVC Send Letter task" do
         existing_remand = cavc_remand.remand_appeal
         expect { subject }.not_to raise_error
@@ -218,7 +219,7 @@ describe CavcRemand do
       context "that had mandate" do
         let(:cavc_remand) { create(:cavc_remand, type) }
         it "throws an error" do
-          expect { subject }.to raise_error(Caseflow::Error::MandatedRemandsNoUpdate)
+          expect { subject }.to raise_error(Caseflow::Error::CannotUpdateMandatedRemands)
         end
       end
 

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -165,4 +165,93 @@ describe CavcRemand do
       include_examples "works for all remand subtypes"
     end
   end
+
+  describe ".update!" do
+    let(:remand_appeal_id) { cavc_remand.remand_appeal_id  }
+    let(:remand_appeal_uuid) { Appeal.find(cavc_remand.remand_appeal_id).uuid  }
+    let(:judgement_date) { 2.days.ago }
+    let(:mandate_date) { 2.days.ago }
+    let(:instructions) { "Do this!"  }
+    let(:params) do
+      {
+        judgement_date: judgement_date,
+        mandate_date: mandate_date,
+        instructions: instructions
+      }
+    end
+
+    subject { cavc_remand.update(params) }
+
+    context "on a JMR appeal" do
+      let(:cavc_remand) { create(:cavc_remand) }
+      it "throws an error" do
+        expect { subject }.to raise_error(Caseflow::Error::MandatedRemandsNoUpdate)
+      end
+    end
+
+    context "on an MDR appeal" do
+      let(:cavc_remand) { create(:cavc_remand, :mdr) }
+      it "completes the MDR hold" do
+        existing_remand = cavc_remand.remand_appeal
+        cavc_task = CavcTask.find_by(appeal_id: remand_appeal_id)
+        mdr_task = MdrTask.find_by(appeal_id: remand_appeal_id)
+        hold_task = TimedHoldTask.find_by(appeal_id: remand_appeal_id)
+
+        expect(cavc_task.open?).to be(true)
+        expect(mdr_task.open?).to be(true)
+        expect(hold_task.open?).to be(true)
+
+        expect { subject }.not_to raise_error
+
+        expect(cavc_task.reload.open?).to be(true)
+        expect(mdr_task.reload.open?).to be(false)
+        expect(hold_task.reload.open?).to be(false)
+      end
+      it "opens a CAVC Send Letter task" do
+        existing_remand = cavc_remand.remand_appeal
+        expect { subject }.not_to raise_error
+        expect(SendCavcRemandProcessedLetterTask.find_by(appeal_id: remand_appeal_id).open?).to be(true)
+      end
+    end
+
+    shared_examples "shared straight reversal death dismissal flow" do |type|
+      context "that had mandate" do
+        let(:cavc_remand) { create(:cavc_remand, type) }
+        it "throws an error" do
+          expect { subject }.to raise_error(Caseflow::Error::MandatedRemandsNoUpdate)
+        end
+      end
+
+      context "without mandate" do
+        let(:cavc_remand) { create(:cavc_remand, type, :no_mandate) }
+        it "sends the appeal to distribution" do
+          existing_remand = cavc_remand.remand_appeal
+          dist_task = DistributionTask.find_by(appeal_id: remand_appeal_id)
+          cavc_task = CavcTask.find_by(appeal_id: remand_appeal_id)
+          mandate_hold_task = MandateHoldTask.find_by(appeal_id: remand_appeal_id)
+          hold_task = TimedHoldTask.find_by(appeal_id: remand_appeal_id)
+
+          expect(dist_task.open?).to be(true)
+          expect(cavc_task.open?).to be(true)
+          expect(mandate_hold_task.open?).to be(true)
+          expect(hold_task.open?).to be(true)
+
+          expect { subject }.not_to raise_error
+
+          expect(dist_task.reload.active?).to be(true)
+          expect(cavc_task.reload.open?).to be(false)
+          expect(mandate_hold_task.reload.open?).to be(false)
+          expect(hold_task.reload.open?).to be(false)
+        end
+      end
+    end
+
+    context "on a Straight Reversal appeal" do
+      include_examples "shared straight reversal death dismissal flow", :straight_reversal
+    end
+
+    context "on a Death Dismissal appeal" do
+      include_examples "shared straight reversal death dismissal flow", :death_dismissal
+    end
+  end
 end


### PR DESCRIPTION
Bumps [CASEFLOW-98](https://vajira.max.gov/browse/CASEFLOW-98)

### Description
Allows for the submission of the Mandate form on MDR, DD, and SR.

Stack PR for [CASEFLOW-98](https://vajira.max.gov/browse/CASEFLOW-98)

Part 1 - Adds the Remand Received action to MDR Task #15860
Part 2 - Allows for the submission of the Mandate form on MDR, DD, and SR.
Part 3 - TK FeatureTest & seeds

### Acceptance Criteria
 - [ ] Work is behind the feature toggle: mdr_cavc_remand
 - [ ] Accessible to the CAVC Litigation Support team
 - [ ] Verify confirmation banner is presented on the users queue when submit is clicked on the new page with the following copy:
"You have successfully created a CAVC Remand case
This has generated a 90 day letter task in your organizations queue"
 - [ ]  On submission of the form for MDR
   - the missing dates and instructions on an MDR are updated
   - the MDR task is completed
   - the 90 day letter task is created in CAVC Litigation Supports queue
 - [ ]  On submission of the form for SR & DD
   - the missing dates and instructions on an MDR are updated
   - the MDR & CAVC task are completed
   - the Distribution Task is active
   - the success detail says it went to distribution _instead_ of to CAVC Lit Support queue

### Testing Plan
1. Create an MDR cavc remand
    `FactoryBot.create(:cavc_remand, :mdr).remand_appeal.uuid`
2. Sign in as a CAVC Lit Support user and navigate to the appeal
3. fill out the form & submit
   - [ ] Confirm it submits & shows the message
   - [ ] Confirm the appeal has its send letter task assigned to CavcLitSupport
4. Repeat for No mandate Straight Reversal
    `FactoryBot.create(:cavc_remand, :straight_reversal, :no_mandate).remand_appeal.uuid`
   - [ ] Confirm it submits & shows the message
   - [ ] Confirm the appeal has an active Distribution Task
5. Repeat for No mandate Death Dismissal
   `FactoryBot.create(:cavc_remand, :death_dismissal, :no_mandate).remand_appeal.uuid`
   - [ ] Confirm it submits & shows the message
   - [ ] Confirm the appeal has an active Distribution Task