### PR TITLE
Unscheduled Notes component

### DIFF
--- a/client/app/components/TextareaField.jsx
+++ b/client/app/components/TextareaField.jsx
@@ -104,7 +104,7 @@ TextareaField.defaultProps = {
   disabled: false,
   optional: false,
   required: false,
-  characterLimitTopRight: false,
+  characterLimitTopRight: false
 };
 
 TextareaField.propTypes = {

--- a/client/app/components/TextareaField.jsx
+++ b/client/app/components/TextareaField.jsx
@@ -35,6 +35,7 @@ export const TextareaField = (props) => {
     labelStyling,
     placeholder,
     optional,
+    characterLimitTopRight,
   } = props;
 
   const className = classNamesFn('cf-form-textarea', {
@@ -55,6 +56,15 @@ export const TextareaField = (props) => {
     />
   );
 
+  const characterLimitContent = (
+    <p style={characterLimitTopRight ? { float: 'right', marginBottom: 0 } : {}}>
+      <i>
+        {characterLimitCount} {pluralize('character', characterLimitCount)}{' '}
+        left
+      </i>
+    </p>
+  );
+
   // hideLabel still leaves the label element in the DOM (for a11y purposes)
   // but makes it invisible to any screens
   return (
@@ -69,6 +79,7 @@ export const TextareaField = (props) => {
       {errorMessage && (
         <span className="usa-input-error-message">{errorMessage}</span>
       )}
+      {characterLimitCount !== null && characterLimitTopRight && characterLimitContent}
       <textarea
         {...textAreaStyling}
         name={name}
@@ -84,14 +95,7 @@ export const TextareaField = (props) => {
         ref={inputRef}
         {...inputProps}
       />
-      {characterLimitCount !== null && (
-        <p>
-          <i>
-            {characterLimitCount} {pluralize('character', characterLimitCount)}{' '}
-            left
-          </i>
-        </p>
-      )}
+      {characterLimitCount !== null && !characterLimitTopRight && characterLimitContent}
     </div>
   );
 };
@@ -100,6 +104,7 @@ TextareaField.defaultProps = {
   disabled: false,
   optional: false,
   required: false,
+  characterLimitTopRight: false,
 };
 
 TextareaField.propTypes = {
@@ -111,6 +116,11 @@ TextareaField.propTypes = {
 
   hideLabel: PropTypes.bool,
   id: PropTypes.string,
+
+  /**
+    * Position the character limit in the top-right corner (default: false == position bottom left)
+    */
+  characterLimitTopRight: PropTypes.bool,
 
   /**
    * Props to be applied to the `input` element

--- a/client/app/hearings/components/UnscheduledNotes.jsx
+++ b/client/app/hearings/components/UnscheduledNotes.jsx
@@ -12,24 +12,23 @@ export const UnscheduledNotes = ({
   updatedAt,
   onChange,
   uniqueId,
-  unscheduledNotes,
-  ...props
+  unscheduledNotes
 }) => {
   return (
     <React.Fragment>
       <TextareaField
         maxlength={1000}
-        label='Notes'
+        label="Notes"
         name={`${uniqueId}-unscheduled-notes`}
         strongLabel
         onChange={(notes) => onChange(notes)}
-        labelStyling={css({float: 'left'})}
-        styling={css({marginBottom: 1})}
+        labelStyling={css({ float: 'left' })}
+        styling={css({ marginBottom: 1 })}
         value={unscheduledNotes ?? ''}
         characterLimitTopRight
       />
       {updatedByCssId && updatedAt && unscheduledNotes &&
-        <span style={{color: COLORS.GREY}}>
+        <span style={{ color: COLORS.GREY }}>
           {`Last updated by ${updatedByCssId} on ${moment(updatedAt).format('MM/DD/YYYY')}`}
         </span>
       }
@@ -42,5 +41,5 @@ UnscheduledNotes.propTypes = {
   updatedAt: PropTypes.string,
   unscheduledNotes: PropTypes.string,
   onChange: PropTypes.func,
-  uniqueId: PropTypes.integer
+  uniqueId: PropTypes.number
 };

--- a/client/app/hearings/components/UnscheduledNotes.jsx
+++ b/client/app/hearings/components/UnscheduledNotes.jsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from 'glamor';
+import moment from 'moment';
+
+import { COLORS } from '../../constants/AppConstants';
+
+import TextareaField from '../../components/TextareaField';
+
+export const UnscheduledNotes = ({
+  updatedByCssId,
+  updatedAt,
+  onChange,
+  uniqueId,
+  unscheduledNotes,
+  ...props
+}) => {
+  return (
+    <React.Fragment>
+      <TextareaField
+        maxlength={1000}
+        label='Notes'
+        name={`${uniqueId}-unscheduled-notes`}
+        strongLabel
+        onChange={(notes) => onChange(notes)}
+        labelStyling={css({float: 'left'})}
+        styling={css({marginBottom: 1})}
+        value={unscheduledNotes ?? ''}
+        characterLimitTopRight
+      />
+      {updatedByCssId && updatedAt && unscheduledNotes &&
+        <span style={{color: COLORS.GREY}}>
+          {`Last updated by ${updatedByCssId} on ${moment(updatedAt).format('MM/DD/YYYY')}`}
+        </span>
+      }
+    </React.Fragment>
+  );
+};
+
+UnscheduledNotes.propTypes = {
+  updatedByCssId: PropTypes.string,
+  updatedAt: PropTypes.string,
+  unscheduledNotes: PropTypes.string,
+  onChange: PropTypes.func,
+  uniqueId: PropTypes.integer
+};

--- a/client/app/hearings/components/UnscheduledNotes.stories.js
+++ b/client/app/hearings/components/UnscheduledNotes.stories.js
@@ -1,0 +1,42 @@
+import React, { useState } from 'react';
+
+import { UnscheduledNotes } from './UnscheduledNotes';
+
+export default {
+  title: 'Hearings/Components/UnscheduledNotes',
+  component: UnscheduledNotes,
+  parameters: {
+    docs: {
+      inlineStories: false,
+      iframeHeight: 760,
+    },
+  },
+};
+
+const Template = (args) => {
+  const [notes, setNotes] = useState(args.unscheduledNotes ?? '')
+  return (
+    <UnscheduledNotes
+      {...args}
+      onChange={(...params) => {
+        args.onChange(...params);
+        setNotes(...params);
+      }}
+      unscheduledNotes={notes}
+    />
+  )
+}
+
+export const Basic = Template.bind({});
+Basic.args = {
+  updatedByCssId: 'VACOUSER',
+  updatedAt: '2020-09-08T10:03:49.210-04:00',
+  unscheduledNotes: 'Type notes here',
+  onChange: () => {}
+}
+
+export const FirstEdit = Template.bind({});
+FirstEdit.args = {
+  onChange: () => {},
+  unscheduledNotes: ''
+}

--- a/client/test/app/components/TextareaField.test.js
+++ b/client/test/app/components/TextareaField.test.js
@@ -121,4 +121,20 @@ describe('TextareaField', () => {
     expect(textField.find('i')).toHaveLength(0);
     expect(textField).toMatchSnapshot();
   });
+
+  test('Respects characterLimitTopRight prop on the textarea field', () => {
+    // Setup the test
+    const textField = mount(
+      <TextareaField
+        maxlength={limit}
+        onChange={changeSpy}
+        name={name}
+        characterLimitTopRight={true}
+        value={'Notes'}
+      />
+    );
+    expect(textField.find('i')).toHaveLength(1);
+    expect(textField.find('p').first().props().style).toEqual({ float: 'right', marginBottom: 0 });
+    expect(textField).toMatchSnapshot();
+  })
 });

--- a/client/test/app/components/__snapshots__/TextareaField.test.js.snap
+++ b/client/test/app/components/__snapshots__/TextareaField.test.js.snap
@@ -428,6 +428,76 @@ exports[`TextareaField Matches snapshot with default props 1`] = `
 </TextareaField>
 `;
 
+exports[`TextareaField Respects characterLimitTopRight prop on the textarea field 1`] = `
+<TextareaField
+  characterLimitTopRight={true}
+  disabled={false}
+  maxlength={10}
+  name="Test Field"
+  onChange={
+    [MockFunction] {
+      "calls": Array [
+        Array [
+          "hello",
+        ],
+      ],
+      "results": Array [
+        Object {
+          "type": "return",
+          "value": undefined,
+        },
+      ],
+    }
+  }
+  optional={false}
+  required={false}
+  value="Notes"
+>
+  <div
+    className="cf-form-textarea"
+  >
+    <label
+      className="question-label"
+      htmlFor="Test Field"
+    >
+      <FormLabel
+        name="Test Field"
+        optional={false}
+        required={false}
+      >
+        <span>
+          Test Field
+        </span>
+      </FormLabel>
+    </label>
+    <p
+      style={
+        Object {
+          "float": "right",
+          "marginBottom": 0,
+        }
+      }
+    >
+      <i>
+        5
+         
+        characters
+         
+        left
+      </i>
+    </p>
+    <textarea
+      disabled={false}
+      id="Test Field"
+      maxLength={10}
+      name="Test Field"
+      onChange={[Function]}
+      value="Notes"
+    />
+  </div>
+</TextareaField>
+`;
+
 exports[`TextareaField Respects disabled prop on the textarea field 1`] = `
 <TextareaField
   characterLimitTopRight={false}

--- a/client/test/app/components/__snapshots__/TextareaField.test.js.snap
+++ b/client/test/app/components/__snapshots__/TextareaField.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`TextareaField Can accept input 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   name="Test Field"
   onChange={
@@ -51,6 +52,7 @@ exports[`TextareaField Can accept input 1`] = `
 
 exports[`TextareaField Displays a bold label when strongLabel prop is true 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   name="Test Field"
   onChange={
@@ -103,6 +105,7 @@ exports[`TextareaField Displays a bold label when strongLabel prop is true 1`] =
 
 exports[`TextareaField Displays character count when maxlength and value are present 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   maxlength={10}
   name="Test Field"
@@ -150,7 +153,9 @@ exports[`TextareaField Displays character count when maxlength and value are pre
       onChange={[Function]}
       value="hello"
     />
-    <p>
+    <p
+      style={Object {}}
+    >
       <i>
         5
          
@@ -165,6 +170,7 @@ exports[`TextareaField Displays character count when maxlength and value are pre
 
 exports[`TextareaField Displays error message when present 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   errorMessage="Something went wrong"
   name="Test Field"
@@ -220,6 +226,7 @@ exports[`TextareaField Displays error message when present 1`] = `
 
 exports[`TextareaField Displays screen-reader only label when hideLabel prop is true 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   hideLabel={true}
   name="Test Field"
@@ -270,6 +277,7 @@ exports[`TextareaField Displays screen-reader only label when hideLabel prop is 
 
 exports[`TextareaField Does not display character count when maxlength is present, but value is not present 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   maxlength={10}
   name="Test Field"
@@ -321,6 +329,7 @@ exports[`TextareaField Does not display character count when maxlength is presen
 
 exports[`TextareaField Emojis consume 2 characters 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   maxlength={2}
   name="Test Field"
@@ -368,7 +377,9 @@ exports[`TextareaField Emojis consume 2 characters 1`] = `
       onChange={[Function]}
       value="😀"
     />
-    <p>
+    <p
+      style={Object {}}
+    >
       <i>
         0
          
@@ -383,6 +394,7 @@ exports[`TextareaField Emojis consume 2 characters 1`] = `
 
 exports[`TextareaField Matches snapshot with default props 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   name="Test Field"
   onChange={[MockFunction]}
@@ -418,6 +430,7 @@ exports[`TextareaField Matches snapshot with default props 1`] = `
 
 exports[`TextareaField Respects disabled prop on the textarea field 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={true}
   name="Test Field"
   onChange={
@@ -467,6 +480,7 @@ exports[`TextareaField Respects disabled prop on the textarea field 1`] = `
 
 exports[`TextareaField Respects optional prop on the textarea field 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   name="Test Field"
   onChange={
@@ -521,6 +535,7 @@ exports[`TextareaField Respects optional prop on the textarea field 1`] = `
 
 exports[`TextareaField Respects required prop on the textarea field 1`] = `
 <TextareaField
+  characterLimitTopRight={false}
   disabled={false}
   name="Test Field"
   onChange={

--- a/client/test/app/hearings/components/UnscheduledNotes.test.js
+++ b/client/test/app/hearings/components/UnscheduledNotes.test.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import userEvent from '@testing-library/user-event';
+
+import { UnscheduledNotes } from 'app/hearings/components/UnscheduledNotes';
+
+describe('UnscheduledNotes', () => {
+  const onChange = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const inputText = 'Type notes here'
+  const maxCharLimit = 1000
+  const defaultProps = {
+    updatedByCssId: 'VACOUSER',
+    updatedAt: '2020-09-08T10:03:49.210-04:00',
+    unscheduledNotes: inputText,
+    onChange
+  };
+
+  it('renders correctly', () => {
+    const { container } = render(<UnscheduledNotes {...defaultProps} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('passes a11y testing', async () => {
+    const { container } = render(<UnscheduledNotes {...defaultProps} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('correctly calls onChange', async () => {
+    const container = render(
+      <UnscheduledNotes {...defaultProps} unscheduledNotes={''} />
+    );
+
+    const inputField = container.getByLabelText('Notes')
+
+    await userEvent.type(inputField, inputText);
+
+    // Calls onChange handler each time a key is pressed
+    expect(onChange).toHaveBeenCalledTimes(inputText.length);
+    expect(onChange).toHaveBeenLastCalledWith(inputText[inputText.length - 1]);
+  });
+
+  it('displays character limit info when notes is present', () => {
+    const container = render(<UnscheduledNotes {...defaultProps} />);
+
+    const charLimitMessage = `${maxCharLimit - inputText.length} characters left`
+    expect(container.getByText(charLimitMessage)).toBeInTheDocument()
+  });
+})

--- a/client/test/app/hearings/components/__snapshots__/UnscheduledNotes.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/UnscheduledNotes.test.js.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`UnscheduledNotes renders correctly 1`] = `
+<div>
+  <div
+    class="cf-form-textarea"
+    data-css-jz0ijb=""
+  >
+    <label
+      class="question-label"
+      data-css-42cjjw=""
+      for="undefined-unscheduled-notes"
+    >
+      <strong>
+        <span>
+          Notes
+        </span>
+      </strong>
+    </label>
+    <p
+      style="float: right; margin-bottom: 0px;"
+    >
+      <i>
+        985
+         
+        characters
+         
+        left
+      </i>
+    </p>
+    <textarea
+      id="undefined-unscheduled-notes"
+      maxlength="1000"
+      name="undefined-unscheduled-notes"
+    >
+      Type notes here
+    </textarea>
+  </div>
+  <span
+    style="color: rgb(91, 97, 107);"
+  >
+    Last updated by VACOUSER on 09/08/2020
+  </span>
+</div>
+`;

--- a/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
@@ -6193,6 +6193,7 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
         </div>
         <div>
           <TextareaField
+            characterLimitTopRight={false}
             disabled={false}
             maxlength={1000}
             name="Notes"
@@ -16487,6 +16488,7 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
         </div>
         <div>
           <TextareaField
+            characterLimitTopRight={false}
             disabled={false}
             maxlength={1000}
             name="Notes"
@@ -28226,6 +28228,7 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
         </div>
         <div>
           <TextareaField
+            characterLimitTopRight={false}
             disabled={false}
             maxlength={1000}
             name="Notes"
@@ -39966,6 +39969,7 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
         </div>
         <div>
           <TextareaField
+            characterLimitTopRight={false}
             disabled={false}
             maxlength={1000}
             name="Notes"
@@ -51668,6 +51672,7 @@ exports[`DetailsForm Matches snapshot with for legacy hearing 1`] = `
         </div>
         <div>
           <TextareaField
+            characterLimitTopRight={false}
             disabled={false}
             maxlength={1000}
             name="Notes"

--- a/client/test/app/queue/__snapshots__/AddCavcDatesModal.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcDatesModal.test.js.snap
@@ -502,6 +502,7 @@ exports[`AddCavcDatesModal renders correctly 1`] = `
                             </TextField>
                           </DateSelector>
                           <TextareaField
+                            characterLimitTopRight={false}
                             disabled={false}
                             errorMessage={null}
                             label="Provide context and instructions for this action"
@@ -1122,6 +1123,7 @@ exports[`AddCavcDatesModal submits succesfully 1`] = `
                             </TextField>
                           </DateSelector>
                           <TextareaField
+                            characterLimitTopRight={false}
                             disabled={false}
                             errorMessage={null}
                             label="Provide context and instructions for this action"

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -3676,6 +3676,7 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   </fieldset>
                 </CheckboxGroup>
                 <TextareaField
+                  characterLimitTopRight={false}
                   disabled={false}
                   errorMessage={null}
                   label="Provide context and instructions for this action"

--- a/client/test/app/queue/components/__snapshots__/CavcReviewExtensionRequestModal.test.js.snap
+++ b/client/test/app/queue/components/__snapshots__/CavcReviewExtensionRequestModal.test.js.snap
@@ -205,6 +205,7 @@ exports[`CavcReviewExtensionRequestModal renders correctly 1`] = `
                 </fieldset>
               </RadioField>
               <TextareaField
+                characterLimitTopRight={false}
                 disabled={false}
                 errorMessage={null}
                 label="Provide context and instructions for this action"


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-499

### Description
- Write a new component `UnscheduledNotes.jsx`
- Modify `TextareaField` to display character count on top right
- Write a storybook component for UnscheduledNotes

### Acceptance Criteria
- [x] Text area with "Notes" label
- [x] "x Characters Left" counter above right corner of text area
   - [x] Visible only if starts with value or user has typed something in
   - [x] Prevents continued typing when limit is reached
 
 - [x] Last updated by <CSS_ID> on <MM/DD/YYYY>" below text area
    - [x] Hidden if adding notes for the first time

### Testing Plan
1. run `make storybook`
2. find the component `Unscheduled Notes` under Hearings/Components

### User Facing Changes
<img width="492" alt="Screen Shot 2021-04-13 at 11 09 23 PM" src="https://user-images.githubusercontent.com/20735998/114648722-4a9cd700-9cad-11eb-9957-c5267d2950f6.png">

### Storybook Story
*For Frontend (Presentationa) Components*
* [x] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [x] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [x] Write a separate story (within the same file) for each discrete variation of the component
