### PR TITLE
Prevent selection of current docket on DocketSwitchReviewRequestForm

### DIFF
--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestContainer.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestContainer.jsx
@@ -34,6 +34,7 @@ export const DocketSwitchReviewRequestContainer = () => {
         onCancel={handleCancel}
         onSubmit={handleSubmit}
         appellantName={appeal.appellantFullName}
+        docketFrom={appeal.docketName}
         issues={appeal.issues}
       />
     </>

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.jsx
@@ -42,6 +42,7 @@ export const DocketSwitchReviewRequestForm = ({
   onSubmit,
   onCancel,
   appellantName,
+  docketFrom,
   issues,
 }) => {
   const {
@@ -75,6 +76,15 @@ export const DocketSwitchReviewRequestForm = ({
       ),
     []
   );
+
+  // We want to prevent accidental selection of the same docket type
+  const filteredDocketTypeOpts = useMemo(() => {
+    return docketTypeRadioOptions.map(({ value, displayText }) => ({
+      value,
+      displayText: value === docketFrom ? `${displayText} (current docket)` : displayText,
+      disabled: value === docketFrom,
+    }));
+  }, [docketTypeRadioOptions, docketFrom]);
 
   const watchDisposition = watch('disposition');
 
@@ -147,7 +157,7 @@ export const DocketSwitchReviewRequestForm = ({
           <RadioField
             name="docketType"
             label="Which docket will the issue(s) be switched to?"
-            options={docketTypeRadioOptions}
+            options={filteredDocketTypeOpts}
             inputRef={register}
             strongLabel
             vertical
@@ -169,5 +179,6 @@ DocketSwitchReviewRequestForm.propTypes = {
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func,
   appellantName: PropTypes.string.isRequired,
+  docketFrom: PropTypes.string.isRequired,
   issues: PropTypes.array,
 };

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.stories.js
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.stories.js
@@ -16,8 +16,9 @@ export default {
   ],
   parameters: {},
   args: {
-  appellantName: 'Jane Doe',
-  issues
+    appellantName: 'Jane Doe',
+    docketFrom: 'direct_review',
+    issues,
   },
   argTypes: {
     onCancel: { action: 'cancel' },
@@ -31,6 +32,7 @@ export const Basic = Template.bind({});
 
 Basic.parameters = {
   docs: {
-    storyDescription: 'Used by attorney in Clerk of the Board office to complete a grant of a docket switch checkout flow ',
+    storyDescription:
+      'Used by attorney in Clerk of the Board office to complete a grant of a docket switch checkout flow ',
   },
 };

--- a/client/test/app/queue/docketSwitch/DocketSwitchReviewRequestForm.test.js
+++ b/client/test/app/queue/docketSwitch/DocketSwitchReviewRequestForm.test.js
@@ -17,7 +17,8 @@ describe('DocketSwitchReviewRequestForm', () => {
     { id: 1, program: 'compensation', description: 'PTSD denied' },
     { id: 2, program: 'compensation', description: 'Left  knee denied' },
   ];
-  const defaults = { onSubmit, onCancel, appellantName, issues };
+  const docketFrom = 'evidence_submission';
+  const defaults = { onSubmit, onCancel, appellantName, docketFrom, issues };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -40,6 +41,24 @@ describe('DocketSwitchReviewRequestForm', () => {
     ).toBeInTheDocument();
   });
 
+  it('disables current docket', async () => {
+    render(<DocketSwitchReviewRequestForm {...defaults} />);
+
+    // Set disposition to show docket selection
+    await userEvent.click(
+      screen.getByRole('radio', { name: /grant all issues/i })
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Evidence Submission (current docket)')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('radio', { name: /evidence submission/i })
+      ).toBeDisabled();
+    });
+  });
+
   it('fires onCancel', async () => {
     render(<DocketSwitchReviewRequestForm {...defaults} />);
     expect(onCancel).not.toHaveBeenCalled();
@@ -51,8 +70,6 @@ describe('DocketSwitchReviewRequestForm', () => {
 
   describe('form validation for all granted issues', () => {
     const receiptDate = '2020-10-01';
-    const disposition = 'granted';
-    const docketType = 'direct_review';
 
     it('fires onSubmit with correct values', async () => {
       render(<DocketSwitchReviewRequestForm {...defaults} />);
@@ -71,7 +88,9 @@ describe('DocketSwitchReviewRequestForm', () => {
 
       // Wait for docketType to show up
       await waitFor(() => {
-        expect(screen.getByRole('radio', { name: /direct review/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('radio', { name: /direct review/i })
+        ).toBeInTheDocument();
       });
 
       //   Set docketType
@@ -86,7 +105,7 @@ describe('DocketSwitchReviewRequestForm', () => {
       await userEvent.click(submit);
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalled();
       });
     });
   });
@@ -95,7 +114,7 @@ describe('DocketSwitchReviewRequestForm', () => {
     const receiptDate = '2020-10-01';
     const disposition = 'partially_granted';
     const docketType = 'direct_review';
-    const issueIds = ['1']
+    const issueIds = ['1'];
     const fillForm = async () => {
       //   Set receipt date
       await fireEvent.change(screen.getByLabelText(/receipt date/i), {
@@ -125,7 +144,9 @@ describe('DocketSwitchReviewRequestForm', () => {
 
       // Wait for docketType to show up
       await waitFor(() => {
-        expect(screen.getByRole('radio', { name: /direct review/i })).toBeInTheDocument();
+        expect(
+          screen.getByRole('radio', { name: /direct review/i })
+        ).toBeInTheDocument();
       });
 
       //   Set docketType
@@ -149,7 +170,7 @@ describe('DocketSwitchReviewRequestForm', () => {
       await userEvent.click(submit);
 
       await waitFor(() => {
-        expect(onSubmit).toHaveBeenCalled()
+        expect(onSubmit).toHaveBeenCalled();
       });
     });
   });


### PR DESCRIPTION
### Description
Adds logic to `DocketSwitchReviewRequestForm` to prevent selection of the current docket type

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Radio button for current docket type is disabled and label indicates it is current type


### Design
<img width="849" alt="Screen Shot 2021-02-05 at 12 47 24 PM" src="https://user-images.githubusercontent.com/2581274/107102104-44cad700-67ce-11eb-9f99-7f6571c2cf56.png">

### Testing
Verification of this can be done in Storybook