### PR TITLE
Updated queue table to resolve 508 compliance issues

### DIFF
--- a/client/app/components/TableFilter.jsx
+++ b/client/app/components/TableFilter.jsx
@@ -185,6 +185,7 @@ class TableFilter extends React.PureComponent {
     return (
       <span {...iconStyle}>
         <FilterIcon
+          aria-label={this.filterIconAriaLabel()}
           label={this.filterIconAriaLabel()}
           getRef={this.props.getFilterIconRef}
           selected={this.isFilterOpen()}

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -113,11 +113,19 @@ export const HeaderRow = (props) => {
           let sortIcon;
           let filterIcon;
 
+          // Define the aria label to exclude the filter/sort
+          const ariaLabel = column?.ariaLabel ? column?.ariaLabel : `header-${column.columnName}`;
+
+          // Set the Sort name for the column if sorting by this column
+          const sorting = props.sortColName === column.name;
+          const sortLabel = sorting && props.sortAscending ? 'ascending' : 'descending';
+
+          // Set the aria props for this column header
+          const sortProps = sorting ? { 'aria-sort': sortLabel } : {};
+
           if ((!props.useTaskPagesApi || column.backendCanSort) && column.getSortValue) {
-            const topColor =
-              props.sortColName === column.name && !props.sortAscending ? COLORS.PRIMARY : COLORS.GREY_LIGHT;
-            const botColor =
-              props.sortColName === column.name && props.sortAscending ? COLORS.PRIMARY : COLORS.GREY_LIGHT;
+            const topColor = sorting && !props.sortAscending ? COLORS.PRIMARY : COLORS.GREY_LIGHT;
+            const botColor = sorting && props.sortAscending ? COLORS.PRIMARY : COLORS.GREY_LIGHT;
 
             sortIcon = (
               <span
@@ -155,9 +163,9 @@ export const HeaderRow = (props) => {
               />
             );
           }
-          const columnTitleContent = <span>{column.header || ''}</span>;
+          const columnTitleContent = <span id={`header-${column.columnName}`}>{column.header || ''}</span>;
           const columnContent = (
-            <span {...iconHeaderStyle} aria-label="">
+            <span {...iconHeaderStyle}>
               {columnTitleContent}
               {sortIcon}
               {filterIcon}
@@ -165,7 +173,15 @@ export const HeaderRow = (props) => {
           );
 
           return (
-            <th role="columnheader" scope="col" key={columnNumber} className={cellClasses(column)}>
+            <th
+              {...sortProps}
+              {...(column?.sortProps || {})}
+              role="columnheader"
+              scope="col"
+              key={columnNumber}
+              className={cellClasses(column)}
+              aria-labelledby={ariaLabel}
+            >
               {column.tooltip ? (
                 <Tooltip id={`tooltip-${columnNumber}`} text={column.tooltip}>
                   {columnContent}

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -114,7 +114,7 @@ export const HeaderRow = (props) => {
           let filterIcon;
 
           // Determine whether to apply an ID to the column title
-          const titleId = column?.columnName ? `header-${column.columnName}` : '';
+          const titleId = column?.columnName ? `header-${_.camelCase(column.columnName)}` : '';
 
           // Define the aria label to exclude the filter/sort
           const ariaLabel = column?.ariaLabel ? column?.ariaLabel : titleId;

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -113,8 +113,11 @@ export const HeaderRow = (props) => {
           let sortIcon;
           let filterIcon;
 
+          // Determine whether to apply an ID to the column title
+          const titleId = column?.columnName ? `header-${column.columnName}` : '';
+
           // Define the aria label to exclude the filter/sort
-          const ariaLabel = column?.ariaLabel ? column?.ariaLabel : `header-${column.columnName}`;
+          const ariaLabel = column?.ariaLabel ? column?.ariaLabel : titleId;
 
           // Set the Sort name for the column if sorting by this column
           const sorting = props.sortColName === column.name;
@@ -163,9 +166,9 @@ export const HeaderRow = (props) => {
               />
             );
           }
-          const columnTitleContent = <span id={`header-${column.columnName}`}>{column.header || ''}</span>;
+          const columnTitleContent = <span {...(titleId ? { id: titleId } : {})}>{column.header || ''}</span>;
           const columnContent = (
-            <span {...iconHeaderStyle}>
+            <span {...iconHeaderStyle} aria-label="">
               {columnTitleContent}
               {sortIcon}
               {filterIcon}
@@ -176,11 +179,11 @@ export const HeaderRow = (props) => {
             <th
               {...sortProps}
               {...(column?.sortProps || {})}
+              {...(ariaLabel ? { 'aria-labelledby': ariaLabel } : {})}
               role="columnheader"
               scope="col"
               key={columnNumber}
               className={cellClasses(column)}
-              aria-labelledby={ariaLabel}
             >
               {column.tooltip ? (
                 <Tooltip id={`tooltip-${columnNumber}`} text={column.tooltip}>

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -14,12 +14,21 @@ import CommentIndicator from './CommentIndicator';
 import DropdownFilter from '../components/DropdownFilter';
 import { bindActionCreators } from 'redux';
 import Highlight from '../components/Highlight';
-import { setDocListScrollPosition, changeSortState, clearTagFilters, clearCategoryFilters,
-  setTagFilter, setCategoryFilter, toggleDropdownFilterVisibility
+import {
+  setDocListScrollPosition,
+  changeSortState,
+  clearTagFilters,
+  clearCategoryFilters,
+  setTagFilter,
+  setCategoryFilter,
+  toggleDropdownFilterVisibility,
 } from '../reader/DocumentList/DocumentListActions';
 import { getAnnotationsPerDocument } from './selectors';
 import {
-  SortArrowUp, SortArrowDown, DoubleArrow } from '../components/RenderFunctions';
+  SortArrowUp,
+  SortArrowDown,
+  DoubleArrow,
+} from '../components/RenderFunctions';
 import DocCategoryPicker from './DocCategoryPicker';
 import DocTagPicker from './DocTagPicker';
 import FilterIcon from '../components/FilterIcon';
@@ -36,7 +45,7 @@ export const getRowObjects = (documents, annotationsPerDocument) => {
     if (docHasComments && doc.listComments) {
       acc.push({
         ...doc,
-        isComment: true
+        isComment: true,
       });
     }
 
@@ -52,16 +61,17 @@ class DocumentsTable extends React.Component {
       if (this.lastReadIndicatorElem) {
         const lastReadBoundingRect = this.lastReadIndicatorElem.getBoundingClientRect();
         const tbodyBoundingRect = this.tbodyElem.getBoundingClientRect();
-        const lastReadIndicatorIsInView = tbodyBoundingRect.top <= lastReadBoundingRect.top &&
+        const lastReadIndicatorIsInView =
+          tbodyBoundingRect.top <= lastReadBoundingRect.top &&
           lastReadBoundingRect.bottom <= tbodyBoundingRect.bottom;
 
         if (!lastReadIndicatorIsInView) {
-          const rowWithLastRead = _.find(
-            this.tbodyElem.children,
-            (tr) => tr.querySelector(`#${this.lastReadIndicatorElem.id}`)
+          const rowWithLastRead = _.find(this.tbodyElem.children, (tr) =>
+            tr.querySelector(`#${this.lastReadIndicatorElem.id}`)
           );
 
-          this.tbodyElem.scrollTop += rowWithLastRead.getBoundingClientRect().top - tbodyBoundingRect.top;
+          this.tbodyElem.scrollTop +=
+            rowWithLastRead.getBoundingClientRect().top - tbodyBoundingRect.top;
         }
       }
     }
@@ -71,25 +81,31 @@ class DocumentsTable extends React.Component {
     this.props.setDocListScrollPosition(this.tbodyElem.scrollTop);
   }
 
-  getTbodyRef = (elem) => this.tbodyElem = elem
-  getLastReadIndicatorRef = (elem) => this.lastReadIndicatorElem = elem
-  getCategoryFilterIconRef = (categoryFilterIcon) => this.categoryFilterIcon = categoryFilterIcon
-  getTagFilterIconRef = (tagFilterIcon) => this.tagFilterIcon = tagFilterIcon
-  toggleCategoryDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('category')
-  toggleTagDropdownFilterVisiblity = () => this.props.toggleDropdownFilterVisibility('tag')
+  getTbodyRef = (elem) => (this.tbodyElem = elem);
+  getLastReadIndicatorRef = (elem) => (this.lastReadIndicatorElem = elem);
+  getCategoryFilterIconRef = (categoryFilterIcon) =>
+    (this.categoryFilterIcon = categoryFilterIcon);
+  getTagFilterIconRef = (tagFilterIcon) => (this.tagFilterIcon = tagFilterIcon);
+  toggleCategoryDropdownFilterVisiblity = () =>
+    this.props.toggleDropdownFilterVisibility('category');
+  toggleTagDropdownFilterVisiblity = () =>
+    this.props.toggleDropdownFilterVisibility('tag');
 
   getKeyForRow = (index, { isComment, id }) => {
     return isComment ? `${id}-comment` : id;
-  }
+  };
 
   // eslint-disable-next-line max-statements
   getDocumentColumns = (row) => {
-    const sortArrowIcon = this.props.docFilterCriteria.sort.sortAscending ? <SortArrowUp /> : <SortArrowDown />;
+    const sortArrowIcon = this.props.docFilterCriteria.sort.sortAscending ? (
+      <SortArrowUp />
+    ) : (
+      <SortArrowDown />
+    );
     const notSortedIcon = <DoubleArrow />;
 
-    const anyFiltersSet = (filterType) => (
-      Boolean(_.some(this.props.docFilterCriteria[filterType]))
-    );
+    const anyFiltersSet = (filterType) =>
+      Boolean(_.some(this.props.docFilterCriteria[filterType]));
 
     const anyCategoryFiltersAreSet = anyFiltersSet('category');
     const anyTagFiltersAreSet = anyFiltersSet('tag');
@@ -98,145 +114,201 @@ class DocumentsTable extends React.Component {
     // We use onMouseUp instead of onClick for filename event handler since OnMouseUp
     // is triggered when a middle mouse button is clicked while onClick isn't.
     if (row && row.isComment) {
+      return [
+        {
+          valueFunction: (doc) => {
+            const comments = _.sortBy(
+              this.props.annotationsPerDocument[doc.id],
+              ['page', 'y']
+            );
+            const commentNodes = comments.map((comment, commentIndex) => {
+              return (
+                <Comment
+                  key={comment.uuid}
+                  id={`comment${doc.id}-${commentIndex}`}
+                  selected={false}
+                  page={comment.page}
+                  onJumpToComment={this.props.onJumpToComment(comment)}
+                  uuid={comment.uuid}
+                  date={comment.relevant_date}
+                  horizontalLayout
+                >
+                  {comment.comment}
+                </Comment>
+              );
+            });
 
-      return [{
-        valueFunction: (doc) => {
-          const comments = _.sortBy(this.props.annotationsPerDocument[doc.id], ['page', 'y']);
-          const commentNodes = comments.map((comment, commentIndex) => {
-            return <Comment
-              key={comment.uuid}
-              id={`comment${doc.id}-${commentIndex}`}
-              selected={false}
-              page={comment.page}
-              onJumpToComment={this.props.onJumpToComment(comment)}
-              uuid={comment.uuid}
-              date={comment.relevant_date}
-              horizontalLayout>
-              {comment.comment}
-            </Comment>;
-          });
-
-          return <ul className="cf-no-styling-list" aria-label="Document comments">
-            {commentNodes}
-          </ul>;
+            return (
+              <ul className="cf-no-styling-list" aria-label="Document comments">
+                {commentNodes}
+              </ul>
+            );
+          },
+          span: _.constant(NUMBER_OF_COLUMNS),
         },
-        span: _.constant(NUMBER_OF_COLUMNS)
-      }];
+      ];
     }
 
-    const isCategoryDropdownFilterOpen =
-      _.get(this.props.pdfList, ['dropdowns', 'category']);
+    const isCategoryDropdownFilterOpen = _.get(this.props.pdfList, [
+      'dropdowns',
+      'category',
+    ]);
 
-    const isTagDropdownFilterOpen =
-      _.get(this.props.pdfList, ['dropdowns', 'tag']);
+    const isTagDropdownFilterOpen = _.get(this.props.pdfList, [
+      'dropdowns',
+      'tag',
+    ]);
 
-    const sortDirectionAriaLabel =
-      `Sorted ${this.props.docFilterCriteria.sort.sortAscending ? 'ascending' : 'descending'}`;
+    const sortDirectionAriaLabel = `${
+      this.props.docFilterCriteria.sort.sortAscending ?
+        'ascending' :
+        'descending'
+    }`;
 
     return [
       {
         cellClass: 'last-read-column',
-        valueFunction: (doc) => <LastReadIndicator docId={doc.id} getRef={this.getLastReadIndicatorRef} />
+        valueFunction: (doc) => (
+          <LastReadIndicator
+            docId={doc.id}
+            getRef={this.getLastReadIndicatorRef}
+          />
+        ),
       },
       {
         cellClass: 'categories-column',
-        header: <div
-          id="categories-header">
-          Categories <FilterIcon
-            label="Filter by category"
-            idPrefix="category"
-            getRef={this.getCategoryFilterIconRef}
-            selected={isCategoryDropdownFilterOpen || anyCategoryFiltersAreSet}
-            handleActivate={this.toggleCategoryDropdownFilterVisiblity} />
-
-          {isCategoryDropdownFilterOpen &&
-            <DropdownFilter
-              clearFilters={this.props.clearCategoryFilters}
-              name="category"
-              isClearEnabled={anyCategoryFiltersAreSet}
-              handleClose={this.toggleCategoryDropdownFilterVisiblity}
-              addClearFiltersRow>
-              <DocCategoryPicker
-                categoryToggleStates={this.props.docFilterCriteria.category}
-                handleCategoryToggle={this.props.setCategoryFilter} />
-            </DropdownFilter>
-          }
-
-        </div>,
-        valueFunction: (doc) => <DocumentCategoryIcons doc={doc} />
+        ariaLabel: 'categories-header-label',
+        header: (
+          <div id="categories-header">
+            <span id="categories-header-label">
+              Categories{' '}
+              {anyCategoryFiltersAreSet ? 'Filtering by Category' : ''}
+            </span>
+            <FilterIcon
+              label="Filter by category"
+              idPrefix="category"
+              getRef={this.getCategoryFilterIconRef}
+              selected={
+                isCategoryDropdownFilterOpen || anyCategoryFiltersAreSet
+              }
+              handleActivate={this.toggleCategoryDropdownFilterVisiblity}
+            />
+            {isCategoryDropdownFilterOpen && (
+              <DropdownFilter
+                clearFilters={this.props.clearCategoryFilters}
+                name="category"
+                isClearEnabled={anyCategoryFiltersAreSet}
+                handleClose={this.toggleCategoryDropdownFilterVisiblity}
+                addClearFiltersRow
+              >
+                <DocCategoryPicker
+                  categoryToggleStates={this.props.docFilterCriteria.category}
+                  handleCategoryToggle={this.props.setCategoryFilter}
+                />
+              </DropdownFilter>
+            )}
+          </div>
+        ),
+        valueFunction: (doc) => <DocumentCategoryIcons doc={doc} />,
       },
       {
         cellClass: 'receipt-date-column',
-        header: <Button
-          name="Receipt Date"
-          id="receipt-date-header"
-          classNames={['cf-document-list-button-header']}
-          ariaLabel={`Sort by Receipt Date. ${this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ?
-            sortDirectionAriaLabel :
-            '' }`}
-          onClick={() => this.props.changeSortState('receivedAt')}>
-          Receipt Date {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ? sortArrowIcon : notSortedIcon }
-        </Button>,
-        valueFunction: (doc) => <span className="document-list-receipt-date">
-          <Highlight>
-            {formatDateStr(doc.receivedAt)}
-          </Highlight>
-        </span>
+        ariaLabel: 'receipt-date-header-label',
+        sortProps: this.props.docFilterCriteria.sort.sortBy ===
+          'receivedAt' && { 'aria-sort': sortDirectionAriaLabel },
+        header: (
+          <Button
+            name="Receipt Date"
+            id="receipt-date-header"
+            classNames={['cf-document-list-button-header']}
+            onClick={() => this.props.changeSortState('receivedAt')}
+          >
+            <span id="receipt-date-header-label">Receipt Date</span>
+            {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ?
+              sortArrowIcon :
+              notSortedIcon}
+          </Button>
+        ),
+        valueFunction: (doc) => (
+          <span className="document-list-receipt-date">
+            <Highlight>{formatDateStr(doc.receivedAt)}</Highlight>
+          </span>
+        ),
       },
       {
         cellClass: 'doc-type-column',
-        header: <Button id="type-header"
-          name="Document Type"
-          classNames={['cf-document-list-button-header']}
-          ariaLabel={`Sort by Document Type. ${this.props.docFilterCriteria.sort.sortBy === 'type' ?
-            sortDirectionAriaLabel :
-            '' }`}
-          onClick={() => this.props.changeSortState('type')}>
-          Document Type {this.props.docFilterCriteria.sort.sortBy === 'type' ? sortArrowIcon : notSortedIcon }
-        </Button>,
-        valueFunction: (doc) => <DocTypeColumn doc={doc}
-          documentPathBase={this.props.documentPathBase} />
+        ariaLabel: 'type-header-label',
+        sortProps: this.props.docFilterCriteria.sort.sortBy === 'type' && {
+          'aria-sort': sortDirectionAriaLabel,
+        },
+        header: (
+          <Button
+            id="type-header"
+            name="Document Type"
+            classNames={['cf-document-list-button-header']}
+            onClick={() => this.props.changeSortState('type')}
+          >
+            <span id="type-header-label">Document Type</span>
+            {this.props.docFilterCriteria.sort.sortBy === 'type' ?
+              sortArrowIcon :
+              notSortedIcon}
+          </Button>
+        ),
+        valueFunction: (doc) => (
+          <DocTypeColumn
+            doc={doc}
+            documentPathBase={this.props.documentPathBase}
+          />
+        ),
       },
       {
         cellClass: 'tags-column',
-        header: <div id="tags-header"
-          className="document-list-header-issue-tags">
-          Issue Tags <FilterIcon
-            label="Filter by tag"
-            idPrefix="tag"
-            getRef={this.getTagFilterIconRef}
-            selected={isTagDropdownFilterOpen || anyTagFiltersAreSet}
-            handleActivate={this.toggleTagDropdownFilterVisiblity}
-          />
-          {isTagDropdownFilterOpen &&
-            <DropdownFilter
-              clearFilters={this.props.clearTagFilters}
-              name="tag"
-              isClearEnabled={anyTagFiltersAreSet}
-              handleClose={this.toggleTagDropdownFilterVisiblity}
-              addClearFiltersRow>
-              <DocTagPicker
-                tags={this.props.tagOptions}
-                tagToggleStates={this.props.docFilterCriteria.tag}
-                handleTagToggle={this.props.setTagFilter} />
-            </DropdownFilter>
-          }
-        </div>,
+        ariaLabel: 'tag-header-label',
+        header: (
+          <div id="tags-header" className="document-list-header-issue-tags">
+            <span id="tag-header-label">
+              Issue Tags
+              {anyTagFiltersAreSet ? 'Filtering by Issue Tags' : ''}
+            </span>
+            <FilterIcon
+              label="Filter by tag"
+              idPrefix="tag"
+              getRef={this.getTagFilterIconRef}
+              selected={isTagDropdownFilterOpen || anyTagFiltersAreSet}
+              handleActivate={this.toggleTagDropdownFilterVisiblity}
+            />
+            {isTagDropdownFilterOpen && (
+              <DropdownFilter
+                clearFilters={this.props.clearTagFilters}
+                name="tag"
+                isClearEnabled={anyTagFiltersAreSet}
+                handleClose={this.toggleTagDropdownFilterVisiblity}
+                addClearFiltersRow
+              >
+                <DocTagPicker
+                  tags={this.props.tagOptions}
+                  tagToggleStates={this.props.docFilterCriteria.tag}
+                  handleTagToggle={this.props.setTagFilter}
+                />
+              </DropdownFilter>
+            )}
+          </div>
+        ),
         valueFunction: (doc) => {
           return <TagTableColumn tags={doc.tags} />;
-        }
+        },
       },
       {
         cellClass: 'comments-column',
-        header: <div
-          id="comments-header"
-          className="document-list-header-comments">
-          Comments
-        </div>,
-        valueFunction: (doc) => <CommentIndicator docId={doc.id} />
-      }
+        header: (
+          <div id="comments-header" className="document-list-header-comments">
+            Comments
+          </div>
+        ),
+        valueFunction: (doc) => <CommentIndicator docId={doc.id} />,
+      },
     ];
-  }
+  };
 
   render() {
     const rowObjects = getRowObjects(
@@ -244,20 +316,22 @@ class DocumentsTable extends React.Component {
       this.props.annotationsPerDocument
     );
 
-    return <div>
-      <Table
-        columns={this.getDocumentColumns}
-        rowObjects={rowObjects}
-        summary="Document list"
-        className="documents-table"
-        headerClassName="cf-document-list-header-row"
-        bodyClassName="cf-document-list-body"
-        rowsPerRowObject={2}
-        tbodyId="documents-table-body"
-        tbodyRef={this.getTbodyRef}
-        getKeyForRow={this.getKeyForRow}
-      />
-    </div>;
+    return (
+      <div>
+        <Table
+          columns={this.getDocumentColumns}
+          rowObjects={rowObjects}
+          summary="Document list"
+          className="documents-table"
+          headerClassName="cf-document-list-header-row"
+          bodyClassName="cf-document-list-body"
+          rowsPerRowObject={2}
+          tbodyId="documents-table-body"
+          tbodyRef={this.getTbodyRef}
+          getKeyForRow={this.getKeyForRow}
+        />
+      </div>
+    );
   }
 }
 
@@ -267,7 +341,7 @@ DocumentsTable.propTypes = {
   sortBy: PropTypes.string,
   pdfList: PropTypes.shape({
     lastReadDocId: PropTypes.number,
-    scrollTop: PropTypes.number
+    scrollTop: PropTypes.number,
   }),
   changeSortState: PropTypes.func.isRequired,
   clearCategoryFilters: PropTypes.func,
@@ -279,25 +353,30 @@ DocumentsTable.propTypes = {
   setTagFilter: PropTypes.func.isRequired,
   setDocListScrollPosition: PropTypes.func.isRequired,
   toggleDropdownFilterVisibility: PropTypes.func.isRequired,
-  tagOptions: PropTypes.arrayOf(PropTypes.object).isRequired
+  tagOptions: PropTypes.arrayOf(PropTypes.object).isRequired,
 };
 
-const mapDispatchToProps = (dispatch) => bindActionCreators({
-  setDocListScrollPosition,
-  clearTagFilters,
-  clearCategoryFilters,
-  setTagFilter,
-  changeSortState,
-  toggleDropdownFilterVisibility,
-  setCategoryFilter
-}, dispatch);
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      setDocListScrollPosition,
+      clearTagFilters,
+      clearCategoryFilters,
+      setTagFilter,
+      changeSortState,
+      toggleDropdownFilterVisibility,
+      setCategoryFilter,
+    },
+    dispatch
+  );
 
 const mapStateToProps = (state) => ({
   annotationsPerDocument: getAnnotationsPerDocument(state),
   ..._.pick(state.documentList, 'docFilterCriteria', 'pdfList'),
-  ..._.pick(state.pdfViewer, 'tagOptions')
+  ..._.pick(state.pdfViewer, 'tagOptions'),
 });
 
 export default connect(
-  mapStateToProps, mapDispatchToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(DocumentsTable);

--- a/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
@@ -195,6 +195,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-label"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -203,7 +204,9 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-label"
+                      >
                         Tasks
                       </span>
                       <span
@@ -299,6 +302,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-appeal.caseType"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -307,7 +311,9 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-appeal.caseType"
+                      >
                         Types
                       </span>
                       <span
@@ -403,6 +409,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-appeal.docketName"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -411,7 +418,9 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-appeal.docketName"
+                      >
                         Docket
                       </span>
                       <span
@@ -1107,6 +1116,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-label"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -1115,7 +1125,9 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-label"
+                      >
                         Tasks
                       </span>
                       <span
@@ -1211,6 +1223,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-appeal.caseType"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -1219,7 +1232,9 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-appeal.caseType"
+                      >
                         Types
                       </span>
                       <span
@@ -1315,6 +1330,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
+                    aria-labelledby="header-appeal.docketName"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -1323,7 +1339,9 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                       aria-label=""
                       data-css-9shxm7=""
                     >
-                      <span>
+                      <span
+                        id="header-appeal.docketName"
+                      >
                         Docket
                       </span>
                       <span

--- a/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
@@ -302,7 +302,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    aria-labelledby="header-appeal.caseType"
+                    aria-labelledby="header-appealCaseType"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -312,7 +312,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                       data-css-9shxm7=""
                     >
                       <span
-                        id="header-appeal.caseType"
+                        id="header-appealCaseType"
                       >
                         Types
                       </span>
@@ -409,7 +409,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    aria-labelledby="header-appeal.docketName"
+                    aria-labelledby="header-appealDocketName"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -419,7 +419,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                       data-css-9shxm7=""
                     >
                       <span
-                        id="header-appeal.docketName"
+                        id="header-appealDocketName"
                       >
                         Docket
                       </span>
@@ -1223,7 +1223,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    aria-labelledby="header-appeal.caseType"
+                    aria-labelledby="header-appealCaseType"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -1233,7 +1233,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                       data-css-9shxm7=""
                     >
                       <span
-                        id="header-appeal.caseType"
+                        id="header-appealCaseType"
                       >
                         Types
                       </span>
@@ -1330,7 +1330,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                     </span>
                   </th>
                   <th
-                    aria-labelledby="header-appeal.docketName"
+                    aria-labelledby="header-appealDocketName"
                     class=""
                     role="columnheader"
                     scope="col"
@@ -1340,7 +1340,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                       data-css-9shxm7=""
                     >
                       <span
-                        id="header-appeal.docketName"
+                        id="header-appealDocketName"
                       >
                         Docket
                       </span>

--- a/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
+++ b/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
@@ -170,6 +170,7 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and filte
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -185,6 +186,7 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and filte
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -200,6 +202,8 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and filte
       </span>
     </th>
     <th
+      aria-labelledby="header-type"
+      aria-sort="descending"
       className="testClasses"
       key="2"
       role="columnheader"
@@ -209,7 +213,9 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and filte
         aria-label=""
         data-css-9shxm7=""
       >
-        <span>
+        <span
+          id="header-type"
+        >
           Third
         </span>
         <TableFilter
@@ -251,6 +257,7 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and getti
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -266,6 +273,7 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and getti
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -281,6 +289,8 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and getti
       </span>
     </th>
     <th
+      aria-labelledby="header-type"
+      aria-sort="descending"
       className="testClasses"
       key="2"
       role="columnheader"
@@ -290,7 +300,9 @@ exports[`QueueTable HeaderRow Can filter when not using task pages API and getti
         aria-label=""
         data-css-9shxm7=""
       >
-        <span>
+        <span
+          id="header-type"
+        >
           Third
         </span>
         <TableFilter
@@ -332,6 +344,7 @@ exports[`QueueTable HeaderRow Can filter when using task pages API and column ha
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -347,6 +360,7 @@ exports[`QueueTable HeaderRow Can filter when using task pages API and column ha
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -362,6 +376,8 @@ exports[`QueueTable HeaderRow Can filter when using task pages API and column ha
       </span>
     </th>
     <th
+      aria-labelledby="header-type"
+      aria-sort="descending"
       className="testClasses"
       key="2"
       role="columnheader"
@@ -371,7 +387,9 @@ exports[`QueueTable HeaderRow Can filter when using task pages API and column ha
         aria-label=""
         data-css-9shxm7=""
       >
-        <span>
+        <span
+          id="header-type"
+        >
           Third
         </span>
         <TableFilter
@@ -415,6 +433,7 @@ exports[`QueueTable HeaderRow Can sort when not using the tasks API and getting 
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -430,6 +449,7 @@ exports[`QueueTable HeaderRow Can sort when not using the tasks API and getting 
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -481,6 +501,7 @@ exports[`QueueTable HeaderRow Can sort when the backend can sort and getting col
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -496,6 +517,7 @@ exports[`QueueTable HeaderRow Can sort when the backend can sort and getting col
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -547,6 +569,7 @@ exports[`QueueTable HeaderRow Matches snapshot with default props 1`] = `
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -562,6 +585,7 @@ exports[`QueueTable HeaderRow Matches snapshot with default props 1`] = `
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -577,6 +601,7 @@ exports[`QueueTable HeaderRow Matches snapshot with default props 1`] = `
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="2"
       role="columnheader"
@@ -601,6 +626,7 @@ exports[`QueueTable HeaderRow Renders tooltip when present on the column 1`] = `
     role="row"
   >
     <th
+      aria-sort="descending"
       className="testClasses"
       key="0"
       role="columnheader"
@@ -616,6 +642,7 @@ exports[`QueueTable HeaderRow Renders tooltip when present on the column 1`] = `
       </span>
     </th>
     <th
+      aria-sort="descending"
       className="testClasses"
       key="1"
       role="columnheader"
@@ -911,6 +938,7 @@ exports[`QueueTable render() Can filter rows 1`] = `
               </span>
             </th>
             <th
+              aria-labelledby="header-type"
               className="testClasses"
               key="2"
               role="columnheader"
@@ -920,7 +948,9 @@ exports[`QueueTable render() Can filter rows 1`] = `
                 aria-label=""
                 data-css-9shxm7=""
               >
-                <span>
+                <span
+                  id="header-type"
+                >
                   Third
                 </span>
                 <TableFilter


### PR DESCRIPTION
Resolves [CASEFLOW-1141](https://vajira.max.gov/browse/CASEFLOW-1141)

### Description
Adds aria labelling to resolve the issues with the screen reader announcing sort/filter on individual cells as well as announcing the state on filter/sort

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Follow the instructions in the [Screen Reader Guide](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/Engineering/accessibility-jaws-setup.md) to setup your machine and ensure that JAWS reads the table correctly

