### PR TITLE
WIP | HearingDays Missing When Retrieving for Large Date Range

### DIFF
--- a/app/services/hearing_day_range.rb
+++ b/app/services/hearing_day_range.rb
@@ -46,14 +46,15 @@ class HearingDayRange
     end
   end
 
-  def upcoming_days_for_vso_user(user)
+  # Using limit here produces undesirable behavior, remaining_days_limit is only used to test this
+  def upcoming_days_for_vso_user(user, remaining_days_limit = 1000)
     days_in_range = hearing_days_in_range
 
     ama_days = days_in_range.select do |hearing_day|
       self.class.ama_hearing_day_for_vso_user?(hearing_day, user)
     end
 
-    remaining_days = days_in_range.where.not(id: ama_days.pluck(:id)).order(:scheduled_for).limit(1000)
+    remaining_days = days_in_range.where.not(id: ama_days.pluck(:id)).order(:scheduled_for).limit(remaining_days_limit)
 
     vacols_hearings_for_remaining_days = HearingRepository.fetch_hearings_for_parents(remaining_days.map(&:id))
 

--- a/spec/services/hearing_day_range_spec.rb
+++ b/spec/services/hearing_day_range_spec.rb
@@ -324,8 +324,8 @@ describe HearingDayRange, :all_dbs do
     let(:start_date) { Time.zone.now + 1.day - 1.month }
     let(:end_date)   { Time.zone.now - 1.day + 1.year }
     # This is set to 1000 in production, so this bug isn't often seen
-    # to reproduce it easily in this test we need to set this lower than
-    # the number of HearingDays we create
+    # to reproduce it easily in this test it's easiest to set this lower
+    # than the number of HearingDays we create
     let(:remaining_days_limit) { 5 }
     subject { HearingDayRange.new(start_date, end_date).upcoming_days_for_vso_user(current_user, remaining_days_limit) }
 
@@ -339,10 +339,9 @@ describe HearingDayRange, :all_dbs do
         .with(vso_participant_id).and_return(vso_participant_ids)
     end
 
+    # This succeeds when we have the undesired behavior, it will fail when
+    # there's a fix
     it "returns a set of hearing days that might not be what you'd expect" do
-      # Once this is fixed we expect to see:
-      # subject.count == HearingDay.count == 7 (six legacy, one ama)
-      # subject.pluck(:id) == ids of all seven days in order
       expect(subject.count).to eq 4
       expect(HearingDay.count).to eq 7
       expect(subject.pluck(:id)).to match_array [
@@ -350,6 +349,24 @@ describe HearingDayRange, :all_dbs do
         legacy_day_two.id,
         legacy_day_three.id,
         legacy_day_four.id
+      ]
+    end
+
+    # This test will succeed when the behavior has been adjusted
+    it "returns the correct set of all hearing days" do
+      # Once this is fixed we expect to see:
+      # subject.count == HearingDay.count == 7 (six legacy, one ama)
+      # subject.pluck(:id) == ids of all seven days in order
+      expect(subject.count).to eq 7
+      expect(HearingDay.count).to eq 7
+      expect(subject.pluck(:id)).to match_array [
+        legacy_day_one.id,
+        legacy_day_two.id,
+        ama_day_one.id,
+        legacy_day_three.id,
+        legacy_day_four.id,
+        legacy_day_five.id,
+        legacy_day_six.id
       ]
     end
   end


### PR DESCRIPTION
Resolves [No github issue yet]

### Description
A user reported via batteam, `INC16879837`, that Caseflow doesn't show all expected hearing days when using a large date range (06/06/2021 - 06/10/2022). This PR does not solve that problem yet, but it provides the ability to reproduce the error.

Run: `make one-test spec/services/hearing_day_range_spec.rb`
