### PR TITLE
Shalliburton/caseflow 956 combine time slot endpoint

### DIFF
--- a/app/controllers/hearings/hearing_day/filled_hearing_slots_controller.rb
+++ b/app/controllers/hearings/hearing_day/filled_hearing_slots_controller.rb
@@ -30,6 +30,7 @@ class Hearings::HearingDay::FilledHearingSlotsController < ApplicationController
 
     open_hearings.map do |hearing|
       {
+        external_id: hearing.external_id,
         hearing_time: hearing.scheduled_time_string,
         issue_count: hearing.current_issue_count,
         docket_number: hearing.docket_number,

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -180,6 +180,8 @@ class Veteran < CaseflowRecord
 
   # Postal code might be stored in address line 3 for international addresses
   def zip_code
+    return nil unless bgs_record_found?
+
     zip_code = bgs_record&.[](:zip_code)
     zip_code ||= (@address_line3 if (@address_line3 || "").match?(Address::ZIP_CODE_REGEX))
 

--- a/client/app/components/common/actions.js
+++ b/client/app/components/common/actions.js
@@ -134,5 +134,11 @@ export const fetchScheduledHearings = (hearingDay) => (dispatch) => {
         ApiUtil.convertToCamelCase(body.filled_hearing_slots)
       ),
     });
-  });
+  }).
+    catch(() => {
+      dispatch({
+        type: ACTIONS.SET_SCHEDULED_HEARINGS,
+        payload: [],
+      });
+    });
 };

--- a/client/app/components/common/actions.js
+++ b/client/app/components/common/actions.js
@@ -1,62 +1,63 @@
 import { ACTIONS } from './actionTypes';
+import ApiUtil from '../../util/ApiUtil';
 
 export const onReceiveRegionalOffices = (regionalOffices) => ({
   type: ACTIONS.RECEIVE_REGIONAL_OFFICES,
   payload: {
-    regionalOffices
-  }
+    regionalOffices,
+  },
 });
 
 export const onRegionalOfficeChange = (regionalOffice) => ({
   type: ACTIONS.REGIONAL_OFFICE_CHANGE,
   payload: {
-    regionalOffice
-  }
+    regionalOffice,
+  },
 });
 
 export const onReceiveHearingDays = (hearingDays) => ({
   type: ACTIONS.RECEIVE_HEARING_DAYS,
   payload: {
-    hearingDays
-  }
+    hearingDays,
+  },
 });
 
 export const onFetchDropdownData = (dropdownName) => ({
   type: ACTIONS.FETCH_DROPDOWN_DATA,
   payload: {
-    dropdownName
-  }
+    dropdownName,
+  },
 });
 
 export const onReceiveDropdownData = (dropdownName, data) => ({
   type: ACTIONS.RECEIVE_DROPDOWN_DATA,
   payload: {
     dropdownName,
-    data
-  }
+    data,
+  },
 });
 
 export const onDropdownError = (dropdownName, errorMsg) => ({
   type: ACTIONS.DROPDOWN_ERROR,
   payload: {
     dropdownName,
-    errorMsg
-  }
+    errorMsg,
+  },
 });
 
 export const onHearingOptionalTime = (optionalTime) => ({
   type: ACTIONS.HEARING_OPTIONAL_TIME_CHANGE,
   payload: {
-    optionalTime
-  }
+    optionalTime,
+  },
 });
 
 export const onChangeFormData = (formName, formData) => ({
   type: ACTIONS.CHANGE_FORM_DATA,
   payload: {
     formName,
-    formData
-  }
+    formData,
+  },
 });
 
 export const onReceiveAlerts = (alerts) => {
@@ -67,9 +68,9 @@ export const onReceiveAlerts = (alerts) => {
     payload: {
       alerts: (alerts || []).map((alert) => ({
         ...alert,
-        timestamp
-      }))
-    }
+        timestamp,
+      })),
+    },
   };
 };
 
@@ -77,22 +78,22 @@ export const onReceiveTransitioningAlert = (alert, key) => ({
   type: ACTIONS.RECEIVE_TRANSITIONING_ALERT,
   payload: {
     alert,
-    key
-  }
+    key,
+  },
 });
 
 export const transitionAlert = (key) => ({
   type: ACTIONS.TRANSITION_ALERT,
   payload: {
-    key
-  }
+    key,
+  },
 });
 
 export const removeAlertsWithTimestamps = (timestamps) => ({
   type: ACTIONS.REMOVE_ALERTS_WITH_EXPIRATION,
   payload: {
-    timestamps
-  }
+    timestamps,
+  },
 });
 
 export const clearAlerts = () => ({
@@ -103,27 +104,36 @@ export const startPollingHearing = (externalId) => ({
   type: ACTIONS.START_POLLING,
   payload: {
     externalId,
-    polling: true
-  }
+    polling: true,
+  },
 });
 
 export const stopPollingHearing = () => ({
   type: ACTIONS.STOP_POLLING,
   payload: {
     externalId: null,
-    polling: false
-  }
+    polling: false,
+  },
 });
 
 export const setScheduledHearing = (payload) => ({
   type: ACTIONS.SET_SCHEDULE_HEARING_PAYLOAD,
-  payload
+  payload,
 });
 
