### PR TITLE
Allow sending Docket Switches to OCB VLJs only

### DIFF
--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -177,7 +177,10 @@ class TaskActionRepository
 
     def docket_switch_send_to_judge_data(_task, _user = nil)
       {
-        type: DocketSwitchRulingTask.name
+        type: DocketSwitchRulingTask.name,
+        options: ClerkOfTheBoard.singleton.users.select(&:judge?).map do |judge|
+          { value: judge.id, label: judge.display_name }
+        end
       }
     end
 

--- a/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
+++ b/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useHistory, useParams } from 'react-router';
+import { useHistory, useParams, useRouteMatch } from 'react-router';
 import { fetchJudges } from 'app/queue/QueueActions';
+import { appealWithDetailSelector, rootTasksForAppeal, taskById } from 'app/queue/selectors';
+import { taskActionData } from 'app/queue/utils';
 
-import { appealWithDetailSelector, rootTasksForAppeal } from '../../selectors';
 import DISPOSITIONS from 'constants/DOCKET_SWITCH_DISPOSITIONS';
 
 import { RecommendDocketSwitchForm } from './RecommendDocketSwitchForm';
@@ -43,7 +44,13 @@ export const RecommendDocketSwitchContainer = () => {
 
   const appeal = useSelector((state) => appealWithDetailSelector(state, { appealId }));
   const rootTask = useSelector((state) => rootTasksForAppeal(state, { appealId }))[0];
+  const task = useSelector((state) => taskById(state, { taskId }));
 
+  const match = useRouteMatch();
+  const options = taskActionData({ task, match })?.options;
+
+  /* For now, we're only allowing OCB VLJs to be assigned. Instead of fetching all judges, we
+     use the task action repository.
   const judges = useSelector((state) => state.queue.judges);
   const judgeOptions = useMemo(
     () =>
@@ -59,6 +66,7 @@ export const RecommendDocketSwitchContainer = () => {
     // eslint-disable-next-line no-undefined
     return appeal.assignedJudge?.id ?? undefined;
   }, [judges, appeal]);
+  */
 
   // eslint-disable-next-line no-console
   const handleSubmit = async (formData) => {
@@ -95,18 +103,20 @@ export const RecommendDocketSwitchContainer = () => {
     }
   };
 
+  /* No need to make an extra XHR until we roll out to all judges.
   useEffect(() => {
     if (!judgeOptions.length) {
       dispatch(fetchJudges());
     }
   });
+  */
 
   return (
     <RecommendDocketSwitchForm
       onCancel={goBack}
       onSubmit={handleSubmit}
-      judgeOptions={judgeOptions}
-      defaultJudgeId={defaultJudgeId}
+      judgeOptions={options}
+      defaultJudgeId={undefined}
       appellantName={appeal.appellantFullName}
     />
   );

--- a/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
+++ b/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useMemo } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams, useRouteMatch } from 'react-router';
-import { fetchJudges } from 'app/queue/QueueActions';
+// import { fetchJudges } from 'app/queue/QueueActions';
 import { appealWithDetailSelector, rootTasksForAppeal, taskById } from 'app/queue/selectors';
 import { taskActionData } from 'app/queue/utils';
 
@@ -116,7 +116,7 @@ export const RecommendDocketSwitchContainer = () => {
       onCancel={goBack}
       onSubmit={handleSubmit}
       judgeOptions={options}
-      defaultJudgeId={undefined}
+      defaultJudgeId={null}
       appellantName={appeal.appellantFullName}
     />
   );

--- a/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
+++ b/client/app/queue/docketSwitch/recommendDocketSwitch/RecommendDocketSwitchContainer.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useHistory, useParams, useRouteMatch } from 'react-router';
-// import { fetchJudges } from 'app/queue/QueueActions';
 import { appealWithDetailSelector, rootTasksForAppeal, taskById } from 'app/queue/selectors';
 import { taskActionData } from 'app/queue/utils';
 
