### PR TITLE
Add missing foreign keys to Organization and User tables (Phase 2)

### DIFF
--- a/db/migrate/20210412223749_add_foreign_keys_to_orgs_and_users_table.rb
+++ b/db/migrate/20210412223749_add_foreign_keys_to_orgs_and_users_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToOrgsAndUsersTable < Caseflow::Migration
+  def change
+    add_foreign_key "ihp_drafts", "organizations", validate: false
+    add_foreign_key "organizations_users", "organizations", validate: false
+    add_foreign_key "vso_configs", "organizations", validate: false
+
+    add_foreign_key "job_notes", "users", validate: false
+    add_foreign_key "messages", "users", validate: false
+  end
+end

--- a/db/migrate/20210412224203_validate_foreign_keys_to_orgs_and_users_table.rb
+++ b/db/migrate/20210412224203_validate_foreign_keys_to_orgs_and_users_table.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ValidateForeignKeysToOrgsAndUsersTable < Caseflow::Migration
+  def change
+    validate_foreign_key "ihp_drafts", "organizations"
+    validate_foreign_key "organizations_users", "organizations"
+    validate_foreign_key "vso_configs", "organizations"
+
+    validate_foreign_key "job_notes", "users"
+    validate_foreign_key "messages", "users"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_06_122353) do
+ActiveRecord::Schema.define(version: 2021_04_12_224203) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1655,7 +1655,9 @@ ActiveRecord::Schema.define(version: 2021_04_06_122353) do
   add_foreign_key "hearings", "users", column: "created_by_id"
   add_foreign_key "hearings", "users", column: "judge_id"
   add_foreign_key "hearings", "users", column: "updated_by_id"
+  add_foreign_key "ihp_drafts", "organizations"
   add_foreign_key "intakes", "users"
+  add_foreign_key "job_notes", "users"
   add_foreign_key "judge_case_reviews", "users", column: "attorney_id"
   add_foreign_key "judge_case_reviews", "users", column: "judge_id"
   add_foreign_key "legacy_appeals", "appeal_series"
@@ -1664,8 +1666,10 @@ ActiveRecord::Schema.define(version: 2021_04_06_122353) do
   add_foreign_key "legacy_hearings", "users", column: "created_by_id"
   add_foreign_key "legacy_hearings", "users", column: "updated_by_id"
   add_foreign_key "legacy_issue_optins", "legacy_issues"
+  add_foreign_key "messages", "users"
   add_foreign_key "nod_date_updates", "appeals"
   add_foreign_key "nod_date_updates", "users"
+  add_foreign_key "organizations_users", "organizations"
   add_foreign_key "organizations_users", "users"
   add_foreign_key "post_decision_motions", "appeals"
   add_foreign_key "post_decision_motions", "tasks"
@@ -1682,4 +1686,5 @@ ActiveRecord::Schema.define(version: 2021_04_06_122353) do
   add_foreign_key "user_quotas", "users"
   add_foreign_key "virtual_hearings", "users", column: "created_by_id"
   add_foreign_key "virtual_hearings", "users", column: "updated_by_id"
+  add_foreign_key "vso_configs", "organizations"
 end

--- a/spec/controllers/organizations/users_controller_spec.rb
+++ b/spec/controllers/organizations/users_controller_spec.rb
@@ -291,6 +291,8 @@ describe Organizations::UsersController, :postgres, type: :controller do
         expect(OrganizationsUser.where(organization: org).count).to eq(2)
         subject
         resp = JSON.parse(response.body)
+        # response has the removed user
+        expect(resp["users"]["data"].first["attributes"]["css_id"]).to eq user.css_id
 
         expect(OrganizationsUser.where(organization: org).count).to eq(1)
         expect(org.admins.count).to eq(1)

--- a/spec/controllers/organizations/users_controller_spec.rb
+++ b/spec/controllers/organizations/users_controller_spec.rb
@@ -268,24 +268,37 @@ describe Organizations::UsersController, :postgres, type: :controller do
     end
   end
 
-  describe "DELETE /organizations/:org_url/users/:user_id", skip: "Flake" do
+  describe "DELETE /organizations/:org_url/users/:user_id" do
     subject { post(:destroy, params: params, as: :json) }
 
     let!(:params) { { organization_url: org.url, id: user.id } }
 
     let(:org) { create(:judge_team, :has_judge_team_lead_as_admin) }
-    let(:user) { org.judge }
-    let(:admin) do
-      create(:user).tap do |u|
-        OrganizationsUser.make_user_admin(u, org)
+    let!(:user) do
+      create(:user).tap do |user|
+        org.add_user(user)
       end
     end
 
