### PR TITLE
Updates Gemfile.lock to mimemagic 0.3.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,7 +384,7 @@ GEM
     mime-types (3.3)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.5)
+    mimemagic (0.3.6)
     mini_mime (1.0.2)
     mini_portile2 (2.5.0)
     minitest (5.14.3)


### PR DESCRIPTION
See https://github.com/minad/mimemagic/issues/98

0.3.5 was yanked from the Internet due to a licensing issue, and an 0.4.0 version was released. But ActiveStorage depends on marcel which depends on 0.3.x, so an 0.3.6 version was released.

```
    marcel (0.3.3)
      mimemagic (~> 0.3.2)
```

This version GPL2 licensed. This appears to be a non-issue for our case but IANAL.

### Description
Please explain the changes you made here.

### Acceptance Criteria
- [ ] Test suite passes
- [ ] We may want to deploy to UAT?

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)