### PR TITLE
[Fix flaky] Reschedule to a Virtual hearing without error  - cannot detect expected alert

### DIFF
--- a/spec/feature/hearings/hearing_scheduled_in_error_spec.rb
+++ b/spec/feature/hearings/hearing_scheduled_in_error_spec.rb
@@ -60,7 +60,7 @@ RSpec.feature "Remove hearing scheduled in error" do
     let(:fill_in_veteran_email) { "vet@testingEmail.com" }
     let(:fill_in_representative_email) { "email@testingEmail.com" }
     let(:expected_alert) do
-      COPY::VIRTUAL_HEARING_PROGRESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % appeal.veteran&.name
+      COPY::VIRTUAL_HEARING_SUCCESS_ALERTS["CHANGED_TO_VIRTUAL"]["TITLE"] % appeal.veteran&.name
     end
   end
 


### PR DESCRIPTION
Similar change to #15988 but for a new file
Resolves [flake](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/40026/workflows/98741ca0-fd88-4810-b5f9-6e6ade660ae2/jobs/153030) found in `spec/feature/hearings/hearing_scheduled_in_error_spec.rb`