### PR TITLE
Store original hearing request type on appeals and legacy appeals

### DIFF
--- a/app/models/concerns/hearing_request_type_concern.rb
+++ b/app/models/concerns/hearing_request_type_concern.rb
@@ -17,9 +17,14 @@ module HearingRequestTypeConcern
                 message: "changed request type (%<value>s) is invalid"
               },
               allow_nil: true
-  end
 
-  class InvalidChangedRequestType < StandardError; end
+    validates :original_request_type,
+              inclusion: {
+                in: %w[central central_office travel_board video virtual],
+                message: "original request type (%<value>s) is invalid"
+              },
+              allow_nil: true
+  end
 
   # uses the paper_trail version on LegacyAppeal
   def latest_appeal_event
@@ -27,21 +32,16 @@ module HearingRequestTypeConcern
   end
 
   def original_hearing_request_type(readable: false)
-    # Use the VACOLS value for LegacyAppeals otherwise use the closest regional office
-    original_hearing_request_type = is_a?(LegacyAppeal) ? hearing_request_type : closest_regional_office
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(original_hearing_request_type)
+    # get the formatted original request type (and save it if it's not already saved)
+    formatted_request_type = save_original_hearing_request_type
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
   end
 
   def current_hearing_request_type(readable: false)
-    request_type = changed_request_type.presence || original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(changed_request_type)
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
@@ -54,36 +54,37 @@ module HearingRequestTypeConcern
     diff = latest_appeal_event&.diff || {} # Example of diff: {"changed_request_type"=>[nil, "R"]}
     previous_hearing_request_type = diff["changed_request_type"]&.first
 
-    request_type = previous_hearing_request_type.presence || original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(previous_hearing_request_type)
 
     # Return the human readable request type or the symbol of request type
     readable ? LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type] : formatted_request_type
   end
 
-  def hearing_request_type_for_task(id, version)
-    return nil if id.nil?
+  def hearing_request_type_for_task(task_id, version)
+    return nil if task_id.nil?
 
-    request_type_index = tasks.where(type: "ChangeHearingRequestTypeTask").order(:created_at).map(&:id).index(id)
+    request_type_index = tasks.where(type: "ChangeHearingRequestTypeTask").order(:id).map(&:id).index(task_id)
 
     diff = versions[request_type_index].changeset["changed_request_type"]
     versioned_request_type = (version == :prev) ? diff&.first : diff&.last
 
-    # Revive the original appeal to retrieve its values
-    original = versions[request_type_index].reify
-
-    request_type = versioned_request_type.presence || original.original_hearing_request_type
-
-    # Format the request type into a symbol
-    formatted_request_type = format_hearing_request_type(request_type)
+    # Format the request type into a symbol, or retrieve the original request type
+    formatted_request_type = format_or_formatted_original_request_type(versioned_request_type)
 
     # Return the human readable request type or the symbol of request type
     LegacyAppeal::READABLE_HEARING_REQUEST_TYPES[formatted_request_type]
   end
 
   private
+
+  def format_or_formatted_original_request_type(request_type)
+    if request_type.present?
+      format_hearing_request_type(request_type)
+    else
+      original_hearing_request_type
+    end
+  end
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_hearing_request_type(request_type)
@@ -92,6 +93,8 @@ module HearingRequestTypeConcern
     case request_type
     when HearingDay::REQUEST_TYPES[:central], :central_office, :central
       is_a?(LegacyAppeal) ? :central_office : :central
+    when HearingDay::REQUEST_TYPES[:travel]
+      :travel_board
     when :travel_board
       video_hearing_requested ? :video : :travel_board
     when HearingDay::REQUEST_TYPES[:virtual]
@@ -101,4 +104,16 @@ module HearingRequestTypeConcern
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity
+
+  def save_original_hearing_request_type
+    return original_request_type.to_sym if original_request_type.present?
+
+    # Use the VACOLS value for LegacyAppeals, otherwise use the closest regional office
+    original = is_a?(LegacyAppeal) ? hearing_request_type : closest_regional_office
+    # Format the request type into a symbol
+    formatted_request_type = format_hearing_request_type(original)
+    # save the original type for future reference
+    update!(original_request_type: formatted_request_type&.to_s)
+    formatted_request_type
+  end
 end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -85,6 +85,8 @@ class ChangeHearingRequestTypeTask < Task
 
   def update_appeal_and_self(payload_values, params)
     multi_transaction do
+      # this will save the original request type if needed
+      appeal.original_hearing_request_type
       appeal.update!(
         changed_request_type: payload_values[:changed_request_type],
         closest_regional_office: payload_values[:closest_regional_office]

--- a/app/models/tasks/schedule_hearing_task.rb
+++ b/app/models/tasks/schedule_hearing_task.rb
@@ -185,14 +185,14 @@ class ScheduleHearingTask < Task
 
   # Method to change the hearing request type on an appeal
   def change_hearing_request_type(params, current_user)
-    changed_request_type = ChangeHearingRequestTypeTask.create!(
+    change_hearing_request_type_task = ChangeHearingRequestTypeTask.create!(
       appeal: appeal,
       assigned_to: current_user,
       parent: self
     )
 
     # Call the child method so that we follow that workflow when changing the hearing request type
-    changed_request_type.update_from_params(params, current_user)
+    change_hearing_request_type_task.update_from_params(params, current_user)
   end
 
   def cancel_parent_task(parent)

--- a/app/services/cached_appeal_service.rb
+++ b/app/services/cached_appeal_service.rb
@@ -209,11 +209,8 @@ class CachedAppealService
   end
 
   # Gets the symbolic representation of the original type of hearing requested for a vacols case record
-  # Replicates logic in LegacyAppeal#original_hearing_request_type
   def original_hearing_request_type_for_vacols_case(vacols_case)
-    request_type = VACOLS::Case::HEARING_REQUEST_TYPES[vacols_case.bfhr]
-
-    (request_type == :travel_board && vacols_case.bfdocind == "V") ? :video : request_type
+    LegacyAppeal.find_or_create_by_vacols_id(vacols_case.bfkey).original_hearing_request_type
   end
 
   # Maps vacols ids to their leagcy appeal's changed hearing request type


### PR DESCRIPTION
Connects [CASEFLOW-425](https://vajira.max.gov/browse/CASEFLOW-425)

🥞  stacked PR 3 of 3
part 1: #15847
part 2: #15879

### Description
Saves the original hearing request type on appeal and legacy appeal models, and uses that value when it's available.