### PR TITLE
Setup script now install shared-mime-info

### DIFF
--- a/scripts/dev_env_setup_step1.sh
+++ b/scripts/dev_env_setup_step1.sh
@@ -44,7 +44,7 @@ else
 fi
 
 echo "==> Installing the base dependencies"
-brew install rbenv nodenv yarn jq
+brew install rbenv nodenv yarn jq shared-mime-info
 brew tap ouchxp/nodenv
 brew install nodenv-nvmrc
 brew install postgres


### PR DESCRIPTION
### Description
The mimemagic gem, since version 0.3.7, requires this.

The package name is the same on RHEL derivatives, but it's
a dependency of yum so it should already be present there.

### Acceptance Criteria
- [ ] Script passes on a Mac

### Testing Plan
1. Manually exercise script