### PR TITLE
CASEFLOW-1060 Copy DocketSwitchGranted Task to New Appeal Stream

### DIFF
--- a/app/models/docket_switch.rb
+++ b/app/models/docket_switch.rb
@@ -84,7 +84,7 @@ class DocketSwitch < CaseflowRecord
 
   # We want the granted/denied tasks to be visible on the new stream as well as the old to give user context
   def copy_ds_tasks_to_new_stream
-    new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream).dup
+    new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream, assigned_to_type: "User").dup
     new_completed_task.assign_attributes(
       appeal_id: new_docket_stream.id,
       parent_id: new_docket_stream.root_task.id,

--- a/app/models/docket_switch.rb
+++ b/app/models/docket_switch.rb
@@ -85,9 +85,12 @@ class DocketSwitch < CaseflowRecord
   # We want the granted/denied tasks to be visible on the new stream as well as the old to give user context
   def copy_ds_tasks_to_new_stream
     new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream).dup
-    new_completed_task.appeal_id = new_docket_stream.id
-    new_completed_task.parent_id = new_docket_stream.root_task.id
-    new_completed_task.status = Constants.TASK_STATUSES.completed
+    new_completed_task.assign_attributes(
+      appeal_id: new_docket_stream.id,
+      parent_id: new_docket_stream.root_task.id,
+      status: Constants.TASK_STATUSES.completed
+    )
+    # Disable validation to avoid errors re creating with status of completed
     new_completed_task.save(validate: false)
   end
 end

--- a/app/models/docket_switch.rb
+++ b/app/models/docket_switch.rb
@@ -48,6 +48,8 @@ class DocketSwitch < CaseflowRecord
         new_admin_actions: admin_actions_params
       ).call
 
+      copy_ds_tasks_to_new_stream
+
       task.update(status: Constants.TASK_STATUSES.completed)
     end
   end
@@ -78,5 +80,11 @@ class DocketSwitch < CaseflowRecord
         "is required for partially_granted disposition"
       )
     end
+  end
+
+  # We want the granted/denied tasks to be visible on the new stream as well as the old to give user context
+  def copy_ds_tasks_to_new_stream
+    new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream).clone
+    new_completed_task.update!(appeal: new_docket_stream, parent: new_docket_stream.root_task)
   end
 end

--- a/app/models/docket_switch.rb
+++ b/app/models/docket_switch.rb
@@ -84,7 +84,10 @@ class DocketSwitch < CaseflowRecord
 
   # We want the granted/denied tasks to be visible on the new stream as well as the old to give user context
   def copy_ds_tasks_to_new_stream
-    new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream).clone
-    new_completed_task.update!(appeal: new_docket_stream, parent: new_docket_stream.root_task)
+    new_completed_task = DocketSwitchGrantedTask.find_by(appeal: old_docket_stream).dup
+    new_completed_task.appeal_id = new_docket_stream.id
+    new_completed_task.parent_id = new_docket_stream.root_task.id
+    new_completed_task.status = Constants.TASK_STATUSES.completed
+    new_completed_task.save(validate: false)
   end
 end

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -368,7 +368,7 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(docket_switch.disposition).to eq "granted"
       expect(docket_switch.docket_type).to eq "direct_review"
 
-      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream, assigned_to_type: "User")
       expect(new_completed_task).to_not be_nil
     end
 
@@ -580,7 +580,7 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 
-      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream, assigned_to_type: "User")
       expect(new_completed_task).to_not be_nil
     end
   end

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -368,7 +368,10 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(docket_switch.disposition).to eq "granted"
       expect(docket_switch.docket_type).to eq "direct_review"
 
-      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream, assigned_to_type: "User")
+      new_completed_task = DocketSwitchGrantedTask.find_by(
+        appeal: docket_switch.new_docket_stream,
+        assigned_to_type: "User"
+      )
       expect(new_completed_task).to_not be_nil
     end
 
@@ -580,7 +583,10 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 
-      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream, assigned_to_type: "User")
+      new_completed_task = DocketSwitchGrantedTask.find_by(
+        appeal: docket_switch.new_docket_stream,
+        assigned_to_type: "User"
+      )
       expect(new_completed_task).to_not be_nil
     end
   end

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -367,6 +367,9 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       expect(docket_switch.disposition).to eq "granted"
       expect(docket_switch.docket_type).to eq "direct_review"
+
+      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+      expect(new_completed_task).to_not be_nil
     end
 
     it "allows attorney to complete a partial docket switch" do
@@ -576,6 +579,9 @@ RSpec.feature "Docket Switch", :all_dbs do
       expect(docket_switch).to_not be_nil
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
+
+      new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+      expect(new_completed_task).to_not be_nil
     end
   end
 end

--- a/spec/models/docket_switch_spec.rb
+++ b/spec/models/docket_switch_spec.rb
@@ -110,7 +110,10 @@ RSpec.describe DocketSwitch, type: :model do
           expect(docket_switch_task).to be_completed
 
           # Docket switch task has been copied to new appeal stream
-          new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+          new_completed_task = DocketSwitchGrantedTask.find_by(
+            appeal: docket_switch.new_docket_stream,
+            assigned_to_type: "User"
+          )
           expect(new_completed_task).to_not be_nil
           expect(new_completed_task).to be_completed
 

--- a/spec/models/docket_switch_spec.rb
+++ b/spec/models/docket_switch_spec.rb
@@ -79,6 +79,10 @@ RSpec.describe DocketSwitch, type: :model do
 
           # Appeal Status API shows original stream's status of archived
           expect(appeal.status.to_sym).to eq :archived
+
+          # Docket switch task has been copied to new appeal stream
+          new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+          expect(new_completed_task).to_not be_nil
         end
       end
 
@@ -103,6 +107,10 @@ RSpec.describe DocketSwitch, type: :model do
 
           # Docket switch task gets completed
           expect(docket_switch_task).to be_completed
+
+          # Docket switch task has been copied to new appeal stream
+          new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
+          expect(new_completed_task).to_not be_nil
 
           # To do: Check for correct appeal status after task handling logic is implemented
         end

--- a/spec/models/docket_switch_spec.rb
+++ b/spec/models/docket_switch_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe DocketSwitch, type: :model do
           # Docket switch task has been copied to new appeal stream
           new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
           expect(new_completed_task).to_not be_nil
+          expect(new_completed_task).to be_completed
         end
       end
 
@@ -111,6 +112,7 @@ RSpec.describe DocketSwitch, type: :model do
           # Docket switch task has been copied to new appeal stream
           new_completed_task = DocketSwitchGrantedTask.find_by(appeal: docket_switch.new_docket_stream)
           expect(new_completed_task).to_not be_nil
+          expect(new_completed_task).to be_completed
 
           # To do: Check for correct appeal status after task handling logic is implemented
         end


### PR DESCRIPTION
Connects [CASEFLOW-1060](https://vajira.max.gov/browse/CASEFLOW-1060)

### Description
This adds logic to copy the `DocketSwitchGrantedTask` to the new appeal stream so that it shows up both places.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `DocketSwitchGrantedTask` shows up on new appeal stream
- [ ] `DocketSwitchGrantedTask` still shows up on old appeal stream