-    before do
-      User.stub = admin
+    let(:bva_admin_user) do
+      create(:user).tap { |bva_admin| Bva.singleton.add_user(bva_admin) }
     end
 
-    context "when user is the judge in the organization" do
+    before { User.stub = bva_admin_user }
+
+    context "when user is a non-judge in the organization" do
+      it "returns an error" do
+        expect(OrganizationsUser.where(organization: org).count).to eq(2)
+        subject
+        resp = JSON.parse(response.body)
+
+        expect(OrganizationsUser.where(organization: org).count).to eq(1)
+        expect(org.admins.count).to eq(1)
+        expect(org.non_admins.count).to eq(0)
+      end
+    end
+
+    context "when user is the judge in the organization", skip: "Flake" do
       it "returns an error" do
         subject
 

--- a/spec/controllers/organizations/users_controller_spec.rb
+++ b/spec/controllers/organizations/users_controller_spec.rb
@@ -287,7 +287,7 @@ describe Organizations::UsersController, :postgres, type: :controller do
     before { User.stub = bva_admin_user }
 
     context "when user is a non-judge in the organization" do
-      it "returns an error" do
+      it "removes user from organization" do
         expect(OrganizationsUser.where(organization: org).count).to eq(2)
         subject
         resp = JSON.parse(response.body)

--- a/spec/models/organization_spec.rb
+++ b/spec/models/organization_spec.rb
@@ -236,4 +236,26 @@ describe Organization, :postgres do
       )
     end
   end
+
+  describe ".destroy" do
+    context "when organization has members and is destroyed" do
+      let(:org) { create(:organization) }
+      let(:member_cnt) { 3 }
+      let(:users) { create_list(:user, member_cnt) }
+      before { users.each { |u| org.add_user(u) } }
+
+      subject { org.destroy }
+
+      it "should also destroy associated OrganizationsUser records" do
+        expect(Organization.count).to eq(1)
+        expect(org.users.length).to eq(member_cnt)
+        expect(OrganizationsUser.count).to eq(member_cnt)
+
+        expect(subject).to eq(org)
+
+        expect(Organization.count).to eq(0)
+        expect(OrganizationsUser.count).to eq(0)
+      end
+    end
+  end
 end

--- a/spec/models/organizations_user_spec.rb
+++ b/spec/models/organizations_user_spec.rb
@@ -71,6 +71,25 @@ describe OrganizationsUser, :postgres do
     end
   end
 
+  describe "when making organization inactive" do
+    subject { organization.inactive! }
+
+    before { organization.add_user(user) }
+
+    it "doesn't list the organization for the user" do
+      expect(organization.users.count).to eq(1)
+      expect(OrganizationsUser.count).to eq(1)
+      subject
+      # User is no longer part of the inactive organization
+      expect(user.organizations).to_not include organization
+
+      # However, associations queried from the organization are unchanged
+      expect(organization.users.count).to eq(1)
+      # because record in OrganizationsUser table still exists
+      expect(OrganizationsUser.count).to eq(1)
+    end
+  end
+
   describe ".make_user_admin" do
     context "when the organization is not a judge team" do
       before { OrganizationsUser.make_user_admin(user, organization) }


### PR DESCRIPTION
Bumps #14732
* This is phase 2 of a [multi-phase plan](https://hackmd.io/wum2LtUfSHC-1o6-peBseQ) to add missing foreign keys.
* Phase 1 #16034 has more details.

### Description
Add foreign keys to the `organizations` and `users` table. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Before deployment, rerun the following to ensure the foreign keys will be valid:
```ruby
IhpDraft.includes(:organization).where.not(organization_id: nil).select{|r| r.organization == nil}.count
=>0

ou=OrganizationsUser.includes(:organization).where.not(organization_id: nil).select{|r| r.organization == nil};
ou.count
=>45
org_ids = ou.map(&:organization_id).uniq
=> [130, 139, 408, 163, 171, 190, 412, 320]
=> [130, 139, 408, 163, 171, 183, 190, 212, 412, 320] # Apr 12th

org_ids.count
=> 10
# Check inactive orgs
ou2=Organization.unscoped.find(org_ids).count
=> 10
# All 10 exists

OrganizationsUser.includes(:user).where.not(user_id: nil).select{|r| r.user == nil}.count
=> 0

vc=VsoConfig.includes(:organization).where.not(organization_id: nil).select{|r| r.organization == nil};
vc.count
=> 0

JobNote.includes(:user).where.not(user_id: nil).select{|r| r.user == nil}.count
=>0
Message.includes(:user).where.not(user_id: nil).select{|r| r.user == nil}.count
=>0
```

Also check and fix records in UAT as well.

### Database Changes

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR
