### PR TITLE
Mkerns/caseflow 992 case details headings

### DIFF
--- a/client/app/hearings/components/details/DetailsHeader.jsx
+++ b/client/app/hearings/components/details/DetailsHeader.jsx
@@ -24,7 +24,11 @@ const headerContainerStyling = css({
 });
 
 const headerStyling = css({
-  paddingLeft: 0
+  paddingLeft: 0,
+  fontFamily: 'Source Sans Pro',
+  fontWeight: 700,
+  fontSize: '34px',
+  lineHeight: '1.3em/44px'
 });
 
 export const DetailsHeader = (
@@ -90,9 +94,9 @@ export const DetailsHeader = (
   return (
     <React.Fragment>
       <div {...headerContainerStyling}>
-        <h1 className="cf-margin-bottom-0" {...headerStyling}>
+        <p className="cf-margin-bottom-0" {...headerStyling}>
           {`${veteranFirstName} ${veteranLastName}'s Hearing Details`}
-        </h1>
+        </p>
         <div>
           Veteran ID: <CopyTextButton text={veteranFileNumber} label="Veteran ID" />
         </div>

--- a/client/app/hearings/components/details/DetailsHeader.jsx
+++ b/client/app/hearings/components/details/DetailsHeader.jsx
@@ -25,10 +25,6 @@ const headerContainerStyling = css({
 
 const headerStyling = css({
   paddingLeft: 0,
-  fontFamily: 'Source Sans Pro',
-  fontWeight: 700,
-  fontSize: '34px',
-  lineHeight: '1.3em/44px'
 });
 
 export const DetailsHeader = (
@@ -94,9 +90,9 @@ export const DetailsHeader = (
   return (
     <React.Fragment>
       <div {...headerContainerStyling}>
-        <p className="cf-margin-bottom-0" {...headerStyling}>
+        <h1 className="cf-margin-bottom-0" {...headerStyling}>
           {`${veteranFirstName} ${veteranLastName}'s Hearing Details`}
-        </p>
+        </h1>
         <div>
           Veteran ID: <CopyTextButton text={veteranFileNumber} label="Veteran ID" />
         </div>


### PR DESCRIPTION
Resolves [CASEFLOW-992](https://vajira.max.gov/browse/CASEFLOW-992)

### Description
Replaced the h1 tag for a p tag with exact styling used on h1 tags.

### Acceptance Criteria
- [] JAWS correctly reads Case Details Headings as intended.

### Testing Plan
1. Go to Case Details page.
2. Run JAWS.
3. Activate 'Headings' Mode.
4. Verify that JAWS reads the heading in the correct order.

