### PR TITLE
Add a COTB VLJ in database seeds

### DIFF
--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -77,7 +77,7 @@ module Seeds
       create_cavc_lit_support_user
       create_pulac_cerullo_user
       create_mail_team_user
-      create_clerk_of_the_board_user
+      create_clerk_of_the_board_users
       create_case_search_only_user
       create_judge_teams
       create_dvc_teams
@@ -347,15 +347,18 @@ module Seeds
       MailTeam.singleton.add_user(u)
     end
 
-    def create_clerk_of_the_board_user
-      u = create(
+    def create_clerk_of_the_board_users
+      atty = create(
         :user,
         :with_vacols_attorney_record,
         station_id: 101,
         css_id: "COB_USER",
         full_name: "Clark ClerkOfTheBoardUser Bard"
       )
-      ClerkOfTheBoard.singleton.add_user(u)
+      ClerkOfTheBoard.singleton.add_user(atty)
+      judge = create(:user, full_name: "Judith COTB Judge", css_id: "BVACOTBJUDGE")
+      create(:staff, :judge_role, sdomainid: judge.css_id)
+      ClerkOfTheBoard.singleton.add_user(judge)
     end
 
     def create_case_search_only_user

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -6,7 +6,7 @@ describe Seeds::Users do
 
     it "creates all kinds of users and organizations" do
       expect { subject }.to_not raise_error
-      expect(User.count).to eq(89)
+      expect(User.count).to eq(90)
       expect(Organization.count).to eq(29)
     end
   end


### PR DESCRIPTION
### Description
The "assign docket switch to judge" screen can't be completed if no judge is available, which is especially an issue when docket switch assignments are limited to judges at the Clerk of the Board. This adds a COTB judge to the seed data.

Screenshot of the new COTB judge, running on a fresh re-seed.
<img width="423" src="https://user-images.githubusercontent.com/282869/114092326-bf27de00-9887-11eb-91a6-b5e5373f78ce.png">
