### PR TITLE
Remove wholly unused method in task.rb

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -680,10 +680,6 @@ class Task < CaseflowRecord
     @alerts ||= []
   end
 
-  def org_task_and_cavc_lit_support_member(user)
-    assigned_to_type == "Organization" && CavcLitigationSupport.singleton.user_has_access?(user)
-  end
-
   private
 
   def create_and_auto_assign_child_task(options = {})


### PR DESCRIPTION
Kudos to @yoomlam for noticing that this method I added recently was in Ferris's [list of unused methods](https://github.com/department-of-veterans-affairs/caseflow/issues/12728#issuecomment-776045790).

I traced this back to https://github.com/department-of-veterans-affairs/caseflow/commit/7b537d9896b3bd85aeeda11c4c3d194a04ad8fc1 and had apparently removed the callers even before this was committed.

![bye felicia](https://media.giphy.com/media/GB0lKzzxIv1te/giphy.gif)

### Description
Simply removing a method that nothing calls.

### Acceptance Criteria
- [x] Tests pass
- [x] A search of the codebase reveals no uses

### Testing Plan
1. `git grep` or `ag` the code if you'd like