### PR TITLE
capture RecipientIsDeceasedVeteran when sending emails in the CreateConferenceJob

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -84,7 +84,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     begin
       send_emails(email_type) if virtual_hearing.active?
     rescue StandardError => error
-      capture_exception(error: error)
+      Raven.capture_exception(error: error, extra: { virtual_hearing_id: virtual_hearing.id, email_type: email_type })
     end
 
     if virtual_hearing.can_be_established?
@@ -215,7 +215,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
         alias_with_host: link_service.alias_with_host
       )
     rescue StandardError => error
-      capture_exception(error: error)
+      Raven.capture_exception(error: error)
       raise VirtualHearingLinkGenerationFailed
     end
   end

--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -81,7 +81,11 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     create_conference unless virtual_hearing.active?
 
     # when a conference has been created and emails sent, the virtual hearing can be established
-    send_emails(email_type) if virtual_hearing.active?
+    begin
+      send_emails(email_type) if virtual_hearing.active?
+    rescue StandardError => error
+      capture_exception(error: error)
+    end
 
     if virtual_hearing.can_be_established?
       Rails.logger.info("Attempting to flag virtual hearing establishment as processed...")


### PR DESCRIPTION
### Description
Capture VirtualHearings::SendEmail::RecipientIsDeceasedVeteran and other errors when sending emails from the CreateConferenceJob. This will allow the process to continue and route RecipientIsDeceasedVeteran errors to the correct Slack channel.
