### PR TITLE
therubyracer needs a different libv8 on Catalina to install

### DIFF
--- a/scripts/dev_env_setup_step2.sh
+++ b/scripts/dev_env_setup_step2.sh
@@ -3,6 +3,11 @@
 # Continuation of Developer Setup at
 # https://github.com/department-of-veterans-affairs/caseflow/blob/master/README.md#install-ruby-dependencies
 
+function detectVersion(){
+	# https://stackoverflow.com/questions/3466166/how-to-check-if-running-in-cygwin-mac-or-linux
+	version="$(sw_vers -productVersion)"
+	echo ${version}
+}
 echo "==> Installing Ruby dependencies"
 rbenv install $(cat .ruby-version)
 rbenv rehash
@@ -16,6 +21,15 @@ if [ $? == 0 ]; then
 	# this means you have not propertly configured your rbenv.
 	# Debug.
 	# !! Do *not* proceed by running sudo gem install bundler. !!
+
+	VERSION=$(detectVersion)
+	echo "==> Detected OS Version $VERSION"
+
+	if [[ "$VERSION" == "10.15"* ]]; then
+		brew install v8@3.15
+		bundle config build.libv8 --with-system-v8
+		bundle config build.therubyracer --with-v8-dir=$(brew --prefix v8@3.15)
+	fi
 
 	bundle install
 fi


### PR DESCRIPTION
Resolves issue when installing gems on macOS Catalina setting up dev environment with `scripts/dev_env_setup_step2.sh`

### Description
Installing `therubyracer` on macOS Catalina (10.15.x) fails due to an issue installing `libv8`. Solution is to install `libv8` via Homebrew and building `therubyracer` off of that `libv8`.

### Acceptance Criteria
- [ ] Setup script runs successfully.

### Testing Plan
1. Run `$ ./dev_env_setup_step2.sh` and confirm script completes successfully.
