### PR TITLE
Add Straight Reversal to CAVC Entry Form

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -150,6 +150,7 @@
   "CAVC_MANDATE_DATE": "What is the Court's mandate date?",
   "CAVC_MANDATE_DATE_ERROR": "Please select a valid mandate date.",
   "CAVC_ISSUES_LABEL": "Which issues are being addressed by the court?",
+  "CAVC_NO_ISSUES_ERROR": "Please select at least one of the issues to proceed",
   "CAVC_INSTRUCTIONS_LABEL": "Provide context and instructions for this action",
   "CAVC_INSTRUCTIONS_ERROR": "Please provide context and instructions for the remand",
   "CAVC_REMAND_CREATED_TITLE": "You have successfully created a CAVC remand case",

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -132,7 +132,9 @@ const AddCavcRemandView = (props) => {
   const validDocketNumber = () => (/^\d{2}-\d{1,5}$/).exec(docketNumber);
   const validJudge = () => Boolean(judge);
   const validDecisionDate = () => Boolean(decisionDate) && validateDateNotInFuture(decisionDate);
-  const mandateNotRequired = () => !mandateAvailable || mdrSubtype();
+  const validDecisionIssues = () => selectedIssues && selectedIssues.length > 0;
+  const mandateNotRequired = () => !mandateAvailable || mdrSubtype() ||
+  ((straightReversalType() || deathDismissalType()) && (isMandateProvided === 'false'));
   const validJudgementDate = () => {
     return (Boolean(judgementDate) && validateDateNotInFuture(judgementDate)) || mandateNotRequired();
   };
@@ -141,7 +143,7 @@ const AddCavcRemandView = (props) => {
 
   const validateForm = () => {
     return validDocketNumber() && validJudge() && validDecisionDate() && validJudgementDate() && validMandateDate() &&
-      validInstructions();
+      validInstructions() && validDecisionIssues();
   };
 
   const mandateDatesPopulated = () => {
@@ -308,6 +310,7 @@ const AddCavcRemandView = (props) => {
       options={issueOptions()}
       values={issues}
       onChange={(val) => onIssueChange(val)}
+      errorMessage={highlightInvalid && !validDecisionIssues() ? COPY.CAVC_NO_ISSUES_ERROR : null}
     />
   </React.Fragment>;
 
@@ -343,7 +346,7 @@ const AddCavcRemandView = (props) => {
       {mandateAvailable() && judgementField }
       {mandateAvailable() && mandateField }
       {!mandateAvailable() && type !== CAVC_DECISION_TYPES.remand && noMandateBanner }
-      {issuesField}
+      {!deathDismissalType() && issuesField}
       {instructionsField}
     </QueueFlowPage>
   );

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -133,12 +133,10 @@ const AddCavcRemandView = (props) => {
   const validJudge = () => Boolean(judge);
   const validDecisionDate = () => Boolean(decisionDate) && validateDateNotInFuture(decisionDate);
   const validDecisionIssues = () => selectedIssues && selectedIssues.length > 0;
-  const mandateNotRequired = () => !mandateAvailable || mdrSubtype() ||
-  ((straightReversalType() || deathDismissalType()) && (isMandateProvided === 'false'));
   const validJudgementDate = () => {
-    return (Boolean(judgementDate) && validateDateNotInFuture(judgementDate)) || mandateNotRequired();
+    return (Boolean(judgementDate) && validateDateNotInFuture(judgementDate)) || !mandateAvailable();
   };
-  const validMandateDate = () => (Boolean(mandateDate) && validateDateNotInFuture(mandateDate)) || mandateNotRequired();
+  const validMandateDate = () => (Boolean(mandateDate) && validateDateNotInFuture(mandateDate)) || !mandateAvailable();
   const validInstructions = () => instructions && instructions.length > 0;
 
   const validateForm = () => {

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -51,11 +51,11 @@ describe('AddCavcRemandView', () => {
   });
 
   it('selects all issues on page load', () => {
-    const descisionIssues = amaAppeal.decisionIssues;
+    const decisionIssues = amaAppeal.decisionIssues;
     const cavcForm = setup({ appealId });
     const decisionIssueChecks = cavcForm.find(CheckboxGroup).props().values;
 
-    expect(descisionIssues.map((issue) => issue.id).every((id) => decisionIssueChecks[id])).toBeTruthy();
+    expect(decisionIssues.map((issue) => issue.id).every((id) => decisionIssueChecks[id])).toBeTruthy();
   });
 
   describe('Are judgement and mandate dates provided?', () => {
@@ -105,7 +105,7 @@ describe('AddCavcRemandView', () => {
       });
     });
 
-    describe('dismisal_cavc_remand', () => {
+    describe('dismissal_cavc_remand', () => {
       it('hides dismissal when not toggled', () => {
         const cavcForm = setup({ appealId, dismissalToggled: false });
 

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -3468,6 +3468,7 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   </span>
                 </Button>
                 <CheckboxGroup
+                  errorMessage={null}
                   getCheckbox={[Function]}
                   hideErrorMessage={false}
                   onChange={[Function]}


### PR DESCRIPTION
Resolves [CASEFLOW-228](https://vajira.max.gov/browse/CASEFLOW-228),  [CASEFLOW-938](https://vajira.max.gov/browse/CASEFLOW-938), & [CASEFLOW-976](https://vajira.max.gov/browse/CASEFLOW-976)

### Description
Adds correct straight reversal behavior to the CAVC form as well as feature tests for both straight reversal and death dismissal (CASEFLOW-228) and removes the decision issues from view for Death Dismissal (CASEFLOW-938)

### Acceptance Criteria
#### CASEFLOW-228
- [x] Verify the Straight Reversal radio button under the "how are you proceeding?" area of the CAVC entry form
- [x] Display the issues when reversal is selected
- [x] Verify validation (required to select at least one) occurs on issues
- [x] Verify Add "Are judgement and mandate dates provided" question to the UI if Straight Reversal radio button is selected
- [x] Verify If the Straight Reversal radio button and the No radio button under the "are judgement and mandate dates provided" question then the following copy should appear: see "
CAVC_REMAND_NO_MANDATE_TEXT"
- [x] Verify if the Yes radio button is clicked under the "Are judgement and mandate dates provided?" question then the following date picker fields display:
What is the Court's judgement date? 
What is the Court's mandate date?
- [x] Verify If the No radio button is selected under the "Are judgement & Mandate dates provided" question and the submit button is clicked then a confirmation banner with the following copy displays on the users Your Cases page:
"You have successfully created a CAVC Remand case and have put it on hold for 90-days"
Subtext: "You can find this case in your teams queue" 
- [x] Verify If the Yes radio button is selected under the "Are judgement & Mandate dates provided" question and the submit button is clicked then a confirmation banner with the following copy displays on the users Your Cases page:
"You have successfully created a CAVC Remand case and sent it to case distribution"
Subtext: "The case will be distributed to a judge for further processing" 
- [x] Verify Straight Reversal & DD Feature Tests are complete
#### CASEFLOW-938
- [x] Given the CAVC Litigation Support user is entering a Death Dismissal from CAVC
When the user selects Death Dismissal under the  how are you proceeding question
Then the "Which issues are being addressed by the Court" section is hidden
#### CASEFOW-976
- [x] Given a CAVC Litigation Support user is completing the remand entry form, when I have selected no decision issues, validation should occur disallowing submitting and informing the user they must select at least 1
### Testing Plan
1. As a CAVC lit user, locate a dispatched appeal (can do so by simply visiting the org queue and searching any of the docket numbers for CAVC appeals)
2. Fill out the form and under "How are you proceeding?" select "Straight Reversal"
3. Under "Are judgment and mandate dates provided?" select "No"
4. Fill out the remainder of the form but unselect all of the decision issues
5. Click "Submit" and ensure you see the error "Please select at least one of the issues to proceed" 
6. Select a decision issue and click "Submit" once again.
7. Ensure the remand is submitted successfully and you are redirected to the case details page
8. Repeat steps but select "Death Dismissal"
9. Ensure that upon selection that the decision issue section is no longer visible

### Straight Reversal
![Screen Shot 2021-02-18 at 10 25 40 AM](https://user-images.githubusercontent.com/18618189/108379850-518afa00-71d4-11eb-8c7b-c56d7e2807e8.png)
### Death Dismissal
![Screen Shot 2021-02-18 at 10 25 57 AM](https://user-images.githubusercontent.com/18618189/108379919-5f407f80-71d4-11eb-99a2-36d9e8310a7f.png)

