### PR TITLE
CASEFLOW-942 Require Federal Circuit parameter for CAVC Remand controller and model

### DIFF
--- a/app/controllers/cavc_remands_controller.rb
+++ b/app/controllers/cavc_remands_controller.rb
@@ -25,6 +25,10 @@ class CavcRemandsController < ApplicationController
     :updated_by_id
   ].freeze
 
+  MDR_REQUIRED_PARAMS = [
+    :federal_circuit
+  ].freeze
+
   JMR_REQUIRED_PARAMS = [
     :judgement_date,
     :mandate_date
@@ -33,6 +37,7 @@ class CavcRemandsController < ApplicationController
   PERMITTED_PARAMS = [
     REMAND_REQUIRED_PARAMS,
     JMR_REQUIRED_PARAMS,
+    MDR_REQUIRED_PARAMS,
     :remand_subtype
   ].flatten.freeze
 
@@ -80,7 +85,7 @@ class CavcRemandsController < ApplicationController
     when Constants.CAVC_DECISION_TYPES.remand
       case params["remand_subtype"]
       when Constants.CAVC_REMAND_SUBTYPES.mdr
-        REMAND_REQUIRED_PARAMS
+        REMAND_REQUIRED_PARAMS + MDR_REQUIRED_PARAMS
       else
         REMAND_REQUIRED_PARAMS + JMR_REQUIRED_PARAMS
       end

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -19,6 +19,7 @@ class CavcRemand < CaseflowRecord
   validates :remand_subtype, presence: true, if: :remand?
   validates :judgement_date, :mandate_date, presence: true, unless: :mandate_not_required?
   validate :decision_issue_ids_match_appeal_decision_issues, if: -> { remand? && jmr? }
+  # TODO: test this: validate :federal_circuit, presence: true, if: -> { remand? && mdr? }
 
   before_create :normalize_cavc_docket_number
   before_save :establish_appeal_stream, if: :cavc_remand_form_complete?

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -19,7 +19,7 @@ class CavcRemand < CaseflowRecord
   validates :remand_subtype, presence: true, if: :remand?
   validates :judgement_date, :mandate_date, presence: true, unless: :mandate_not_required?
   validate :decision_issue_ids_match_appeal_decision_issues, if: -> { remand? && jmr? }
-  validates :federal_circuit, presence: true, if: -> { remand? && mdr? }
+  validates :federal_circuit, inclusion: { in: [true, false] }, if: -> { remand? && mdr? }
 
   before_create :normalize_cavc_docket_number
   before_save :establish_appeal_stream, if: :cavc_remand_form_complete?

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -19,7 +19,7 @@ class CavcRemand < CaseflowRecord
   validates :remand_subtype, presence: true, if: :remand?
   validates :judgement_date, :mandate_date, presence: true, unless: :mandate_not_required?
   validate :decision_issue_ids_match_appeal_decision_issues, if: -> { remand? && jmr? }
-  # TODO: test this: validate :federal_circuit, presence: true, if: -> { remand? && mdr? }
+  validates :federal_circuit, presence: true, if: -> { remand? && mdr? }
 
   before_create :normalize_cavc_docket_number
   before_save :establish_appeal_stream, if: :cavc_remand_form_complete?

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -126,6 +126,7 @@
   "CASE_DETAILS_CAVC_DECISION_DATE": "Court's decision date",
   "CASE_DETAILS_CAVC_JUDGEMENT_DATE": "Judgement date",
   "CASE_DETAILS_CAVC_MANDATE_DATE": "Mandate date",
+  "CASE_DETAILS_CAVC_FEDERAL_CIRCUIT": "Appealed to Federal Circuit",
   "CASE_DETAILS_CAVC_REMAND_INSTRUCTIONS": "Remand Instructions",
 
   "POST_DISPATCH_TITLE": "Post-dispatch actions",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -151,6 +151,8 @@
   "CAVC_MANDATE_DATE_ERROR": "Please select a valid mandate date.",
   "CAVC_ISSUES_LABEL": "Which issues are being addressed by the court?",
   "CAVC_NO_ISSUES_ERROR": "Please select at least one of the issues to proceed",
+  "CAVC_FEDERAL_CIRCUIT_HEADER": "Notice of Appeal to the Federal Circuit",
+  "CAVC_FEDERAL_CIRCUIT_LABEL": "Yes, this case has been appealed to the Federal Circuit",
   "CAVC_INSTRUCTIONS_LABEL": "Provide context and instructions for this action",
   "CAVC_INSTRUCTIONS_ERROR": "Please provide context and instructions for the remand",
   "CAVC_REMAND_CREATED_TITLE": "You have successfully created a CAVC remand case",

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -190,6 +190,7 @@ const AddCavcRemandView = (props) => {
         remand_subtype: type === CAVC_DECISION_TYPES.remand ? subType : null,
         represented_by_attorney: attorney === '1',
         decision_issue_ids: selectedIssues,
+        federal_circuit: mdrSubtype() ? federalCircuit : null,
         instructions
       }
     };

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -16,6 +16,7 @@ import { validateDateNotInFuture } from '../intake/util/issues';
 import TextField from '../components/TextField';
 import RadioField from '../components/RadioField';
 import DateSelector from '../components/DateSelector';
