### PR TITLE
Update kramdown to 2.3.1 for CVE-2021-28834

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -357,7 +357,7 @@ GEM
     kaminari-core (1.2.1)
     knapsack_pro (2.8.0)
       rake
-    kramdown (2.3.0)
+    kramdown (2.3.1)
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)


### PR DESCRIPTION
Addresses [CVE-2021-28834](https://github.com/advisories/GHSA-52p9-v744-mwjj)

It looks like only dangerbot relies on kramdown, so this doesn't affect any production code.