### PR TITLE
Workaround for Flakes in CavcTaskQueue Spec

### DIFF
--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -304,7 +304,7 @@ feature "Intake Add Issues Page", :all_dbs do
       add_intake_nonrating_issue(
         category: "Dependent Child - Biological",
         description: "test",
-        date: "04/04/2020"
+        date: 30.days.ago.to_date.strftime("%-m/%-d/%Y")
       )
       click_on "Establish appeal"
       expect(page).to have_content("correct the issues")

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
     # Specifying date for test run due to hard-coded dates being used below
     # Workaround due to weird interaction between using fill_in with dynamic dates and controlled DateSelector fields
     before do
-      Timecop.travel(Time.new(2021,04,13))
+      Timecop.travel(Time.zone.local(2021, 4, 13))
     end
 
     after do

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -15,6 +15,16 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
   describe "when intaking a cavc remand" do
     before { BvaDispatch.singleton.add_user(create(:user)) }
 
+    # Specifying date for test run due to hard-coded dates being used below
+    # Workaround due to weird interaction between using fill_in with dynamic dates and controlled DateSelector fields
+    before do
+      Timecop.travel(Time.new(2021,04,13))
+    end
+
+    after do
+      Timecop.return
+    end
+
     let(:appeal) { create(:appeal, :dispatched) }
 
     let(:notes) { "Pain disorder with 100\% evaluation per examination" }
@@ -33,8 +43,8 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
 
     let(:docket_number) { "12-1234" }
     # Use a decision date within the last 90 days so that it is automatically put on hold for MDR
-    let(:date) { 40.days.ago.to_date.strftime("%-m/%-d/%Y") }
-    let(:later_date) { 20.days.ago.to_date.strftime("%-m/%-d/%Y") }
+    let(:date) { "3/13/2021" }
+    let(:later_date) { "3/23/2021" }
     let(:instructions) { "Please process this remand" }
     let(:mandate_instructions) { "Mandate received!" }
     let(:judge_name) { Constants::CAVC_JUDGE_FULL_NAMES.first }

--- a/spec/models/tasks/mandate_hold_task_spec.rb
+++ b/spec/models/tasks/mandate_hold_task_spec.rb
@@ -68,6 +68,9 @@ describe MandateHoldTask, :postgres do
         Timecop.travel(decision_date + 91.days)
         TaskTimerJob.perform_now
       end
+      after do
+        Timecop.return
+      end
       it "marks MandateHoldTask as assigned" do
         expect(mandate_task.reload.status).to eq Constants.TASK_STATUSES.assigned
         child_timed_hold_tasks = mandate_task.children.where(type: :TimedHoldTask)

--- a/spec/models/tasks/mdr_task_spec.rb
+++ b/spec/models/tasks/mdr_task_spec.rb
@@ -68,6 +68,10 @@ describe MdrTask, :postgres do
         Timecop.travel(decision_date + 91.days)
         TaskTimerJob.perform_now
       end
+      after do
+        Timecop.return
+      end
+
       it "marks MdrTask as assigned" do
         expect(mdr_task.reload.status).to eq Constants.TASK_STATUSES.assigned
         child_timed_hold_tasks = mdr_task.children.where(type: :TimedHoldTask)


### PR DESCRIPTION
### Description
This switches to hard-coded dates (along w/ related time travel) in CAVC Task Queue feature spec. This is a workaround for what appears to be buggy behavior with dynamic dates and controlled DateSelector fields on this form.

This PR also includes a fix for a recent issue in `add_issues_spec` caused by hardcoded date for an issue that now exceeds the limit for timeliness.

This also incorporates an update to snapshots for `ScheduleVeteran` Jest tests, as we're seeing a few changes to TZ offsets for `Africa/Casablanca` for some reason.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass


