### PR TITLE
Bubble appeals without a decision date to the top of search results

### DIFF
--- a/client/app/queue/CaseListView.jsx
+++ b/client/app/queue/CaseListView.jsx
@@ -64,6 +64,13 @@ class CaseListView extends React.PureComponent {
       });
   };
 
+  sortAppeals = () => {
+    this.props.appeals.sort((a,b)=> {
+      if (a.decisionDate == null) return -1;
+      return  (a.id < b.id ? 1 : -1);
+    });
+  };
+
   searchPageHeading = () => <React.Fragment>
     <h1 className="cf-push-left" {...fullWidth}>{COPY.CASE_SEARCH_HOME_PAGE_HEADING}</h1>
     <p>{COPY.CASE_SEARCH_INPUT_INSTRUCTION}</p>
@@ -87,6 +94,7 @@ class CaseListView extends React.PureComponent {
     // Using the first appeal in the list to get the Veteran's name and ID. We expect that data to be
     // the same for all appeals in the list.
     if (this.props.appeals.length > 0) {
+      this.sortAppeals();
       const firstAppeal = this.props.appeals[0];
 
       heading = `${appealsCount} ${pluralize('case', appealsCount)} found for


### PR DESCRIPTION
Resolves #9016

### Description
Results when searching for appeals were sorted by newest first, regardless of decision date. Now the results bubble up appeals without a decision date to the top of the results.

### Acceptance Criteria
- [ ] Code compiles correctly

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="800" alt="image" src="https://user-images.githubusercontent.com/2308626/113711933-8505e300-96b3-11eb-8042-f16e3456a942.png">
 | 
<img width="800" alt="image" src="https://user-images.githubusercontent.com/2308626/113711899-7b7c7b00-96b3-11eb-9670-f8113f8dc318.png">