### PR TITLE
CASEFLOW-948 CAVC entry form: JMR/JMPR dynamic issue validation

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -143,6 +143,7 @@
   "CAVC_COURT_DECISION_DATE": "What is the Court's decision date?",
   "CAVC_DECISION_DATE_ERROR": "Please select a valid date for the court's decision",
   "JMR_SELECTION_ISSUE_INFO_BANNER": "For a JMR you must select all issues to proceed",
+  "JMPR_SELECTION_ISSUE_INFO_BANNER": "For a JMPR you must select at least one issue to proceed",
   "MDR_SELECTION_ALERT_BANNER": "Choosing MDR will set a 90-day hold on this case starting from the Court's decision date listed above. The hold is to wait for the Court's judgement and mandate dates. This remand case will be accessible in your organization's Assigned tab and will return to the team's Unassigned tab when the 90 days are over or the hold is manually ended, at which point the judgement and mandate dates can be entered.",
   "CAVC_REMAND_NO_MANDATE_TEXT": "This task will be put on hold for 90 days to wait for the Court's judgement and mandate dates. This case will be accessible in the Assigned tab and will return to the team's Unassigned tab when the 90 days has passed.",
   "CAVC_JUDGEMENT_DATE_HEADER": "Judgement and mandate date",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -154,6 +154,7 @@
   "CAVC_MANDATE_DATE_ERROR": "Please select a valid mandate date.",
   "CAVC_ISSUES_LABEL": "Which issues are being addressed by the court?",
   "CAVC_NO_ISSUES_ERROR": "Please select at least one of the issues to proceed",
+  "CAVC_ALL_ISSUES_ERROR": "Please select all issues to proceed",
   "CAVC_FEDERAL_CIRCUIT_HEADER": "Notice of Appeal to the Federal Circuit",
   "CAVC_FEDERAL_CIRCUIT_LABEL": "Yes, this case has been appealed to the Federal Circuit",
   "CAVC_INSTRUCTIONS_LABEL": "Provide context and instructions for this action",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -144,6 +144,7 @@
   "CAVC_DECISION_DATE_ERROR": "Please select a valid date for the court's decision",
   "JMR_SELECTION_ISSUE_INFO_BANNER": "For a JMR you must select all issues to proceed",
   "JMPR_SELECTION_ISSUE_INFO_BANNER": "For a JMPR you must select at least one issue to proceed",
+  "MDR_SELECTION_ISSUE_INFO_BANNER": "For a MDR you must select at least one issue to proceed",
   "MDR_SELECTION_ALERT_BANNER": "Choosing MDR will set a 90-day hold on this case starting from the Court's decision date listed above. The hold is to wait for the Court's judgement and mandate dates. This remand case will be accessible in your organization's Assigned tab and will return to the team's Unassigned tab when the 90 days are over or the hold is manually ended, at which point the judgement and mandate dates can be entered.",
   "CAVC_REMAND_NO_MANDATE_TEXT": "This task will be put on hold for 90 days to wait for the Court's judgement and mandate dates. This case will be accessible in the Assigned tab and will return to the team's Unassigned tab when the 90 days has passed.",
   "CAVC_JUDGEMENT_DATE_HEADER": "Judgement and mandate date",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -142,6 +142,7 @@
   "CAVC_SUB_TYPE_LABEL": "What type of remand is this?",
   "CAVC_COURT_DECISION_DATE": "What is the Court's decision date?",
   "CAVC_DECISION_DATE_ERROR": "Please select a valid date for the court's decision",
+  "JMR_SELECTION_ISSUE_INFO_BANNER": "For a JMR you must select all issues to proceed",
   "MDR_SELECTION_ALERT_BANNER": "Choosing MDR will set a 90-day hold on this case starting from the Court's decision date listed above. The hold is to wait for the Court's judgement and mandate dates. This remand case will be accessible in your organization's Assigned tab and will return to the team's Unassigned tab when the 90 days are over or the hold is manually ended, at which point the judgement and mandate dates can be entered.",
   "CAVC_REMAND_NO_MANDATE_TEXT": "This task will be put on hold for 90 days to wait for the Court's judgement and mandate dates. This case will be accessible in the Assigned tab and will return to the team's Unassigned tab when the 90 days has passed.",
   "CAVC_JUDGEMENT_DATE_HEADER": "Judgement and mandate date",

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -27,9 +27,7 @@ import { withRouter } from 'react-router';
 
 const radioLabelStyling = css({ marginTop: '2.5rem' });
 const buttonStyling = css({ paddingLeft: '0' });
