### PR TITLE
Don't allow future dates for 'remand' decision type

### DIFF
--- a/client/app/queue/cavc/EditCavcRemandForm.jsx
+++ b/client/app/queue/cavc/EditCavcRemandForm.jsx
@@ -248,7 +248,7 @@ export const EditCavcRemandForm = ({
           />
         </div>
 
-        {watchDecisionType && !watchDecisionType.includes('remand') && (
+        {(watchDecisionType && !watchDecisionType.includes('remand')) ? (
           <RadioField
             inputRef={register}
             styling={radioLabelStyling}
@@ -257,8 +257,17 @@ export const EditCavcRemandForm = ({
             options={YesNoOpts}
             strongLabel
             errorMessage={errors?.remandDatesProvided?.message}
-          />
-        )}
+          />) :
+          (<div style={{ display: 'none' }}>
+            <RadioField
+              inputRef={register}
+              name="remandDatesProvided"
+              options={YesNoOpts}
+            />
+          </div>)
+        }
+        {/* Above is another Workaround: must have component that uses `register`
+            with `remandDatesProvided` name so that it can be used by yup */}
 
         <DateSelector
           inputRef={register}


### PR DESCRIPTION
### Description
 - Do not allow future dates when Editing Judgement Dates and Mandate Dates.
 - Do not allow empty dates when Editing Judgement Dates and Mandate Dates for JMR and JMPR.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
See [Slack](https://dsva.slack.com/archives/CJL810329/p1617893645247000?thread_ts=1617834040.237500&cid=CJL810329) for testing description.
@pbradin is working on Jest tests

### User Facing Changes
![image](https://user-images.githubusercontent.com/55255674/114082548-7f56fb80-9873-11eb-8b79-8daea9fb838e.png)

