### PR TITLE
Correctly identify if an appeal is active for correct issues permissions

### DIFF
--- a/app/policies/appeal_request_issues_policy.rb
+++ b/app/policies/appeal_request_issues_policy.rb
@@ -29,7 +29,11 @@ class AppealRequestIssuesPolicy
   end
 
   def case_is_not_in_active_review?
-    Task.where(appeal: appeal, type: "AttorneyTask").empty?
+    Task.where(
+      appeal: appeal,
+      type: "AttorneyTask",
+      status: [Constants.TASK_STATUSES.assigned, Constants.TASK_STATUSES.in_progress]
+    ).empty?
   end
 
   def hearing_is_assigned_to_judge_user?

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -82,24 +82,24 @@ describe AppealRequestIssuesPolicy, :postgres do
     context "when user is a member of the Case Review team, and the appeal has
             already been assigned to an attorney" do
       let(:user) { create(:user) }
-      let!(:attorney_task) {
+      let!(:attorney_task) do
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,
                assigned_to: build_stubbed(:user))
-      }
+      end
       before { CaseReview.singleton.add_user(user) }
 
-      it { binding.pry; is_expected.to be false }
+      it { is_expected.to be false }
 
       context "when the attorney task has been completed and the case is not in active review" do
-        let!(:attorney_task) {
+        let!(:attorney_task) do
           create(:task,
                  :completed,
                  type: "AttorneyTask",
                  appeal: appeal,
                  assigned_to: build_stubbed(:user))
-        }
+        end
 
         it { is_expected.to be true }
       end

--- a/spec/policies/appeal_request_issues_policy_spec.rb
+++ b/spec/policies/appeal_request_issues_policy_spec.rb
@@ -82,15 +82,26 @@ describe AppealRequestIssuesPolicy, :postgres do
     context "when user is a member of the Case Review team, and the appeal has
             already been assigned to an attorney" do
       let(:user) { create(:user) }
-
-      it "returns false" do
-        CaseReview.singleton.add_user(user)
+      let!(:attorney_task) {
         create(:task,
                type: "AttorneyTask",
                appeal: appeal,
                assigned_to: build_stubbed(:user))
+      }
+      before { CaseReview.singleton.add_user(user) }
 
-        expect(subject).to be false
+      it { binding.pry; is_expected.to be false }
+
+      context "when the attorney task has been completed and the case is not in active review" do
+        let!(:attorney_task) {
+          create(:task,
+                 :completed,
+                 type: "AttorneyTask",
+                 appeal: appeal,
+                 assigned_to: build_stubbed(:user))
+        }
+
+        it { is_expected.to be true }
       end
     end
   end


### PR DESCRIPTION
### Description
There's some old code determining when to show the "Correct issues" link on Case Details. One method is incorrectly looking at whether an appeal has any Attorney tasks to see if it's still active, not just active Attorney tasks.

[Batteam Slack thread](https://dsva.slack.com/archives/CHX8FMP28/p1618341025388200)