### PR TITLE
BUG: Receipt Date of Docket Switch on Docket Switch Confirmation Page Incorrect

### DIFF
--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirm.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirm.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { sprintf } from 'sprintf-js';
 import { format } from 'date-fns';
 import { css } from 'glamor';
+import { formatDateStr } from '../../../util/DateUtil';
 
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
@@ -94,7 +95,7 @@ export const DocketSwitchReviewConfirm = ({
             </tr>
             <tr>
               <td>Docket Switch Receipt Date</td>
-              <td>{format(docketSwitchReceiptDate, 'M/d/y')}</td>
+              <td>{formatDateStr(docketSwitchReceiptDate)}</td>
             </tr>
             <tr>
               <td>New Review option</td>

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirm.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirm.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { sprintf } from 'sprintf-js';
 import { format } from 'date-fns';
 import { css } from 'glamor';
-import { formatDateStr } from '../../../util/DateUtil';
 
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 
@@ -95,7 +94,7 @@ export const DocketSwitchReviewConfirm = ({
             </tr>
             <tr>
               <td>Docket Switch Receipt Date</td>
-              <td>{formatDateStr(docketSwitchReceiptDate)}</td>
+              <td>{format(docketSwitchReceiptDate, 'M/d/y')}</td>
             </tr>
             <tr>
               <td>New Review option</td>

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
@@ -16,7 +16,6 @@ import {
   DOCKET_SWITCH_FULL_GRANTED_SUCCESS_TITLE,
   DOCKET_SWITCH_GRANTED_SUCCESS_MESSAGE
 } from 'app/../COPY';
-import { formatDateStr } from '../../../util/DateUtil';
 
 export const reformatTaskType = (type) => {
   const truncated = type.replace('ColocatedTask', '');
@@ -127,7 +126,7 @@ export const DocketSwitchReviewConfirmContainer = () => {
       claimantName={appeal.claimantName}
       docketFrom={StringUtil.snakeCaseToCapitalized(appeal.docketName)}
       docketTo={StringUtil.snakeCaseToCapitalized(formData.docketType)}
-      docketSwitchReceiptDate={formatDateStr(formData.receiptDate)}
+      docketSwitchReceiptDate={parseISO(formData.receiptDate)}
       issuesSwitched={issuesSwitched}
       issuesRemaining={issuesRemaining}
       onBack={goBack}

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewConfirmContainer.jsx
@@ -16,6 +16,7 @@ import {
   DOCKET_SWITCH_FULL_GRANTED_SUCCESS_TITLE,
   DOCKET_SWITCH_GRANTED_SUCCESS_MESSAGE
 } from 'app/../COPY';
+import { formatDateStr } from '../../../util/DateUtil';
 
 export const reformatTaskType = (type) => {
   const truncated = type.replace('ColocatedTask', '');
@@ -126,7 +127,7 @@ export const DocketSwitchReviewConfirmContainer = () => {
       claimantName={appeal.claimantName}
       docketFrom={StringUtil.snakeCaseToCapitalized(appeal.docketName)}
       docketTo={StringUtil.snakeCaseToCapitalized(formData.docketType)}
-      docketSwitchReceiptDate={new Date(formData.receiptDate)}
+      docketSwitchReceiptDate={formatDateStr(formData.receiptDate)}
       issuesSwitched={issuesSwitched}
       issuesRemaining={issuesRemaining}
       onBack={goBack}

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -308,9 +308,11 @@ RSpec.feature "Docket Switch", :all_dbs do
 
       expect(page).to have_content(format(COPY::DOCKET_SWITCH_GRANTED_REQUEST_LABEL, appeal.claimant.name))
       expect(page).to have_content(COPY::DOCKET_SWITCH_GRANTED_REQUEST_INSTRUCTIONS)
-
       fill_in "What is the Receipt Date of the docket switch request?", with: receipt_date
 
+      expect(find_field(
+        "What is the Receipt Date of the docket switch request?"
+      ).value).to have_content(receipt_date.to_s)
       # select full grants
       within_fieldset("How are you proceeding with this request to switch dockets?") do
         find("label", text: "Grant all issues").click
@@ -345,6 +347,7 @@ RSpec.feature "Docket Switch", :all_dbs do
         "/queue/appeals/#{appeal.uuid}/tasks/#{docket_switch_granted_task.id}/docket_switch/checkout/grant/confirm"
       )
       expect(page).to have_content appeal.veteran_full_name
+      expect(page).to have_content(receipt_date.strftime("%-m/%-d/%Y"))
 
       click_button(text: "Confirm docket switch")
 


### PR DESCRIPTION
Connects https://vajira.max.gov/browse/CASEFLOW-1261

### Description
When processing the docket switch as the COB user, the receipt date entered changed on the confirmation page for all of the docket switches I processed today.  As indicated in the snips below, I entered the docket switch receipt date as “3/26/2021” on the first page; however, on the confirmation page, the date reverted to “3/25/2021,” which was the date of receipt of the VA Form 10182 for all of these appeals.

### Acceptance Criteria
- [x] docketSwitchReceiptDate shows the receipt date entered changed on the confirmation page

### User Facing Changes
 
<img width="1211" alt="Screen Shot 2021-03-29 at 2 34 47 PM" src="https://user-images.githubusercontent.com/23080951/112885539-e2d87080-909e-11eb-89c3-772a52e5a77e.png">
<img width="1317" alt="Screen Shot 2021-03-29 at 2 35 33 PM" src="https://user-images.githubusercontent.com/23080951/112885540-e2d87080-909e-11eb-9ca8-2682d025fa53.png">