-const bottomInfoStyling = css({
-  marginBottom: '4rem'
-});
+const bottomInfoStyling = css({ marginBottom: '4rem' });
 
 const judgeOptions = _.map(CAVC_JUDGE_FULL_NAMES, (value) => ({
   label: value,
@@ -284,12 +282,19 @@ const AddCavcRemandView = (props) => {
     strongLabel
   />;
 
-  const jmrIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.JMR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
-  const jmprIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
+  const jmrIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
+    {COPY.JMR_SELECTION_ISSUE_INFO_BANNER}
+  </Alert>;
+  const jmprIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
+    {COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}
+  </Alert>;
 
-  const mdrBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.MDR_SELECTION_ALERT_BANNER}</Alert>;
-
-  const noMandateBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.CAVC_REMAND_NO_MANDATE_TEXT}</Alert>;
+  const mdrBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
+    {COPY.MDR_SELECTION_ALERT_BANNER}
+  </Alert>;
+  const noMandateBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
+    {COPY.CAVC_REMAND_NO_MANDATE_TEXT}
+  </Alert>;
 
   const judgementField = <DateSelector
     label={COPY.CAVC_JUDGEMENT_DATE}

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -121,9 +121,8 @@ const AddCavcRemandView = (props) => {
   // populate all of our checkboxes on initial render
   useEffect(() => selectAllIssues(), []);
 
-  const allIssuesSelected = useMemo(() => {
-    return Object.values(issues).every((isChecked) => isChecked);
-  }, [issues]);
+  const allIssuesSelected = useMemo(() => Object.values(issues).every((isChecked) => isChecked), [issues]);
+  const allIssuesUnselected = useMemo(() => Object.values(issues).every((isChecked) => !isChecked), [issues]);
 
   const onIssueChange = (evt) => {
     setIssues({ ...issues, [evt.target.name]: evt.target.checked });
@@ -133,6 +132,7 @@ const AddCavcRemandView = (props) => {
   const straightReversalType = () => type === CAVC_DECISION_TYPES.straight_reversal;
   const deathDismissalType = () => type === CAVC_DECISION_TYPES.death_dismissal;
   const jmrSubtype = () => subType === CAVC_REMAND_SUBTYPES.jmr;
+  const jmprSubtype = () => subType === CAVC_REMAND_SUBTYPES.jmpr;
   const mdrSubtype = () => subType === CAVC_REMAND_SUBTYPES.mdr;
   const mandateAvailable = () => {
     return !(type === CAVC_DECISION_TYPES.remand && mdrSubtype()) && (isMandateProvided === 'true');
@@ -282,6 +282,7 @@ const AddCavcRemandView = (props) => {
   />;
 
   const jmrIssuesBanner = <Alert type="info" scrollOnAlert={false}>{COPY.JMR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
+  const jmprIssuesBanner = <Alert type="info" scrollOnAlert={false}>{COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
 
   const mdrBanner = <Alert type="info" scrollOnAlert={false}>{COPY.MDR_SELECTION_ALERT_BANNER}</Alert>;
 
@@ -365,6 +366,7 @@ const AddCavcRemandView = (props) => {
       {!mandateAvailable() && type !== CAVC_DECISION_TYPES.remand && noMandateBanner }
       {!deathDismissalType() && issuesField}
       {remandType() && jmrSubtype() && !allIssuesSelected && jmrIssuesBanner }
+      {remandType() && jmprSubtype() && allIssuesUnselected && jmprIssuesBanner }
       {remandType() && mdrSubtype() && federalCircuitField }
       {instructionsField}
     </QueueFlowPage>

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -101,7 +101,7 @@ const AddCavcRemandView = (props) => {
   const filteredRemandTypes = subTypeOptions.filter((subTypeOption) => supportedRemandTypes[subTypeOption.value]);
 
   const issueOptions = () => decisionIssues.map((decisionIssue) => ({
-    id: decisionIssue.id,
+    id: decisionIssue.id.toString(),
     label: decisionIssue.description
   }));
 

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -83,7 +83,7 @@ const AddCavcRemandView = (props) => {
   // issues is a hash keyed on decisionIssue.id with boolean values indicating checkbox state
   const [issues, setIssues] = useState({});
   const [federalCircuit, setFederalCircuit] = useState(false);
-  const [instructions, setInstructions] = useState(null);
+  const [instructions, setInstructions] = useState('');
   const [isMandateProvided, setMandateProvided] = useState('true');
   const [isMandateSame, setMandateSame] = useState(true);
   const supportedDecisionTypes = {
@@ -356,6 +356,8 @@ const AddCavcRemandView = (props) => {
       onClick={selectAllIssues}
     />
     <CheckboxGroup
+      name="issuesList"
+      hideLabel
       styling={issueListStyling}
       options={issueOptions()}
       values={issues}

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -122,7 +122,7 @@ const AddCavcRemandView = (props) => {
   useEffect(() => selectAllIssues(), []);
 
   const allIssuesSelected = useMemo(() => {
-    return Object.values(issues).filter((isChecked) => !isChecked).length === 0;
+    return Object.values(issues).every((isChecked) => isChecked);
   }, [issues]);
 
   const onIssueChange = (evt) => {

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -28,6 +28,7 @@ import { withRouter } from 'react-router';
 const radioLabelStyling = css({ marginTop: '2.5rem' });
 const buttonStyling = css({ paddingLeft: '0' });
 const bottomInfoStyling = css({ marginBottom: '4rem' });
+const issueListStyling = css({ marginTop: '0rem' });
 
 const judgeOptions = _.map(CAVC_JUDGE_FULL_NAMES, (value) => ({
   label: value,
@@ -142,7 +143,17 @@ const AddCavcRemandView = (props) => {
   const validDocketNumber = () => (/^\d{2}[-‐−–—]\d{1,5}$/).exec(docketNumber);
   const validJudge = () => Boolean(judge);
   const validDecisionDate = () => Boolean(decisionDate) && validateDateNotInFuture(decisionDate);
-  const validDecisionIssues = () => selectedIssueIds?.length > 0;
+
+  const validDecisionIssues = () => {
+    if (remandType() && jmrSubtype()) {
+      return allIssuesSelected;
+    }
+
+    return selectedIssueIds?.length > 0;
+  };
+  const issueSelectionError = () =>
+    (remandType() && jmrSubtype() && !allIssuesSelected) ? COPY.CAVC_ALL_ISSUES_ERROR : COPY.CAVC_NO_ISSUES_ERROR;
+
   const validJudgementDate = () => {
     return (Boolean(judgementDate) && validateDateNotInFuture(judgementDate)) || !mandateAvailable();
   };
@@ -328,10 +339,11 @@ const AddCavcRemandView = (props) => {
       onClick={selectAllIssues}
     />
     <CheckboxGroup
+      styling={issueListStyling}
       options={issueOptions()}
       values={issues}
       onChange={(val) => onIssueChange(val)}
-      errorMessage={highlightInvalid && !validDecisionIssues() ? COPY.CAVC_NO_ISSUES_ERROR : null}
+      errorMessage={highlightInvalid && !validDecisionIssues() ? issueSelectionError() : null}
     />
   </React.Fragment>;
 

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -27,6 +27,9 @@ import { withRouter } from 'react-router';
 
 const radioLabelStyling = css({ marginTop: '2.5rem' });
 const buttonStyling = css({ paddingLeft: '0' });
+const bottomInfoStyling = css({
+  marginBottom: '4rem'
+});
 
 const judgeOptions = _.map(CAVC_JUDGE_FULL_NAMES, (value) => ({
   label: value,
@@ -281,12 +284,12 @@ const AddCavcRemandView = (props) => {
     strongLabel
   />;
 
-  const jmrIssuesBanner = <Alert type="info" scrollOnAlert={false}>{COPY.JMR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
-  const jmprIssuesBanner = <Alert type="info" scrollOnAlert={false}>{COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
+  const jmrIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.JMR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
+  const jmprIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
 
-  const mdrBanner = <Alert type="info" scrollOnAlert={false}>{COPY.MDR_SELECTION_ALERT_BANNER}</Alert>;
+  const mdrBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.MDR_SELECTION_ALERT_BANNER}</Alert>;
 
-  const noMandateBanner = <Alert type="info" scrollOnAlert={false}>{COPY.CAVC_REMAND_NO_MANDATE_TEXT}</Alert>;
+  const noMandateBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>{COPY.CAVC_REMAND_NO_MANDATE_TEXT}</Alert>;
 
   const judgementField = <DateSelector
     label={COPY.CAVC_JUDGEMENT_DATE}

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -288,6 +288,9 @@ const AddCavcRemandView = (props) => {
   const jmprIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
     {COPY.JMPR_SELECTION_ISSUE_INFO_BANNER}
   </Alert>;
+  const mdrIssuesBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
+    {COPY.MDR_SELECTION_ISSUE_INFO_BANNER}
+  </Alert>;
 
   const mdrBanner = <Alert type="info" styling={bottomInfoStyling} scrollOnAlert={false}>
     {COPY.MDR_SELECTION_ALERT_BANNER}
@@ -375,6 +378,7 @@ const AddCavcRemandView = (props) => {
       {!deathDismissalType() && issuesField}
       {remandType() && jmrSubtype() && !allIssuesSelected && jmrIssuesBanner }
       {remandType() && jmprSubtype() && allIssuesUnselected && jmprIssuesBanner }
+      {remandType() && mdrSubtype() && allIssuesUnselected && mdrIssuesBanner }
       {remandType() && mdrSubtype() && federalCircuitField }
       {instructionsField}
     </QueueFlowPage>

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -282,7 +282,7 @@ const AddCavcRemandView = (props) => {
   />;
 
   const jmrIssuesBanner = <Alert type="info" scrollOnAlert={false}>{COPY.JMR_SELECTION_ISSUE_INFO_BANNER}</Alert>;
-  
+
   const mdrBanner = <Alert type="info" scrollOnAlert={false}>{COPY.MDR_SELECTION_ALERT_BANNER}</Alert>;
 
   const noMandateBanner = <Alert type="info" scrollOnAlert={false}>{COPY.CAVC_REMAND_NO_MANDATE_TEXT}</Alert>;

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -279,36 +279,8 @@ describe('AddCavcRemandView', () => {
 
       it('shows error when any issue is not selected', () => {
         const cavcForm = setup({ appealId });
-        const decisionIssues = amaAppeal.decisionIssues;
-        const decisionIssueChecks = cavcForm.find(CheckboxGroup).props().values;
-
-        console.log("amaAppeal", amaAppeal);
-        console.log("decisionIssues", decisionIssues);
-        console.log("decisionIssueChecks", decisionIssueChecks);
-
-        console.log("input2 before", cavcForm.find('input[id="2"]').debug());
-
-        console.log("mandate before", cavcForm.find('input#mandate-dates-same-toggle').debug());
-        cavcForm.find('input#mandate-dates-same-toggle').simulate('change', { target: { checked: false } });
-        console.log("mandate after change", cavcForm.find('input#mandate-dates-same-toggle').debug());
-
-        // cavcForm.find('input#2').simulate('change', { target: { checked: false } });
-        // cavcForm.find('input#2').update();
-        // console.log("input#2 after change", cavcForm.find('input#2').debug());
 
         cavcForm.find('input[id="2"]').simulate('change', { target: { checked: false } });
-        cavcForm.find('input[id="2"]').update();
-        cavcForm.update();
-        console.log("input2 after change", cavcForm.find('input[id="2"]').debug());
-        // console.log("input2 state after change", cavcForm.state());
-
-        // cavcForm.find('label[htmlFor=2]').simulate('click');
-        // cavcForm.find('input[id="2"]').update();
-        // console.log("input2 after click", cavcForm.find('input[id="2"]').debug());
-        // debugger;
-
-        console.log("decisionIssueChecks2", cavcForm.find(CheckboxGroup).props().values);
-        expect(decisionIssues.map((issue) => issue.id).every((id) => decisionIssueChecks[id])).toBeTruthy();
 
         expect(validationErrorShows(cavcForm, error)).toBeTruthy();
       });

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -259,6 +259,10 @@ describe('AddCavcRemandView', () => {
       });
     });
 
+    describe('issue selection validations', () => {
+      
+    });
+
     describe('cavc form instructions validations', () => {
       const error = COPY.CAVC_INSTRUCTIONS_ERROR;
 

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -15,7 +15,6 @@ describe('AddCavcRemandView', () => {
   beforeEach(() => jest.clearAllMocks());
 
   const appealId = amaAppeal.externalId;
-  const decisionIssues2 = amaAppeal.decisionIssues;
 
   const setup = ({ appealId: id, mdrToggled, reversalToggled, dismissalToggled }) => {
     return mount(
@@ -280,8 +279,12 @@ describe('AddCavcRemandView', () => {
 
       it('shows error when any issue is not selected', () => {
         const cavcForm = setup({ appealId });
-        console.log("amaAppeal", amaAppeal)
-        console.log("decisionIssues2", decisionIssues2);
+        const decisionIssues = amaAppeal.decisionIssues;
+        const decisionIssueChecks = cavcForm.find(CheckboxGroup).props().values;
+
+        console.log("amaAppeal", amaAppeal);
+        console.log("decisionIssues", decisionIssues);
+        console.log("decisionIssueChecks", decisionIssueChecks);
 
         console.log("input2 before", cavcForm.find('input[id="2"]').debug());
 
@@ -303,6 +306,9 @@ describe('AddCavcRemandView', () => {
         // cavcForm.find('input[id="2"]').update();
         // console.log("input2 after click", cavcForm.find('input[id="2"]').debug());
         // debugger;
+
+        console.log("decisionIssueChecks2", cavcForm.find(CheckboxGroup).props().values);
+        expect(decisionIssues.map((issue) => issue.id).every((id) => decisionIssueChecks[id])).toBeTruthy();
 
         expect(validationErrorShows(cavcForm, error)).toBeTruthy();
       });

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -283,13 +283,25 @@ describe('AddCavcRemandView', () => {
         console.log("amaAppeal", amaAppeal)
         console.log("decisionIssues2", decisionIssues2);
 
-        console.log("input2 before", cavcForm.find('input[id=2]').debug());
+        console.log("input2 before", cavcForm.find('input[id="2"]').debug());
 
-        cavcForm.find('input[id=2]').simulate('change', { target: { checked: false } });
-        console.log("input2 after change", cavcForm.find('input[id=2]').debug());
+        console.log("mandate before", cavcForm.find('input#mandate-dates-same-toggle').debug());
+        cavcForm.find('input#mandate-dates-same-toggle').simulate('change', { target: { checked: false } });
+        console.log("mandate after change", cavcForm.find('input#mandate-dates-same-toggle').debug());
 
-        cavcForm.find('label[htmlFor=2]').simulate('click');
-        console.log("input2 after click", cavcForm.find('input[id=2]').debug());
+        // cavcForm.find('input#2').simulate('change', { target: { checked: false } });
+        // cavcForm.find('input#2').update();
+        // console.log("input#2 after change", cavcForm.find('input#2').debug());
+
+        cavcForm.find('input[id="2"]').simulate('change', { target: { checked: false } });
+        cavcForm.find('input[id="2"]').update();
+        cavcForm.update();
+        console.log("input2 after change", cavcForm.find('input[id="2"]').debug());
+        // console.log("input2 state after change", cavcForm.state());
+
+        // cavcForm.find('label[htmlFor=2]').simulate('click');
+        // cavcForm.find('input[id="2"]').update();
+        // console.log("input2 after click", cavcForm.find('input[id="2"]').debug());
         // debugger;
 
         expect(validationErrorShows(cavcForm, error)).toBeTruthy();

--- a/client/test/app/queue/AddCavcRemandView.test.js
+++ b/client/test/app/queue/AddCavcRemandView.test.js
@@ -15,6 +15,7 @@ describe('AddCavcRemandView', () => {
   beforeEach(() => jest.clearAllMocks());
 
   const appealId = amaAppeal.externalId;
+  const decisionIssues2 = amaAppeal.decisionIssues;
 
   const setup = ({ appealId: id, mdrToggled, reversalToggled, dismissalToggled }) => {
     return mount(
@@ -260,7 +261,24 @@ describe('AddCavcRemandView', () => {
     });
 
     describe('issue selection validations', () => {
-      
+      const error = COPY.CAVC_ALL_ISSUES_ERROR;
+
+      it('shows error when any issue is not selected', () => {
+        const cavcForm = setup({ appealId });
+        console.log("amaAppeal", amaAppeal)
+        console.log("decisionIssues2", decisionIssues2);
+
+        console.log("input2 before", cavcForm.find('input[id=2]').debug());
+
+        cavcForm.find('input[id=2]').simulate('change', { target: { checked: false } });
+        console.log("input2 after change", cavcForm.find('input[id=2]').debug());
+
+        cavcForm.find('label[htmlFor=2]').simulate('click');
+        console.log("input2 after click", cavcForm.find('input[id=2]').debug());
+        // debugger;
+
+        expect(validationErrorShows(cavcForm, error)).toBeTruthy();
+      });
     });
 
     describe('cavc form instructions validations', () => {

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -59,11 +59,11 @@ exports[`AddCavcRemandView renders correctly 1`] = `
         Array [
           Object {
             "description": "This is a description of the decision",
-            "id": "1",
+            "id": 1,
           },
           Object {
             "description": "This is a description of another decision",
-            "id": "2",
+            "id": 2,
           },
         ]
       }

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -3485,6 +3485,11 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                     ]
                   }
                   required={false}
+                  styling={
+                    Object {
+                      "data-css-13g2xn1": "",
+                    }
+                  }
                   values={
                     Object {
                       "1": true,
@@ -3494,6 +3499,7 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                 >
                   <fieldset
                     className="checkbox-wrapper-undefined cf-form-checkboxes cf-checkbox-group-inline"
+                    data-css-13g2xn1=""
                   >
                     <legend
                       className=""

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -59,11 +59,11 @@ exports[`AddCavcRemandView renders correctly 1`] = `
         Array [
           Object {
             "description": "This is a description of the decision",
-            "id": 1,
+            "id": "1",
           },
           Object {
             "description": "This is a description of another decision",
-            "id": 2,
+            "id": "2",
           },
         ]
       }
@@ -3382,15 +3382,17 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   errorMessage={null}
                   getCheckbox={[Function]}
                   hideErrorMessage={false}
+                  hideLabel={true}
+                  name="issuesList"
                   onChange={[Function]}
                   options={
                     Array [
                       Object {
-                        "id": 1,
+                        "id": "1",
                         "label": "This is a description of the decision",
                       },
                       Object {
-                        "id": 2,
+                        "id": "2",
                         "label": "This is a description of another decision",
                       },
                     ]
@@ -3409,13 +3411,15 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   }
                 >
                   <fieldset
-                    className="checkbox-wrapper-undefined cf-form-checkboxes cf-checkbox-group-inline"
+                    className="checkbox-wrapper-issuesList cf-form-checkboxes cf-checkbox-group-inline"
                     data-css-13g2xn1=""
                   >
                     <legend
-                      className=""
+                      className="hidden-field"
                     >
-                      <span />
+                      <span>
+                        issuesList
+                      </span>
                     </legend>
                     <div
                       className="checkbox"
@@ -3424,13 +3428,13 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                       <input
                         checked={true}
                         disabled=""
-                        id={1}
-                        name={1}
+                        id="1"
+                        name="1"
                         onChange={[Function]}
                         type="checkbox"
                       />
                       <label
-                        htmlFor={1}
+                        htmlFor="1"
                       >
                         This is a description of the decision
                       </label>
@@ -3442,13 +3446,13 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                       <input
                         checked={true}
                         disabled=""
-                        id={2}
-                        name={2}
+                        id="2"
+                        name="2"
                         onChange={[Function]}
                         type="checkbox"
                       />
                       <label
-                        htmlFor={2}
+                        htmlFor="2"
                       >
                         This is a description of another decision
                       </label>
@@ -3464,7 +3468,7 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   optional={false}
                   required={false}
                   strongLabel={true}
-                  value={null}
+                  value=""
                 >
                   <div
                     className="cf-form-textarea"
@@ -3491,7 +3495,7 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                       id="context-and-instructions-textBox"
                       name="context-and-instructions-textBox"
                       onChange={[Function]}
-                      value={null}
+                      value=""
                     />
                   </div>
                 </TextareaField>

--- a/client/test/data/appeals.js
+++ b/client/test/data/appeals.js
@@ -72,10 +72,10 @@ export const appealData = {
   issues: [],
   decisionIssues: [
     {
-      id: 1,
+      id: '1',
       description: 'This is a description of the decision'
     }, {
-      id: 2,
+      id: '2',
       description: 'This is a description of another decision'
     }
   ],

--- a/client/test/data/appeals.js
+++ b/client/test/data/appeals.js
@@ -72,10 +72,10 @@ export const appealData = {
   issues: [],
   decisionIssues: [
     {
-      id: '1',
+      id: 1,
       description: 'This is a description of the decision'
     }, {
-      id: '2',
+      id: 2,
       description: 'This is a description of another decision'
     }
   ],

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -92,6 +92,13 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "mandate-date", with: date
           fill_in "context-and-instructions-textBox", with: "Please process this remand"
 
+          # unselect an issue
+          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          expect(page).to have_content COPY::JMR_SELECTION_ISSUE_INFO_BANNER
+          # select the issue; all issues must be selected for JMR
+          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          expect(page).to_not have_content COPY::JMR_SELECTION_ISSUE_INFO_BANNER
+
           page.find("button", text: "Submit").click
 
           expect(page).to have_content COPY::CAVC_REMAND_CREATED_TITLE
@@ -121,14 +128,25 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           visit "queue/appeals/#{appeal.external_id}"
           page.find("button", text: "+ Add CAVC Remand").click
 
-          # unselect an issue
           fill_in "docket-number", with: docket_number
           click_dropdown(text: judge_name)
           find("label", text: "Joint Motion for Partial Remand (JMPR)").click
           fill_in "decision-date", with: date
           fill_in "judgement-date", with: date
           fill_in "mandate-date", with: date
+
+          # unselect all issues
+          find(".checkbox-wrapper-undefined").find("label[for=\"1\"]").click
+          expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
+          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
           find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          expect(page).to have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
+
+          # only need one issue selected for JMPR
+          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
+
           fill_in "context-and-instructions-textBox", with: "Please process this remand"
 
           page.find("button", text: "Submit").click

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -91,10 +91,10 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "context-and-instructions-textBox", with: "Please process this remand"
 
           # unselect an issue
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           expect(page).to have_content COPY::JMR_SELECTION_ISSUE_INFO_BANNER
           # select the issue; all issues must be selected for JMR
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           expect(page).to_not have_content COPY::JMR_SELECTION_ISSUE_INFO_BANNER
 
           page.find("button", text: "Submit").click
@@ -137,15 +137,15 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "mandate-date", with: date
 
           # unselect all issues
-          find(".checkbox-wrapper-undefined").find("label[for=\"1\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"1\"]").click
           expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
-          find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"3\"]").click
           expect(page).to have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
 
           # only need one issue selected for JMPR
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           expect(page).to_not have_content COPY::JMPR_SELECTION_ISSUE_INFO_BANNER
 
           fill_in "context-and-instructions-textBox", with: "Please process this remand"
@@ -190,7 +190,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "judgement-date", with: later_date
           fill_in "mandate-date", with: later_date
           find(".checkbox-wrapper-mandate-dates-same-toggle").find("label[for=\"mandate-dates-same-toggle\"]").click
-          find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"3\"]").click
           fill_in "context-and-instructions-textBox", with: "Please process this remand"
 
           page.find("button", text: "Submit").click
@@ -234,15 +234,15 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           fill_in "decision-date", with: date
 
           # unselect all issues
-          find(".checkbox-wrapper-undefined").find("label[for=\"1\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"1\"]").click
           expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
-          find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"3\"]").click
           expect(page).to have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
 
           # only need one issue selected for MDR
-          find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"3\"]").click
           expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
 
           fill_in "context-and-instructions-textBox", with: instructions
@@ -332,7 +332,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           click_dropdown(text: judge_name)
           find("label", text: "Straight Reversal").click
           fill_in "decision-date", with: date
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           fill_in "context-and-instructions-textBox", with: instructions
           page.find("button", text: "Submit").click
 
@@ -368,7 +368,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           page.all(".cf-form-radio-inline")[1].find("label[for=\"remand-provided-toggle_false\"]").click
           expect(page).to have_content COPY::CAVC_REMAND_NO_MANDATE_TEXT
           fill_in "decision-date", with: date
-          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          find(".checkbox-wrapper-issuesList").find("label[for=\"2\"]").click
           fill_in "context-and-instructions-textBox", with: instructions
           page.find("button", text: "Submit").click
 

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -186,9 +186,21 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
           expect(page).to have_content COPY::CAVC_FEDERAL_CIRCUIT_HEADER
           expect(page).to have_content COPY::CAVC_FEDERAL_CIRCUIT_LABEL
 
-          # unselect an issue and don't fill in judgement date or mandate date
+          # don't fill in judgement date or mandate date
           fill_in "decision-date", with: date
+
+          # unselect all issues
+          find(".checkbox-wrapper-undefined").find("label[for=\"1\"]").click
+          expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
+          find(".checkbox-wrapper-undefined").find("label[for=\"2\"]").click
+          expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
           find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          expect(page).to have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
+
+          # only need one issue selected for MDR
+          find(".checkbox-wrapper-undefined").find("label[for=\"3\"]").click
+          expect(page).to_not have_content COPY::MDR_SELECTION_ISSUE_INFO_BANNER
+
           fill_in "context-and-instructions-textBox", with: instructions
           page.find("button", text: "Submit").click
 


### PR DESCRIPTION
Resolves [CASEFLOW-948](https://vajira.max.gov/browse/CASEFLOW-948)

As a CAVC Litigation Support user, when I select/de-select issues, I want an informational banner noting all issues need to be selected for JMR Remands and at least one needs to be selected for JMPR, so that I do not have to hit submit before I see an error. 

### Description
For the CAVC entry form when JMR or JMPR is selected, show informational banner based on number of issues selected.

### Acceptance Criteria
- [x] Code compiles correctly

Scenario: Given I am a CAVC Litigation Support user entering a CAVC Remand
When I identify the remand type is JMR and I de-select one or more issues
- [x] Then an informational banner displays below the issues section with the following copy: "For a JMR you must select all issues to proceed"

When I identify the remand type is a JMPR **or MDR** and I de-select all issues
- [x] Then an informational banner displays below the issues section with the following copy: "For a JMPR you must select at least one issue to proceed" 

(The MDR requirement was added during a demo to Ann-Marie.)

### Testing Plan
1. Open a Rails console and create a ready for CAVC appeal, note the `stream_docket_number` so you can search for the appeal in the UI or the `uuid`.
```ruby
original_appeal = FactoryBot.create(:appeal, :dispatched, associated_judge: JudgeTeam.first.judge, associated_attorney: JudgeTeam.first.attorneys.first);
FactoryBot.create_list(:request_issue, 2, :rating, :with_rating_decision_issue, decision_review: original_appeal, veteran_participant_id: Veteran.first.participant_id, contested_issue_description: "issue_description", notes: "issue_notes");
original_appeal.uuid
```
2. Login as a CAVC lit support user 
3. Search for the dispatched appeal you just created and select it to go to Case Details: `http://localhost:3000/queue/appeals/<UUID>`
4. Click the "+ Add CAVC Remand" button in the "Post-Dispatch actions" section
5. Fill out the "Add a Court Remand" form
   * select JMR: Unselect an issue and notice the informational banner.
   * select JMPR: Unselect all issue and notice the informational banner.
   * select MDR: Unselect all issue and notice the informational banner.
6. Play around, stress test, and find bugs early

### User Facing Changes
 - [ ] Screenshots of UI changes

 BEFORE|AFTER
 ---|---
![image](https://user-images.githubusercontent.com/55255674/109034764-965bd880-768d-11eb-9422-23a04f46dd08.png) | ![image](https://user-images.githubusercontent.com/55255674/109034054-dc646c80-768c-11eb-958e-18f6d98826b1.png)
![image](https://user-images.githubusercontent.com/55255674/109034815-a2479a80-768d-11eb-8516-3aeedae9074d.png) | ![image](https://user-images.githubusercontent.com/55255674/109034096-e8502e80-768c-11eb-8baf-ec045f604adb.png)


### Storybook Story
* [ ] ~Write a separate story (within the same file) for each discrete variation of the component~ This is not a sufficiently controlled component, so I can change the remand subtype or select issues.