+import Checkbox from '../components/Checkbox';
 import CheckboxGroup from '../components/CheckboxGroup';
 import TextareaField from '../components/TextareaField';
 import Button from '../components/Button';
@@ -78,6 +79,7 @@ const AddCavcRemandView = (props) => {
   const [judgementDate, setJudgementDate] = useState(null);
   const [mandateDate, setMandateDate] = useState(null);
   const [issues, setIssues] = useState({});
+  const [federalCircuit, setFederalCircuit] = useState(false);
   const [instructions, setInstructions] = useState(null);
   const [isMandateProvided, setMandateProvided] = useState('true');
 
@@ -313,6 +315,14 @@ const AddCavcRemandView = (props) => {
     />
   </React.Fragment>;
 
+  const federalCircuitField = <React.Fragment>
+    <legend><strong>{COPY.CAVC_FEDERAL_CIRCUIT_HEADER}</strong></legend>
+    <Checkbox name="federalCircuit" label={COPY.CAVC_FEDERAL_CIRCUIT_LABEL}
+      value={federalCircuit}
+      onChange={(evt) => setFederalCircuit(evt)}
+    />
+  </React.Fragment>;
+
   const instructionsField = <TextareaField
     label={COPY.CAVC_INSTRUCTIONS_LABEL}
     name="context-and-instructions-textBox"
@@ -346,6 +356,7 @@ const AddCavcRemandView = (props) => {
       {mandateAvailable() && mandateField }
       {!mandateAvailable() && type !== CAVC_DECISION_TYPES.remand && noMandateBanner }
       {!deathDismissalType() && issuesField}
+      {type === CAVC_DECISION_TYPES.remand && mdrSubtype() && federalCircuitField }
       {instructionsField}
     </QueueFlowPage>
   );

--- a/client/app/queue/CavcDetail.jsx
+++ b/client/app/queue/CavcDetail.jsx
@@ -20,6 +20,7 @@ const CavcDetail = (props) => {
     decision_date: decisionDate,
     judgement_date: judgementDate,
     mandate_date: mandateDate,
+    federal_circuit: federalCircuit,
     instructions: instructionText
   } = props;
 
@@ -86,6 +87,13 @@ const CavcDetail = (props) => {
     });
   }
 
