### PR TITLE
Move TimedHoldTask when assigning CAVC ResponseWindowTask to a user

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -511,6 +511,10 @@ class Task < CaseflowRecord
   def when_child_task_created(child_task)
     cancel_timed_hold unless child_task.is_a?(TimedHoldTask)
 
+    put_on_hold_due_to_new_child_task
+  end
+
+  def put_on_hold_due_to_new_child_task
     if !on_hold?
       Raven.capture_message("Closed task #{id} re-opened because child task created") if !open?
       update!(status: :on_hold)

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -84,20 +84,6 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
     []
   end
 
-  def when_child_task_completed(child_task)
-    pp "when_child_task_completed: #{child_task.id}"
-    if same_task_type_assigned_to_user(child_task)
-      # Move any open TimedHoldTask to the this task
-      child_task.children.open.where(type: :TimedHoldTask).each do |timed_hold_task|
-        timed_hold_task.update(parent_id: id)
-      end
-    end
-
-    # call super after moving open TimedHoldTask to this task so that task's status is correctly set
-    super
-    # binding.pry
-  end
-
   def same_task_type_assigned_to_user(child_task)
     child_task.type == type && child_task.assigned_to_type == "User"
   end

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -92,15 +92,14 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
   def when_child_task_created(child_task)
     if same_task_type_assigned_to_user(child_task)
       # Move any open TimedHoldTask to the child_task
-      timed_hold_tasks = children.open.where(type: :TimedHoldTask).find_each do |timed_hold_task|
+      children.open.where(type: :TimedHoldTask).find_each do |timed_hold_task|
         timed_hold_task.update!(parent_id: child_task.id)
       end
 
-      child_task.update!(status: :on_hold) if timed_hold_tasks.any?
+      child_task.update!(status: :on_hold) if child_task.children.open.any?
     end
 
     put_on_hold_due_to_new_child_task
-    # binding.pry
   end
 
   private

--- a/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
+++ b/app/models/tasks/cavc_remand_processed_letter_response_window_task.rb
@@ -84,6 +84,7 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
     []
   end
 
+  # :reek:FeatureEnvy
   def same_task_type_assigned_to_user(child_task)
     child_task.type == type && child_task.assigned_to_type == "User"
   end
@@ -91,7 +92,7 @@ class CavcRemandProcessedLetterResponseWindowTask < Task
   def when_child_task_created(child_task)
     if same_task_type_assigned_to_user(child_task)
       # Move any open TimedHoldTask to the child_task
-      timed_hold_tasks = children.open.where(type: :TimedHoldTask).each do |timed_hold_task|
+      timed_hold_tasks = children.open.where(type: :TimedHoldTask).find_each do |timed_hold_task|
         timed_hold_task.update!(parent_id: child_task.id)
       end
 

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -156,7 +156,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
 
     context "when assigning task to person" do
       context "open TimedHoldTask child exists" do
-        it "has open TimedHoldTask child exists under newly created child task" do
+        it "has open TimedHoldTask child under newly created child task" do
           timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
           expect(timed_hold_task.status).to eq "assigned"
         end

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -155,9 +155,21 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     end
 
     context "when assigning task to person" do
-      it "open TimedHoldTask child exists under newly created child task" do
-        timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
-        expect(timed_hold_task.status).to eq "assigned"
+      context "open TimedHoldTask child exists" do
+        it "has open TimedHoldTask child exists under newly created child task" do
+          timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
+          expect(timed_hold_task.status).to eq "assigned"
+        end
+      end
+      context "no open TimedHoldTask child exists" do
+        before do
+          timed_hold_task = window_task.children.open.where(type: :TimedHoldTask).first
+          timed_hold_task.cancelled!
+        end
+        it "does not have TimedHoldTask child under newly created child task" do
+          timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
+          expect(timed_hold_task).to eq nil
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #15893

### Description
When assigning `CavcRemandProcessedLetterResponseWindowTask` to a user, move any open TimedHoldTask from the org-task to the child user-task.

* The TimedHoldTask is not really cancelled, so let's not cancel it at all.
* In case the user-task is cancelled (not currently a capability), the TimedHoldTask can be moved back to the org-task. Basically the TimedHoldTask can move between the org-task and user-task. If a user wants to cancel and then reassign to a new user, the TimedHoldTask would move from old user-task to parent org-task to new user-task.

### Acceptance Criteria
- [ ] The timed hold continues to be open with the same end time when `CavcRemandProcessedLetterResponseWindowTask` is assigned or reassigned to a user
- [ ] Any **open** TimedHoldTask remains active and should move under the active `CavcRemandProcessedLetterResponseWindowTask`.
- [ ] Any **closed** `TimedHoldTask`remains where it is.
- [ ] Only 1 TimedHoldTask is open at a time.

### Testing Plan
1. Login as a CAVC lit support user
1. Go to http://localhost:3000/organizations/cavc-lit-support?tab=unassignedTab
1. Select an appeal with "Send CAVC-Remand-Processed Letter Task" to view the Case Details page. Note the docket number and UUID so you can find this appeal later. 
1. After each of the following steps, check the task tree in the browser (`http://localhost:3000/task_tree/appeals/<UUID>`) or in a Rails console:
    ```ruby
    cavc_appeal=Appeal.find_by_uuid(<UUID>)
    cavc_appeal.reload.treee
    ```
1. Select "Assign to person". Select some user, possibly yourself. If you choose another user, log in as that other user.
1. Go to Case Details for the case you just modified.
1. Select "Mark as complete" and submit.
1. Check the task tree.  Note the status of `CavcRemandProcessedLetterResponseWindowTask` and its child.
1. Go to Case Details for the case you just modified. Check the "Case Timeline" reflects your actions.
1. Select "Assign to person". Check the task tree.  Play around and "Re-assign to person", checking the task tree each time.
   * Play around by selecting "End hold early" and "Put task on hold" to close and create `TimedHoldTask`s.
   * Any **open** `TimedHoldTask` should be moved to the new task. 
   * Any **closed** `TimedHoldTask` should remain where it is.
   * Only 1 TimedHoldTask should be open at a time.
   * Check that appeal is in the appropriate Queue tab -- see question #2 at https://github.com/department-of-veterans-affairs/caseflow/issues/15893#issuecomment-788374117
1. Play around, stress test, and find bugs.

