### PR TITLE
Fix median, and add test coverage

### DIFF
--- a/app/services/concerns/reporter.rb
+++ b/app/services/concerns/reporter.rb
@@ -11,6 +11,8 @@ module Reporter
 
   def median(times)
     return 0 if times.empty?
+    # This algorithm only works if the array is sorted, and our input isn't reliably sorted:
+    times.sort!
 
     len = times.length
     (times[(len - 1) / 2] + times[len / 2]) / 2.0

--- a/app/services/concerns/reporter.rb
+++ b/app/services/concerns/reporter.rb
@@ -11,6 +11,7 @@ module Reporter
 
   def median(times)
     return 0 if times.empty?
+
     # This algorithm only works if the array is sorted, and our input isn't reliably sorted:
     times.sort!
 

--- a/spec/jobs/monthly_metrics_report_job_spec.rb
+++ b/spec/jobs/monthly_metrics_report_job_spec.rb
@@ -5,7 +5,7 @@ describe MonthlyMetricsReportJob, :postgres do
 
   # rubocop:disable Metrics/LineLength
   let(:report) do
-    "Monthly report 2019-02-01 to 2019-02-28\nPercentage of all cases certified with Caseflow: 100.0\nAppeals established within 7 days: 1 (100%)\nSupplemental Claims within 7 days: 1 (25.0%)\nHigher Level Reviews within 7 days: 2 (50.0%)\ntype,total,in_progress,cancelled,processed,established_within_seven_days,established_within_seven_days_percent,median,avg,max,min\nsupplemental_claims,4,1,1,2,1,25.0,373:30:00,373:30:00,743:00:00,04:00:00\nhigher_level_reviews,4,1,0,3,2,50.0,01:00:00,249:20:00,743:00:00,01:00:00\nrequest_issues_updates,3,0,1,2,1,33.33,384:00:00,384:00:00,767:00:00,01:00:00\n"
+    "Monthly report 2019-02-01 to 2019-02-28\nPercentage of all cases certified with Caseflow: 100.0\nAppeals established within 7 days: 1 (100%)\nSupplemental Claims within 7 days: 1 (25.0%)\nHigher Level Reviews within 7 days: 2 (50.0%)\ntype,total,in_progress,cancelled,processed,established_within_seven_days,established_within_seven_days_percent,median,avg,max,min\nsupplemental_claims,4,1,1,2,1,25.0,373:30:00,373:30:00,743:00:00,04:00:00\nhigher_level_reviews,4,1,0,3,2,50.0,04:00:00,249:20:00,743:00:00,01:00:00\nrequest_issues_updates,3,0,1,2,1,33.33,384:00:00,384:00:00,767:00:00,01:00:00\n"
   end
   # rubocop:enable Metrics/LineLength
 

--- a/spec/services/claim_review_async_stats_reporter_spec.rb
+++ b/spec/services/claim_review_async_stats_reporter_spec.rb
@@ -93,7 +93,7 @@ describe ClaimReviewAsyncStatsReporter, :postgres do
           processed: 4,
           established_within_seven_days: 3,
           established_within_seven_days_percent: 50.0,
-          median: 50_400.0,
+          median: 86_400.0,
           avg: 481_500.0,
           max: 1_738_800.0,
           min: 14_400.0
@@ -106,7 +106,7 @@ describe ClaimReviewAsyncStatsReporter, :postgres do
           processed: 4,
           established_within_seven_days: 3,
           established_within_seven_days_percent: 50.0,
-          median: 9_000.0,
+          median: 50_400.0,
           avg: 457_200.0,
           max: 1_724_400.0,
           min: 3_600.0
@@ -133,7 +133,7 @@ describe ClaimReviewAsyncStatsReporter, :postgres do
 
     it "returns CSV" do
       csv = subject
-      expect(csv).to match(/supplemental_claims,6,1,1,4,3,50.0,14:00:00,133:45:00,483:00:00,04:00:00/)
+      expect(csv).to match(/supplemental_claims,6,1,1,4,3,50.0,24:00:00,133:45:00,483:00:00,04:00:00/)
     end
   end
 end

--- a/spec/services/concerns/reporter_spec.rb
+++ b/spec/services/concerns/reporter_spec.rb
@@ -1,0 +1,89 @@
+require 'rspec'
+
+# frozen_string_literal: true
+
+describe Reporter do
+  class TestReporter
+    include Reporter
+  end
+
+  describe "#average" do
+    let(:thing) { TestReporter.new }
+
+    subject { thing.average(items) }
+
+    context "when there are no items" do
+      let(:items) { [] }
+      it "returns 0" do
+        expect(subject).to eq 0
+      end
+    end
+
+    context "when there is only one item" do
+      let(:items) { [123] }
+      it "returns that item" do
+        expect(subject).to eq 123
+      end
+    end
+
+    context "when passed two items" do
+      let(:items) { [20, 30] }
+      it "returns the average" do
+        expect(subject).to eq 25
+      end
+    end
+
+  end
+
+  describe "#median" do
+    let(:thing) { TestReporter.new }
+    subject { thing.median(items) }
+
+    describe "when called with an empty array" do
+      let(:items) { [] }
+
+      it "returns 0" do
+        expect(subject).to eq 0
+      end
+    end
+
+    describe "when called with one item" do
+      let(:items) { [50] }
+
+      it "returns that item" do
+        expect(subject).to eq 50
+      end
+    end
+
+    describe "when called with two items" do
+      let(:items) { [50, 52] }
+
+      it "returns the average?" do
+        expect(subject).to eq 51
+      end
+    end
+
+    describe "when called with three items" do
+      let(:items) { [1, 50, 51] }
+
+      it "returns the middle item" do
+        expect(subject).to eq 50
+      end
+    end
+
+    describe "when called with four erratically spaced items" do
+      let(:items) { [-10, 1, 5, 30000]}
+      it "returns the average of the middle two" do
+        expect(subject).to eq 3
+      end
+    end
+
+    describe "when called with an out-of-order set" do
+      let(:items) { [2, -7, 1]}
+      it "sorts the list and returns the true median" do
+        expect(subject).to eq 1
+      end
+    end
+
+  end
+end

--- a/spec/services/concerns/reporter_spec.rb
+++ b/spec/services/concerns/reporter_spec.rb
@@ -1,4 +1,4 @@
-require 'rspec'
+require "rspec"
 
 # frozen_string_literal: true
 
@@ -32,7 +32,6 @@ describe Reporter do
         expect(subject).to eq 25
       end
     end
-
   end
 
   describe "#median" do
@@ -72,18 +71,17 @@ describe Reporter do
     end
 
     describe "when called with four erratically spaced items" do
-      let(:items) { [-10, 1, 5, 30000]}
+      let(:items) { [-10, 1, 5, 30_000] }
       it "returns the average of the middle two" do
         expect(subject).to eq 3
       end
     end
 
     describe "when called with an out-of-order set" do
-      let(:items) { [2, -7, 1]}
+      let(:items) { [2, -7, 1] }
       it "sorts the list and returns the true median" do
         expect(subject).to eq 1
       end
     end
-
   end
 end

--- a/spec/services/concerns/reporter_spec.rb
+++ b/spec/services/concerns/reporter_spec.rb
@@ -8,9 +8,9 @@ describe Reporter do
   end
 
   describe "#average" do
-    let(:thing) { TestReporter.new }
+    let(:reporter) { TestReporter.new }
 
-    subject { thing.average(items) }
+    subject { reporter.average(items) }
 
     context "when there are no items" do
       let(:items) { [] }
@@ -35,8 +35,8 @@ describe Reporter do
   end
 
   describe "#median" do
-    let(:thing) { TestReporter.new }
-    subject { thing.median(items) }
+    let(:reporter) { TestReporter.new }
+    subject { reporter.median(items) }
 
     describe "when called with an empty array" do
       let(:items) { [] }

--- a/spec/services/concerns/reporter_spec.rb
+++ b/spec/services/concerns/reporter_spec.rb
@@ -57,7 +57,7 @@ describe Reporter do
     describe "when called with two items" do
       let(:items) { [50, 52] }
 
-      it "returns the average?" do
+      it "returns the average" do
         expect(subject).to eq 51
       end
     end


### PR DESCRIPTION
Also fixes the old test that asserted incorrect behavior!

Fixes #16006

### Description
We ran into [this weird flake](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/39962/workflows/7f06f229-5ed6-4922-b58b-82d2241520b5/jobs/152724) recently.

I _think_ the immediate cause of the error was that we assumed the database output was in chronological order, but never used an `ORDER BY`, so there was no contract for the ordering.

But in looking at this, I was skeptical that `Reporter#median` was correct. I added some tests that prove it is--as long as the input sorted. Since that was clearly not always true, I made the method sort its input, since it returns nonsense otherwise. (Previously, the output was literally the middle value, so the "median" of `[1, 1, -10000, 1, 1]` would be `-10000` which is certainly not what statisticians would expect.)

"Fixing" the method broke the existing test (!), so I also fixed that.

### Acceptance Criteria
- [ ] Tests pass successfully