### PR TITLE
Add foreign keys for cavc_remands table (Phase 4)

### DIFF
--- a/db/migrate/20210416191939_add_foreign_keys_to_cavc_remands_table.rb
+++ b/db/migrate/20210416191939_add_foreign_keys_to_cavc_remands_table.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddForeignKeysToCavcRemandsTable < Caseflow::Migration
+  def change
+    add_foreign_key "cavc_remands", "appeals", column: "remand_appeal_id", validate: false
+    add_foreign_key "cavc_remands", "appeals", column: "source_appeal_id", validate: false
+  end
+end

--- a/db/migrate/20210416192302_validate_new_foreign_keys_on_cavc_remands_table.rb
+++ b/db/migrate/20210416192302_validate_new_foreign_keys_on_cavc_remands_table.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class ValidateNewForeignKeysOnCavcRemandsTable < Caseflow::Migration
+  def change
+    validate_foreign_key "cavc_remands", column: "remand_appeal_id"
+    validate_foreign_key "cavc_remands", column: "source_appeal_id"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_13_192533) do
+ActiveRecord::Schema.define(version: 2021_04_16_192302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1635,6 +1635,8 @@ ActiveRecord::Schema.define(version: 2021_04_13_192533) do
   add_foreign_key "appellant_substitutions", "appeals", column: "source_appeal_id"
   add_foreign_key "appellant_substitutions", "appeals", column: "target_appeal_id"
   add_foreign_key "appellant_substitutions", "users", column: "created_by_id"
+  add_foreign_key "cavc_remands", "appeals", column: "remand_appeal_id"
+  add_foreign_key "cavc_remands", "appeals", column: "source_appeal_id"
   add_foreign_key "cavc_remands", "users", column: "created_by_id"
   add_foreign_key "cavc_remands", "users", column: "updated_by_id"
   add_foreign_key "certifications", "users"


### PR DESCRIPTION
Bumps #14732
* This is phase 4 of a [multi-phase plan](https://hackmd.io/wum2LtUfSHC-1o6-peBseQ) to add missing foreign keys.
* Phase 3 PR #16120.
* Phase 2 PR #16114.
* Phase 1 PR #16034 has more details.

### Description
Add foreign keys to source and remand appeals for the `cavc_remands` table. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
```ruby
CavcRemand.includes(:remand_appeal).where.not(remand_appeal_id: nil).select{|r| r.remand_appeal == nil}.count
=>0

CavcRemand.includes(:source_appeal).where.not(source_appeal_id: nil).select{|r| r.source_appeal == nil}.count
=>0
```

Also check records in UAT as well.

### Database Changes

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR