### PR TITLE
Return correct type for known representatives

### DIFF
--- a/app/models/attorney_power_of_attorney.rb
+++ b/app/models/attorney_power_of_attorney.rb
@@ -17,7 +17,9 @@ class AttorneyPowerOfAttorney
   end
 
   def representative_type
-    "Attorney"
+    # See the BgsAttorney factory for record_type values as seen in the wild.
+    # We remove "POA" prefix to be consistent with BgsPowerOfAttorney#representative_type
+    bgs_attorney.record_type.delete_prefix("POA ")
   end
 
   def bgs_attorney

--- a/spec/models/other_claimant_spec.rb
+++ b/spec/models/other_claimant_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe OtherClaimant, :postgres do
+  let(:claimant) { create(:claimant, type: "OtherClaimant") }
+
   describe "#save_unrecognized_details!" do
-    let(:claimant) { create(:claimant, type: "OtherClaimant") }
     let(:first_name) { "John" }
     let(:last_name) { nil }
     let(:name) { nil }
@@ -111,6 +112,19 @@ describe OtherClaimant, :postgres do
           expect(subject.power_of_attorney.address).to_not be_nil
         end
       end
+    end
+  end
+
+  describe "#representative_type" do
+    let(:atty) { create(:bgs_attorney, record_type: "POA Agent") }
+    let!(:unrecognized_appellant) do
+      create(:unrecognized_appellant, claimant: claimant, poa_participant_id: atty.participant_id)
+    end
+
+    subject { claimant.representative_type }
+
+    it "returns the correct type for a known representative" do
+      expect(subject).to eq("Agent")
     end
   end
 end


### PR DESCRIPTION
Resolves [CASEFLOW-1402](https://vajira.max.gov/browse/CASEFLOW-1402)

### Description
This PR fixes `OtherClaimant#representative_type` when the rep is known in BGS.

### Testing Plan
1. Added new unit test