### PR TITLE
CASEFLOW-981 CAVC remand form accepts hyphen & dash, others

### DIFF
--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -20,6 +20,7 @@ class CavcRemand < CaseflowRecord
   validates :judgement_date, :mandate_date, presence: true, unless: :mandate_not_required?
   validate :decision_issue_ids_match_appeal_decision_issues, if: -> { remand? && jmr? }
 
+  before_create :normalize_cavc_docket_number
   before_save :establish_appeal_stream, if: :cavc_remand_form_complete?
 
   enum cavc_decision_type: {
@@ -91,6 +92,11 @@ class CavcRemand < CaseflowRecord
     elsif straight_reversal? || death_dismissal?
       CavcTask.find_by(appeal_id: remand_appeal_id).descendants.each(&:completed!)
     end
+  end
+
+  # we want to be generous to whatever the user types, but normalize to a dash
+  def normalize_cavc_docket_number
+    self.cavc_docket_number.sub!(/[‐−–—]/, "-")
   end
 
   def cavc_task

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -96,7 +96,7 @@ class CavcRemand < CaseflowRecord
 
   # we want to be generous to whatever the user types, but normalize to a dash
   def normalize_cavc_docket_number
-    self.cavc_docket_number.sub!(/[‐−–—]/, "-")
+    cavc_docket_number.sub!(/[‐−–—]/, "-")
   end
 
   def cavc_task

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -129,7 +129,7 @@ const AddCavcRemandView = (props) => {
   const mandateAvailable = () => {
     return !(type === CAVC_DECISION_TYPES.remand && mdrSubtype()) && (isMandateProvided === 'true');
   };
-  //We accept ‐ HYPHEN, - Hyphen-minus, − MINUS SIGN, – EN DASH, — EM DASH
+  // We accept ‐ HYPHEN, - Hyphen-minus, − MINUS SIGN, – EN DASH, — EM DASH
   const validDocketNumber = () => (/^\d{2}[-‐−–—]\d{1,5}$/).exec(docketNumber);
   const validJudge = () => Boolean(judge);
   const validDecisionDate = () => Boolean(decisionDate) && validateDateNotInFuture(decisionDate);

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -129,7 +129,8 @@ const AddCavcRemandView = (props) => {
   const mandateAvailable = () => {
     return !(type === CAVC_DECISION_TYPES.remand && mdrSubtype()) && (isMandateProvided === 'true');
   };
-  const validDocketNumber = () => (/^\d{2}-\d{1,5}$/).exec(docketNumber);
+  //We accept ‐ HYPHEN, - Hyphen-minus, − MINUS SIGN, – EN DASH, — EM DASH
+  const validDocketNumber = () => (/^\d{2}[-‐−–—]\d{1,5}$/).exec(docketNumber);
   const validJudge = () => Boolean(judge);
   const validDecisionDate = () => Boolean(decisionDate) && validateDateNotInFuture(decisionDate);
   const validDecisionIssues = () => selectedIssues && selectedIssues.length > 0;

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -146,10 +146,18 @@ describe('AddCavcRemandView', () => {
         expect(validationErrorShows(cavcForm, error)).toBeTruthy();
       });
 
-      it('does not show error on correctly formatted docket number', () => {
+      it('does not show error on correctly formatted docket number with dash', () => {
         const cavcForm = setup({ appealId });
 
         cavcForm.find('input#docket-number').simulate('change', { target: { value: '20-39283' } });
+
+        expect(validationErrorShows(cavcForm, error)).toBeFalsy();
+      });
+
+      it('does not show error on correctly formatted docket number with hyphen', () => {
+        const cavcForm = setup({ appealId });
+
+        cavcForm.find('input#docket-number').simulate('change', { target: { value: '20‐39283' } });
 
         expect(validationErrorShows(cavcForm, error)).toBeFalsy();
       });


### PR DESCRIPTION
Resolves [CASEFLOW-981](https://vajira.max.gov/browse/CASEFLOW-981)

### Description
 - Makes the javascript validation more lenient
 - Adds a before_create hook to normalize to a dash

### Acceptance Criteria
- [ ] Code compiles correctly
- Given the CAVC Litigation Support user is entering the Court Docket Number on the CAVC entry form...
  - [ ] The field allows a dash
  - [ ] The field allows a hyphen
- ~The error copy is updated to "Please enter a valid docket number provided by CAVC (12-3456 or 12—3456)~ Decided not to change [see convo](https://dsva.slack.com/archives/CQCUMFA0H/p1614088180030800?thread_ts=1614087625.029300&cid=CQCUMFA0H)

### Testing Plan
1. Create a Dispatched appeal with Issues on your console:
   `appeal = FactoryBot.create(:appeal, :dispatched)`
   `FactoryBot.create_list(:request_issue, 2, :rating, :with_rating_decision_issue, decision_review: appeal, veteran_participant_id: appeal.veteran.participant_id, contested_issue_description: "Veteran contesting this issue", notes: "Some very impt notes")`
  `appeal.uuid`
2. Login as a CAVC user http://localhost:3000/test/users
3. Navigate to the appeal you've created and select `+Add CAVC Remand`
4. Enter a completely invalid docket number like `12354321512` and hit submit
   - [ ] Validation alerts for bad entry
5. Change it to with a dash: 13-12311
   - [ ] Validation Does Not alert for bad entry
6. Change it to a hyphen: 
    - [ ] Validation Does Not alert for bad entry
7. Copy/Paste from an [actual cavc case](https://efiling.uscourts.cavc.gov/cmecf/servlet/TransportRoom?servlet=CaseSummary.jsp&caseNum=10-1515&incOrigDkt=Y&incDktEntries=Y):
    - [ ] Validation Does Not alert for bad entry
8. Change it to an emdash: 12—1324 
9. Fill out the rest of the form and submit
10. Scroll down to the CAVC section
    - [ ] The value has a dash
 
### User Facing Changes

 BEFORE|AFTER
 ---|---
![CAVC Remand Entry Form showing validation error for a hyphen](https://user-images.githubusercontent.com/6129479/108858831-9dfe7d00-75ba-11eb-8028-764191dd403d.png)  | ![CAVC Remand Entry Form showing no validation error for a hyphen](https://user-images.githubusercontent.com/6129479/108858937-b8385b00-75ba-11eb-87cd-6fbf3a250a62.png)