### PR TITLE
Fix Flake in Pushing Priority Appeals Tests

### DIFF
--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -458,10 +458,13 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
     context "tracking distributions over time" do
       let(:number_judges) { rand(5..10) }
       let(:priority_count) { rand(10..30) }
+      # Github Issue 15984, this stops this test from flaking, by making sure the
+      # expects below are achievable for all values rand() will produce.
+      let(:max_preexisting_cases) { (priority_count / (number_judges - 1)).floor }
 
       before do
         # Mock cases already distributed this month
-        @distribution_counts = to_judge_hash(Array.new(number_judges).map { rand(12) })
+        @distribution_counts = to_judge_hash(Array.new(number_judges).map { rand(max_preexisting_cases) })
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)
           .to receive(:priority_distributions_this_month_for_eligible_judges).and_return(@distribution_counts)
         allow_any_instance_of(PushPriorityAppealsToJudgesJob)


### PR DESCRIPTION
Resolves #15984

### Description
This change fixes a flake in priority_push_appeals_to_judges_job_spec.rb as part of the ip sprint. See the github issue for discussion.

### Acceptance Criteria
- [ ] The flake detailed in that github issue does not appear again.

### Testing Plan
1. Wrap priority_push_appeals_to_judges_job_spec.rb:459-485 in a (1..100).each do |i|  ... end
1. Run make one-test spec/jobs/push_priority_appeals_to_judges_job_spec.rb and see that there are no failures.