### PR TITLE
Correctly set new stream's docket type and redirect to it

### DIFF
--- a/app/controllers/docket_switches_controller.rb
+++ b/app/controllers/docket_switches_controller.rb
@@ -32,7 +32,7 @@ class DocketSwitchesController < ApplicationController
 
     docket_switch.process!
 
-    render json: { docket_switch: docket_switch }
+    render json: WorkQueue::DocketSwitchSerializer.new(docket_switch).serializable_hash
   end
 
   private

--- a/app/models/docket_switch.rb
+++ b/app/models/docket_switch.rb
@@ -36,8 +36,10 @@ class DocketSwitch < CaseflowRecord
 
   def process_granted!
     transaction do
-      update!(new_docket_stream: old_docket_stream.create_stream(:original))
-
+      new_stream = old_docket_stream.create_stream(:original).tap do |stream|
+        stream.update!(docket_type: docket_type)
+      end
+      update!(new_docket_stream: new_stream)
       copy_granted_request_issues!
 
       DocketSwitch::TaskHandler.new(

--- a/app/models/serializers/work_queue/docket_switch_serializer.rb
+++ b/app/models/serializers/work_queue/docket_switch_serializer.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class WorkQueue::DocketSwitchSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attribute :disposition
+  attribute :docket_type
+  attribute :receipt_date
+
+  attribute :old_appeal_uuid do |object|
+    object.old_docket_stream.uuid
+  end
+  attribute :new_appeal_uuid do |object|
+    object.new_docket_stream&.uuid
+  end
+end

--- a/client/app/queue/docketSwitch/docketSwitchSlice.js
+++ b/client/app/queue/docketSwitch/docketSwitchSlice.js
@@ -44,9 +44,12 @@ export const completeDocketSwitchGranted = createAsyncThunk(
   async (data) => {
     try {
       const res = await ApiUtil.post('/docket_switches', { data });
-      const result = res.body?.data?.attributes?.new_appeal_uuid;
+      const attrs = res.body?.data?.attributes;
 
-      return result;
+      return {
+        oldAppealId: attrs?.old_appeal_uuid,
+        newAppealId: attrs?.new_appeal_uuid,
+      };
     } catch (error) {
       console.error('Error granting docket switch', error);
       throw error;

--- a/client/app/queue/docketSwitch/docketSwitchSlice.js
+++ b/client/app/queue/docketSwitch/docketSwitchSlice.js
@@ -43,9 +43,8 @@ export const completeDocketSwitchGranted = createAsyncThunk(
   'docketSwitch/grant',
   async (data) => {
     try {
-      // Update this to conform to submission endpoint expectations
       const res = await ApiUtil.post('/docket_switches', { data });
-      const result = res.body?.data;
+      const result = res.body?.data?.attributes?.new_appeal_uuid;
 
       return result;
     } catch (error) {

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
@@ -83,11 +83,11 @@ export const DocketSwitchReviewConfirmContainer = () => {
     };
 
     try {
-      await dispatch(completeDocketSwitchGranted(docketSwitch));
+      const newAppealId = (await dispatch(completeDocketSwitchGranted(docketSwitch))).payload;
 
       dispatch(showSuccessMessage(successMessage));
       dispatch(stepForward());
-      push(`/queue/appeals/${appealId}`);
+      push(`/queue/appeals/${newAppealId}`);
     } catch (error) {
       // Perhaps show an alert that indicates error, advise trying again...?
       console.error('Error Granting Docket Switch', error);

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams } from 'react-router';
+import { unwrapResult } from '@reduxjs/toolkit';
 import { parseISO } from 'date-fns';
 import StringUtil from 'app/util/StringUtil';
 import { appealWithDetailSelector } from 'app/queue/selectors';
@@ -83,7 +84,8 @@ export const DocketSwitchReviewConfirmContainer = () => {
     };
 
     try {
-      const newAppealId = (await dispatch(completeDocketSwitchGranted(docketSwitch))).payload;
+      const resultAction = await dispatch(completeDocketSwitchGranted(docketSwitch));
+      const { newAppealId } = unwrapResult(resultAction);
 
       dispatch(showSuccessMessage(successMessage));
       dispatch(stepForward());

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -341,7 +341,6 @@ RSpec.feature "Docket Switch", :all_dbs do
       click_button(text: "Confirm docket switch")
 
       # Return back to user's queue
-      expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
       expect(page).to have_content format(
         COPY::DOCKET_SWITCH_FULL_GRANTED_SUCCESS_TITLE,
         appeal.claimant.name,
@@ -350,11 +349,13 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(page).to have_content format(COPY::DOCKET_SWITCH_GRANTED_SUCCESS_MESSAGE)
 
       # Verify that full grant completed correctly
+      docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
+      expect(docket_switch).to_not be_nil
+      expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
+
       expect(docket_switch_granted_task.reload.status).to eq Constants.TASK_STATUSES.completed
       expect(existing_admin_action1.reload.status).to eq Constants.TASK_STATUSES.cancelled
 
-      docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
-      expect(docket_switch).to_not be_nil
       expect(docket_switch.disposition).to eq "granted"
       expect(docket_switch.docket_type).to eq "direct_review"
     end

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -218,7 +218,9 @@ RSpec.feature "Docket Switch", :all_dbs do
       )
     end
 
-    let(:colocated_user) { create(:user) }
+    let(:colocated_user) do
+      create(:user).tap { |user| Colocated.singleton.add_user(user) }
+    end
     let!(:colocated_staff) { create(:staff, :colocated_role, sdomainid: colocated_user.css_id) }
 
     let!(:existing_admin_action1) do
@@ -351,6 +353,7 @@ RSpec.feature "Docket Switch", :all_dbs do
       # Verify that full grant completed correctly
       docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
       expect(docket_switch).to_not be_nil
+      expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 
       expect(docket_switch_granted_task.reload.status).to eq Constants.TASK_STATUSES.completed
@@ -391,13 +394,11 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       expect(page).to have_button("Continue", disabled: false)
       click_button(text: "Continue")
-      # Should now be on confirmation page
+      # Should now be on add/remove tasks page
       expect(page).to have_content("Switch Docket: Add/Remove Tasks")
       expect(page).to have_content("You are switching from Evidence Submission to Direct Review")
 
       click_button(text: "Continue")
-
-      click_button(text: "Confirm docket switch")
 
       # Should now be on confirmation page
       expect(page).to have_current_path(
@@ -415,7 +416,6 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       click_button(text: "Confirm docket switch")
       # Return back to user's queue
-      expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
       expect(page).to have_content format(
         COPY::DOCKET_SWITCH_PARTIAL_GRANTED_SUCCESS_TITLE,
         appeal.claimant.name,
@@ -429,8 +429,9 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
       expect(docket_switch).to_not be_nil
-      expect(docket_switch.disposition).to eq "partially_granted"
-      expect(docket_switch.docket_type).to eq "direct_review"
+      expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
+      expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
+      expect(docket_switch).to have_attributes(disposition: "partially_granted", docket_type: "direct_review")
     end
 
     it "allows attorney to edit tasks and proceed to confirmation page" do
@@ -557,15 +558,18 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(page).to have_button("Confirm docket switch", disabled: false)
 
       click_button(text: "Confirm docket switch")
-      # Add checks for post-submit
 
-      expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}")
       expect(page).to have_content format(
         COPY::DOCKET_SWITCH_PARTIAL_GRANTED_SUCCESS_TITLE,
         appeal.claimant.name,
         new_task_type
       )
       expect(page).to have_content format(COPY::DOCKET_SWITCH_GRANTED_SUCCESS_MESSAGE)
+
+      docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
+      expect(docket_switch).to_not be_nil
+      expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
+      expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
     end
   end
 end

--- a/spec/models/docket_switch_spec.rb
+++ b/spec/models/docket_switch_spec.rb
@@ -65,6 +65,9 @@ RSpec.describe DocketSwitch, type: :model do
 
           subject
 
+          # new stream has a the new docket type
+          expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
+
           # all request issues are copied to new appeal stream, accessible as new_docket_stream
           expect(docket_switch.new_docket_stream.request_issues.count).to eq appeal.request_issues.count
 
@@ -87,6 +90,9 @@ RSpec.describe DocketSwitch, type: :model do
           expect(docket_switch_task).to be_assigned
 
           subject
+
+          # new stream has a the new docket type
+          expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
 
           # granted request issues are copied to new appeal stream
           expect(docket_switch.new_docket_stream.request_issues.count).to eq 2


### PR DESCRIPTION
Resolves [CASEFLOW-1058](https://vajira.max.gov/browse/CASEFLOW-1058)

### Description
- Fixes a bug to ensure that the new docket-switched appeal stream actually has the new docket type.
- Adds a DocketSwitchSerializer which includes the UUIDs of the old and, if applicable, new appeal streams
- Redirects to the new appeal stream after successfully completing the grant flow.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Updated model test for `DocketSwitch#process!` to check new stream's docket type
2. Updated feature test to check redirected appeal's UUID
