### PR TITLE
[Fix flaky] Reschedule a virtual hearing scheduled in error - cannot find content "Schedule Veteran for a Hearing"

### DIFF
--- a/spec/feature/hearings/hearing_scheduled_in_error_spec.rb
+++ b/spec/feature/hearings/hearing_scheduled_in_error_spec.rb
@@ -124,7 +124,7 @@ RSpec.feature "Remove hearing scheduled in error" do
     find("label", text: COPY::RESCHEDULE_IMMEDIATELY_DISPLAY_TEXT).click
     fill_in "scheduled-in-error-notes", with: fill_in_notes
     click_button("Submit")
-    expect(page).to have_content("Schedule Veteran for a Hearing")
+    expect(page).to have_content("Schedule Veteran for a Hearing", wait: 30)
   end
 
   def fill_case_details_reschedule_form
@@ -134,7 +134,7 @@ RSpec.feature "Remove hearing scheduled in error" do
     find("label", text: COPY::RESCHEDULE_IMMEDIATELY_DISPLAY_TEXT).click
     fill_in "Notes", with: fill_in_notes
     click_button("Submit")
-    expect(page).to have_content("Schedule Veteran for a Hearing")
+    expect(page).to have_content("Schedule Veteran for a Hearing", wait: 30)
   end
 
   def fill_schedule_veteran_form(virtual = false)


### PR DESCRIPTION
Resolves #15996
### Description
I believe the reason why the tests were flaking was because after `click_button("Submit")` we're redirected to Case Details page which tends to take some time. I think introducing a wait will reduce the flakyness. 

### Testing Plan
First to reproduce the issue, try running that test `bundle exec rspec spec/feature/hearings/hearing_scheduled_in_error_spec.rb`  a few times checked out to `master`. It failed a few times for me.

Then checkout to this branch and try running it a few times again.