+  if (federalCircuit !== null) {
+    details.push({
+      label: COPY.CASE_DETAILS_CAVC_FEDERAL_CIRCUIT,
+      value: (federalCircuit === true) ? 'Yes' : 'No'
+    });
+  }
+
   if (instructionText) {
     details.push({
       label: COPY.CASE_DETAILS_CAVC_REMAND_INSTRUCTIONS,
@@ -111,6 +119,7 @@ CavcDetail.propTypes = {
   decision_date: PropTypes.string.isRequired,
   judgement_date: PropTypes.string,
   mandate_date: PropTypes.string,
+  federal_circuit: PropTypes.bool.isRequired,
   instructions: PropTypes.string.isRequired
 };
 

--- a/client/app/queue/CavcDetail.jsx
+++ b/client/app/queue/CavcDetail.jsx
@@ -119,7 +119,7 @@ CavcDetail.propTypes = {
   decision_date: PropTypes.string.isRequired,
   judgement_date: PropTypes.string,
   mandate_date: PropTypes.string,
-  federal_circuit: PropTypes.bool.isRequired,
+  federal_circuit: PropTypes.bool,
   instructions: PropTypes.string.isRequired
 };
 

--- a/spec/controllers/cavc_remands_controller_spec.rb
+++ b/spec/controllers/cavc_remands_controller_spec.rb
@@ -68,14 +68,6 @@ RSpec.describe CavcRemandsController, type: :controller do
       }
     end
 
-    let(:expected_remand_values) do
-      {
-        "source_appeal_id": source_appeal.id,
-        "decision_issue_ids": decision_issue_ids,
-        "federal_circuit": federal_circuit
-      }
-    end
-
     subject { post :create, params: params }
 
     shared_examples "creates a remand depending on the sub-type" do
@@ -89,9 +81,7 @@ RSpec.describe CavcRemandsController, type: :controller do
 
         expect(response_body["cavc_remand"]["source_appeal_id"]).to eq(source_appeal.id)
         expect(response_body["cavc_remand"]["decision_issue_ids"]).to match_array(decision_issue_ids)
-        expected_remand_values.each do |key, value|
-          expect(response_body["cavc_remand"][key]).to eq value
-        end
+        expect(response_body["cavc_remand"]["federal_circuit"]).to eq(federal_circuit)
         expect(CavcRemand.count).to eq(remand_count + 1)
 
         expect(response_body["cavc_appeal"]["id"])

--- a/spec/factories/cavc_remand.rb
+++ b/spec/factories/cavc_remand.rb
@@ -10,7 +10,7 @@ FactoryBot.define do
     decision_date { 30.days.ago.to_date }
     judgement_date { 30.days.ago.to_date }
     mandate_date { 30.days.ago.to_date }
-    federal_circuit { false }
+    federal_circuit { (remand_subtype == Constants::CAVC_REMAND_SUBTYPES["mdr"]) ? false : nil }
     instructions { "Sample CAVC Remand from factory" }
     created_by { User.first || create(:user) }
 

--- a/spec/factories/cavc_remand.rb
+++ b/spec/factories/cavc_remand.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     decision_date { 30.days.ago.to_date }
     judgement_date { 30.days.ago.to_date }
     mandate_date { 30.days.ago.to_date }
+    federal_circuit { false }
     instructions { "Sample CAVC Remand from factory" }
     created_by { User.first || create(:user) }
 

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -172,6 +172,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "decision-date", with: date
           find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
           fill_in "context-and-instructions-textBox", with: instructions
+          find("label", text: "Yes, this case has been appealed to the Federal Circuit").click
           page.find("button", text: "Submit").click
 
           expect(page).to have_content COPY::CAVC_REMAND_CREATED_TITLE
@@ -193,6 +194,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           expect(page).to have_content "#{COPY::CASE_DETAILS_CAVC_DECISION_DATE}: #{date}"
           expect(page.has_no_content?("#{COPY::CASE_DETAILS_CAVC_JUDGEMENT_DATE}:")).to eq(true)
           expect(page.has_no_content?("#{COPY::CASE_DETAILS_CAVC_MANDATE_DATE}:")).to eq(true)
+          expect(page).to have_content "#{COPY::CASE_DETAILS_CAVC_FEDERAL_CIRCUIT}: Yes"
 
           find(".cf-select__control", text: "Select an action").click
           expect(page).to have_content Constants.TASK_ACTIONS.END_TIMED_HOLD.label

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -160,10 +160,15 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           visit "queue/appeals/#{appeal.external_id}"
           page.find("button", text: "+ Add CAVC Remand").click
 
-          # unselect an issue and don't fill in judgement date or mandate date
           fill_in "docket-number", with: docket_number
           click_dropdown(text: judge_name)
           find("label", text: "Memorandum Decision on Remand (MDR)").click
+
+          expect(page).to have_content COPY::MDR_SELECTION_ALERT_BANNER
+          expect(page).to have_content COPY::CAVC_FEDERAL_CIRCUIT_HEADER
+          expect(page).to have_content COPY::CAVC_FEDERAL_CIRCUIT_LABEL
+
+          # unselect an issue and don't fill in judgement date or mandate date
           fill_in "decision-date", with: date
           find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
           fill_in "context-and-instructions-textBox", with: instructions

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -27,6 +27,7 @@ describe CavcRemand do
       )
     end
     let(:decision_issue_ids) { decision_issues.map(&:id) }
+    let(:federal_circuit) { nil }
     let(:instructions) { "Instructions!" }
 
     let(:params) do
@@ -43,6 +44,7 @@ describe CavcRemand do
         judgement_date: judgement_date,
         mandate_date: mandate_date,
         decision_issue_ids: decision_issue_ids,
+        federal_circuit: federal_circuit,
         instructions: instructions
       }
     end

