### PR TITLE
Fix bug with EvidenceSubmissionWindowTask being created every few hours

### DIFF
--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -85,9 +85,9 @@ class HearingTask < Task
     if hearing&.no_show?
       # if there was already a completed ESWT, reopen it
       # More info in slack: https://dsva.slack.com/archives/C3EAF3Q15/p1617048776125000
-      if self.children.closed.where(type: EvidenceSubmissionWindowTask.name).present?
+      if children.closed.where(type: EvidenceSubmissionWindowTask.name).present?
         # the appeal may already have many ESWT so pick the last completed one
-        eswt =  self.children.closed.where(type: EvidenceSubmissionWindowTask.name).order(:closed_at).last
+        eswt = children.closed.where(type: EvidenceSubmissionWindowTask.name).order(:closed_at).last
         eswt.update!(status: :assigned)
       else
         EvidenceSubmissionWindowTask.create!(

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -83,12 +83,10 @@ class HearingTask < Task
 
   def create_evidence_or_ihp_task
     if hearing&.no_show?
-      # if there was already a completed ESWT, reopen it
+      # if there was already a completed ESWT, set the appeal ready for distribution
       # More info in slack: https://dsva.slack.com/archives/C3EAF3Q15/p1617048776125000
       if children.closed.where(type: EvidenceSubmissionWindowTask.name).present?
-        # the appeal may already have many ESWT so pick the last completed one
-        eswt = children.closed.where(type: EvidenceSubmissionWindowTask.name).order(:closed_at).last
-        eswt.update!(status: :assigned)
+        update!(status: Constants.TASK_STATUSES.completed)
       else
         EvidenceSubmissionWindowTask.create!(
           appeal: appeal,

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -48,5 +48,21 @@ FactoryBot.define do
                appeal: hearing.appeal)
       end
     end
+
+    trait :with_completed_tasks do
+      after(:create) do |hearing, _evaluator|
+        create(:hearing_task_association,
+               hearing: hearing,
+               hearing_task: create(:hearing_task, appeal: hearing.appeal))
+        create(:schedule_hearing_task,
+               :completed,
+               parent: hearing.hearing_task_association.hearing_task,
+               appeal: hearing.appeal)
+        create(:assign_hearing_disposition_task,
+               :completed,
+               parent: hearing.hearing_task_association.hearing_task,
+               appeal: hearing.appeal)
+      end
+    end
   end
 end

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -49,11 +49,18 @@ FactoryBot.define do
       end
     end
 
+    # A better representation of a hearing subtree:
+    # RootTask, on_hold
+    #   DistributionTask, on_hold
+    #     HearingTask, assigned
+    #       ScheduleHearingTask, completed
+    #       AssignHeringDispositionTask, completed
     trait :with_completed_tasks do
       after(:create) do |hearing, _evaluator|
+        dist_task = DistributionTask.create!(appeal: hearing.appeal, parent: hearing.appeal.root_task)
         create(:hearing_task_association,
                hearing: hearing,
-               hearing_task: create(:hearing_task, appeal: hearing.appeal))
+               hearing_task: create(:hearing_task, appeal: hearing.appeal, parent: dist_task))
         create(:schedule_hearing_task,
                :completed,
                parent: hearing.hearing_task_association.hearing_task,

--- a/spec/models/tasks/evidence_submission_window_task_spec.rb
+++ b/spec/models/tasks/evidence_submission_window_task_spec.rb
@@ -62,7 +62,7 @@ describe EvidenceSubmissionWindowTask, :postgres do
 
       let!(:task) do
         EvidenceSubmissionWindowTask.create!(
-          appeal: appeal,
+          appeal: appeal_no_vso,
           assigned_to: MailTeam.singleton,
           parent: HearingTaskAssociation.find_by(hearing_id: hearing.id).hearing_task
         )
@@ -70,12 +70,12 @@ describe EvidenceSubmissionWindowTask, :postgres do
 
       subject { task.when_timer_ends }
 
-      it "reopens task" do
+      it "closes parent HearingTask and assigns grandparent DistributionTask" do
         subject
         task.reload
 
-        expect(task.status).to eq(Constants.TASK_STATUSES.assigned)
-        expect(task.closed_at).to eq(nil)
+        expect(task.parent.status).to eq(Constants.TASK_STATUSES.completed)
+        expect(task.parent.parent.status).to eq(Constants.TASK_STATUSES.assigned)
       end
     end
 


### PR DESCRIPTION
Resolves issue described [here](https://dsva.slack.com/archives/C3EAF3Q15/p1617048776125000)

### Description
This PR creates a solution to stop EvidenceSubmissionWindowTasks every 4 hours for appeals where a hearing has a no_show disposition when the timer ends. 
- set appeal to be ready for distribution i.e close HearingTask and set DistributionTask to be assigned
- write tests