### PR TITLE
Add missing foreign keys to the users table (Phase 1)

### DIFF
--- a/db/migrate/20210322215845_add_foreign_keys_to_users_table.rb
+++ b/db/migrate/20210322215845_add_foreign_keys_to_users_table.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToUsersTable < Caseflow::Migration
+  def change
+    add_foreign_key "cavc_remands", "users", column: "created_by_id", validate: false
+    add_foreign_key "cavc_remands", "users", column: "updated_by_id", validate: false
+    add_foreign_key "virtual_hearings", "users", column: "created_by_id", validate: false
+
+    add_foreign_key "tasks", "users", column: "assigned_by_id", validate: false
+    add_foreign_key "tasks", "users", column: "cancelled_by_id", validate: false
+
+    add_foreign_key "distributions", "users", column: "judge_id", validate: false
+    add_foreign_key "hearings", "users", column: "judge_id", validate: false
+    add_foreign_key "hearing_days", "users", column: "judge_id", validate: false
+    add_foreign_key "sent_hearing_email_events", "users", column: "sent_by_id", validate: false
+
+    add_foreign_key "judge_case_reviews", "users", column: "attorney_id", validate: false
+    add_foreign_key "judge_case_reviews", "users", column: "judge_id", validate: false
+  end
+end

--- a/db/migrate/20210322220713_validate_foreign_keys_to_users_table.rb
+++ b/db/migrate/20210322220713_validate_foreign_keys_to_users_table.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class ValidateForeignKeysToUsersTable < Caseflow::Migration
+  def change
+    validate_foreign_key "cavc_remands", column: "created_by_id"
+    validate_foreign_key "cavc_remands", column: "updated_by_id"
+    validate_foreign_key "virtual_hearings", column: "created_by_id"
+
+    validate_foreign_key "tasks", column: "assigned_by_id"
+    validate_foreign_key "tasks", column: "cancelled_by_id"
+
+    validate_foreign_key "distributions", column: "judge_id"
+    validate_foreign_key "hearings", column: "judge_id"
+    validate_foreign_key "hearing_days", column: "judge_id"
+    validate_foreign_key "sent_hearing_email_events", column: "sent_by_id"
+
+    validate_foreign_key "judge_case_reviews", column: "attorney_id"
+    validate_foreign_key "judge_case_reviews", column: "judge_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_22_135622) do
+ActiveRecord::Schema.define(version: 2021_03_22_220713) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1619,9 +1619,12 @@ ActiveRecord::Schema.define(version: 2021_03_22_135622) do
   add_foreign_key "annotations", "users"
   add_foreign_key "api_views", "api_keys"
   add_foreign_key "appeal_views", "users"
+  add_foreign_key "cavc_remands", "users", column: "created_by_id"
+  add_foreign_key "cavc_remands", "users", column: "updated_by_id"
   add_foreign_key "certifications", "users"
   add_foreign_key "claims_folder_searches", "users"
   add_foreign_key "dispatch_tasks", "users"
+  add_foreign_key "distributions", "users", column: "judge_id"
   add_foreign_key "docket_switches", "appeals", column: "new_docket_stream_id"
   add_foreign_key "docket_switches", "appeals", column: "old_docket_stream_id"
   add_foreign_key "docket_switches", "tasks"
@@ -1630,11 +1633,15 @@ ActiveRecord::Schema.define(version: 2021_03_22_135622) do
   add_foreign_key "end_product_updates", "end_product_establishments"
   add_foreign_key "end_product_updates", "users"
   add_foreign_key "hearing_days", "users", column: "created_by_id"
+  add_foreign_key "hearing_days", "users", column: "judge_id"
   add_foreign_key "hearing_days", "users", column: "updated_by_id"
   add_foreign_key "hearing_views", "users"
   add_foreign_key "hearings", "users", column: "created_by_id"
+  add_foreign_key "hearings", "users", column: "judge_id"
   add_foreign_key "hearings", "users", column: "updated_by_id"
   add_foreign_key "intakes", "users"
+  add_foreign_key "judge_case_reviews", "users", column: "attorney_id"
+  add_foreign_key "judge_case_reviews", "users", column: "judge_id"
   add_foreign_key "legacy_appeals", "appeal_series"
   add_foreign_key "legacy_hearings", "hearing_days"
   add_foreign_key "legacy_hearings", "users"