--- a/spec/models/cavc_remand_spec.rb
+++ b/spec/models/cavc_remand_spec.rb
@@ -132,6 +132,7 @@ describe CavcRemand do
     shared_examples "works for all remand subtypes" do
       context "when remand subtype is MDR" do
         let(:remand_subtype) { Constants.CAVC_REMAND_SUBTYPES.mdr }
+        let(:federal_circuit) { false }
 
         it "creates the record" do
           expect { subject }.not_to raise_error


### PR DESCRIPTION
Step 3 of [CASEFLOW-942](https://vajira.max.gov/browse/CASEFLOW-942).

Step 1 was adding the DB field -- see PR #15923.
Step 2 was adding the Federal Circuit question to MDR CAVC entry form #15924

### Description
Require Federal Circuit parameter for CAVC Remand controller and model.
Show "Appealed to Federal Circuit" in the CAVC Remand Section of Case Details.

### Acceptance Criteria
- [x]  Federal Circuit parameter is saved to DB for MDR CAVC remands

Scenario: Given a Caseflow user with access to the case is viewing the Case Details page
When the user scrolls to the CAVC Remand Section and the appeal has been identified as appealed to the Federal Circuit
- [x] the following copy displays in the CAVC Remand Section: *Appealed to Federal Circuit:* Yes

### Testing Plan
1. Open a Rails console and create a ready for CAVC appeal, note the `stream_docket_number` so you can search for the appeal in the UI or the `uuid`.
```ruby
original_appeal = FactoryBot.create(:appeal, 
                           :dispatched, 
                           associated_judge: JudgeTeam.first.judge, 
                           associated_attorney: JudgeTeam.first.attorneys.first)
FactoryBot.create_list(:request_issue, 2,                                                                                  
            :rating,                                                                                            
            :with_rating_decision_issue,                                                                           
            decision_review: original_appeal,                                                                               
            veteran_participant_id: Veteran.first.participant_id,                                                        
            contested_issue_description: "issue_description",                                                              
            notes: "issue_notes")
original_appeal.uuid
```
2. Login as a CAVC lit support user 
3. Search for the dispatched appeal you just created and select it to go to Case Details: `http://localhost:3000/queue/appeals/<UUID>`
4. Click the "+ Add CAVC Remand" button in the "Post-Dispatch actions" section
5. Fill out the "Add a Court Remand" form, selecting MDR. Notice the MDR banner and new federal circuit question.
6. Submit form.
7. Copy the UUID of the newly created cavc appeal and check out its task tree in the console
```ruby
cavc_appeal=Appeal.find_by_uuid("be9b6b0f-e2cc-4617-b2e7-f8a24f121da2")
cavc_appeal.treee
                                          ┌─────────────────────────────────────────────────────────────────────────────┐
Appeal 1039 (E 210120-1038 Court Remand)  │ ID   │ STATUS   │ ASGN_BY │ ASGN_TO               │ UPDATED_AT              │
└── RootTask                              │ 3428 │ on_hold  │         │ Bva                   │ 2021-01-21 19:57:47 UTC │
    └── DistributionTask                  │ 3429 │ on_hold  │         │ Bva                   │ 2021-01-21 19:57:47 UTC │
        └── CavcTask                      │ 3430 │ on_hold  │         │ Bva                   │ 2021-01-21 19:57:47 UTC │
            └── MdrTask                   │ 3431 │ on_hold  │         │ CavcLitigationSupport │ 2021-01-21 19:57:47 UTC │
                └── TimedHoldTask         │ 3432 │ assigned │         │ CavcLitigationSupport │ 2021-01-21 19:57:47 UTC │
                                          └─────────────────────────────────────────────────────────────────────────────┘
```
or in the browser: `http://localhost:3000/task_tree/appeals/be9b6b0f-e2cc-4617-b2e7-f8a24f121da2`
8. And examine the CAVC Remand:
```ruby
cavc_remand=CavcRemand.where(source_appeal_id: original_appeal.id).first
cavc_remand.federal_circuit
```
9. Check for "Appealed to Federal Circuit" in the CAVC Remand Section of Case Details.
10. Play around, stress test, and find bugs early


### User Facing Changes

BEFORE|AFTER
---|---
![image](https://user-images.githubusercontent.com/55255674/108912668-9062ea80-75ee-11eb-9a6e-d78395ffe0b9.png) | ![image](https://user-images.githubusercontent.com/55255674/108912608-7d501a80-75ee-11eb-8ae3-bf78f02f8c5e.png)

