### PR TITLE
original_request_type for appeals & legacy appeals

### DIFF
--- a/app/models/concerns/hearing_request_type_concern.rb
+++ b/app/models/concerns/hearing_request_type_concern.rb
@@ -17,9 +17,14 @@ module HearingRequestTypeConcern
                 message: "changed request type (%<value>s) is invalid"
               },
               allow_nil: true
-  end
 
-  class InvalidChangedRequestType < StandardError; end
+    validates :original_request_type,
+              inclusion: {
+                in: %w[central central_office travel_board video virtual],
+                message: "original request type (%<value>s) is invalid"
+              },
+              allow_nil: true
+  end
 
   # uses the paper_trail version on LegacyAppeal
   def latest_appeal_event
@@ -27,21 +32,16 @@ module HearingRequestTypeConcern
   end
 
   def original_hearing_request_type(readable: false)
-    # Use the VACOLS value for LegacyAppeals otherwise use the closest regional office
-    original_hearing_request_type = is_a?(LegacyAppeal) ? hearing_request_type : closest_regional_office
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(original_hearing_request_type)
+    # get the formatted original request type (and save it if it's not already saved)
+    formatted_request_type = save_original_hearing_request_type
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
   end
 
   def current_hearing_request_type(readable: false)
-    request_type = changed_request_type.presence || original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(changed_request_type)
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
@@ -54,36 +54,37 @@ module HearingRequestTypeConcern
     diff = latest_appeal_event&.diff || {} # Example of diff: {"changed_request_type"=>[nil, "R"]}
     previous_hearing_request_type = diff["changed_request_type"]&.first
 
-    request_type = previous_hearing_request_type.presence || original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(previous_hearing_request_type)
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
   end
 
-  def hearing_request_type_for_task(id, version)
-    return nil if id.nil?
+  def hearing_request_type_for_task(task_id, version)
+    return nil if task_id.nil?
 
-    request_type_index = tasks.where(type: "ChangeHearingRequestTypeTask").order(:created_at).map(&:id).index(id)
+    request_type_index = tasks.where(type: "ChangeHearingRequestTypeTask").order(:id).map(&:id).index(task_id)
 
     diff = versions[request_type_index].changeset["changed_request_type"]
     versioned_request_type = (version == :prev) ? diff&.first : diff&.last
 
-    # Revive the original appeal to retrieve its values
-    original = versions[request_type_index].reify
-
-    request_type = versioned_request_type.presence || original.original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(versioned_request_type)
 
     # Return the human readable request type or the symbol of request type
     LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type]
   end
 
   private
+
+  def format_or_formatted_original_request_type(request_type)
+    if request_type.present?
+      format_hearing_request_type(request_type)
+    else
+      original_hearing_request_type
+    end
+  end
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_hearing_request_type(request_type)
@@ -92,6 +93,8 @@ module HearingRequestTypeConcern
     case request_type
     when HearingDay::REQUEST_TYPES[:central], :central_office, :central
       is_a?(LegacyAppeal) ? :central_office : :central
+    when HearingDay::REQUEST_TYPES[:travel]
+      :travel_board
     when :travel_board
       video_hearing_requested ? :video : :travel_board
     when HearingDay::REQUEST_TYPES[:virtual]
@@ -101,4 +104,16 @@ module HearingRequestTypeConcern
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+
+  def save_original_hearing_request_type
+    return original_request_type.to_sym if original_request_type.present?
+
+    # Use the VACOLS value for LegacyAppeals, otherwise use the closest regional office
+    original = is_a?(LegacyAppeal) ? hearing_request_type : closest_regional_office
+    # Format the request type into a symbol
+    formatted_request_type = format_hearing_request_type(original)
+    # save the original type for future reference
+    update!(original_request_type: formatted_request_type&.to_s)
+    formatted_request_type
+  end
 end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -85,6 +85,8 @@ class ChangeHearingRequestTypeTask < Task
 
   def update_appeal_and_self(payload_values, params)
     multi_transaction do
