### PR TITLE
fix flakey test: Non-veteran claimants with non_veteran_claimants feature toggle allows selecting claimant not listed

### DIFF
--- a/spec/feature/intake/non_veteran_claimants_spec.rb
+++ b/spec/feature/intake/non_veteran_claimants_spec.rb
@@ -83,6 +83,7 @@ feature "Non-veteran claimants", :postgres do
 
       safe_click ".dropdown-listedAttorney"
       fill_in("listedAttorney", with: "Name not listed").send_keys :enter
+      find("div", class: "cf-select__menu", text: "Name not listed")
       select_claimant(0)
 
       expect(page).to have_content("Is the claimant an organization or individual?")
@@ -165,6 +166,7 @@ feature "Non-veteran claimants", :postgres do
       # Fill in Name not listed
       safe_click ".dropdown-listedAttorney"
       fill_in("listedAttorney", with: "Name not listed").send_keys :enter
+      find("div", class: "cf-select__menu", text: "Name not listed")
       select_claimant(0)
       expect(page).to have_content("Is the representative an organization or individual?")
 


### PR DESCRIPTION
Resolves #16014

### Description
Fixes a flakey test by waiting for a drop-down menu to display the desired text after an XHR request before trying to select it.

Screenshots of the failure show that on occasional test runs, there are fake `BgsAttorney` with names that include a substring of the search text `"Name not listed"` (examples: `Natalia Lindgren`, `Lisha Nader`), and that those names are selected instead.

Waiting for the search to resolve with `"Name not listed"` as implemented in this PR should fix the flake.