@@ -1650,9 +1657,13 @@ ActiveRecord::Schema.define(version: 2021_03_22_135622) do
   add_foreign_key "ramp_election_rollbacks", "users"
   add_foreign_key "request_issues_updates", "users"
   add_foreign_key "schedule_periods", "users"
+  add_foreign_key "sent_hearing_email_events", "users", column: "sent_by_id"
+  add_foreign_key "tasks", "users", column: "assigned_by_id"
+  add_foreign_key "tasks", "users", column: "cancelled_by_id"
   add_foreign_key "unrecognized_appellants", "claimants"
   add_foreign_key "unrecognized_appellants", "unrecognized_party_details"
   add_foreign_key "unrecognized_appellants", "unrecognized_party_details", column: "unrecognized_power_of_attorney_id"
   add_foreign_key "user_quotas", "users"
+  add_foreign_key "virtual_hearings", "users", column: "created_by_id"
   add_foreign_key "virtual_hearings", "users", column: "updated_by_id"
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1440,10 +1440,11 @@ describe Task, :all_dbs do
         expect(task.closed_at).to_not eq(nil)
       end
 
+      let(:some_user) { create(:user) }
       it "does not set the cancelled_by_id if there is no logged in user" do
-        task.update!(cancelled_by_id: 1)
+        task.update!(cancelled_by_id: some_user.id)
         task.update!(status: status)
-        expect(task.cancelled_by_id).to eq(1)
+        expect(task.cancelled_by_id).to eq(some_user.id)
       end
 
       context "when a user is logged in" do


### PR DESCRIPTION
Bumps #14732
This is phase 1 of a [multi-phase plan](https://hackmd.io/wum2LtUfSHC-1o6-peBseQ) to add missing foreign keys.

Resolves lack of foreign keys. See https://thoughtbot.com/blog/referential-integrity-with-foreign-keys
[Slack discussion](https://dsva.slack.com/archives/CQTDX9BF0/p1616429065002700)

### Description
Add foreign keys to the `users` table. 

FYI: StrongMigrations' suggestion:
```
=== Dangerous operation detected #strong_migrations ===

New foreign keys are validated by default. This acquires an AccessExclusiveLock,
which is expensive on large tables. Instead, validate it in a separate migration
with a more agreeable RowShareLock.

class StrongMigrations::Checker < ActiveRecord::Migration[5.2]
  def change
    add_foreign_key "cavc_remands", "users", column: "created_by_id", validate: false
  end
end

class ValidateStrongMigrations::Checker < ActiveRecord::Migration[5.2]
  def change
    validate_foreign_key "cavc_remands", "users"
  end
end
```

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Before deployment, rerun the following to ensure the foreign keys will be valid:
```ruby
CavcRemand.includes(:created_by).where.not(created_by_id: nil).select{|cr| cr.created_by == nil}.count
=> 0
CavcRemand.includes(:updated_by).where.not(updated_by_id: nil).select{|cr| cr.updated_by == nil}.count
=> 0
VirtualHearing.includes(:created_by).where.not(created_by_id: nil).select{|cr| cr.created_by == nil}.count
=> 0

Task.includes(:assigned_by).where.not(assigned_by_id: nil).select{|cr| cr.assigned_by == nil}.count
=> 0
Task.includes(:cancelled_by).where.not(cancelled_by_id: nil).select{|cr| cr.cancelled_by == nil}.count
=> 0

Distribution.includes(:judge).where.not(judge_id: nil).select{|cr| cr.judge == nil}.count
=> 0
Hearing.includes(:judge).where.not(judge_id: nil).select{|cr| cr.judge == nil}.count
=> 0
HearingDay.includes(:judge).where.not(judge_id: nil).select{|cr| cr.judge == nil}.count
=> 0
SentHearingEmailEvent.includes(:sent_by).where.not(sent_by_id: nil).select{|cr| cr.sent_by == nil}.count
=> 0

JudgeCaseReview.includes(:attorney).where.not(attorney_id: nil).select{|cr| cr.attorney == nil}.count
=> 0
JudgeCaseReview.includes(:judge).where.not(judge_id: nil).select{|cr| cr.judge == nil}.count
=> 0
```

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
