### PR TITLE
Fix canceled change hearing request type task bug

### DIFF
--- a/app/models/concerns/hearing_request_type_concern.rb
+++ b/app/models/concerns/hearing_request_type_concern.rb
@@ -84,7 +84,10 @@ module HearingRequestTypeConcern
   end
 
   def changeset_at_index_for_task(task_id)
-    request_type_index = tasks.where(type: "ChangeHearingRequestTypeTask").order(:id).map(&:id).index(task_id)
+    request_type_index = tasks.where(
+      type: "ChangeHearingRequestTypeTask",
+      status: Constants.TASK_STATUSES.completed
+    ).order(:id).map(&:id).index(task_id)
     return nil if request_type_index.blank?
 
     # support versions that were recorded before the column name changed


### PR DESCRIPTION
### Description
Fixes a bug discovered through [a bat team ticket](https://dsva.slack.com/archives/CHX8FMP28/p1617993452357700), where we were unable to discover the previous hearing request type if there was a canceled `ChangeHearingRequestTypeTask` on the appeal.