### PR TITLE
Remove Unused Hearings Code

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -258,14 +258,6 @@ class Appeal < DecisionReview
     @veteran_if_exists ||= Veteran.find_by_file_number(veteran_file_number)
   end
 
-  def veteran_closest_regional_office
-    veteran_if_exists&.closest_regional_office
-  end
-
-  def veteran_available_hearing_locations
-    veteran_if_exists&.available_hearing_locations
-  end
-
   def regional_office_key
     nil
   end

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -33,6 +33,10 @@ class SentHearingEmailEvent < CaseflowRecord
     }
   ), _prefix: :is
 
+  def readonly?
+    !new_record?
+  end
+
   def sent_to_role
     case recipient_role
     when "judge"

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -33,10 +33,6 @@ class SentHearingEmailEvent < CaseflowRecord
     }
   ), _prefix: :is
 
-  def readonly?
-    !new_record?
-  end
-
   def sent_to_role
     case recipient_role
     when "judge"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -438,13 +438,6 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     @user_info ||= self.class.user_repository.user_info_from_vacols(css_id)
   end
 
-  def get_appeal_stream_hearings(appeal_streams)
-    appeal_streams.reduce({}) do |acc, (appeal_id, appeals)|
-      acc[appeal_id] = appeal_hearings(appeals.map(&:id))
-      acc
-    end
-  end
-
   def appeal_hearings(appeal_ids)
     LegacyHearing.where(appeal_id: appeal_ids)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -438,10 +438,6 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     @user_info ||= self.class.user_repository.user_info_from_vacols(css_id)
   end
 
-  def appeal_hearings(appeal_ids)
-    LegacyHearing.where(appeal_id: appeal_ids)
-  end
-
   class << self
     attr_writer :authentication_service
     delegate :authenticate_vacols, to: :authentication_service

--- a/app/models/vacols/travel_board_schedule.rb
+++ b/app/models/vacols/travel_board_schedule.rb
@@ -15,28 +15,6 @@ class VACOLS::TravelBoardSchedule < VACOLS::Record
 
   # :nocov:
   class << self
-    def hearings_for_judge_before_hearing_prep_cutoff_date(css_id)
-      id = connection.quote(css_id)
-
-      # css_id is stored in the STAFF.SDOMAINID column and corresponds to TBSCHED.tbmem1, tbmem2, tbmem3, tbmem4
-      select("(TBSCHED.TBYEAR||'-'||TBSCHED.TBTRIP||'-'||TBSCHED.TBLEG) as tbsched_vdkey",
-             :tbmem1,
-             :tbmem2,
-             :tbmem3,
-             :tbmem4,
-             :tbro,
-             :tbstdate,
-             :tbenddate)
-        .joins("join staff on
-                staff.sattyid = tbmem1 OR
-                staff.sattyid = tbmem2 OR
-                staff.sattyid = tbmem3 OR
-                staff.sattyid = tbmem4")
-        .where("staff.sdomainid = #{id}")
-        .where("tbstdate > ?", 1.year.ago.beginning_of_day)
-        .where("tbstdate < ?", Date.new(2019, 5, 19).beginning_of_day)
-    end
-
     def load_days_for_range(start_date, end_date)
       where("tbstdate BETWEEN ? AND ?", start_date, end_date)
     end

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -136,14 +136,6 @@ class HearingRepository
 
     private
 
-    def worksheet_issues_for_appeals(appeal_ids)
-      WorksheetIssue.issues_for_appeals(appeal_ids)
-        .each_with_object({}) do |issue, hash|
-        hash[issue.appeal_id] ||= []
-        hash[issue.appeal_id] << issue
-      end
-    end
-
     # Gets the regional office to use when mapping the VACOLS hearing date to
     # the local scheduled time.
     #

--- a/app/workflows/hearing_request_case_distributor.rb
+++ b/app/workflows/hearing_request_case_distributor.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class HearingRequestCaseDistributor
-  class CannotDistribute < StandardError; end
-
   def initialize(appeals:, genpop:, distribution:, priority:)
     @appeals = appeals
     @genpop = genpop


### PR DESCRIPTION
Resolves #12728 

### Description

Cleaning up some unused hearings code

**How I found unused code**:

1. Install `unused` https://github.com/unused-code/unused
  For Macs you can install using brew (see repo README)
  For Linux only, you'll also need to setup https://github.com/microsoft/mimalloc
2. Setup `ctags`
  For Macs, you can install with `brew`. For Linux, you can install with your package manager most likely
3. Generate `ctags` for Caseflow Rails:
    ```
    ctags -R app/*
    ```
4. Run `unused`:
    ```
    unused -l medium,high > unused.txt
    ```