### PR TITLE
Fix Hearing Time related flaky tests 

### DIFF
--- a/spec/services/hearing_time_service_spec.rb
+++ b/spec/services/hearing_time_service_spec.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 describe HearingTimeService, :all_dbs do
+  before do
+    Timecop.freeze(Time.utc(2020, 1, 1, 0, 0, 0))
+  end
+
   shared_context "legacy_hearing" do
     let!(:legacy_hearing) do
       # vacols requires us to pass a time set in ET even though it reflects local time


### PR DESCRIPTION
Resolves #15552

### Description
Bunch of time related test in `hearing_time_service_spec.rb` would fail around some time after midnight because the expected times are calculated with time zones PST and CST which are 3 hour and 1 hour behind eastern but the hearing time is calculated in Eastern. This PR sets freezes time so it would never get into a situation where it's using the next day's time for hearing time and the time from the day before to calculate expected times. I ran this around midnight and it passed. 

### Testing Plan
not a good way to test this in local unfortunately because it's hard to reproduce. You could checkout to master and add some time freeze statement [here](https://github.com/department-of-veterans-affairs/caseflow/blob/cbfaa8a93317c132ea72d53461fbf3e0dd5d9991/spec/services/hearing_time_service_spec.rb#L5) like
```
Timecop.freeze(Date.yesterday)
```
and run the test `bundle exec rspec spec/services/hearing_time_service_spec.rb` and expect some tests to fail.