### PR TITLE
Task Handler not moving docket switchable tasks to new appeal stream

### DIFF
--- a/app/workflows/docket_switch/task_handler.rb
+++ b/app/workflows/docket_switch/task_handler.rb
@@ -70,7 +70,7 @@ class DocketSwitch::TaskHandler
   end
 
   def persistent_tasks
-    @persistent_tasks ||= docket_switchable_tasks.select { |task| selected_task_ids.include?(task.id) }
+    @persistent_tasks ||= docket_switchable_tasks.select { |task| selected_task_ids.include?(task.id.to_s) }
   end
 
   def attorney_user

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -33,6 +33,13 @@ RSpec.feature "Docket Switch", :all_dbs do
   let(:cotb_attorney) { create(:user, :with_vacols_attorney_record, full_name: "Clark Bard") }
   let!(:cotb_non_attorney) { create(:user, full_name: "Aang Bender") }
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
+  let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
+  let!(:old_docket_stream_tasks) do
+    [
+      create(:aod_motion_mail_task, appeal: appeal, parent: root_task),
+      create(:foia_task, appeal: appeal, parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization))
+    ]
+  end
 
   describe "create DocketSwitchMailTask" do
     it "allows Clerk of the Board users to create DocketSwitchMailTask" do
@@ -584,6 +591,9 @@ RSpec.feature "Docket Switch", :all_dbs do
       docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
       expect(docket_switch).to_not be_nil
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
+      aod_motion_mail_task = new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
+      foia_task = new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
+      expect(aod_motion_mail_task && foia_task).to be_active
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 
       new_completed_task = DocketSwitchGrantedTask.find_by(

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -34,9 +34,12 @@ RSpec.feature "Docket Switch", :all_dbs do
   let!(:cotb_non_attorney) { create(:user, full_name: "Aang Bender") }
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
   let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
-  let!(:aod_motion_mail_task, appeal: appeal, parent: root_task),
-  let!(:foia_task, appeal: appeal, parent: create(
-    :translation_task, parent: appeal.root_task, assigned_to: other_organization))
+  let!(:aod_motion_mail_task) create(:aod_motion_mail_task, appeal: appeal, parent: root_task)
+  let!(:foia_task) do
+    create(:foia_task, 
+      appeal: appeal, 
+      parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization)
+    )
   end
 
   describe "create DocketSwitchMailTask" do

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -34,13 +34,9 @@ RSpec.feature "Docket Switch", :all_dbs do
   let!(:cotb_non_attorney) { create(:user, full_name: "Aang Bender") }
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
   let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
-  let!(:old_docket_stream_tasks) do
-    [
-      create(:aod_motion_mail_task, appeal: appeal, parent: root_task),
-      create(:foia_task, appeal: appeal, parent: create(
-        :translation_task, parent: appeal.root_task, assigned_to: other_organization)
-      )
-    ]
+  let!(:aod_motion_mail_task, appeal: appeal, parent: root_task),
+  let!(:foia_task, appeal: appeal, parent: create(
+    :translation_task, parent: appeal.root_task, assigned_to: other_organization))
   end
 
   describe "create DocketSwitchMailTask" do

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature "Docket Switch", :all_dbs do
   let!(:cotb_non_attorney) { create(:user, full_name: "Aang Bender") }
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
   let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