@@ -49,25 +48,6 @@ export const RecommendDocketSwitchContainer = () => {
   const match = useRouteMatch();
   const options = taskActionData({ task, match })?.options;
 
-  /* For now, we're only allowing OCB VLJs to be assigned. Instead of fetching all judges, we
-     use the task action repository.
-  const judges = useSelector((state) => state.queue.judges);
-  const judgeOptions = useMemo(
-    () =>
-      Object.values(judges).map(({ id: value, display_name: label }) => ({
-        label,
-        value,
-      })),
-    [judges]
-  );
-
-  // We want to default the judge selection to the VLJ currently assigned to the case, if exists
-  const defaultJudgeId = useMemo(() => {
-    // eslint-disable-next-line no-undefined
-    return appeal.assignedJudge?.id ?? undefined;
-  }, [judges, appeal]);
-  */
-
   // eslint-disable-next-line no-console
   const handleSubmit = async (formData) => {
 
@@ -102,14 +82,6 @@ export const RecommendDocketSwitchContainer = () => {
       console.error('Error saving task', error);
     }
   };
-
-  /* No need to make an extra XHR until we roll out to all judges.
-  useEffect(() => {
-    if (!judgeOptions.length) {
-      dispatch(fetchJudges());
-    }
-  });
-  */
 
   return (
     <RecommendDocketSwitchForm

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -85,10 +85,6 @@ RSpec.feature "Docket Switch", :all_dbs do
       find("label[for=disposition_#{disposition}]").click
       fill_in("hyperlink", with: hyperlink)
 
-      # Normally, we expect the previously assigned judge to be selected.
-      # expect(page).to have_content(judge_assign_task.assigned_to.display_name)
-
-      # For now, there is no default as the previously assigned judge is likely not an OCB VLJ.
       find(".cf-select__control", text: "Select judge").click
       find("div", class: "cf-select__option", text: judge.display_name).click
 

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature "Docket Switch", :all_dbs do
       fill_in("hyperlink", with: hyperlink)
 
       # Normally, we expect the previously assigned judge to be selected.
-      #expect(page).to have_content(judge_assign_task.assigned_to.display_name)
+      # expect(page).to have_content(judge_assign_task.assigned_to.display_name)
 
       # For now, there is no default as the previously assigned judge is likely not an OCB VLJ.
       find(".cf-select__control", text: "Select judge").click

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -7,6 +7,7 @@ RSpec.feature "Docket Switch", :all_dbs do
     cotb_org.add_user(cotb_attorney)
     cotb_org.add_user(cotb_non_attorney)
     create(:staff, :judge_role, sdomainid: judge.css_id)
+    cotb_org.add_user(judge)
   end
   after { FeatureToggle.disable!(:docket_switch) }
 
@@ -84,8 +85,12 @@ RSpec.feature "Docket Switch", :all_dbs do
       find("label[for=disposition_#{disposition}]").click
       fill_in("hyperlink", with: hyperlink)
 
-      # The previously assigned judge should be selected
-      expect(page).to have_content(judge_assign_task.assigned_to.display_name)
+      # Normally, we expect the previously assigned judge to be selected.
+      #expect(page).to have_content(judge_assign_task.assigned_to.display_name)
+
+      # For now, there is no default as the previously assigned judge is likely not an OCB VLJ.
+      find(".cf-select__control", text: "Select judge").click
+      find("div", class: "cf-select__option", text: judge.display_name).click
 
       click_button(text: "Submit")
 


### PR DESCRIPTION
For roll-out of docket switch, we have been asked to allow only OCB VLJs to be sent docket switch recommendations.

Since the original judge is unlikely to now also be an OCB member, the judge dropdown now has no default value, and the user must explicitly choose the judge.

~I'm keeping the old functionality, which loads a list of all Board judges, as commented-out code, until a final decision is made on assignable judges.~ As per @leikkisa's recommendation, the previous functionality has been removed.