### PR TITLE
rake script for changing legacy appeal VACOLS location in bulk

### DIFF
--- a/lib/tasks/appeals.rake
+++ b/lib/tasks/appeals.rake
@@ -14,7 +14,7 @@ namespace :appeals do
   task :change_vacols_location, [:from_location, :to_location, :dry_run] => :environment do |_, args|
     extras = args.extras
     dry_run = args.dry_run&.to_s&.strip&.upcase != "FALSE"
-    if dry_run && args.dry_run.to_i > 0
+    if dry_run && args.dry_run.present?
       extras.unshift(args.dry_run)
     end
 

--- a/lib/tasks/appeals.rake
+++ b/lib/tasks/appeals.rake
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+namespace :appeals do
+  class NotEnoughArguments < StandardError; end
+  class InvalidLocationPassed < StandardError; end
+  class VacolsIdsRequired < StandardError; end
+
+  # usage:
+  # Move legacy appeals matching the passed VACOLS ids from/to the passed VACOLS locations (dry run)
+  #   $ bundle exec rake appeals:change_vacols_location[55,81,12345,23456,34567,45678]
+  # Move legacy appeals matching the passed VACOLS ids from/to the passed VACOLS locations (execute)
+  #   $ bundle exec rake appeals:change_vacols_location[55,81,false,12345,23456,34567,45678]
+  desc "move legacy appeals from one location to another"
+  task :change_vacols_location, [:from_location, :to_location, :dry_run] => :environment do |_, args|
+    extras = args.extras
+    dry_run = args.dry_run&.to_s&.strip&.upcase != "FALSE"
+    if dry_run && args.dry_run.to_i > 0
+      extras.unshift(args.dry_run)
+    end
+
+    logger_tag = "rake appeals:change_vacols_location"
+    message = "Invoked with: #{args.to_a.join(', ')}"
+    message = "(dry run) " + message if dry_run
+    Rails.logger.tagged(logger_tag) { Rails.logger.info(message) }
+    puts_output = ""
+
+    # make sure the minimum number of arguments were passed
+    if args.to_a.length < 3
+      fail NotEnoughArguments,
+           "requires at least three arguments: a from location, a to location, and at least one VACOLS ID"
+    end
+
+    if extras.empty?
+      fail NotEnoughArguments,
+           "you must pass VACOLS IDs for the appeals you want to change locations for"
+    end
+
+    # make sure valid location codes were passed
+    [args.from_location, args.to_location].each do |location|
+      if LegacyAppeal::LOCATION_CODES.values.exclude? location
+        fail InvalidLocationPassed, "#{location} is not a valid VACOLS location"
+      end
+    end
+
+    if dry_run
+      puts_output += "*** DRY RUN\n"
+      puts_output += "*** pass 'false' as the third argument to execute\n"
+    end
+
+    # step through the passed vacols IDs
+    message = "Changing location for #{extras.length} legacy appeals"
+    Rails.logger.tagged(logger_tag) { Rails.logger.info(message) } if !dry_run
+    puts_output += message + "\n"
+
+    appeals_moved = 0
+    extras.each do |vacols_id|
+      la = LegacyAppeal.find_by(vacols_id: vacols_id)
+      if la.blank?
+        message = "No legacy appeal found for vacols_id #{vacols_id}; skipping."
+        Rails.logger.tagged(logger_tag) { Rails.logger.info(message) } if !dry_run
+        puts_output += message + "\n"
+        next
+      end
+
+      # make sure the current location is as expected
+      current_location = la.location_code
+      if current_location != args.from_location
+        message = "Legacy appeal with vacols_id #{vacols_id} is in location " \
+                  "#{current_location}, not #{args.from_location}; skipping."
+        Rails.logger.tagged(logger_tag) { Rails.logger.info(message) } if !dry_run
+        puts_output += message + "\n"
+        next
+      end
+
+      message = "Moving legacy appeal with vacols_id #{vacols_id} from " \
+                "location #{args.from_location} to #{args.to_location}."
+
+      if !dry_run
+        AppealRepository.update_location!(la, args.to_location)
+        Rails.logger.tagged(logger_tag) { Rails.logger.info(message) }
+      end
+
+      puts_output += message + "\n"
+
+      appeals_moved += 1
+    end
+
+    message = "Moved #{appeals_moved} of #{extras.length} legacy appeals from " \
+              "location #{args.from_location} to #{args.to_location}."
+    Rails.logger.tagged(logger_tag) { Rails.logger.info(message) } if !dry_run
+    puts_output += message + "\n"
+    puts puts_output
+  end
+end

