### PR TITLE
Charley/caseflow 395 display more appeal info when scheduling

### DIFF
--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -8,6 +8,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 import Button from '../../components/Button';
 import PropTypes from 'prop-types';
 import { CSVLink } from 'react-csv';
+import { formatHearingType } from '../utils';
 import {
   toggleTypeFilterVisibility, toggleLocationFilterVisibility,
   toggleVljFilterVisibility, onReceiveHearingSchedule,
@@ -186,13 +187,7 @@ class ListSchedule extends React.Component {
         align: 'left',
         tableData: hearingScheduleRows,
         enableFilter: true,
-        filterValueTransform: (hearingType) => {
-          if (hearingType.toLowerCase().startsWith('video')) {
-            return VIDEO_HEARING_LABEL;
-          }
-
-          return hearingType;
-        },
+        filterValueTransform: formatHearingType,
         anyFiltersAreSet: true,
         label: 'Filter by type',
         columnName: 'readableRequestType',

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -72,10 +72,16 @@ const UpcomingHearingDaysNav = ({
 
     return hearingType;
   };
-  // This is necessecary otherwise 'null' is displayed when there's no room or judge
-  const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
   // Check if there's a judge assigned
   const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
+  // Check if there's a room assigned (there never is for virtual)
+  const hearingDayHasRoom = (hearingDay) => Boolean(hearingDay.room);
+  // Check if there's a judge or room assigned
+  const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) || hearingDayHasRoom(hearingDay);
+
+  const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '-' : '';
+  // This is necessecary otherwise 'null' is displayed when there's no room or judge
+  const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
   // This came out of ListSchedule, should be refactored into common import
   // I modified it though, will need to make that change in ListSchedule
   const formatVljName = (hearingDay) => {
@@ -100,12 +106,12 @@ const UpcomingHearingDaysNav = ({
               const dateSelected = selectedHearingDay?.id === hearingDay?.id;
               const formattedHearingType = formatHearingType(hearingDay.readableRequestType);
               const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
+              const separator = separatorIfJudgeOrRoomPresent(hearingDay);
 
               // This came from AssignHearingTabs, modified
               const scheduledHearings = _.get(hearingDay, 'hearings', {});
               const scheduledHearingCount = Object.keys(scheduledHearings).length;
               const availableSlotCount = _.get(selectedHearingDay, 'totalSlots', 0) - scheduledHearingCount;
-
               const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
 
               return (
@@ -120,7 +126,7 @@ const UpcomingHearingDaysNav = ({
                           {moment(hearingDay.scheduledFor).format('ddd MMM Do')}
                         </div>
                         <div {...typeAndJudgeStyle}>
-                          {`${formattedHearingType} - ${judgeOrRoom}`}
+                          {`${formattedHearingType} ${separator} ${judgeOrRoom}`}
                         </div>
                       </div>
                       <div {...rightColumnStyle} >

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -27,8 +27,8 @@ const sectionNavigationListStyling = css({
 
 const buttonCommonStyle = {
   width: '90%',
-  paddingTop: '1em',
-  paddingBottom: '1em',
+  paddingTop: '1.5rem',
+  paddingBottom: '1.5rem',
 };
 
 const buttonUnselectedStyle = css(
@@ -49,6 +49,8 @@ const buttonSelectedStyle = css(
     }
   });
 
+const fontSizeStyle = css({ fontSize: '1.5rem' });
+const dateStyle = css({ fontWeight: 'bold' });
 const leftColumnStyle = css({ width: '60%', display: 'inline-block', textAlign: 'left' });
 const rightColumnStyle = css({ width: '40%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' });
 const typeAndJudgeStyle = css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' });
@@ -79,7 +81,7 @@ const UpcomingHearingDaysNav = ({
   // Check if there's a judge or room assigned
   const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) || hearingDayHasRoom(hearingDay);
 
-  const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '-' : '';
+  const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
   // This is necessecary otherwise 'null' is displayed when there's no room or judge
   const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
   // This came out of ListSchedule, should be refactored into common import
@@ -108,7 +110,7 @@ const UpcomingHearingDaysNav = ({
               const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
               const separator = separatorIfJudgeOrRoomPresent(hearingDay);
 
-              // This came from AssignHearingTabs, modified
+              // This came from AssignHearingTabs, modified, the slots dont match new work
               const scheduledHearings = _.get(hearingDay, 'hearings', {});
               const scheduledHearingCount = Object.keys(scheduledHearings).length;
               const availableSlotCount = _.get(selectedHearingDay, 'totalSlots', 0) - scheduledHearingCount;
@@ -120,9 +122,9 @@ const UpcomingHearingDaysNav = ({
                     styling={dateSelected ? buttonSelectedStyle : buttonUnselectedStyle}
                     onClick={() => onSelectedHearingDayChange(hearingDay)}
                     linkStyling>
-                    <div>
+                    <div {...fontSizeStyle}>
                       <div {...leftColumnStyle} >
-                        <div>
+                        <div {...dateStyle}>
                           {moment(hearingDay.scheduledFor).format('ddd MMM Do')}
                         </div>
                         <div {...typeAndJudgeStyle}>

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -49,8 +49,8 @@ const buttonSelectedStyle = css(
     }
   });
 
-const leftColumnStyle = css({ width: '67%', display: 'inline-block', textAlign: 'left' });
-const rightColumnStyle = css({ width: '33%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' });
+const leftColumnStyle = css({ width: '60%', display: 'inline-block', textAlign: 'left' });
+const rightColumnStyle = css({ width: '40%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' });
 const typeAndJudgeStyle = css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' });
 
 const roSelectionStyling = css({ marginTop: '10px', textAlign: 'center' });

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -2,14 +2,11 @@ import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
-import moment from 'moment';
 
 import { COLORS } from '../../../constants/AppConstants';
 import { NoUpcomingHearingDayMessage } from './Messages';
 import AssignHearingsTabs from './AssignHearingsTabs';
-import Button from '../../../components/Button';
-
-import { VIDEO_HEARING_LABEL } from '../../constants';
+import HearingDayInfoButton from './HearingDayInfoButton';
 
 const horizontalRuleStyling = css({
   border: 0,
@@ -24,106 +21,8 @@ const sectionNavigationListStyling = css({
     borderWidth: 0
   }
 });
-
-const buttonCommonStyle = {
-  width: '90%',
-  paddingTop: '1.5rem',
-  paddingBottom: '1.5rem',
-};
-
-const buttonUnselectedStyle = css(
-  buttonCommonStyle
-);
-
-const buttonSelectedStyle = css(
-  {
-    ...buttonCommonStyle,
-    ...{
-      backgroundColor: COLORS.GREY_DARK,
-      color: COLORS.WHITE,
-      borderRadius: '0.1rem 0.1rem 0 0',
-      '&:hover': {
-        backgroundColor: COLORS.GREY_DARK,
-        color: COLORS.WHITE
-      }
-    }
-  });
-
-const fontSizeStyle = css({ fontSize: '1.5rem' });
-const dateStyle = css({ fontWeight: 'bold' });
-const leftColumnStyle = css({ width: '60%', display: 'inline-block', textAlign: 'left' });
-const rightColumnStyle = css({ width: '40%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' });
-const typeAndJudgeStyle = css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' });
-
 const roSelectionStyling = css({ marginTop: '10px', textAlign: 'center' });
 
-const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDayChange }) => {
-  // This came out of ListSchedule, should be refactored into common import
-  const formatHearingType = (hearingType) => {
-    if (hearingType.toLowerCase().startsWith('video')) {
-      return VIDEO_HEARING_LABEL;
-    }
-
-    return hearingType;
-  };
-    // Check if there's a judge assigned
-  const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
-  // Check if there's a room assigned (there never is for virtual)
-  const hearingDayHasRoom = (hearingDay) => Boolean(hearingDay.room);
-  // Check if there's a judge or room assigned
-  const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) || hearingDayHasRoom(hearingDay);
-
-  const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
-  // This is necessecary otherwise 'null' is displayed when there's no room or judge
-  const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
-  // This came out of ListSchedule, should be refactored into common import
-  // I modified it though, will need to make that change in ListSchedule
-  const formatVljName = (hearingDay) => {
-    const first = hearingDay?.judgeFirstName;
-    const last = hearingDay?.judgeLastName;
-
-    if (last && first) {
-      return `${last}, ${first}`;
-    }
-
-    return '';
-  };
-  const formattedHearingType = formatHearingType(hearingDay.readableRequestType);
-  const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
-  const separator = separatorIfJudgeOrRoomPresent(hearingDay);
-
-  // This came from AssignHearingTabs, modified, the slots dont match new work
-  const scheduledHearings = _.get(hearingDay, 'hearings', {});
-  const scheduledHearingCount = Object.keys(scheduledHearings).length;
-  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
-  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
-
-  return (
-    <Button
-      styling={selected ? buttonSelectedStyle : buttonUnselectedStyle}
-      onClick={() => onSelectedHearingDayChange(hearingDay)}
-      linkStyling>
-      <div {...fontSizeStyle}>
-        <div {...leftColumnStyle} >
-          <div {...dateStyle}>
-            {moment(hearingDay.scheduledFor).format('ddd MMM Do')}
-          </div>
-          <div {...typeAndJudgeStyle}>
-            {`${formattedHearingType} ${separator} ${judgeOrRoom}`}
-          </div>
-        </div>
-        <div {...rightColumnStyle} >
-          <div>
-            {formattedSlotRatio}
-          </div>
-          <div>
-                        scheduled
-          </div>
-        </div>
-      </div>
-    </Button>
-  );
-};
 const UpcomingHearingDaysNav = ({
   upcomingHearingDays, selectedHearingDay,
   onSelectedHearingDayChange

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -23,18 +23,33 @@ const sectionNavigationListStyling = css({
   }
 });
 
-const buttonColorSelected = css({
+const buttonCommonStyle = {
   width: '90%',
   paddingTop: '1em',
   paddingBottom: '1em',
-  backgroundColor: COLORS.GREY_DARK,
-  color: COLORS.WHITE,
-  borderRadius: '0.1rem 0.1rem 0 0',
-  '&:hover': {
-    backgroundColor: COLORS.GREY_DARK,
-    color: COLORS.WHITE
-  }
-});
+};
+
+const buttonUnselectedStyle = css(
+  buttonCommonStyle
+);
+
+const buttonSelectedStyle = css(
+  {
+    ...buttonCommonStyle,
+    ...{
+      backgroundColor: COLORS.GREY_DARK,
+      color: COLORS.WHITE,
+      borderRadius: '0.1rem 0.1rem 0 0',
+      '&:hover': {
+        backgroundColor: COLORS.GREY_DARK,
+        color: COLORS.WHITE
+      }
+    }
+  });
+
+const leftColumnStyle = css({ width: '67%', display: 'inline-block', textAlign: 'left' });
+const rightColumnStyle = css({ width: '33%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' });
+const typeAndJudgeStyle = css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' });
 
 const roSelectionStyling = css({ marginTop: '10px', textAlign: 'center' });
 
@@ -46,11 +61,6 @@ const UpcomingHearingDaysNav = ({
     Object.values(upcomingHearingDays),
     (hearingDay) => hearingDay.scheduledFor, 'asc'
   );
-
-  /*
-                      {`${moment(hearingDay.scheduledFor).format('ddd M/DD/YYYY')}
-                      ${hearingDay.room ?? ''}`
-  */
 
   return (
     <div className="usa-width-one-fourth" {...roSelectionStyling}>
@@ -65,19 +75,19 @@ const UpcomingHearingDaysNav = ({
               return (
                 <li key={hearingDay.id} >
                   <Button
-                    styling={dateSelected ? buttonColorSelected : css({ width: '90%', paddingTop: '1em', paddingBottom: '1em' })}
+                    styling={dateSelected ? buttonSelectedStyle : buttonUnselectedStyle}
                     onClick={() => onSelectedHearingDayChange(hearingDay)}
                     linkStyling>
                     <div>
-                      <div {...css({ width: '67%', display: 'inline-block', textAlign: 'left' })} >
+                      <div {...leftColumnStyle} >
                         <div>
                         Thu Apr 1
                         </div>
-                        <div {...css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' })}>
+                        <div {...typeAndJudgeStyle}>
                           Virtual * VLJVigsittaboorn
                         </div>
                       </div>
-                      <div {...css({ width: '33%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' })} >
+                      <div {...rightColumnStyle} >
                         <div>
                         2 of 4
                         </div>

--- a/client/app/hearings/components/assignHearings/AssignHearings.jsx
+++ b/client/app/hearings/components/assignHearings/AssignHearings.jsx
@@ -9,15 +9,24 @@ import { NoUpcomingHearingDayMessage } from './Messages';
 import AssignHearingsTabs from './AssignHearingsTabs';
 import Button from '../../../components/Button';
 
+const horizontalRuleStyling = css({
+  border: 0,
+  width: '90%',
+  borderTop: `1px solid ${COLORS.GREY_LIGHT}`,
+  margin: 'auto',
+});
+
 const sectionNavigationListStyling = css({
   '& > li': {
-    backgroundColor: COLORS.GREY_BACKGROUND,
     color: COLORS.PRIMARY,
     borderWidth: 0
   }
 });
 
 const buttonColorSelected = css({
+  width: '90%',
+  paddingTop: '1em',
+  paddingBottom: '1em',
   backgroundColor: COLORS.GREY_DARK,
   color: COLORS.WHITE,
   borderRadius: '0.1rem 0.1rem 0 0',
@@ -27,7 +36,7 @@ const buttonColorSelected = css({
   }
 });
 
-const roSelectionStyling = css({ marginTop: '10px' });
+const roSelectionStyling = css({ marginTop: '10px', textAlign: 'center' });
 
 const UpcomingHearingDaysNav = ({
   upcomingHearingDays, selectedHearingDay,
@@ -37,6 +46,11 @@ const UpcomingHearingDaysNav = ({
     Object.values(upcomingHearingDays),
     (hearingDay) => hearingDay.scheduledFor, 'asc'
   );
+
+  /*
+                      {`${moment(hearingDay.scheduledFor).format('ddd M/DD/YYYY')}
+                      ${hearingDay.room ?? ''}`
+  */
 
   return (
     <div className="usa-width-one-fourth" {...roSelectionStyling}>
@@ -51,12 +65,29 @@ const UpcomingHearingDaysNav = ({
               return (
                 <li key={hearingDay.id} >
                   <Button
-                    styling={dateSelected ? buttonColorSelected : {}}
+                    styling={dateSelected ? buttonColorSelected : css({ width: '90%', paddingTop: '1em', paddingBottom: '1em' })}
                     onClick={() => onSelectedHearingDayChange(hearingDay)}
                     linkStyling>
-                    {`${moment(hearingDay.scheduledFor).format('ddd M/DD/YYYY')}  
-                      ${hearingDay.room ?? ''}`}
+                    <div>
+                      <div {...css({ width: '67%', display: 'inline-block', textAlign: 'left' })} >
+                        <div>
+                        Thu Apr 1
+                        </div>
+                        <div {...css({ textOverflow: 'ellipsis', overflowX: 'hidden', overflowY: 'hidden', whiteSpace: 'nowrap' })}>
+                          Virtual * VLJVigsittaboorn
+                        </div>
+                      </div>
+                      <div {...css({ width: '33%', display: 'inline-block', textAlign: 'right', overflowX: 'hidden', overflowY: 'hidden' })} >
+                        <div>
+                        2 of 4
+                        </div>
+                        <div>
+                        scheduled
+                        </div>
+                      </div>
+                    </div>
                   </Button>
+                  <hr {...horizontalRuleStyling} />
                 </li>
               );
             }

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -21,7 +21,7 @@ const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingD
 const hearingDayHasRoom = (hearingDay) => Boolean(hearingDay.room);
 // Check if there's a judge or room assigned
 const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) || hearingDayHasRoom(hearingDay);
-
+// Make the '·' separator appear or disappear
 const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
 // This is necessecary otherwise 'null' is displayed when there's no room or judge
 const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
@@ -31,16 +31,19 @@ export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDa
   const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
   const separator = separatorIfJudgeOrRoomPresent(hearingDay);
   const formattedSlotRatio = formatSlotRatio(hearingDay);
+  const formattedDate = moment(hearingDay.scheduledFor).format('ddd MMM Do');
+  const classNames = selected ? ['selected-hearing-day-info-button'] : ['unselected-hearing-day-info-button'];
 
   return (
     <Button
       styling={selected ? buttonSelectedStyle : buttonUnselectedStyle}
       onClick={() => onSelectedHearingDayChange(hearingDay)}
+      classNames={classNames}
       linkStyling>
       <div >
         <div {...leftColumnStyle} >
           <div {...dateStyle}>
-            {moment(hearingDay.scheduledFor).format('ddd MMM Do')}
+            {formattedDate}
           </div>
           <div {...typeAndJudgeStyle}>
             {`${formattedHearingType} ${separator} ${judgeOrRoom}`}

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -1,0 +1,137 @@
+import { css } from 'glamor';
+import PropTypes from 'prop-types';
+import React from 'react';
+import _ from 'lodash';
+import moment from 'moment';
+
+import { COLORS } from '../../../constants/AppConstants';
+import Button from '../../../components/Button';
+
+import { VIDEO_HEARING_LABEL } from '../../constants';
+
+const buttonCommonStyle = {
+  width: '90%',
+  paddingTop: '1.5rem',
+  paddingBottom: '1.5rem',
+};
+
+const buttonUnselectedStyle = css(
+  buttonCommonStyle
+);
+
+const buttonSelectedStyle = css(
+  {
+    ...buttonCommonStyle,
+    ...{
+      backgroundColor: COLORS.GREY_DARK,
+      color: COLORS.WHITE,
+      borderRadius: '0.1rem 0.1rem 0 0',
+      '&:hover': {
+        backgroundColor: COLORS.GREY_DARK,
+        color: COLORS.WHITE
+      }
+    }
+  });
+
+const fontSizeStyle = css({ fontSize: '1.5rem' });
+
+const dateStyle = css({ fontWeight: 'bold' });
+
+const leftColumnStyle = css({
+  width: '60%',
+  display: 'inline-block',
+  textAlign: 'left'
+});
+const rightColumnStyle = css({
+  width: '40%',
+  display: 'inline-block',
+  textAlign: 'right',
+  overflowX: 'hidden',
+  overflowY: 'hidden'
+});
+const typeAndJudgeStyle = css({
+  textOverflow: 'ellipsis',
+  overflowX: 'hidden',
+  overflowY: 'hidden',
+  whiteSpace: 'nowrap'
+});
+
+// This came out of ListSchedule, should be refactored into common import
+const formatHearingType = (hearingType) => {
+  if (hearingType.toLowerCase().startsWith('video')) {
+    return VIDEO_HEARING_LABEL;
+  }
+
+  return hearingType;
+};
+  // Check if there's a judge assigned
+const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
+// Check if there's a room assigned (there never is for virtual)
+const hearingDayHasRoom = (hearingDay) => Boolean(hearingDay.room);
+// Check if there's a judge or room assigned
+const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) || hearingDayHasRoom(hearingDay);
+
+const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
+// This is necessecary otherwise 'null' is displayed when there's no room or judge
+const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
+// This came out of ListSchedule, should be refactored into common import
+// I modified it though, will need to make that change in ListSchedule
+const formatVljName = (hearingDay) => {
+  const first = hearingDay?.judgeFirstName;
+  const last = hearingDay?.judgeLastName;
+
+  if (last && first) {
+    return `${last}, ${first}`;
+  }
+
+  return '';
+};
+
+export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDayChange }) => {
+  const formattedHearingType = formatHearingType(hearingDay.readableRequestType);
+  const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
+  const separator = separatorIfJudgeOrRoomPresent(hearingDay);
+
+  // This came from AssignHearingTabs, modified, the slots dont match new work
+  const scheduledHearings = _.get(hearingDay, 'hearings', {});
+  const scheduledHearingCount = Object.keys(scheduledHearings).length;
+  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
+  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
+
+  return (
+    <Button
+      styling={selected ? buttonSelectedStyle : buttonUnselectedStyle}
+      onClick={() => onSelectedHearingDayChange(hearingDay)}
+      linkStyling>
+      <div {...fontSizeStyle}>
+        <div {...leftColumnStyle} >
+          <div {...dateStyle}>
+            {moment(hearingDay.scheduledFor).format('ddd MMM Do')}
+          </div>
+          <div {...typeAndJudgeStyle}>
+            {`${formattedHearingType} ${separator} ${judgeOrRoom}`}
+          </div>
+        </div>
+        <div {...rightColumnStyle} >
+          <div>
+            {formattedSlotRatio}
+          </div>
+          <div>
+                          scheduled
+          </div>
+        </div>
+      </div>
+    </Button>
+  );
+};
+
+HearingDayInfoButton.propTypes = {
+  hearingDay: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.object
+  ]),
+  selected: PropTypes.bool,
+  onSelectedHearingDayChange: PropTypes.func,
+};
+
+export default HearingDayInfoButton;

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -13,7 +13,7 @@ import {
   typeAndJudgeStyle
 } from './styles';
 
-import { VIDEO_HEARING_LABEL } from '../../constants';
+import { formatHearingType, formatVljName, formatSlotRatio } from '../../utils';
 
 // Check if there's a judge assigned
 const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
@@ -25,35 +25,6 @@ const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) 
 const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
 // This is necessecary otherwise 'null' is displayed when there's no room or judge
 const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
-// This came out of ListSchedule, should be refactored into common import
-const formatHearingType = (hearingType) => {
-  if (hearingType.toLowerCase().startsWith('video')) {
-    return VIDEO_HEARING_LABEL;
-  }
-
-  return hearingType;
-};
-// This came out of ListSchedule, should be refactored into common import
-// I modified it though, will need to make that change in ListSchedule
-const formatVljName = (hearingDay) => {
-  const first = hearingDay?.judgeFirstName;
-  const last = hearingDay?.judgeLastName;
-
-  if (last && first) {
-    return `${last}, ${first}`;
-  }
-
-  return '';
-};
-const formatSlotRatio = (hearingDay) => {
-// This came from AssignHearingTabs, modified, the slots dont match new work
-  const scheduledHearings = _.get(hearingDay, 'hearings', {});
-  const scheduledHearingCount = Object.keys(scheduledHearings).length;
-  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
-  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
-
-  return formattedSlotRatio;
-};
 
 export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDayChange }) => {
   const formattedHearingType = formatHearingType(hearingDay.readableRequestType);

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -56,15 +56,7 @@ const typeAndJudgeStyle = css({
   whiteSpace: 'nowrap'
 });
 
-// This came out of ListSchedule, should be refactored into common import
-const formatHearingType = (hearingType) => {
-  if (hearingType.toLowerCase().startsWith('video')) {
-    return VIDEO_HEARING_LABEL;
-  }
-
-  return hearingType;
-};
-  // Check if there's a judge assigned
+// Check if there's a judge assigned
 const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
 // Check if there's a room assigned (there never is for virtual)
 const hearingDayHasRoom = (hearingDay) => Boolean(hearingDay.room);
@@ -74,6 +66,14 @@ const hearingDayHasJudgeOrRoom = (hearingDay) => hearingDayHasJudge(hearingDay) 
 const separatorIfJudgeOrRoomPresent = (hearingDay) => hearingDayHasJudgeOrRoom(hearingDay) ? '·' : '';
 // This is necessecary otherwise 'null' is displayed when there's no room or judge
 const formatHearingRoom = (hearingDay) => hearingDay.room ? hearingDay.room : '';
+// This came out of ListSchedule, should be refactored into common import
+const formatHearingType = (hearingType) => {
+  if (hearingType.toLowerCase().startsWith('video')) {
+    return VIDEO_HEARING_LABEL;
+  }
+
+  return hearingType;
+};
 // This came out of ListSchedule, should be refactored into common import
 // I modified it though, will need to make that change in ListSchedule
 const formatVljName = (hearingDay) => {
@@ -86,17 +86,21 @@ const formatVljName = (hearingDay) => {
 
   return '';
 };
+const formatSlotRatio = (hearingDay) => {
+// This came from AssignHearingTabs, modified, the slots dont match new work
+  const scheduledHearings = _.get(hearingDay, 'hearings', {});
+  const scheduledHearingCount = Object.keys(scheduledHearings).length;
+  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
+  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
+
+  return formattedSlotRatio;
+};
 
 export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDayChange }) => {
   const formattedHearingType = formatHearingType(hearingDay.readableRequestType);
   const judgeOrRoom = hearingDayHasJudge(hearingDay) ? formatVljName(hearingDay) : formatHearingRoom(hearingDay);
   const separator = separatorIfJudgeOrRoomPresent(hearingDay);
-
-  // This came from AssignHearingTabs, modified, the slots dont match new work
-  const scheduledHearings = _.get(hearingDay, 'hearings', {});
-  const scheduledHearingCount = Object.keys(scheduledHearings).length;
-  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
-  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
+  const formattedSlotRatio = formatSlotRatio(hearingDay);
 
   return (
     <Button
@@ -116,9 +120,7 @@ export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDa
           <div>
             {formattedSlotRatio}
           </div>
-          <div>
-                          scheduled
-          </div>
+          <div>scheduled</div>
         </div>
       </div>
     </Button>

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -13,6 +13,7 @@ const buttonCommonStyle = {
   width: '90%',
   paddingTop: '1.5rem',
   paddingBottom: '1.5rem',
+  outline: 'none'
 };
 
 const buttonUnselectedStyle = css(

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -1,61 +1,19 @@
-import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import React from 'react';
 import _ from 'lodash';
 import moment from 'moment';
 
-import { COLORS } from '../../../constants/AppConstants';
 import Button from '../../../components/Button';
+import {
+  buttonSelectedStyle,
+  buttonUnselectedStyle,
+  dateStyle,
+  leftColumnStyle,
+  rightColumnStyle,
+  typeAndJudgeStyle
+} from './styles';
 
 import { VIDEO_HEARING_LABEL } from '../../constants';
-
-const buttonCommonStyle = {
-  width: '90%',
-  paddingTop: '1.5rem',
-  paddingBottom: '1.5rem',
-  outline: 'none'
-};
-
-const buttonUnselectedStyle = css(
-  buttonCommonStyle
-);
-
-const buttonSelectedStyle = css(
-  {
-    ...buttonCommonStyle,
-    ...{
-      backgroundColor: COLORS.GREY_DARK,
-      color: COLORS.WHITE,
-      borderRadius: '0.1rem 0.1rem 0 0',
-      '&:hover': {
-        backgroundColor: COLORS.GREY_DARK,
-        color: COLORS.WHITE
-      }
-    }
-  });
-
-const fontSizeStyle = css({ fontSize: '1.5rem' });
-
-const dateStyle = css({ fontWeight: 'bold' });
-
-const leftColumnStyle = css({
-  width: '60%',
-  display: 'inline-block',
-  textAlign: 'left'
-});
-const rightColumnStyle = css({
-  width: '40%',
-  display: 'inline-block',
-  textAlign: 'right',
-  overflowX: 'hidden',
-  overflowY: 'hidden'
-});
-const typeAndJudgeStyle = css({
-  textOverflow: 'ellipsis',
-  overflowX: 'hidden',
-  overflowY: 'hidden',
-  whiteSpace: 'nowrap'
-});
 
 // Check if there's a judge assigned
 const hearingDayHasJudge = (hearingDay) => hearingDay.judgeFirstName && hearingDay.judgeLastName;
@@ -108,7 +66,7 @@ export const HearingDayInfoButton = ({ hearingDay, selected, onSelectedHearingDa
       styling={selected ? buttonSelectedStyle : buttonUnselectedStyle}
       onClick={() => onSelectedHearingDayChange(hearingDay)}
       linkStyling>
-      <div {...fontSizeStyle}>
+      <div >
         <div {...leftColumnStyle} >
           <div {...dateStyle}>
             {moment(hearingDay.scheduledFor).format('ddd MMM Do')}

--- a/client/app/hearings/components/assignHearings/styles.jsx
+++ b/client/app/hearings/components/assignHearings/styles.jsx
@@ -1,7 +1,55 @@
 import { css } from 'glamor';
+import { COLORS } from '../../../constants/AppConstants';
 
 export const tableNumberStyling = css({
   '& tr > td:first-child': {
     paddingRight: 0
   }
+});
+
+// Used by HearingDayInfoButton
+const buttonCommonStyle = {
+  width: '90%',
+  paddingTop: '1.5rem',
+  paddingBottom: '1.5rem',
+  outline: 'none'
+};
+
+export const buttonUnselectedStyle = css(
+  buttonCommonStyle
+);
+
+export const buttonSelectedStyle = css(
+  {
+    ...buttonCommonStyle,
+    ...{
+      backgroundColor: COLORS.GREY_DARK,
+      color: COLORS.WHITE,
+      borderRadius: '0.1rem 0.1rem 0 0',
+      '&:hover': {
+        backgroundColor: COLORS.GREY_DARK,
+        color: COLORS.WHITE
+      }
+    }
+  });
+
+export const dateStyle = css({ fontWeight: 'bold' });
+
+export const leftColumnStyle = css({
+  width: '60%',
+  display: 'inline-block',
+  textAlign: 'left'
+});
+export const rightColumnStyle = css({
+  width: '40%',
+  display: 'inline-block',
+  textAlign: 'right',
+  overflowX: 'hidden',
+  overflowY: 'hidden'
+});
+export const typeAndJudgeStyle = css({
+  textOverflow: 'ellipsis',
+  overflowX: 'hidden',
+  overflowY: 'hidden',
+  whiteSpace: 'nowrap'
 });

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -9,6 +9,7 @@ import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMA
 // To see how values were determined: https://github.com/department-of-veterans-affairs/caseflow/pull/14556#discussion_r447102582
 import TIMEZONES from '../../constants/TIMEZONES';
 import { COMMON_TIMEZONES, REGIONAL_OFFICE_ZONE_ALIASES } from '../constants/AppConstants';
+import { VIDEO_HEARING_LABEL } from './constants';
 import ApiUtil from '../util/ApiUtil';
 import { RESET_VIRTUAL_HEARING } from './contexts/HearingsFormContext';
 import HEARING_REQUEST_TYPES from '../../constants/HEARING_REQUEST_TYPES';
@@ -548,6 +549,34 @@ export const formatTimeSlotLabel = (time, zone) => {
   }
 
   return `${coTime} (${roTime})`;
+};
+
+export const formatHearingType = (hearingType) => {
+  if (hearingType.toLowerCase().startsWith('video')) {
+    return VIDEO_HEARING_LABEL;
+  }
+
+  return hearingType;
+};
+
+export const formatVljName = (hearingDay) => {
+  const first = hearingDay?.judgeFirstName;
+  const last = hearingDay?.judgeLastName;
+
+  if (last && first) {
+    return `${last}, ${first}`;
+  }
+
+  return '';
+};
+
+export const formatSlotRatio = (hearingDay) => {
+  const scheduledHearings = _.get(hearingDay, 'hearings', {});
+  const scheduledHearingCount = Object.keys(scheduledHearings).length;
+  const availableSlotCount = _.get(hearingDay, 'totalSlots', 0) - scheduledHearingCount;
+  const formattedSlotRatio = `${scheduledHearingCount} of ${availableSlotCount}`;
+
+  return formattedSlotRatio;
 };
 
 /* eslint-enable camelcase */

--- a/client/test/app/hearings/components/HearingDayInfoButton.test.js
+++ b/client/test/app/hearings/components/HearingDayInfoButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe } from 'jest-axe';
 
@@ -12,6 +12,7 @@ describe('HearingDayInfoButton', () => {
   const props = {
     hearingDay:
       {
+        scheduledFor: '04/12/2021',
         judgeFirstName: 'Jonas',
         judgeLastName: 'Jerengal',
         room: '14',
@@ -40,54 +41,28 @@ describe('HearingDayInfoButton', () => {
     expect(results).toHaveNoViolations();
   });
 
-  /*
-  it('correctly sets checkbox status when all are unchecked', () => {
-    const uncheckedOptions = props.options.map((opt) => {
-      return { ...opt, checked: false };
-    });
-    const allFalseOptionsProps = { ...props, options: uncheckedOptions };
+  it('has correct class when selected', () => {
+    const selectedProps = { ...props, selected: true };
+    const utils = render(<HearingDayInfoButton {...selectedProps} />);
+    const button = utils.getByRole('button');
 
-    const component = render(<FilterOption {...allFalseOptionsProps} />);
-    const options = component.getAllByRole('checkbox');
-    const checked = options.filter((el) => el.checked);
-
-    expect(checked.length).toBe(0);
+    expect(button).toHaveClass('selected-hearing-day-info-button');
   });
 
-  it('correctly sets checkbox status when all are checked', () => {
-    const checkedOptions = props.options.map((opt) => {
-      return { ...opt, checked: true };
-    });
-    const allTrueOptionsProps = { ...props, options: checkedOptions };
+  it('has correct class when unselected', () => {
+    const selectedProps = { ...props, selected: false };
+    const utils = render(<HearingDayInfoButton {...selectedProps} />);
+    const button = utils.getByRole('button');
 
-    const component = render(<FilterOption {...allTrueOptionsProps} />);
-    const options = component.getAllByRole('checkbox');
-    const checked = options.filter((el) => el.checked);
-
-    expect(checked.length).toBe(options.length);
+    expect(button).toHaveClass('unselected-hearing-day-info-button');
   });
 
-  it('correctly calls setSelectedValue', async () => {
-    const component = render(<FilterOption {...props} />);
+  it('calls setSelected on click', async () => {
+    const utils = render(<HearingDayInfoButton {...props} />);
+    const button = utils.getByRole('button');
 
-    const options = component.getAllByRole('checkbox');
-    const opt = props.options[1];
-    const checkedBefore = options.filter((el) => el.checked);
-
-    expect(checkedBefore.length).toBe(1);
-
-    await userEvent.click(screen.getByLabelText(opt.displayText));
-
-    // Calls onChange handler
+    expect(setSelectedValue).toHaveBeenCalledTimes(0);
+    await userEvent.click(button);
     expect(setSelectedValue).toHaveBeenCalledTimes(1);
-
-    // While we aren't updating value, handleChange is still getting called
-    expect(setSelectedValue).toHaveBeenLastCalledWith(opt.value);
-
-    const checkedAfter = options.filter((el) => el.checked);
-
-    // Value should not have been updated, since we're not doing that
-    expect(checkedAfter.length).toBe(1);
   });
-  */
 });

--- a/client/test/app/hearings/components/HearingDayInfoButton.test.js
+++ b/client/test/app/hearings/components/HearingDayInfoButton.test.js
@@ -1,0 +1,93 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { axe } from 'jest-axe';
+
+import HearingDayInfoButton from 'app/hearings/components/assignHearings/HearingDayInfoButton';
+
+describe('HearingDayInfoButton', () => {
+  const setSelectedValue = jest.fn();
+
+  const props = {
+    hearingDay:
+      {
+        judgeFirstName: 'Jonas',
+        judgeLastName: 'Jerengal',
+        room: '14',
+        readableRequestType: 'video',
+        hearings: {
+          hearing_1: {},
+          hearing_2: {},
+        },
+        totalSlots: 8,
+      },
+    selected: false,
+    onSelectedHearingDayChange: setSelectedValue,
+  };
+
+  it('renders correctly', () => {
+    const { container } = render(<HearingDayInfoButton {...props} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('passes a11y testing', async () => {
+    const { container } = render(<HearingDayInfoButton {...props} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  /*
+  it('correctly sets checkbox status when all are unchecked', () => {
+    const uncheckedOptions = props.options.map((opt) => {
+      return { ...opt, checked: false };
+    });
+    const allFalseOptionsProps = { ...props, options: uncheckedOptions };
+
+    const component = render(<FilterOption {...allFalseOptionsProps} />);
+    const options = component.getAllByRole('checkbox');
+    const checked = options.filter((el) => el.checked);
+
+    expect(checked.length).toBe(0);
+  });
+
+  it('correctly sets checkbox status when all are checked', () => {
+    const checkedOptions = props.options.map((opt) => {
+      return { ...opt, checked: true };
+    });
+    const allTrueOptionsProps = { ...props, options: checkedOptions };
+
+    const component = render(<FilterOption {...allTrueOptionsProps} />);
+    const options = component.getAllByRole('checkbox');
+    const checked = options.filter((el) => el.checked);
+
+    expect(checked.length).toBe(options.length);
+  });
+
+  it('correctly calls setSelectedValue', async () => {
+    const component = render(<FilterOption {...props} />);
+
+    const options = component.getAllByRole('checkbox');
+    const opt = props.options[1];
+    const checkedBefore = options.filter((el) => el.checked);
+
+    expect(checkedBefore.length).toBe(1);
+
+    await userEvent.click(screen.getByLabelText(opt.displayText));
+
+    // Calls onChange handler
+    expect(setSelectedValue).toHaveBeenCalledTimes(1);
+
+    // While we aren't updating value, handleChange is still getting called
+    expect(setSelectedValue).toHaveBeenLastCalledWith(opt.value);
+
+    const checkedAfter = options.filter((el) => el.checked);
+
+    // Value should not have been updated, since we're not doing that
+    expect(checkedAfter.length).toBe(1);
+  });
+  */
+});

--- a/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
@@ -4,7 +4,7 @@ exports[`HearingDayInfoButton renders correctly 1`] = `
 <div>
   <span>
     <button
-      class="cf-submit cf-btn-link usa-button"
+      class="unselected-hearing-day-info-button cf-btn-link usa-button"
       data-css-s0bvcw=""
       type="button"
     >
@@ -15,7 +15,7 @@ exports[`HearingDayInfoButton renders correctly 1`] = `
           <div
             data-css-l6c9n4=""
           >
-            Mon Jul 6th
+            Mon Apr 12th
           </div>
           <div
             data-css-134a1o=""

--- a/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`HearingDayInfoButton renders correctly 1`] = `
+<div>
+  <span>
+    <button
+      class="cf-submit cf-btn-link usa-button"
+      data-css-s0bvcw=""
+      type="button"
+    >
+      <div>
+        <div
+          data-css-16v9b8i=""
+        >
+          <div
+            data-css-l6c9n4=""
+          >
+            Mon Jul 6th
+          </div>
+          <div
+            data-css-134a1o=""
+          >
+            Video · Jerengal, Jonas
+          </div>
+        </div>
+        <div
+          data-css-1fnaqki=""
+        >
+          <div>
+            2 of 6
+          </div>
+          <div>
+            scheduled
+          </div>
+        </div>
+      </div>
+    </button>
+  </span>
+</div>
+`;


### PR DESCRIPTION
Resolves CASEFLOW-395

### Description
Provides more information about hearing days on the "Schedule Veteran" screen. in the left hand column.

#### Before
![Screen Shot 2021-04-02 at 1 36 40 PM](https://user-images.githubusercontent.com/6818839/113439522-bda67380-93b8-11eb-9fd3-dbe4eb85e923.png)

#### After
![Screen Shot 2021-04-02 at 1 35 52 PM](https://user-images.githubusercontent.com/6818839/113439546-ca2acc00-93b8-11eb-8fad-66dbb3aa0614.png)


### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Information shown is correct.
- [ ] Code moved to 'util.js' doesn't change output of other components.