### PR TITLE
Create DocketSwitchRulingTask on RootTask

### DIFF
--- a/app/models/tasks/docket_switch/docket_switch_ruling_task.rb
+++ b/app/models/tasks/docket_switch/docket_switch_ruling_task.rb
@@ -11,7 +11,13 @@ class DocketSwitchRulingTask < JudgeTask
     actions
   end
 
-  def self.label
-    COPY::DOCKET_SWITCH_RULING_TASK_LABEL
+  class << self
+    def label
+      COPY::DOCKET_SWITCH_RULING_TASK_LABEL
+    end
+
+    def verify_user_can_create!(user, parent)
+      parent.is_a?(RootTask) ? true : super(user, parent)
+    end
   end
 end

--- a/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
+++ b/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
@@ -36,7 +36,7 @@ export const formatDocketSwitchRecommendation = ({
 };
 
 export const RecommendDocketSwitchContainer = () => {
-  const { appealId, taskId } = useParams();
+  const { appealId } = useParams();
   const { goBack, push } = useHistory();
   const dispatch = useDispatch();
 

--- a/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
+++ b/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
 import { fetchJudges } from '../../QueueActions';
 
-import { appealWithDetailSelector } from '../../selectors';
+import { appealWithDetailSelector, rootTasksForAppeal } from '../../selectors';
 import DISPOSITIONS from '../../../../constants/DOCKET_SWITCH_DISPOSITIONS';
 import { createDocketSwitchRulingTask } from './recommendDocketSwitchSlice';
 import { RecommendDocketSwitchForm } from './RecommendDocketSwitchForm';
@@ -40,9 +40,8 @@ export const RecommendDocketSwitchContainer = () => {
   const { goBack, push } = useHistory();
   const dispatch = useDispatch();
 
-  const appeal = useSelector((state) =>
-    appealWithDetailSelector(state, { appealId })
-  );
+  const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
+  const rootTask = useSelector((state) => rootTasksForAppeal(state, { appealId }))[0];
 
   const judges = useSelector((state) => state.queue.judges);
   const judgeOptions = useMemo(
@@ -65,7 +64,7 @@ export const RecommendDocketSwitchContainer = () => {
 
     const instructions = formatDocketSwitchRecommendation({ ...formData });
     const newTask = {
-      parent_id: taskId,
+      parent_id: rootTask.taskId,
       type: 'DocketSwitchRulingTask',
       external_id: appeal.externalId,
       instructions,

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -91,6 +91,7 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       judge_task = DocketSwitchRulingTask.find_by(assigned_to: judge)
       expect(judge_task).to_not be_nil
+      expect(judge_task.parent.type).to eq RootTask.name
 
       # Switch to judge to verify instructions
       User.authenticate!(user: judge)


### PR DESCRIPTION
First PR for [CASEFLOW-644](https://vajira.max.gov/browse/CASEFLOW-644)

### Description
This PR makes it so that the DocketSwitchRulingTask is created as a child of the Appeal's RootTask, not the preceding DocketSwitchMailTask.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Feature spec updated with RootTask check