--- a/spec/lib/tasks/appeals_spec.rb
+++ b/spec/lib/tasks/appeals_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+describe "appeals" do
+  include_context "rake"
+
+  describe "appeals:change_vacols_location" do
+    let(:loc_case_storage) { LegacyAppeal::LOCATION_CODES[:case_storage] }
+    let(:loc_service_org) { LegacyAppeal::LOCATION_CODES[:service_organization] }
+    let(:loc_transcription) { LegacyAppeal::LOCATION_CODES[:transcription] }
+
+    let(:loc1) { loc_service_org }
+    let(:vc1) { create(:case, bfcurloc: loc1) }
+    let!(:la1) { create(:legacy_appeal, vacols_case: vc1) }
+
+    let(:loc2) { loc_service_org }
+    let(:vc2) { create(:case, bfcurloc: loc2) }
+    let!(:la2) { create(:legacy_appeal, vacols_case: vc2) }
+
+    let(:args) { [] }
+
+    subject do
+      Rake::Task["appeals:change_vacols_location"].reenable
+      Rake::Task["appeals:change_vacols_location"].invoke(*args)
+    end
+
+    context "expected values are passed" do
+      context "no dry run variable is passed" do
+        let(:output_match) { /\*\*\* DRY RUN/ }
+        let(:args) { [loc_service_org, loc_case_storage, la1.vacols_id, la2.vacols_id] }
+
+        it "doesn't change the appeals' location" do
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_service_org
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_service_org
+
+          expect { subject }.to output(output_match).to_stdout
+
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_service_org
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_service_org
+        end
+      end
+
+      context "dry run is set to false" do
+        let(:output_match) do
+          /Moved 2 of 2 legacy appeals from location #{loc_service_org} to #{loc_case_storage}./
+        end
+        let(:args) { [loc_service_org, loc_case_storage, false, la1.vacols_id, la2.vacols_id] }
+
+        it "moves the appeals to the new location" do
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_service_org
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_service_org
+
+          expect { subject }.to output(output_match).to_stdout
+
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_case_storage
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_case_storage
+        end
+      end
+
+      context "appeals are passed that aren't in the expected location" do
+        let(:loc1) { loc_transcription }
+        let(:output_match) do
+          /vacols_id #{la1.id} is in location #{loc_transcription}, not #{loc_service_org}; skipping./
+        end
+        let(:args) { [loc_service_org, loc_case_storage, false, la1.vacols_id, la2.vacols_id] }
+
+        it "moves one appeal to the new location and doesn't change the other" do
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_transcription
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_service_org
+
+          expect { subject }.to output(output_match).to_stdout
+
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_transcription
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_case_storage
+        end
+      end
+
+      context "an invalid vacols id is passed" do
+        let(:invalid_id) { "invalid_vacols_id" }
+        let(:output_match) { /No legacy appeal found for vacols_id #{invalid_id}; skipping./ }
+        let(:args) { [loc_service_org, loc_case_storage, false, invalid_id, la1.vacols_id, la2.vacols_id] }
+
+        it "notes the invalid id and moves the appeals to the new location" do
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_service_org
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_service_org
+
+          expect { subject }.to output(output_match).to_stdout
+
+          expect(LegacyAppeal.find(la1.id).location_code).to eq loc_case_storage
+          expect(LegacyAppeal.find(la2.id).location_code).to eq loc_case_storage
+        end
+      end
+
+      context "fewer than three arguments are passed" do
+        let(:args) { [loc_service_org, loc_case_storage] }
+        let(:error_output) do
+          "requires at least three arguments: a from location, a to location, and at least one VACOLS ID"
+        end
+
+        it "tells the caller that not enough argments were passed" do
+          expect { subject }.to raise_error(NotEnoughArguments).with_message(error_output)
+        end
+      end
+
+      context "no VACOLS IDs are passed" do
+        let(:args) { [loc_service_org, loc_case_storage, false] }
+        let(:error_output) do
+          "you must pass VACOLS IDs for the appeals you want to change locations for"
+        end
+
+        it "tells the caller to include vacols IDs" do
+          expect { subject }.to raise_error(NotEnoughArguments).with_message(error_output)
+        end
+      end
+
+      context "an invalid VACOLS location is passed" do
+        let(:invalid_location) { "NOT_A_REAL_LOCATION" }
+        let(:args) { [loc_service_org, invalid_location, false, la1.vacols_id, la2.vacols_id] }
+        let(:error_output) { "#{invalid_location} is not a valid VACOLS location" }
+
+        it "alerts the user to the invalid location" do
+          expect { subject }.to raise_error(InvalidLocationPassed).with_message(error_output)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/appeals_spec.rb
+++ b/spec/lib/tasks/appeals_spec.rb
@@ -59,7 +59,7 @@ describe "appeals" do
       context "appeals are passed that aren't in the expected location" do
         let(:loc1) { loc_transcription }
         let(:output_match) do
-          /vacols_id #{la1.id} is in location #{loc_transcription}, not #{loc_service_org}; skipping./
+          /vacols_id #{la1.vacols_id} is in location #{loc_transcription}, not #{loc_service_org}; skipping./
         end
         let(:args) { [loc_service_org, loc_case_storage, false, la1.vacols_id, la2.vacols_id] }
 


### PR DESCRIPTION
### Description
Introduces a rake script for changing the VACOLS location of one or more legacy appeals.

### Testing plan
Go into your dev console and find some legacy appeals in a particular location.
```ruby
LegacyAppeal.all.select { |la| la.location_code == "99" }.pluck(:vacols_id)
=> ["2096907", "3306315", "3642997", "2430857", "3363848"]
```

Use the script to move those appeals to another location; review the script output to verify that it's taking the expected actions
```ruby
# dry run
Rake::Task["appeals:change_vacols_location"].invoke("99", "55", "2096907", "3306315", "3642997", "2430857", "3363848")

# reset to run again
Rake::Task["appeals:change_vacols_location"].reenable

# actually change the locations
Rake::Task["appeals:change_vacols_location"].invoke("99", "55", false, "2096907", "3306315", "3642997", "2430857", "3363848")

# reset to run again
Rake::Task["appeals:change_vacols_location"].reenable

# change the locations back
Rake::Task["appeals:change_vacols_location"].invoke("55", "99", false, "2096907", "3306315", "3642997", "2430857", "3363848")
```

Try to give it bad input and see errors
```ruby
# not enough arguments
Rake::Task["appeals:change_vacols_location"].invoke("55", "99")

# no vacols ids passed
Rake::Task["appeals:change_vacols_location"].invoke("55", "99", false)

# invalid VACOLS location
Rake::Task["appeals:change_vacols_location"].invoke("55", "INVALID LOCATION", false, "2096907")

# invalid VACOLS ID
Rake::Task["appeals:change_vacols_location"].invoke("55", "99", "INVALID ID", "3306315")

# VACOLS ID of an appeal in an unexpected location
LegacyAppeal.all.select { |la| la.location_code == "33" }.pluck(:vacols_id)
=> ["2249056", "2306397"]
Rake::Task["appeals:change_vacols_location"].invoke("55", "99", "2249056", "3306315")
```

Alternatively, you may run the script from the command line
```bash
# bash (dry run)
bundle exec rake appeals:change_vacols_location[99,55,2096907,3306315,3642997,2430857,3363848]

# zsh (dry run)
bundle exec rake appeals:change_vacols_location\[99,55,2096907,3306315,3642997,2430857,3363848\]
```