+      # this will save the original request type if needed
+      appeal.original_hearing_request_type
       appeal.update!(
         changed_request_type: payload_values[:changed_request_type],
         closest_regional_office: payload_values[:closest_regional_office]

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -185,14 +185,14 @@ class ScheduleHearingTask < Task
 
   # Method to change the hearing request type on an appeal
   def change_hearing_request_type(params, current_user)
-    changed_request_type = ChangeHearingRequestTypeTask.create!(
+    change_hearing_request_type_task = ChangeHearingRequestTypeTask.create!(
       appeal: appeal,
       assigned_to: current_user,
       parent: self
     )
 
     # Call the child method so that we follow that workflow when changing the hearing request type
-    changed_request_type.update_from_params(params, current_user)
+    change_hearing_request_type_task.update_from_params(params, current_user)
   end
 
   def cancel_parent_task(parent)

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -209,11 +209,8 @@ class CachedAppealService
   end
 
   # Gets the symbolic representation of the original type of hearing requested for a vacols case record
-  # Replicates logic in LegacyAppeal#original_hearing_request_type
   def original_hearing_request_type_for_vacols_case(vacols_case)
-    request_type = VACOLS::Case::HEARING_REQUEST_TYPES[vacols_case.bfhr]
-
-    (request_type == :travel_board && vacols_case.bfdocind == "V") ? :video : request_type
+    LegacyAppeal.find_or_create_by_vacols_id(vacols_case.bfkey).original_hearing_request_type
   end
 
   # Maps vacols ids to their leagcy appeal's changed hearing request type

--- a/db/migrate/20210205182635_add_original_request_type_to_appeal.rb
+++ b/db/migrate/20210205182635_add_original_request_type_to_appeal.rb
@@ -1,0 +1,8 @@
+class AddOriginalRequestTypeToAppeal < Caseflow::Migration
+  def change
+    add_column :appeals,
+      :original_request_type,
+      :string,
+      comment: "The hearing type preference for an appellant before any changes were made in Caseflow"
+  end
+end

--- a/db/migrate/20210205182649_add_original_request_type_to_legacy_appeal.rb
+++ b/db/migrate/20210205182649_add_original_request_type_to_legacy_appeal.rb
@@ -1,0 +1,8 @@
+class AddOriginalRequestTypeToLegacyAppeal < Caseflow::Migration
+  def change
+    add_column :legacy_appeals,
+      :original_request_type,
+      :string,
+      comment: "The hearing type preference for an appellant before any changes were made in Caseflow"
+  end
+end

--- a/db/migrate/20210205183027_update_change_request_type_comments_on_legacy_appeals.rb
+++ b/db/migrate/20210205183027_update_change_request_type_comments_on_legacy_appeals.rb
@@ -1,0 +1,5 @@
+class UpdateChangeRequestTypeCommentsOnLegacyAppeals < ActiveRecord::Migration[5.2]
+  def change
+    change_column_comment :legacy_appeals, :changed_request_type, "The new hearing type preference for an appellant that needs a hearing scheduled"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1509,7 +1509,6 @@ ActiveRecord::Schema.define(version: 2021_02_05_183027) do
     t.string "closest_regional_office"
     t.datetime "created_at"
     t.date "date_of_death", comment: "Date of Death reported by BGS, cached locally"
-    t.datetime "date_of_death_reported_at", comment: "The datetime that date_of_death last changed for veteran."
     t.string "file_number", null: false
     t.string "first_name"
     t.string "last_name"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_15_212305) do
+ActiveRecord::Schema.define(version: 2021_02_05_183027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_212305) do
     t.datetime "establishment_processed_at", comment: "Timestamp for when the establishment has succeeded in processing."
     t.datetime "establishment_submitted_at", comment: "Timestamp for when the the intake was submitted for asynchronous processing."
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
+    t.string "original_request_type", comment: "The hearing type preference for an appellant before any changes were made in Caseflow"
     t.string "poa_participant_id", comment: "Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
     t.date "receipt_date", comment: "Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues."
     t.string "stream_docket_number", comment: "Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
@@ -898,7 +899,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_212305) do
 
   create_table "legacy_appeals", force: :cascade do |t|
     t.bigint "appeal_series_id"
-    t.string "changed_request_type", comment: "The new hearing type preference for an appellant that had previously requested a travel board hearing"
+    t.string "changed_request_type", comment: "The new hearing type preference for an appellant that needs a hearing scheduled"
     t.string "closest_regional_office"
     t.boolean "contaminated_water_at_camp_lejeune", default: false
     t.datetime "created_at"
@@ -917,6 +918,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_212305) do
     t.boolean "mustard_gas", default: false
     t.boolean "national_cemetery_administration", default: false
     t.boolean "nonrating_issue", default: false
+    t.string "original_request_type", comment: "The hearing type preference for an appellant before any changes were made in Caseflow"
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false
     t.boolean "radiation", default: false
