### PR TITLE
Persist unlisted POA or CorpDB POA to database

### DIFF
--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -49,7 +49,11 @@ class DecisionReviewIntake < Intake
       notes: request_params[:claimant_notes]
     )
     if FeatureToggle.enabled?(:non_veteran_claimants, user: user) && claimant.is_a?(OtherClaimant)
-      claimant.save_unrecognized_details!(request_params[:unlisted_claimant])
+      claimant.save_unrecognized_details!(
+        request_params[:unlisted_claimant],
+        request_params[:unlisted_poa],
+        request_params[:poa_participant_id]
+      )
     end
     update_person!
   end

--- a/app/schemas/intakes_schemas.rb
+++ b/app/schemas/intakes_schemas.rb
@@ -35,6 +35,8 @@ class IntakesSchemas
         # applicable when :claimant_type is "other"
         string :claimant_notes, optional: true, nullable: true, doc: "Appeals only"
         nested :unlisted_claimant, optional: true, nullable: true
+        nested :unlisted_poa, optional: true, nullable: true
+        string :poa_participant_id, optional: true, nullable: true
       end
     end
     # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Connects [CASEFLOW-334](https://vajira.max.gov/browse/CASEFLOW-334)

### Description
This is a small companion PR to #15940 which handles the backend saving unlisted POAs or CorpDB POAs to the database.

### Testing Plan
1. Added new spec to test saving unlisted POA to database
2. Added new spec to test saving CorpDB POA to database