-  let!(:aod_motion_mail_task) create(:aod_motion_mail_task, appeal: appeal, parent: root_task)
+  let!(:aod_motion_mail_task) { create(:aod_motion_mail_task, appeal: appeal, parent: root_task) }
   let!(:foia_task) do
     create(:foia_task, 
       appeal: appeal, 

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -29,17 +29,14 @@ RSpec.feature "Docket Switch", :all_dbs do
     end
   end
 
-  let(:root_task) { create(:root_task, :completed, appeal: appeal) }
+  let(:root_task) { create(:root_task, appeal: appeal) }
   let(:cotb_attorney) { create(:user, :with_vacols_attorney_record, full_name: "Clark Bard") }
   let!(:cotb_non_attorney) { create(:user, full_name: "Aang Bender") }
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
-  let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
+  let(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
   let!(:aod_motion_mail_task) { create(:aod_motion_mail_task, appeal: appeal, parent: root_task) }
-  let!(:foia_task) do
-    create(:foia_task,
-           appeal: appeal,
-           parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization))
-  end
+  let(:translation_task) { create(:translation_task, appeal: appeal, parent: root_task, assigned_to: other_organization) }
+  let!(:foia_task) { create(:foia_task, appeal: appeal, parent: translation_task) }
 
   describe "create DocketSwitchMailTask" do
     it "allows Clerk of the Board users to create DocketSwitchMailTask" do

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -37,7 +37,9 @@ RSpec.feature "Docket Switch", :all_dbs do
   let!(:old_docket_stream_tasks) do
     [
       create(:aod_motion_mail_task, appeal: appeal, parent: root_task),
-      create(:foia_task, appeal: appeal, parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization))
+      create(:foia_task, appeal: appeal, parent: create(
+        :translation_task, parent: appeal.root_task, assigned_to: other_organization)
+      )
     ]
   end
 

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -589,8 +589,8 @@ RSpec.feature "Docket Switch", :all_dbs do
       docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
       expect(docket_switch).to_not be_nil
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
-      aod_motion_mail_task = new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
-      foia_task = new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
+      aod_motion_mail_task = docket_switch.new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
+      foia_task = docket_switch.new_docket_stream.reload.tasks.find { |task| task.type == "FoiaTask" }
       expect(aod_motion_mail_task && foia_task).to be_active
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -35,7 +35,9 @@ RSpec.feature "Docket Switch", :all_dbs do
   let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
   let(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
   let!(:aod_motion_mail_task) { create(:aod_motion_mail_task, appeal: appeal, parent: root_task) }
-  let(:translation_task) { create(:translation_task, appeal: appeal, parent: root_task, assigned_to: other_organization) }
+  let(:translation_task) do
+    create(:translation_task, appeal: appeal, parent: root_task, assigned_to: other_organization)
+  end
   let!(:foia_task) { create(:foia_task, appeal: appeal, parent: translation_task) }
 
   describe "create DocketSwitchMailTask" do

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -36,10 +36,9 @@ RSpec.feature "Docket Switch", :all_dbs do
   let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
   let!(:aod_motion_mail_task) { create(:aod_motion_mail_task, appeal: appeal, parent: root_task) }
   let!(:foia_task) do
-    create(:foia_task, 
-      appeal: appeal, 
-      parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization)
-    )
+    create(:foia_task,
+           appeal: appeal,
+           parent: create(:translation_task, parent: appeal.root_task, assigned_to: other_organization))
   end
 
   describe "create DocketSwitchMailTask" do
@@ -592,9 +591,12 @@ RSpec.feature "Docket Switch", :all_dbs do
       docket_switch = DocketSwitch.find_by(old_docket_stream_id: appeal.id)
       expect(docket_switch).to_not be_nil
       expect(docket_switch.new_docket_stream.docket_type).to eq(docket_switch.docket_type)
-      aod_motion_mail_task = docket_switch.new_docket_stream.reload.tasks.find { |task| task.type == "AodMotionMailTask" }
-      foia_task = docket_switch.new_docket_stream.reload.tasks.find { |task| task.type == "FoiaTask" }
-      expect(aod_motion_mail_task && foia_task).to be_active
+
+      new_tasks = docket_switch.new_docket_stream.reload.tasks
+      aod_motion_mail_task = new_tasks.find { |task| task.type == "AodMotionMailTask" }
+      foia_task = new_tasks.find { |task| task.type == "FoiaTask" }
+      expect(aod_motion_mail_task).to be_active
+      expect(foia_task).to be_active
       expect(page).to have_current_path("/queue/appeals/#{docket_switch.new_docket_stream.uuid}")
 
       new_completed_task = DocketSwitchGrantedTask.find_by(

--- a/spec/workflows/docket_switch_task_handler_spec.rb
+++ b/spec/workflows/docket_switch_task_handler_spec.rb
@@ -50,7 +50,7 @@ describe DocketSwitch::TaskHandler, :all_dbs do
   let!(:translation_organization) { Translation.singleton }
   let!(:other_organization) { Organization.create!(name: "Other organization", url: "other") }
 
-  let(:selected_task_ids) { [old_docket_stream_tasks.first.id] }
+  let(:selected_task_ids) { [old_docket_stream_tasks.first.id.to_s] }
 
   let(:new_admin_actions) do
     [
@@ -142,7 +142,7 @@ describe DocketSwitch::TaskHandler, :all_dbs do
 
         expect(new_docket_task).to be_active
         expect(persistent_task_copy).to be_active
-        removed_task = old_docket_stream_tasks.find { |task| !selected_task_ids.include?(task.id) }
+        removed_task = old_docket_stream_tasks.find { |task| !selected_task_ids.include?(task.id.to_s) }
         expect(new_docket_stream.tasks.find { |task| task.type == removed_task.type }).to be nil
         expect(new_admin_action).to be_active
       end


### PR DESCRIPTION
Resolves [CASEFLOW-1267](https://vajira.max.gov/browse/CASEFLOW-1267)

### Description
Updated the persistent tasks method in task_handler.rb to confirm docket switchable tasks are getting moved to the new appeal stream upon docket switch submission