@@ -1507,6 +1509,7 @@ ActiveRecord::Schema.define(version: 2021_01_15_212305) do
     t.string "closest_regional_office"
     t.datetime "created_at"
     t.date "date_of_death", comment: "Date of Death reported by BGS, cached locally"
+    t.datetime "date_of_death_reported_at", comment: "The datetime that date_of_death last changed for veteran."
     t.string "file_number", null: false
     t.string "first_name"
     t.string "last_name"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -57,6 +57,7 @@ appeals,establishment_processed_at,datetime,,,,,,Timestamp for when the establis
 appeals,establishment_submitted_at,datetime,,,,,,Timestamp for when the the intake was submitted for asynchronous processing.
 appeals,id,integer (8) PK,x,x,,,,
 appeals,legacy_opt_in_approved,boolean,,,,,,Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review.
+appeals,original_request_type,string,,,,,,The hearing type preference for an appellant before any changes were made in Caseflow
 appeals,poa_participant_id,string,,,,,,"Used to identify the power of attorney (POA) at the time the appeal was dispatched to BVA. Sometimes the POA changes in BGS after the fact, and BGS only returns the current representative."
 appeals,receipt_date,date ∗,x,,,,,Receipt date of the appeal form. Used to determine which issues are within the timeliness window to be appealed. Only issues decided prior to the receipt date will show up as contestable issues.
 appeals,stream_docket_number,string,,,,,,"Multiple appeals with the same docket number indicate separate appeal streams, mimicking the structure of legacy appeals."
@@ -677,7 +678,7 @@ judge_case_reviews,task_id,string ∗ FK,x,,x,,,
 judge_case_reviews,updated_at,datetime ∗,x,,,,x,
 legacy_appeals,,,,,,,,
 legacy_appeals,appeal_series_id,integer (8) FK,,,x,,x,
-legacy_appeals,changed_request_type,string,,,,,,The new hearing type preference for an appellant that had previously requested a travel board hearing
+legacy_appeals,changed_request_type,string,,,,,,The new hearing type preference for an appellant that needs a hearing scheduled
 legacy_appeals,closest_regional_office,string,,,,,,
 legacy_appeals,contaminated_water_at_camp_lejeune,boolean,,,,,,
 legacy_appeals,created_at,datetime,,,,,,
@@ -697,6 +698,7 @@ legacy_appeals,manlincon_compliance,boolean,,,,,,
 legacy_appeals,mustard_gas,boolean,,,,,,
 legacy_appeals,national_cemetery_administration,boolean,,,,,,
 legacy_appeals,nonrating_issue,boolean,,,,,,
+legacy_appeals,original_request_type,string,,,,,,The hearing type preference for an appellant before any changes were made in Caseflow
 legacy_appeals,pension_united_states,boolean,,,,,,
 legacy_appeals,private_attorney_or_agent,boolean,,,,,,
 legacy_appeals,radiation,boolean,,,,,,
@@ -1143,6 +1145,7 @@ veterans,,,,,,,,
 veterans,closest_regional_office,string,,,,,,
 veterans,created_at,datetime,,,,,,
 veterans,date_of_death,date,,,,,,"Date of Death reported by BGS, cached locally"
+veterans,date_of_death_reported_at,datetime,,,,,,The datetime that date_of_death last changed for veteran.
 veterans,file_number,string ∗,x,,,,x,
 veterans,first_name,string ∗,x,,,,,
 veterans,id,integer (8) PK,x,x,,,,

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1145,7 +1145,6 @@ veterans,,,,,,,,
 veterans,closest_regional_office,string,,,,,,
 veterans,created_at,datetime,,,,,,
 veterans,date_of_death,date,,,,,,"Date of Death reported by BGS, cached locally"
-veterans,date_of_death_reported_at,datetime,,,,,,The datetime that date_of_death last changed for veteran.
 veterans,file_number,string ∗,x,,,,x,
 veterans,first_name,string ∗,x,,,,,
 veterans,id,integer (8) PK,x,x,,,,


### PR DESCRIPTION
Connects [CASEFLOW-425](https://vajira.max.gov/browse/CASEFLOW-425)

🥞  stacked PR 2 of 3
part 1: #15847
part 3: #15883

### Description
Adds a new column to appeals and legacy appeals that will store the hearing request type before any changes are made in Caseflow.

### Database Changes
*Only for Schema Changes*

* [x] Column comments updated
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