-export const fetchScheduledHearings = () => (dispatch) => {
+export const fetchScheduledHearings = (hearingDay) => (dispatch) => {
   // Dispatch the action to set the pending state for the hearing time
   dispatch({ type: ACTIONS.REQUEST_SCHEDULED_HEARINGS });
 
-  // This will be wrapped in a future PR to handle the backend request
-  dispatch({ type: ACTIONS.SET_SCHEDULED_HEARINGS, payload: [] });
+  ApiUtil.get(
+    `/hearings/hearing_day/${hearingDay?.hearingId}/filled_hearing_slots`
+  ).then(({ body }) => {
+    // This will be wrapped in a future PR to handle the backend request
+    dispatch({
+      type: ACTIONS.SET_SCHEDULED_HEARINGS,
+      payload: Object.values(
+        ApiUtil.convertToCamelCase(body.filled_hearing_slots)
+      ),
+    });
+  });
 };

--- a/client/app/components/common/actions.js
+++ b/client/app/components/common/actions.js
@@ -128,7 +128,6 @@ export const fetchScheduledHearings = (hearingDay) => (dispatch) => {
   ApiUtil.get(
     `/hearings/hearing_day/${hearingDay?.hearingId}/filled_hearing_slots`
   ).then(({ body }) => {
-    // This will be wrapped in a future PR to handle the backend request
     dispatch({
       type: ACTIONS.SET_SCHEDULED_HEARINGS,
       payload: Object.values(

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -27,7 +27,6 @@ import {
   transitionAlert,
   startPollingHearing,
   setScheduledHearing,
-  fetchScheduledHearings
 } from '../../components/common/actions';
 import { ScheduleVeteranForm } from './ScheduleVeteranForm';
 import ApiUtil from '../../util/ApiUtil';
@@ -347,7 +346,6 @@ export const ScheduleVeteran = ({
         )}
         {openHearing && !reschedule ? <Alert title="Open Hearing" type="error">{openHearingDayError}</Alert> : (
           <ScheduleVeteranForm
-            fetchScheduledHearings={props.fetchScheduledHearings}
             scheduledHearingsList={scheduledHearingsList}
             fetchingHearings={fetchingHearings}
             userCanViewTimeSlots={userCanViewTimeSlots}
@@ -440,7 +438,6 @@ ScheduleVeteran.propTypes = {
   userCanViewTimeSlots: PropTypes.bool,
   scheduledHearingsList: PropTypes.array,
   fetchingHearings: PropTypes.bool,
-  fetchScheduledHearings: PropTypes.func,
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -464,7 +461,6 @@ const mapStateToProps = (state, ownProps) => ({
 const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
     {
-      fetchScheduledHearings,
       onReceiveAlerts,
       onReceiveTransitioningAlert,
       transitionAlert,

--- a/client/app/hearings/components/ScheduleVeteranForm.jsx
+++ b/client/app/hearings/components/ScheduleVeteranForm.jsx
@@ -4,12 +4,12 @@ import PropTypes from 'prop-types';
 import {
   TRAVEL_BOARD_HEARING_LABEL,
   VIDEO_HEARING_LABEL,
-  HEARING_CONVERSION_TYPES
+  HEARING_CONVERSION_TYPES,
 } from '../constants';
 import {
   RegionalOfficeDropdown,
   AppealHearingLocationsDropdown,
-  HearingDateDropdown
+  HearingDateDropdown,
 } from '../../components/DataDropdowns';
 import { AddressLine } from './details/Address';
 import { ReadOnly } from './details/ReadOnly';
@@ -20,6 +20,8 @@ import { AppellantSection } from './VirtualHearings/AppellantSection';
 import { marginTop } from './details/style';
 import { isEmpty, orderBy } from 'lodash';
 import { TimeSlot } from './scheduleHearing/TimeSlot';
+import { useDispatch } from 'react-redux';
+import { fetchScheduledHearings } from '../../components/common/actions';
 
 export const ScheduleVeteranForm = ({
   virtual,
@@ -33,16 +35,25 @@ export const ScheduleVeteranForm = ({
   userCanViewTimeSlots,
   ...props
 }) => {
+  const dispatch = useDispatch();
   const ro = hearing?.regionalOffice || initialRegionalOffice;
   const location = hearing?.hearingLocation || appeal?.hearingLocation;
-  const availableHearingLocations = orderBy(appeal?.availableHearingLocations || [], ['distance'], ['asc']);
-  const dynamic = ro !== appeal?.closestRegionalOffice || isEmpty(appeal?.availableHearingLocations);
+  const availableHearingLocations = orderBy(
+    appeal?.availableHearingLocations || [],
+    ['distance'],
+    ['asc']
+  );
+  const dynamic =
+    ro !== appeal?.closestRegionalOffice ||
+    isEmpty(appeal?.availableHearingLocations);
 
   const getOriginalRequestType = () => {
-    if (appeal?.readableOriginalHearingRequestType === TRAVEL_BOARD_HEARING_LABEL) {
-    // For COVID-19, travel board appeals can have either a video or virtual hearing scheduled. In this case,
-    // we consider a travel board hearing as a video hearing, which enables both video and virtual options in
-    // the HearingTypeDropdown
+    if (
+      appeal?.readableOriginalHearingRequestType === TRAVEL_BOARD_HEARING_LABEL
+    ) {
+      // For COVID-19, travel board appeals can have either a video or virtual hearing scheduled. In this case,
+      // we consider a travel board hearing as a video hearing, which enables both video and virtual options in
+      // the HearingTypeDropdown
       return VIDEO_HEARING_LABEL;
     }
 
@@ -65,98 +76,124 @@ export const ScheduleVeteranForm = ({
       </div>
       <div className="cf-help-divider usa-width-one-whole" />
       <div className="usa-width-one-half">
-        {virtual ? <ReadOnly spacing={15} label="Hearing Location" text="Virtual" /> :
-          <ReadOnly spacing={0} label={`${appellantTitle} Address`} text={
-            <AddressLine
-              spacing={5}
-              name={appeal?.appellantFullName}
-              addressLine1={appeal?.appellantAddress?.address_line_1}
-              addressState={appeal?.appellantAddress?.state}
-              addressCity={appeal?.appellantAddress?.city}
-              addressZip={appeal?.appellantAddress?.zip}
-            />}
-          /> }
+        {virtual ? (
+          <ReadOnly spacing={15} label="Hearing Location" text="Virtual" />
+        ) : (
+          <ReadOnly
+            spacing={0}
+            label={`${appellantTitle} Address`}
+            text={
+              <AddressLine
+                spacing={5}
+                name={appeal?.appellantFullName}
+                addressLine1={appeal?.appellantAddress?.address_line_1}
+                addressState={appeal?.appellantAddress?.state}
+                addressCity={appeal?.appellantAddress?.city}
+                addressZip={appeal?.appellantAddress?.zip}
+              />
+            }
+          />
+        )}
         <RegionalOfficeDropdown
           errorMessage={errors?.regionalOffice}
           excludeVirtualHearingsOption
-          onChange={(regionalOffice) => props.onChange('regionalOffice', regionalOffice)}
+          onChange={(regionalOffice) =>
+            props.onChange('regionalOffice', regionalOffice)
+          }
           value={ro}
           validateValueOnMount
         />
         {ro && (
           <React.Fragment>
-            {!virtual && <AppealHearingLocationsDropdown
-              errorMessage={errors?.hearingLocation}
-              key={`hearingLocation__${ro}`}
-              regionalOffice={ro}
-              appealId={appeal.externalId}
-              value={location}
-              onChange={(hearingLocation) => props.onChange('hearingLocation', hearingLocation)}
-              dynamic={dynamic}
-              staticHearingLocations={availableHearingLocations}
-            />}
+            {!virtual && (
+              <AppealHearingLocationsDropdown
+                errorMessage={errors?.hearingLocation}
+                key={`hearingLocation__${ro}`}
+                regionalOffice={ro}
+                appealId={appeal.externalId}
+                value={location}
+                onChange={(hearingLocation) =>
+                  props.onChange('hearingLocation', hearingLocation)
+                }
+                dynamic={dynamic}
+                staticHearingLocations={availableHearingLocations}
+              />
+            )}
             <HearingDateDropdown
               errorMessage={errors?.hearingDay}
               key={`hearingDate__${ro}`}
               regionalOffice={ro}
               value={hearing.hearingDay || initialHearingDate}
-              onChange={(hearingDay) => props.onChange('hearingDay', hearingDay)}
+              onChange={(hearingDay) => {
+                // Call fetch scheduled hearings only if passed
+                fetchScheduledHearings(hearingDay)(dispatch);
+
+                props.onChange('hearingDay', hearingDay);
+              }}
             />
-            {userCanViewTimeSlots ? (
-              <TimeSlot
-                {...props}
-                onChange={props.onChange}
-                hearing={hearing}
-                roTimezone={hearing?.hearingDay?.timezone}
-              />
-            ) : (
-              <HearingTime
-                regionalOffice={ro}
-                errorMessage={errors?.scheduledTimeString}
-                vertical
-                label="Hearing Time"
-                enableZone
-                localZone={hearing?.hearingDay?.timezone}
-                onChange={(scheduledTimeString) => props.onChange('scheduledTimeString', scheduledTimeString)}
-                value={hearing.scheduledTimeString}
-              />
+            {hearing.hearingDay?.hearingId && (
+              <React.Fragment>
+                {userCanViewTimeSlots ? (
+                  <TimeSlot
+                    {...props}
+                    ro={ro}
+                    onChange={props.onChange}
+                    hearing={hearing}
+                    roTimezone={hearing?.hearingDay?.timezone}
+                  />
+                ) : (
+                  <HearingTime
+                    regionalOffice={ro}
+                    errorMessage={errors?.scheduledTimeString}
+                    vertical
+                    label="Hearing Time"
+                    enableZone
+                    localZone={hearing?.hearingDay?.timezone}
+                    onChange={(scheduledTimeString) =>
+                      props.onChange('scheduledTimeString', scheduledTimeString)
+                    }
+                    value={hearing.scheduledTimeString}
+                  />
+                )}
+              </React.Fragment>
             )}
           </React.Fragment>
         )}
-
       </div>
-      {virtual && <div className="usa-width-one-whole" {...marginTop(25)}>
-        <AppellantSection
-          virtual={virtual}
-          errors={errors}
-          video={video}
-          update={(_, virtualHearing) =>
-            props.onChange('virtualHearing', {
-              ...hearing?.virtualHearing,
-              ...virtualHearing,
-            })
-          }
-          appellantTitle={appellantTitle}
-          hearing={hearing}
-          virtualHearing={hearing?.virtualHearing}
-          type={HEARING_CONVERSION_TYPES[0]}
-        />
-        <RepresentativeSection
-          virtual={virtual}
-          errors={errors}
-          video={video}
-          update={(_, virtualHearing) =>
-            props.onChange('virtualHearing', {
-              ...hearing?.virtualHearing,
-              ...virtualHearing,
-            })
-          }
-          appellantTitle={appellantTitle}
-          hearing={hearing}
-          virtualHearing={hearing?.virtualHearing}
-          type={HEARING_CONVERSION_TYPES[0]}
-        />
-      </div>}
+      {virtual && (
+        <div className="usa-width-one-whole" {...marginTop(25)}>
+          <AppellantSection
+            virtual={virtual}
+            errors={errors}
+            video={video}
+            update={(_, virtualHearing) =>
+              props.onChange('virtualHearing', {
+                ...hearing?.virtualHearing,
+                ...virtualHearing,
+              })
+            }
+            appellantTitle={appellantTitle}
+            hearing={hearing}
+            virtualHearing={hearing?.virtualHearing}
+            type={HEARING_CONVERSION_TYPES[0]}
+          />
+          <RepresentativeSection
+            virtual={virtual}
+            errors={errors}
+            video={video}
+            update={(_, virtualHearing) =>
+              props.onChange('virtualHearing', {
+                ...hearing?.virtualHearing,
+                ...virtualHearing,
+              })
+            }
+            appellantTitle={appellantTitle}
+            hearing={hearing}
+            virtualHearing={hearing?.virtualHearing}
+            type={HEARING_CONVERSION_TYPES[0]}
+          />
+        </div>
+      )}
     </React.Fragment>
   );
 };
@@ -172,7 +209,8 @@ ScheduleVeteranForm.propTypes = {
   initialHearingDate: PropTypes.string,
   appellantTitle: PropTypes.string,
   convertToVirtual: PropTypes.func,
-  userCanViewTimeSlots: PropTypes.bool
+  fetchScheduledHearings: PropTypes.func,
+  userCanViewTimeSlots: PropTypes.bool,
 };
 
 /* eslint-enable camelcase */

--- a/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
+++ b/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
@@ -1,5 +1,5 @@
 // External Dependencies
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 // Local Dependencies

--- a/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
+++ b/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
@@ -39,6 +39,9 @@ export const TimeSlot = ({
   // Create a hearing Time ID to associate the label with the appropriate form element
   const hearingTimeId = `hearing-time-${hearing?.scheduledTimeString}`;
 
+  // Determine the column length to evenly distribute the time slots
+  const columnLength = Math.ceil(slots.length / 2);
+
   return (
     <React.Fragment>
       <label className="time-slot-label" htmlFor={hearingTimeId}>
@@ -70,7 +73,7 @@ export const TimeSlot = ({
           ) : (
             <div className="time-slot-button-container">
               <div className="time-slot-container" >
-                {slots.slice(0, slots.length / 2).map((slot) => (
+                {slots.slice(0, columnLength).map((slot) => (
                   <TimeSlotButton
                     {...slot}
                     key={slot.key}
@@ -81,7 +84,7 @@ export const TimeSlot = ({
                 ))}
               </div>
               <div className="time-slot-container">
-                {slots.slice(slots.length / 2, slots.length).map((slot) => (
+                {slots.slice(columnLength, slots.length).map((slot) => (
                   <TimeSlotButton
                     {...slot}
                     key={slot.key}

--- a/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
+++ b/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
@@ -81,7 +81,7 @@ export const TimeSlot = ({
                 ))}
               </div>
               <div className="time-slot-container">
-                {slots.slice(slots.length / 2, slots.length - 1).map((slot) => (
+                {slots.slice(slots.length / 2, slots.length).map((slot) => (
                   <TimeSlotButton
                     {...slot}
                     key={slot.key}

--- a/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
+++ b/client/app/hearings/components/scheduleHearing/TimeSlot.jsx
@@ -15,8 +15,8 @@ export const TimeSlot = ({
   roTimezone,
   onChange,
   hearing,
-  fetchScheduledHearings,
   fetchingHearings,
+  ro
 }) => {
   // Create local state to hold the selected time before saving
   const [selected, setSelected] = useState('');
@@ -25,7 +25,7 @@ export const TimeSlot = ({
   const [custom, setCustom] = useState(false);
 
   // Filter the available time slots to fill in the hearings
-  const slots = setTimeSlots(scheduledHearingsList);
+  const slots = setTimeSlots(scheduledHearingsList, ro);
 
   // Setup the click handler for each time slot
   const handleClick = (time) => {
@@ -39,14 +39,10 @@ export const TimeSlot = ({
   // Create a hearing Time ID to associate the label with the appropriate form element
   const hearingTimeId = `hearing-time-${hearing?.scheduledTimeString}`;
 
-  useEffect(() => {
-    fetchScheduledHearings();
-  }, []);
-
   return (
     <React.Fragment>
       <label className="time-slot-label" htmlFor={hearingTimeId}>
-               Hearing Time
+         Hearing Time
       </label>
       {fetchingHearings ? (
         <SmallLoader spinnerColor={LOGO_COLORS.QUEUE.ACCENT} message="Loading Hearing Times" />
@@ -72,12 +68,9 @@ export const TimeSlot = ({
               value={hearing?.scheduledTimeString}
             />
           ) : (
-            <React.Fragment>
-              <div
-                id={hearingTimeId}
-                className="usa-width-one-third time-slot-container"
-              >
-                {slots.map((slot) => (
+            <div className="time-slot-button-container">
+              <div className="time-slot-container" >
+                {slots.slice(0, slots.length / 2).map((slot) => (
                   <TimeSlotButton
                     {...slot}
                     key={slot.key}
@@ -87,7 +80,18 @@ export const TimeSlot = ({
                   />
                 ))}
               </div>
-            </React.Fragment>
+              <div className="time-slot-container">
+                {slots.slice(slots.length / 2, slots.length - 1).map((slot) => (
+                  <TimeSlotButton
+                    {...slot}
+                    key={slot.key}
+                    roTimezone={roTimezone}
+                    selected={selected === slot.hearingTime}
+                    onClick={() => handleClick(slot.hearingTime)}
+                  />
+                ))}
+              </div>
+            </div>
           )}
         </React.Fragment>
       )}
@@ -96,10 +100,10 @@ export const TimeSlot = ({
 };
 
 TimeSlot.propTypes = {
-  fetchScheduledHearings: PropTypes.func,
   fetchingHearings: PropTypes.bool,
   hearing: PropTypes.object,
   onChange: PropTypes.func,
   scheduledHearingsList: PropTypes.array,
   roTimezone: PropTypes.string,
+  ro: PropTypes.string,
 };

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -485,7 +485,7 @@ export const dispositionLabel = (disposition) => HEARING_DISPOSITION_TYPE_TO_LAB
  * Method to set the available time slots based on the hearings scheduled
  * @param {array} hearings -- List of hearings scheduled for a specific date
  */
-export const setTimeSlots = (hearings) => {
+export const setTimeSlots = (hearings, hearingType) => {
   // Default to using EST for all times before conversion
   moment.tz.setDefault('America/New_York');
 
@@ -502,7 +502,7 @@ export const setTimeSlots = (hearings) => {
   // - We want 8 hours of slots: 8 = 15:30 - 08:30 + 1
   const slotCount = 8;
   // Don't convert startTime to moment here, moment mutates when you 'add'
-  const startTime = '08:30';
+  const startTime = hearingType === 'C' ? '09:00' : '08:30';
 
   // For each possible slot, return it only if it's available. Availability is
   // determined by comparing to the scheduledHearingTimes.

--- a/client/app/styles/hearings/_hearings.scss
+++ b/client/app/styles/hearings/_hearings.scss
@@ -381,11 +381,18 @@
   font-size: medium;
 }
 
-.time-slot-container.usa-width-one-third {
+.time-slot-button-container {
   display: flex;
-  height: 350px;
+  width: 800px;
+}
+
+.time-slot-container {
+  flex: 0;
+  max-width: 46rem;
+  display: flex;
   flex-direction: column;
   flex-wrap: wrap;
+  line-height: normal;
 
   > span {
     margin: 5px;

--- a/client/app/styles/hearings/_hearings.scss
+++ b/client/app/styles/hearings/_hearings.scss
@@ -345,9 +345,10 @@
 }
 
 .time-slot-button {
-  height: 60px;
-  width: 325px;
+  height: 75px;
+  width: 350px;
   text-align: left;
+  padding-left: 25px;
 
   > div:first-child {
     display: flex;
@@ -379,6 +380,11 @@
 .time-slot-details {
   font-weight: 400;
   font-size: medium;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  width: 295px;
+  margin-top: 5px;
 }
 
 .time-slot-button-container {

--- a/client/test/app/hearings/components/ScheduleVeteran.test.js
+++ b/client/test/app/hearings/components/ScheduleVeteran.test.js
@@ -53,6 +53,8 @@ let patchSpy;
 const setState = jest.fn();
 const useStateMock = (initState) => [initState, setState];
 const setScheduledHearingMock = jest.fn();
+const fetchScheduledHearingsMock = jest.fn();
+
 const scheduleVeteranProps = {
   showSuccessMessage: jest.fn(),
   onChangeFormData: changeSpy,
@@ -60,6 +62,7 @@ const scheduleVeteranProps = {
   appealId: amaAppeal.externalId,
   taskId: scheduledHearing.taskId,
   setScheduledHearing: setScheduledHearingMock,
+  fetchScheduledHearings: fetchScheduledHearingsMock,
 };
 
 describe('ScheduleVeteran', () => {
@@ -504,6 +507,7 @@ describe('ScheduleVeteran', () => {
     // Render the scheduleVeteran component
     const scheduleVeteran = mount(
       <ScheduleVeteran
+        fetchScheduledHearings={fetchScheduledHearingsMock}
         scheduledHearing={scheduledHearing}
         onChangeFormData={changeSpy}
         appeals={appealsData}
@@ -564,6 +568,7 @@ describe('ScheduleVeteran', () => {
     // Render the scheduleVeteran component
     const scheduleVeteran = mount(
       <ScheduleVeteran
+        fetchScheduledHearings={fetchScheduledHearingsMock}
         scheduledHearing={scheduledHearing}
         onChangeFormData={changeSpy}
         goBack={cancelSpy}

--- a/client/test/app/hearings/components/ScheduleVeteranForm.test.js
+++ b/client/test/app/hearings/components/ScheduleVeteranForm.test.js
@@ -14,7 +14,6 @@ import {
   AppealHearingLocationsDropdown,
 } from 'app/components/DataDropdowns';
 import { AddressLine } from 'app/hearings/components/details/Address';
-import { HearingTime } from 'app/hearings/components/modalForms/HearingTime';
 import { AppellantSection } from 'app/hearings/components/VirtualHearings/AppellantSection';
 import { RepresentativeSection } from 'app/hearings/components/VirtualHearings/RepresentativeSection';
 import { Timezone } from 'app/hearings/components/VirtualHearings/Timezone';
@@ -42,7 +41,8 @@ describe('ScheduleVeteranForm', () => {
 
     // Assertions
     expect(
-      scheduleVeteran.find(ReadOnly).first().prop('text').props
+      scheduleVeteran.find(ReadOnly).first().
+        prop('text').props
     ).toMatchObject(
       {
         addressLine1: amaAppeal.appellantAddress.address_line_1,
@@ -80,7 +80,6 @@ describe('ScheduleVeteranForm', () => {
     // Assertions
     expect(scheduleVeteran.find(AppealHearingLocationsDropdown)).toHaveLength(1);
     expect(scheduleVeteran.find(HearingDateDropdown)).toHaveLength(1);
-    expect(scheduleVeteran.find(HearingTime)).toHaveLength(1);
     expect(scheduleVeteran.find(AddressLine)).toHaveLength(1);
 
     expect(scheduleVeteran.find(AppellantSection)).toHaveLength(0);

--- a/client/test/app/hearings/components/scheduleHearing/TimeSlot.test.js
+++ b/client/test/app/hearings/components/scheduleHearing/TimeSlot.test.js
@@ -32,7 +32,7 @@ describe('TimeSlot', () => {
     expect(button.getAllByRole('button')).toHaveLength(slotCount + 1);
     expect(document.getElementsByClassName('time-slot-button-toggle')).toHaveLength(1);
     expect(document.getElementById(`hearing-time-${time}`)).toBeNull();
-    expect(document.getElementsByClassName('time-slot-container')).toHaveLength(1);
+    expect(document.getElementsByClassName('time-slot-container')).toHaveLength(2);
     expect(button).toMatchSnapshot();
   });
 
@@ -62,7 +62,7 @@ describe('TimeSlot', () => {
     // Check that the correct elements are displayed
     expect(timeSlot.getAllByRole('button')).toHaveLength(slotCount + 1);
     expect(document.getElementsByClassName('time-slot-button-toggle')).toHaveLength(1);
-    expect(document.getElementsByClassName('time-slot-container')).toHaveLength(1);
+    expect(document.getElementsByClassName('time-slot-container')).toHaveLength(2);
 
     expect(timeSlot).toMatchSnapshot();
   });

--- a/client/test/app/hearings/components/scheduleHearing/__snapshots__/TimeSlot.test.js.snap
+++ b/client/test/app/hearings/components/scheduleHearing/__snapshots__/TimeSlot.test.js.snap
@@ -23,8 +23,194 @@ Object {
         </span>
       </div>
       <div
-        class="usa-width-one-third time-slot-container"
-        id="hearing-time-08:30"
+        class="time-slot-button-container"
+      >
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  8:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  9:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  10:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  11:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  12:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  1:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  2:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  3:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <label
+      class="time-slot-label"
+      for="hearing-time-08:30"
+    >
+      Hearing Time
+    </label>
+    <div>
+      <span>
+        <button
+          class="time-slot-button-toggle cf-btn-link usa-button"
+          type="button"
+        >
+          Choose a 
+          custom time
+        </button>
+      </span>
+    </div>
+    <div
+      class="time-slot-button-container"
+    >
+      <div
+        class="time-slot-container"
       >
         <span>
           <button
@@ -102,6 +288,10 @@ Object {
             </div>
           </button>
         </span>
+      </div>
+      <div
+        class="time-slot-container"
+      >
         <span>
           <button
             class="usa-button-secondary time-slot-button usa-button"
@@ -179,182 +369,6 @@ Object {
           </button>
         </span>
       </div>
-    </div>
-  </body>,
-  "container": <div>
-    <label
-      class="time-slot-label"
-      for="hearing-time-08:30"
-    >
-      Hearing Time
-    </label>
-    <div>
-      <span>
-        <button
-          class="time-slot-button-toggle cf-btn-link usa-button"
-          type="button"
-        >
-          Choose a 
-          custom time
-        </button>
-      </span>
-    </div>
-    <div
-      class="usa-width-one-third time-slot-container"
-      id="hearing-time-08:30"
-    >
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              8:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              9:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              10:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              11:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              12:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              1:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              2:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              3:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
     </div>
   </div>,
   "debug": [Function],
@@ -434,8 +448,194 @@ Object {
         </span>
       </div>
       <div
-        class="usa-width-one-third time-slot-container"
-        id="hearing-time-undefined"
+        class="time-slot-button-container"
+      >
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  8:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  9:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  10:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  11:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  12:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  1:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  2:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  3:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <label
+      class="time-slot-label"
+      for="hearing-time-undefined"
+    >
+      Hearing Time
+    </label>
+    <div>
+      <span>
+        <button
+          class="time-slot-button-toggle cf-btn-link usa-button"
+          type="button"
+        >
+          Choose a 
+          custom time
+        </button>
+      </span>
+    </div>
+    <div
+      class="time-slot-button-container"
+    >
+      <div
+        class="time-slot-container"
       >
         <span>
           <button
@@ -513,6 +713,10 @@ Object {
             </div>
           </button>
         </span>
+      </div>
+      <div
+        class="time-slot-container"
+      >
         <span>
           <button
             class="usa-button-secondary time-slot-button usa-button"
@@ -590,182 +794,6 @@ Object {
           </button>
         </span>
       </div>
-    </div>
-  </body>,
-  "container": <div>
-    <label
-      class="time-slot-label"
-      for="hearing-time-undefined"
-    >
-      Hearing Time
-    </label>
-    <div>
-      <span>
-        <button
-          class="time-slot-button-toggle cf-btn-link usa-button"
-          type="button"
-        >
-          Choose a 
-          custom time
-        </button>
-      </span>
-    </div>
-    <div
-      class="usa-width-one-third time-slot-container"
-      id="hearing-time-undefined"
-    >
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              8:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              9:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              10:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              11:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              12:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              1:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              2:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              3:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
     </div>
   </div>,
   "debug": [Function],
@@ -845,8 +873,190 @@ Object {
         </span>
       </div>
       <div
-        class="usa-width-one-third time-slot-container"
-        id="hearing-time-08:30"
+        class="time-slot-button-container"
+      >
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  8:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button time-slot-button-selected usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  9:30 AM EDT
+                </div>
+                <div />
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  10:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  11:30 AM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+        <div
+          class="time-slot-container"
+        >
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  12:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  1:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  2:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+          <span>
+            <button
+              class="usa-button-secondary time-slot-button usa-button"
+              type="button"
+            >
+              <div>
+                <div
+                  style="flex: 1;"
+                >
+                  3:30 PM EDT
+                </div>
+                <div>
+                  <i
+                    class="fa fa-angle-right time-slot-arrow"
+                  />
+                </div>
+              </div>
+            </button>
+          </span>
+        </div>
+      </div>
+    </div>
+  </body>,
+  "container": <div>
+    <label
+      class="time-slot-label"
+      for="hearing-time-08:30"
+    >
+      Hearing Time
+    </label>
+    <div>
+      <span>
+        <button
+          class="time-slot-button-toggle cf-btn-link usa-button"
+          type="button"
+        >
+          Choose a 
+          custom time
+        </button>
+      </span>
+    </div>
+    <div
+      class="time-slot-button-container"
+    >
+      <div
+        class="time-slot-container"
       >
         <span>
           <button
@@ -920,6 +1130,10 @@ Object {
             </div>
           </button>
         </span>
+      </div>
+      <div
+        class="time-slot-container"
+      >
         <span>
           <button
             class="usa-button-secondary time-slot-button usa-button"
@@ -997,178 +1211,6 @@ Object {
           </button>
         </span>
       </div>
-    </div>
-  </body>,
-  "container": <div>
-    <label
-      class="time-slot-label"
-      for="hearing-time-08:30"
-    >
-      Hearing Time
-    </label>
-    <div>
-      <span>
-        <button
-          class="time-slot-button-toggle cf-btn-link usa-button"
-          type="button"
-        >
-          Choose a 
-          custom time
-        </button>
-      </span>
-    </div>
-    <div
-      class="usa-width-one-third time-slot-container"
-      id="hearing-time-08:30"
-    >
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              8:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button time-slot-button-selected usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              9:30 AM EDT
-            </div>
-            <div />
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              10:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              11:30 AM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              12:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              1:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              2:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
-      <span>
-        <button
-          class="usa-button-secondary time-slot-button usa-button"
-          type="button"
-        >
-          <div>
-            <div
-              style="flex: 1;"
-            >
-              3:30 PM EDT
-            </div>
-            <div>
-              <i
-                class="fa fa-angle-right time-slot-arrow"
-              />
-            </div>
-          </div>
-        </button>
-      </span>
     </div>
   </div>,
   "debug": [Function],

--- a/spec/controllers/hearings/hearing_day/filled_hearing_slots_controller_spec.rb
+++ b/spec/controllers/hearings/hearing_day/filled_hearing_slots_controller_spec.rb
@@ -60,6 +60,8 @@ RSpec.describe Hearings::HearingDay::FilledHearingSlotsController, type: :contro
           .to match_array([ama_hearing.docket_name, legacy_hearing.docket_name])
         expect(response_body["filled_hearing_slots"].map { |res| res["poa_name"] })
           .to match_array([ama_poa_name, legacy_poa_name])
+        expect(response_body["filled_hearing_slots"].map { |res| res["external_id"] })
+          .to match_array([ama_hearing.external_id, legacy_hearing.external_id])
       end
     end
   end

--- a/spec/controllers/hearings/hearing_day/filled_hearing_slots_controller_spec.rb
+++ b/spec/controllers/hearings/hearing_day/filled_hearing_slots_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Hearings::HearingDay::FilledHearingSlotsController, type: :contro
         )
       end
 
-      let(:expected_keys) { %w[hearing_time issue_count docket_number docket_name poa_name] }
+      let(:expected_keys) { %w[external_id hearing_time issue_count docket_number docket_name poa_name] }
 
       it "returns correct data", :aggregate_failures do
         get :index, params: { hearing_day_id: hearing_day.id }, as: :json

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -207,6 +207,24 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       end
     end
 
+    # Method to choose either the hearing time slot buttons or hearing time radio buttons
+    def select_hearing_time(time)
+      if FeatureToggle.enabled?(:enable_hearing_time_slots)
+        find(".time-slot-button", text: "#{time} AM EST").click
+      else
+        find(".cf-form-radio-option", text: time).click
+      end
+    end
+
+    # Method to choose the custom hearing time dropdown
+    def select_custom_hearing_time(time)
+      if FeatureToggle.enabled?(:enable_hearing_time_slots)
+        find(".time-slot-button-toggle", text: "Choose a custom time").click
+      end
+
+      click_dropdown(text: time, name: "optionalHearingTime0")
+    end
+
     shared_examples "scheduling a central hearing" do
       include_context "central_hearings"
 
@@ -227,7 +245,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         # Wait for the contents of the dropdown to finish loading before clicking into the dropdown.
         expect(page).to have_content(hearing_location_dropdown_label)
         click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-        find(".cf-form-radio-option", text: "9:00").click
+        select_hearing_time("9:00")
         click_button("Schedule", exact: true)
         click_on "Back to Schedule Veterans"
         expect(page).to have_content("Schedule Veterans")
@@ -246,7 +264,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       scenario "Schedule Veteran for video" do
         cache_appeals
         navigate_to_schedule_veteran
-        find(".cf-form-radio-option", text: "8:30").click
+        select_hearing_time("8:30")
         click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
         expect(page).not_to have_content("Could not find hearing locations for this veteran")
         expect(page).not_to have_content("There are no upcoming hearing dates for this regional office.")
@@ -430,7 +448,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
         click_dropdown({ text: "Denver" }, find(".dropdown-regionalOffice"))
         click_dropdown(name: "hearingDate", index: 1)
 
-        find("label", text: "8:30").click
+        select_hearing_time("8:30")
         expect(page).to_not have_content("Finding hearing locations", wait: 30)
         click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
         click_on "Schedule"
@@ -472,7 +490,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
             text: "Holdrege, NE (VHA) 0 miles away",
             name: "appealHearingLocation"
           )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          select_custom_hearing_time("10:00")
           click_button("Schedule", exact: true)
 
           expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
@@ -498,7 +516,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
             text: "Holdrege, NE (VHA) 0 miles away",
             name: "appealHearingLocation"
           )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          select_custom_hearing_time("10:00")
           click_button("Schedule", exact: true)
           click_on "Back to Schedule Veterans"
 
@@ -543,7 +561,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
             text: "Holdrege, NE (VHA) 0 miles away",
             name: "appealHearingLocation"
           )
-          click_dropdown(text: "10:00", name: "optionalHearingTime0")
+          select_custom_hearing_time("10:00")
           click_button("Schedule", exact: true)
 
           expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
@@ -573,7 +591,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
           text: "Holdrege, NE (VHA) 0 miles away",
           name: "appealHearingLocation"
         )
-        click_dropdown(text: "10:00", name: "optionalHearingTime0")
+        select_custom_hearing_time("10:00")
         click_button("Schedule", exact: true)
 
         expect(page).to have_content(COPY::SCHEDULE_VETERAN_SUCCESS_MESSAGE_DETAIL)
@@ -607,7 +625,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
                                    else
                                      "#{time} AM Mountain Time (US & Canada) / 10:30 AM Eastern Time (US & Canada)"
                                    end
-        find(".cf-form-radio-option", text: expected_time_radio_text).click
+        select_custom_hearing_time(expected_time_radio_text)
 
         # Fill in appellant details
         click_dropdown(name: "appellantTz", index: 1) if fill_in_timezones
@@ -643,188 +661,221 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       end
     end
 
-    context "with schedule direct to video/virtual feature enabled" do
-      # Ensure the feature flag is enabled before testing
-      before do
-        FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
+    shared_examples "change from Central hearing" do
+      include_context "central_hearings"
+
+      before { cache_appeals }
+
+      it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
+    end
+
+    shared_examples "change from Video hearing" do
+      include_context "video_hearing"
+
+      before { cache_appeals }
+
+      it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
+    end
+
+    shared_examples "withdraw a hearing" do
+      def schedule_hearing(appeal_link)
+        visit appeal_link
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
+        click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
+
+        room_label = HearingRooms.find!(hearing_day.room)&.label
+        date_label = hearing_day.scheduled_for.to_formatted_s(:short_date)
+        dropdown_label = "#{date_label} (0/#{hearing_day.total_slots}) #{room_label}"
+
+        click_dropdown(
+          text: dropdown_label,
+          name: "hearingDate"
+        )
+        select_hearing_time("8:30")
+        click_button("Schedule", exact: true)
       end
 
-      it_behaves_like "scheduling a central hearing"
+      shared_examples "withdrawing ama hearing" do |scheduled = false|
+        scenario "Withdraw Veteran's hearing request" do
+          visit "queue/appeals/#{appeal.uuid}"
 
-      it_behaves_like "scheduling a video hearing"
+          click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
+          expect(page).to have_content(COPY::WITHDRAW_HEARING["AMA"]["MODAL_BODY"])
+          fill_in "taskInstructions", with: "Withdrawing hearing"
 
-      it_behaves_like "scheduling an AMA hearing"
+          click_on "Submit"
 
-      it_behaves_like "scheduling a Legacy hearing"
+          expect(page).to have_content("You have successfully withdrawn")
+          expect(page).to have_content(COPY::WITHDRAW_HEARING["AMA"]["SUCCESS_MESSAGE"])
+          expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
 
-      it_behaves_like "an appeal with a full hearing day"
-
-      it_behaves_like "an appeal where there is an open hearing"
-
-      context "when changing from Central hearing" do
-        include_context "central_hearings"
-
-        before { cache_appeals }
-
-        it_behaves_like "scheduling a virtual hearing", true, "C", "9:00"
+          if scheduled
+            expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.completed
+            )
+            expect(appeal.tasks.where(type: AssignHearingDispositionTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.cancelled
+            )
+            expect(appeal.hearings.last.cancelled?).to eq(true)
+          else
+            expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.cancelled
+            )
+          end
+        end
       end
 
-      context "when changing from Video hearing" do
-        include_context "video_hearing"
+      shared_examples "withdrawing legacy hearing" do |scheduled = false|
+        scenario "Withdraw Veteran's hearing request" do
+          visit "queue/appeals/#{legacy_appeal.vacols_id}"
 
-        before { cache_appeals }
-
-        it_behaves_like "scheduling a virtual hearing", false, "RO39", "8:30"
-      end
-
-      context "withdraw hearing" do
-        def schedule_hearing(appeal_link)
-          visit appeal_link
-          click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
-          find(".cf-form-radio-option", text: "8:30").click
-          click_dropdown(name: "appealHearingLocation", text: "Holdrege, NE (VHA) 0 miles away")
-
-          room_label = HearingRooms.find!(hearing_day.room)&.label
-          date_label = hearing_day.scheduled_for.to_formatted_s(:short_date)
-          dropdown_label = "#{date_label} (0/#{hearing_day.total_slots}) #{room_label}"
-
-          click_dropdown(
-            text: dropdown_label,
-            name: "hearingDate"
+          click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
+          expect(page.html).to include(
+            COPY::WITHDRAW_HEARING["LEGACY_NON_COLOCATED_PRIVATE_ATTORNEY"]["MODAL_BODY"]
           )
-          click_button("Schedule", exact: true)
-        end
+          fill_in "taskInstructions", with: "Withdrawing hearing"
 
-        shared_examples "withdrawing ama hearing" do |scheduled = false|
-          scenario "Withdraw Veteran's hearing request" do
-            visit "queue/appeals/#{appeal.uuid}"
+          click_on "Submit"
 
-            click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
-            expect(page).to have_content(COPY::WITHDRAW_HEARING["AMA"]["MODAL_BODY"])
-            fill_in "taskInstructions", with: "Withdrawing hearing"
+          expect(page).to have_content("You have successfully withdrawn")
+          expect(page.html).to include(
+            COPY::WITHDRAW_HEARING["LEGACY_NON_COLOCATED_PRIVATE_ATTORNEY"]["SUCCESS_MESSAGE"]
+          )
 
-            click_on "Submit"
+          expect(legacy_appeal.case_record.bfhr).to eq("5")
+          expect(legacy_appeal.case_record.bfha).to eq("5")
 
-            expect(page).to have_content("You have successfully withdrawn")
-            expect(page).to have_content(COPY::WITHDRAW_HEARING["AMA"]["SUCCESS_MESSAGE"])
-            expect(appeal.tasks.where(type: EvidenceSubmissionWindowTask.name).count).to eq(1)
-
-            if scheduled
-              expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.completed
-              )
-              expect(appeal.tasks.where(type: AssignHearingDispositionTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.cancelled
-              )
-              expect(appeal.hearings.last.cancelled?).to eq(true)
-            else
-              expect(appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.cancelled
-              )
-            end
-          end
-        end
-
-        shared_examples "withdrawing legacy hearing" do |scheduled = false|
-          scenario "Withdraw Veteran's hearing request" do
-            visit "queue/appeals/#{legacy_appeal.vacols_id}"
-
-            click_dropdown(text: Constants.TASK_ACTIONS.WITHDRAW_HEARING.to_h[:label])
-            expect(page.html).to include(
-              COPY::WITHDRAW_HEARING["LEGACY_NON_COLOCATED_PRIVATE_ATTORNEY"]["MODAL_BODY"]
+          if scheduled
+            expect(legacy_appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.completed
             )
-            fill_in "taskInstructions", with: "Withdrawing hearing"
-
-            click_on "Submit"
-
-            expect(page).to have_content("You have successfully withdrawn")
-            expect(page.html).to include(
-              COPY::WITHDRAW_HEARING["LEGACY_NON_COLOCATED_PRIVATE_ATTORNEY"]["SUCCESS_MESSAGE"]
+            expect(legacy_appeal.tasks.where(type: AssignHearingDispositionTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.cancelled
             )
-
-            expect(legacy_appeal.case_record.bfhr).to eq("5")
-            expect(legacy_appeal.case_record.bfha).to eq("5")
-
-            if scheduled
-              expect(legacy_appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.completed
-              )
-              expect(legacy_appeal.tasks.where(type: AssignHearingDispositionTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.cancelled
-              )
-              expect(legacy_appeal.hearings.last.cancelled?).to eq(true)
-            else
-              expect(legacy_appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
-                Constants.TASK_STATUSES.cancelled
-              )
-            end
+            expect(legacy_appeal.hearings.last.cancelled?).to eq(true)
+          else
+            expect(legacy_appeal.tasks.where(type: ScheduleHearingTask.name).first.status).to eq(
+              Constants.TASK_STATUSES.cancelled
+            )
           end
         end
+      end
 
-        before { cache_appeals }
+      before { cache_appeals }
 
-        context "Scheduled hearing" do
-          context "AMA appeal" do
-            include_context "ama_hearing"
+      context "Scheduled hearing" do
+        context "AMA appeal" do
+          include_context "ama_hearing"
 
-            before do
-              schedule_hearing("queue/appeals/#{appeal.uuid}")
-            end
-
-            it_behaves_like "withdrawing ama hearing", true
+          before do
+            schedule_hearing("queue/appeals/#{appeal.uuid}")
           end
 
-          context "Legacy appeal" do
-            include_context "legacy_hearing"
-
-            let!(:hearing_day) do
-              create(
-                :hearing_day,
-                request_type: HearingDay::REQUEST_TYPES[:video],
-                scheduled_for: Time.zone.today + 160,
-                regional_office: regional_office,
-                room: "1"
-              )
-            end
-
-            before do
-              schedule_hearing("queue/appeals/#{legacy_appeal.vacols_id}")
-            end
-
-            it_behaves_like "withdrawing legacy hearing", true
-          end
+          it_behaves_like "withdrawing ama hearing", true
         end
 
-        context "Unscheduled hearing" do
-          context "AMA appeal" do
-            include_context "ama_hearing"
+        context "Legacy appeal" do
+          include_context "legacy_hearing"
 
-            it_behaves_like "withdrawing ama hearing"
+          let!(:hearing_day) do
+            create(
+              :hearing_day,
+              request_type: HearingDay::REQUEST_TYPES[:video],
+              scheduled_for: Time.zone.today + 160,
+              regional_office: regional_office,
+              room: "1"
+            )
           end
 
-          context "Legacy appeal" do
-            include_context "legacy_hearing"
-
-            let!(:hearing_day) do
-              create(
-                :hearing_day,
-                request_type: HearingDay::REQUEST_TYPES[:video],
-                scheduled_for: Time.zone.today + 160,
-                regional_office: regional_office,
-                room: "1"
-              )
-            end
-
-            it_behaves_like "withdrawing legacy hearing"
+          before do
+            schedule_hearing("queue/appeals/#{legacy_appeal.vacols_id}")
           end
+
+          it_behaves_like "withdrawing legacy hearing", true
+        end
+      end
+
+      context "Unscheduled hearing" do
+        context "AMA appeal" do
+          include_context "ama_hearing"
+
+          it_behaves_like "withdrawing ama hearing"
+        end
+
+        context "Legacy appeal" do
+          include_context "legacy_hearing"
+
+          let!(:hearing_day) do
+            create(
+              :hearing_day,
+              request_type: HearingDay::REQUEST_TYPES[:video],
+              scheduled_for: Time.zone.today + 160,
+              regional_office: regional_office,
+              room: "1"
+            )
+          end
+
+          it_behaves_like "withdrawing legacy hearing"
         end
       end
     end
 
-    context "with schedule direct to video/virtual feature disabled" do
-      # Ensure the feature flag is disabled before testing
+    context "with enable_time_slots feature disabled" do
+      # Ensure the feature flag is enabled before testing
       before do
-        FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
+        FeatureToggle.disable!(:enable_hearing_time_slots)
+      end
+
+      context "with schedule direct to video/virtual feature enabled" do
+        # Ensure the feature flag is enabled before testing
+        before do
+          FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
+        end
+
+        it_behaves_like "scheduling a central hearing"
+
+        it_behaves_like "scheduling a video hearing"
+
+        it_behaves_like "scheduling an AMA hearing"
+
+        it_behaves_like "scheduling a Legacy hearing"
+
+        it_behaves_like "an appeal with a full hearing day"
+
+        it_behaves_like "an appeal where there is an open hearing"
+
+        it_behaves_like "change from Central hearing"
+
+        it_behaves_like "change from Video hearing"
+
+        it_behaves_like "withdraw a hearing"
+      end
+
+      context "with schedule direct to video/virtual feature disabled" do
+        # Ensure the feature flag is disabled before testing
+        before do
+          FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
+        end
+
+        it_behaves_like "scheduling a central hearing"
+
+        it_behaves_like "scheduling a video hearing"
+
+        it_behaves_like "scheduling an AMA hearing"
+
+        it_behaves_like "scheduling a Legacy hearing"
+
+        it_behaves_like "an appeal with a full hearing day"
+
+        it_behaves_like "an appeal where there is an open hearing"
+      end
+    end
+
+    context "with enable_time_slots feature enabled" do
+      # Ensure the feature flag is enabled before testing
+      before do
+        FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
+        FeatureToggle.enable!(:enable_hearing_time_slots)
       end
 
       it_behaves_like "scheduling a central hearing"
@@ -838,6 +889,12 @@ RSpec.feature "Schedule Veteran For A Hearing" do
       it_behaves_like "an appeal with a full hearing day"
 
       it_behaves_like "an appeal where there is an open hearing"
+
+      it_behaves_like "change from Central hearing"
+
+      it_behaves_like "change from Video hearing"
+
+      it_behaves_like "withdraw a hearing"
     end
   end
 

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -76,6 +76,10 @@ describe Veteran, :all_dbs do
           expect(subject.accessible?).to eq(true)
           expect(subject.first_name).to be_nil
         end
+
+        it "returns nil when accessing zip_code" do
+          expect(subject.zip_code).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
Resolves [CASEFLOW-956](https://vajira.max.gov/browse/CASEFLOW-956)

### Description
Combines the frontend and backend work behind a feature toggle for adding the time slot buttons

### Acceptance Criteria
- [ ] Combine work in new PR
  - [ ] make request to endpoint written in https://vajira.max.gov/browse/CASEFLOW-954
  - [ ] store data in redux for the hearing day
  - [ ] fetch data from redux for the hearing day if already stored
- [ ] Write feature tests
  - [ ] test for legacy and ama 

### Testing Plan
1. Shadow user `BVASYELLOW`: http://localhost:3000/test/users
2. Navigate to the hearings app and click "Schedule Veterans"
3. Search for "St. Petersburg FL" in the list and choose one of the veterans in the AMA waiting tab
4. Click the "Schedule Veteran" button from the dropdown
5. Ensure that you are still able to schedule a veteran with the existing radio buttons
6. On the rails console, enable the feature flag: `FeatureToggle.enable!(:enable_hearing_time_slots)`
7. Repeat steps 2 - 5
8. Ensure that this time you see the new time slot options

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
-- |<img width="1920" alt="TimeSlotUnselected" src="https://user-images.githubusercontent.com/61989526/109878760-8c0b8280-7c29-11eb-97b1-3d25b7c6b246.png">
-- | <img width="1220" alt="TimeSlotFilled" src="https://user-images.githubusercontent.com/61989526/109878778-9168cd00-7c29-11eb-9e98-acc9a02ff6ac.png">
-- | <img width="1257" alt="TimeSlotCustom" src="https://user-images.githubusercontent.com/61989526/109878792-975eae00-7c29-11eb-83d8-439a963dc6a0.png">
