### PR TITLE
Add/edit unscheduled hearing notes in Case Details

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -158,4 +158,8 @@ class WorkQueue::TaskSerializer
   attribute :can_move_on_docket_switch do |object|
     object.try(:can_move_on_docket_switch?)
   end
+
+  attribute :unscheduled_hearing_notes do |object|
+    object.try(:unscheduled_hearing_notes)
+  end
 end

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -75,7 +75,7 @@ class HearingTask < Task
 
     {
       updated_at: last_version&.created_at,
-      updated_by_css_id: User.find_by(id: last_version&.whodunnit).first&.css_id,
+      updated_by_css_id: User.find_by(id: last_version&.whodunnit)&.css_id,
       notes: instructions&.first
     }
   end

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -71,11 +71,9 @@ class HearingTask < Task
     last_version =
       versions.sort_by(&:created_at).reverse.detect { |v| v&.changeset&.keys&.include?("instructions") }
 
-    return if last_version.nil?
-
     {
-      updated_at: last_version.created_at,
-      updated_by_css_id: User.find(last_version.whodunnit).css_id,
+      updated_at: last_version&.created_at,
+      updated_by_css_id: User.where(id: last_version&.whodunnit).first&.css_id,
       notes: instructions&.first
     }
   end
@@ -90,7 +88,7 @@ class HearingTask < Task
     if payload_values&.[](:notes).present?
       update_notes_as_instructions(payload_values[:notes])
 
-      [self]
+      [self] + self.children
     else
       super(params, current_user)
     end

--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -69,11 +69,13 @@ class HearingTask < Task
 
   def unscheduled_hearing_notes
     last_version =
-      versions.sort_by(&:created_at).reverse.detect { |v| v&.changeset&.keys&.include?("instructions") }
+      versions.sort_by(&:created_at).reverse.detect do |version|
+        version&.changeset&.keys&.include?("instructions")
+      end
 
     {
       updated_at: last_version&.created_at,
-      updated_by_css_id: User.where(id: last_version&.whodunnit).first&.css_id,
+      updated_by_css_id: User.find_by(id: last_version&.whodunnit).first&.css_id,
       notes: instructions&.first
     }
   end
@@ -88,7 +90,7 @@ class HearingTask < Task
     if payload_values&.[](:notes).present?
       update_notes_as_instructions(payload_values[:notes])
 
-      [self] + self.children
+      [self] + children
     else
       super(params, current_user)
     end

--- a/app/serializers/hearings/appeal_hearing_serializer.rb
+++ b/app/serializers/hearings/appeal_hearing_serializer.rb
@@ -17,4 +17,5 @@ class AppealHearingSerializer
   attribute :viewed_by_judge do |hearing|
     !hearing.hearing_views.empty?
   end
+  attribute :created_at
 end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -99,7 +99,7 @@
   "CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY": "View VLJ Hearing Worksheet",
   "CASE_DETAILS_HEARING_DETAILS_LINK_COPY": "View Hearing Details",
   "CASE_DETAILS_HEARING_WORKSHEET_LINK_TOOLTIP": "This link opens a PDF copy of the Hearing Worksheet",
-  "CASE_DETAILS_HEARING_LIST_LABEL": "Hearings (Oldest to Newest)",
+  "CASE_DETAILS_HEARING_LIST_LABEL": "Hearings (Newest to Oldest)",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL": "This Post Remand data has hearing data associated with a previous original appeal.",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_LINK": "View all cases",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_POST_LINK": " to see other cases associated with this Veteran.",
@@ -1073,5 +1073,10 @@
 
   "PRIORITY_PUSH_WARNING_MESSAGE": "Some cases are ready to distribute but could not be. This could be due to the tied judge being an acting judge or an attorney (`!user.judge_in_vacols?`). These will be handled manually by the board. The tied judge could also have priority distribution turned off and should not be pushed cases (`JudgeTeam.for_judge(user).accepts_priority_pushed_cases?`). There could also be a duplicate distributed case blocking distribution (`DistributedCase.find_by(case_id: case_id`) or our validations for redistributing legacy appeals failed (https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/services/redistributed_case.rb#L26)",
 
-  "INVALID_IHP_DRAFT_PATH": "Path to IHP is invalid. This path should be of the format '\\\\vacoappbva3.dva.va.gov\\DMDI$\\VBMS Paperless IHPs\\VSO\\902\\VetName 12345.pdf' for legacy appeals and '\\\\vacoappbva3.dva.va.gov\\DMDI$\\VBMS Paperless IHPs\\VSO\\AMA IHPs\\VetName 12345.pdf' for AMA appeals. Hold SHIFT and right click the file to copy the path to the drafted IHP."
+  "INVALID_IHP_DRAFT_PATH": "Path to IHP is invalid. This path should be of the format '\\\\vacoappbva3.dva.va.gov\\DMDI$\\VBMS Paperless IHPs\\VSO\\902\\VetName 12345.pdf' for legacy appeals and '\\\\vacoappbva3.dva.va.gov\\DMDI$\\VBMS Paperless IHPs\\VSO\\AMA IHPs\\VetName 12345.pdf' for AMA appeals. Hold SHIFT and right click the file to copy the path to the drafted IHP.",
+
+  "UNSCHEDULED_HEARING_TITLE": "Unscheduled hearing",
+  "SAVE_UNSCHEDULED_NOTES_SUCCESS_MESSAGE": "You updated the notes for %s’s hearing",
+  "SAVE_UNSCHEDULED_NOTES_ERROR_TITLE": "The hearing notes failed to save.",
+  "SAVE_UNSCHEDULED_NOTES_ERROR_DETAIL": "Refresh the page and try again. If the problem persists, please contact the Caseflow team via the VA Enterprise Service Desk at 855-673-4357 or by creating a ticket via YourIT."
 }

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -99,7 +99,7 @@
   "CASE_DETAILS_HEARING_WORKSHEET_LINK_COPY": "View VLJ Hearing Worksheet",
   "CASE_DETAILS_HEARING_DETAILS_LINK_COPY": "View Hearing Details",
   "CASE_DETAILS_HEARING_WORKSHEET_LINK_TOOLTIP": "This link opens a PDF copy of the Hearing Worksheet",
-  "CASE_DETAILS_HEARING_LIST_LABEL": "Hearings (Newest to Oldest)",
+  "CASE_DETAILS_HEARING_LIST_LABEL": "Scheduled Hearings (Newest to Oldest)",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL": "This Post Remand data has hearing data associated with a previous original appeal.",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_LINK": "View all cases",
   "CASE_DETAILS_HEARING_ON_OTHER_APPEAL_POST_LINK": " to see other cases associated with this Veteran.",

--- a/client/app/hearings/components/EditUnscheduledNotesModal.jsx
+++ b/client/app/hearings/components/EditUnscheduledNotesModal.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { sprintf } from 'sprintf-js';
-import { get } from 'lodash';
 
 import COPY from '../../../COPY';
 import { onReceiveAmaTasks } from '../../queue/QueueActions';
@@ -23,7 +22,6 @@ export const EditUnscheduledNotesModal = ({
   const [loading, setLoading] = useState(false);
   const [unscheduledNotes, setUnscheduledNotes] = useState(task?.unscheduledHearingNotes?.notes);
 
-  console.log(task)
   const submit = async () => {
     try {
       const data = {
@@ -51,12 +49,15 @@ export const EditUnscheduledNotesModal = ({
       const error = {
         title: COPY.SAVE_UNSCHEDULED_NOTES_ERROR_TITLE,
         detail: COPY.SAVE_UNSCHEDULED_NOTES_ERROR_DETAIL
-      }
+      };
+
       props.showErrorMessage(error);
     } finally {
       setLoading(false);
-      onCancel(); // close the modal
-      window.scrollTo(0, 0); // Focus the top of the page to display alert
+      // close the modal
+      onCancel();
+      // Focus the top of the page to display alert
+      window.scrollTo(0, 0);
     }
   };
 
@@ -76,7 +77,7 @@ export const EditUnscheduledNotesModal = ({
       />
     </Modal>
   );
-}
+};
 
 EditUnscheduledNotesModal.propTypes = {
   task: PropTypes.object,
@@ -85,7 +86,7 @@ EditUnscheduledNotesModal.propTypes = {
   onReceiveAmaTasks: PropTypes.func,
   showErrorMessage: PropTypes.func,
   showSuccessMessage: PropTypes.func
-}
+};
 
 const mapDispatchToProps = (dispatch) =>
   bindActionCreators(
@@ -97,4 +98,4 @@ const mapDispatchToProps = (dispatch) =>
     dispatch
   );
 
-export default connect(null, mapDispatchToProps)(EditUnscheduledNotesModal)
+export default connect(null, mapDispatchToProps)(EditUnscheduledNotesModal);

--- a/client/app/hearings/components/EditUnscheduledNotesModal.jsx
+++ b/client/app/hearings/components/EditUnscheduledNotesModal.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
+import { sprintf } from 'sprintf-js';
+import { get } from 'lodash';
+
+import COPY from '../../../COPY';
+import { onReceiveAmaTasks } from '../../queue/QueueActions';
+import { showErrorMessage, showSuccessMessage } from '../../queue/uiReducer/uiActions';
+
+import ApiUtil from '../../util/ApiUtil';
+import Modal from '../../components/Modal';
+import Button from '../../components/Button';
+import { UnscheduledNotes } from './UnscheduledNotes';
+
+export const EditUnscheduledNotesModal = ({
+  task,
+  appeal,
+  onCancel,
+  ...props
+}) => {
+  const [loading, setLoading] = useState(false);
+  const [unscheduledNotes, setUnscheduledNotes] = useState(task?.unscheduledHearingNotes?.notes);
+
+  console.log(task)
+  const submit = async () => {
+    try {
+      const data = {
+        task: {
+          business_payloads: {
+            values: {
+              notes: unscheduledNotes
+            }
+          }
+        }
+      };
+
+      setLoading(true);
+      // Add the google analytics event
+      window.analyticsEvent('Hearings', 'Add/edit notes', 'Case Details');
+
+      await ApiUtil.patch(`/tasks/${task.taskId}`, { data }).then((resp) => {
+        props.onReceiveAmaTasks(resp.body.tasks.data);
+        props.showSuccessMessage({
+          title: sprintf(COPY.SAVE_UNSCHEDULED_NOTES_SUCCESS_MESSAGE, appeal?.veteranFullName),
+          detail: null
+        });
+      });
+    } catch (err) {
+      const error = {
+        title: COPY.SAVE_UNSCHEDULED_NOTES_ERROR_TITLE,
+        detail: COPY.SAVE_UNSCHEDULED_NOTES_ERROR_DETAIL
+      }
+      props.showErrorMessage(error);
+    } finally {
+      setLoading(false);
+      onCancel(); // close the modal
+      window.scrollTo(0, 0); // Focus the top of the page to display alert
+    }
+  };
+
+  return (
+    <Modal
+      title="Edit Notes"
+      closeHandler={onCancel}
+      confirmButton={<Button disabled={loading} onClick={submit}>Save</Button>}
+      cancelButton={<Button linkStyling disabled={loading} onClick={onCancel}>Cancel</Button>}
+    >
+      <UnscheduledNotes
+        onChange={(notes) => setUnscheduledNotes(notes)}
+        unscheduledNotes={unscheduledNotes}
+        updatedAt={task?.unscheduledHearingNotes?.updatedAt}
+        updatedByCssId={task?.unscheduledHearingNotes?.updatedByCssId}
+        uniqueId={task?.taskId}
+      />
+    </Modal>
+  );
+}
+
+EditUnscheduledNotesModal.propTypes = {
+  task: PropTypes.object,
+  appeal: PropTypes.object,
+  onCancel: PropTypes.func,
+  onReceiveAmaTasks: PropTypes.func,
+  showErrorMessage: PropTypes.func,
+  showSuccessMessage: PropTypes.func
+}
+
+const mapDispatchToProps = (dispatch) =>
+  bindActionCreators(
+    {
+      onReceiveAmaTasks,
+      showErrorMessage,
+      showSuccessMessage
+    },
+    dispatch
+  );
+
+export default connect(null, mapDispatchToProps)(EditUnscheduledNotesModal)

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -14,7 +14,10 @@ import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import COPY from '../../../COPY';
 import HEARING_DISPOSITION_TYPES from '../../../constants/HEARING_DISPOSITION_TYPES';
 import { CENTRAL_OFFICE_HEARING_LABEL, VIDEO_HEARING_LABEL, VIRTUAL_HEARING_LABEL } from '../constants';
-import { appealWithDetailSelector, scheduleHearingTasksForAppeal } from '../../queue/selectors';
+import {
+  appealWithDetailSelector,
+  openScheduleHearingTasksForAppeal
+} from '../../queue/selectors';
 import { showSuccessMessage, showErrorMessage, requestPatch } from '../../queue/uiReducer/uiActions';
 import { onReceiveAppealDetails } from '../../queue/QueueActions';
 import { formatDateStr } from '../../util/DateUtil';
@@ -471,7 +474,7 @@ const mapStateToProps = (state, ownProps) => ({
   scheduledHearingsList: state.components.scheduledHearingsList,
   fetchingHearings: state.components.fetchingHearings,
   scheduledHearing: state.components.scheduledHearing,
-  scheduleHearingTask: scheduleHearingTasksForAppeal(state, {
+  scheduleHearingTask: openScheduleHearingTasksForAppeal(state, {
     appealId: ownProps.appealId,
   })[0],
   openHearing: find(

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -18,6 +18,7 @@ import {
   appealWithDetailSelector,
   openScheduleHearingTasksForAppeal
 } from '../../queue/selectors';
+import { prepareAppealForStore } from '../../queue/utils';
 import { showSuccessMessage, showErrorMessage, requestPatch } from '../../queue/uiReducer/uiActions';
 import { onReceiveAppealDetails } from '../../queue/QueueActions';
 import { formatDateStr } from '../../util/DateUtil';
@@ -325,6 +326,11 @@ export const ScheduleVeteran = ({
         });
       }
     } finally {
+      // Reload the appeal so updated hearing details display
+      const response = await ApiUtil.get(`/appeals/${props.appealId}`);
+
+      props.onReceiveAppealDetails(prepareAppealForStore([response?.body?.appeal]));
+
       // Clear the loading state
       setLoading(false);
     }

--- a/client/app/hearings/components/ScheduleVeteran.jsx
+++ b/client/app/hearings/components/ScheduleVeteran.jsx
@@ -18,7 +18,6 @@ import {
   appealWithDetailSelector,
   openScheduleHearingTasksForAppeal
 } from '../../queue/selectors';
-import { prepareAppealForStore } from '../../queue/utils';
 import { showSuccessMessage, showErrorMessage, requestPatch } from '../../queue/uiReducer/uiActions';
 import { onReceiveAppealDetails } from '../../queue/QueueActions';
 import { formatDateStr } from '../../util/DateUtil';
@@ -326,11 +325,6 @@ export const ScheduleVeteran = ({
         });
       }
     } finally {
-      // Reload the appeal so updated hearing details display
-      const response = await ApiUtil.get(`/appeals/${props.appealId}`);
-
-      props.onReceiveAppealDetails(prepareAppealForStore([response?.body?.appeal]));
-
       // Clear the loading state
       setLoading(false);
     }

--- a/client/app/hearings/components/UnscheduledNotes.jsx
+++ b/client/app/hearings/components/UnscheduledNotes.jsx
@@ -12,27 +12,31 @@ export const UnscheduledNotes = ({
   updatedAt,
   onChange,
   uniqueId,
-  unscheduledNotes
+  unscheduledNotes,
+  readonly,
+  styling
 }) => {
   return (
-    <React.Fragment>
-      <TextareaField
-        maxlength={1000}
-        label="Notes"
-        name={`${uniqueId}-unscheduled-notes`}
-        strongLabel
-        onChange={(notes) => onChange(notes)}
-        labelStyling={css({ float: 'left' })}
-        styling={css({ marginBottom: 1 })}
-        value={unscheduledNotes ?? ''}
-        characterLimitTopRight
-      />
+    <div style={styling}>
+      {(readonly && unscheduledNotes) ?
+        <React.Fragment><span>{unscheduledNotes}</span> <br /></React.Fragment> :
+        <TextareaField
+          maxlength={1000}
+          label="Notes"
+          name={`${uniqueId}-unscheduled-notes`}
+          strongLabel
+          onChange={(notes) => onChange(notes)}
+          labelStyling={css({ float: 'left' })}
+          styling={css({ marginBottom: 1 })}
+          value={unscheduledNotes ?? ''}
+          characterLimitTopRight
+        />}
       {updatedByCssId && updatedAt && unscheduledNotes &&
         <span style={{ color: COLORS.GREY }}>
           {`Last updated by ${updatedByCssId} on ${moment(updatedAt).format('MM/DD/YYYY')}`}
         </span>
       }
-    </React.Fragment>
+    </div>
   );
 };
 
@@ -41,5 +45,7 @@ UnscheduledNotes.propTypes = {
   updatedAt: PropTypes.string,
   unscheduledNotes: PropTypes.string,
   onChange: PropTypes.func,
-  uniqueId: PropTypes.number
+  uniqueId: PropTypes.number,
+  readonly: PropTypes.bool,
+  styling: PropTypes.object
 };

--- a/client/app/hearings/components/UnscheduledNotes.jsx
+++ b/client/app/hearings/components/UnscheduledNotes.jsx
@@ -45,7 +45,7 @@ UnscheduledNotes.propTypes = {
   updatedAt: PropTypes.string,
   unscheduledNotes: PropTypes.string,
   onChange: PropTypes.func,
-  uniqueId: PropTypes.number,
+  uniqueId: PropTypes.string,
   readonly: PropTypes.bool,
   styling: PropTypes.object
 };

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -9,13 +9,19 @@ import _ from 'lodash';
 
 import { CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
-import { appealWithDetailSelector, getAllTasksForAppeal, hearingTasksForAppeal } from './selectors';
+import {
+  appealWithDetailSelector,
+  getAllTasksForAppeal,
+  scheduleHearingTasksForAppeal,
+  hearingTasksForAppeal
+} from './selectors';
 import {
   stopPollingHearing,
   transitionAlert,
   clearAlerts,
 } from '../components/common/actions';
 import { getQueryParams } from '../util/QueryParamsUtil';
+import { parentTasks } from './utils';
 import { needsPulacCerulloAlert } from './pulacCerullo';
 import {
   resetErrorMessages,
@@ -137,9 +143,13 @@ export const CaseDetailsView = (props) => {
   const showPostDispatch =
     appealIsDispached && (supportCavcRemand || supportSubstituteAppellant);
 
-  const openHearingTasks = useSelector(
+  const openScheduledHearingTasks = useSelector(
+    (state) => scheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
+  );
+  const allHearingTasks = useSelector(
     (state) => hearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
+  const parentHearingTasks = parentTasks(openScheduledHearingTasks, allHearingTasks);
 
   return (
     <React.Fragment>
@@ -208,8 +218,8 @@ export const CaseDetailsView = (props) => {
           />
           {(appeal.hearings.length ||
             appeal.completedHearingOnPreviousAppeal ||
-            openHearingTasks.length) && (
-            <CaseHearingsDetail title="Hearings" appeal={appeal} tasks={openHearingTasks} />
+            openScheduledHearingTasks.length) && (
+            <CaseHearingsDetail title="Hearings" appeal={appeal} hearingTasks={parentHearingTasks} />
           )}
           <VeteranDetail title="About the Veteran" appealId={appealId} />
           {!_.isNull(appeal.appellantFullName) &&

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -12,8 +12,8 @@ import { COLORS } from '../constants/AppConstants';
 import {
   appealWithDetailSelector,
   getAllTasksForAppeal,
-  scheduleHearingTasksForAppeal,
-  hearingTasksForAppeal
+  openScheduleHearingTasksForAppeal,
+  allHearingTasksForAppeal
 } from './selectors';
 import {
   stopPollingHearing,
@@ -144,10 +144,10 @@ export const CaseDetailsView = (props) => {
     appealIsDispached && (supportCavcRemand || supportSubstituteAppellant);
 
   const openScheduledHearingTasks = useSelector(
-    (state) => scheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
+    (state) => openScheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
   const allHearingTasks = useSelector(
-    (state) => hearingTasksForAppeal(state, { appealId: appeal.externalId })
+    (state) => allHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
   const parentHearingTasks = parentTasks(openScheduledHearingTasks, allHearingTasks);
 

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -9,7 +9,7 @@ import _ from 'lodash';
 
 import { CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
-import { appealWithDetailSelector, getAllTasksForAppeal } from './selectors';
+import { appealWithDetailSelector, getAllTasksForAppeal, hearingTasksForAppeal } from './selectors';
 import {
   stopPollingHearing,
   transitionAlert,
@@ -137,6 +137,10 @@ export const CaseDetailsView = (props) => {
   const showPostDispatch =
     appealIsDispached && (supportCavcRemand || supportSubstituteAppellant);
 
+  const openHearingTasks = useSelector(
+    (state) => hearingTasksForAppeal(state, { appealId: appeal.externalId })
+  );
+
   return (
     <React.Fragment>
       {!modalIsOpen && error && (
@@ -203,8 +207,9 @@ export const CaseDetailsView = (props) => {
             appealId={appealId}
           />
           {(appeal.hearings.length ||
-            appeal.completedHearingOnPreviousAppeal) && (
-            <CaseHearingsDetail title="Hearings" appeal={appeal} />
+            appeal.completedHearingOnPreviousAppeal ||
+            openHearingTasks.length) && (
+            <CaseHearingsDetail title="Hearings" appeal={appeal} tasks={openHearingTasks} />
           )}
           <VeteranDetail title="About the Veteran" appealId={appealId} />
           {!_.isNull(appeal.appellantFullName) &&

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -190,13 +190,13 @@ class CaseHearingsDetail extends React.PureComponent {
   getUnscheduledHearingElements = () => {
     const {
       appeal,
-      tasks
+      hearingTasks
     } = this.props;
 
-    return tasks.map((task, index) => <div
-      key={task.id} {...hearingsListStyling} {...css({ marginTop: '1em' })}
+    return hearingTasks.map((task, index) => <div
+      key={task.taskId} {...hearingsListStyling} {...css({ marginTop: '1em' })}
     >
-      <span {...boldText}>{COPY.UNSCHEDULED_HEARING_TITLE}{tasks.length > 1 ?
+      <span {...boldText}>{COPY.UNSCHEDULED_HEARING_TITLE}{hearingTasks.length > 1 ?
         ` ${index + 1}` : ''}:</span>
       <BareList compact
         listStyle={css(marginLeft, noTopBottomMargin)}
@@ -212,7 +212,7 @@ class CaseHearingsDetail extends React.PureComponent {
         hearings,
         completedHearingOnPreviousAppeal,
       },
-      tasks
+      hearingTasks
     } = this.props;
 
     const hearingsListElements = [{
@@ -231,7 +231,7 @@ class CaseHearingsDetail extends React.PureComponent {
             {COPY.CASE_DETAILS_HEARING_ON_OTHER_APPEAL_POST_LINK}
           </React.Fragment>
         }
-        {!_.isEmpty(tasks) && this.getUnscheduledHearingElements()}
+        {!_.isEmpty(hearingTasks) && this.getUnscheduledHearingElements()}
         {!_.isEmpty(hearings) &&
           <BareList
             ListElementComponent="ul"
@@ -265,7 +265,7 @@ CaseHearingsDetail.propTypes = {
   }),
   showVeteranCaseList: PropTypes.func,
   userIsVsoEmployee: PropTypes.bool,
-  tasks: PropTypes.array
+  hearingTasks: PropTypes.array
 };
 
 const mapStateToProps = (state) => {

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -117,18 +117,19 @@ class CaseHearingsDetail extends React.PureComponent {
       appeal: { hearings },
       userIsVsoEmployee
     } = this.props;
-    const orderedHearings = _.orderBy(hearings, 'date', 'desc');
+    const orderedHearings = _.orderBy(hearings, 'createdAt', 'desc');
     const uniqueOrderedHearings = _.uniqWith(orderedHearings, _.isEqual);
 
     if (orderedHearings.length > 1) {
       _.extend(hearingElementsStyle, marginLeft);
     }
 
+    const hearingsLength = uniqueOrderedHearings.length;
     const hearingElements = _.map(uniqueOrderedHearings, (hearing) => <div
       key={hearing.externalId} {...hearingElementsStyle}
     >
-      <span {...boldText}>Hearing{uniqueOrderedHearings.length > 1 ?
-        ` ${uniqueOrderedHearings.indexOf(hearing) + 1}` : ''}:</span>
+      <span {...boldText}>Hearing{hearingsLength > 1 ?
+        ` ${hearingsLength - (uniqueOrderedHearings.indexOf(hearing))}` : ''}:</span>
       <BareList compact
         listStyle={css(marginLeft, noTopBottomMargin)}
         ListElementComponent="ul"

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -171,7 +171,7 @@ class CaseHearingsDetail extends React.PureComponent {
         value: <React.Fragment>
           <Button styling={css({ padding: 0 })} linkStyling onClick={() => this.openModal(task)} >
             <span {...css({ position: 'absolute' })}>{pencilSymbol()}</span>
-            <span {...css({ marginLeft: '20px' })}>Edit</span>
+            <span {...css({ marginLeft: '24px' })}>Edit</span>
           </Button>
           <br />
           {task?.unscheduledHearingNotes?.notes && <UnscheduledNotes

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -222,7 +222,7 @@ class CaseHearingsDetail extends React.PureComponent {
     }];
 
     return (
-      <React.Fragment>
+      <div id="hearing-details">
         {caseType === LEGACY_APPEAL_TYPES.POST_REMAND && completedHearingOnPreviousAppeal &&
           <React.Fragment>
             {COPY.CASE_DETAILS_HEARING_ON_OTHER_APPEAL}&nbsp;
@@ -247,7 +247,7 @@ class CaseHearingsDetail extends React.PureComponent {
             onCancel={this.closeModal}
           />
         }
-      </React.Fragment>
+      </div>
     );
   };
 }

--- a/client/app/queue/components/AssignHearingModal.jsx
+++ b/client/app/queue/components/AssignHearingModal.jsx
@@ -10,7 +10,7 @@ import _ from 'lodash';
 import { CENTRAL_OFFICE_HEARING_LABEL, VIDEO_HEARING_LABEL } from '../../hearings/constants';
 import {
   appealWithDetailSelector,
-  scheduleHearingTasksForAppeal
+  openScheduleHearingTasksForAppeal
 } from '../selectors';
 import { formatDateStr } from '../../util/DateUtil';
 import { fullWidth } from '../constants';
@@ -267,7 +267,7 @@ AssignHearingModal.propTypes = {
 };
 
 const mapStateToProps = (state, ownProps) => ({
-  scheduleHearingTask: scheduleHearingTasksForAppeal(state, { appealId: ownProps.appealId })[0],
+  scheduleHearingTask: openScheduleHearingTasksForAppeal(state, { appealId: ownProps.appealId })[0],
   openHearing: _.find(
     appealWithDetailSelector(state, ownProps).hearings,
     (hearing) => hearing.disposition === null

--- a/client/app/queue/components/PostponeHearingModal.jsx
+++ b/client/app/queue/components/PostponeHearingModal.jsx
@@ -6,12 +6,14 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
-import { onReceiveAmaTasks } from '../QueueActions';
+import { onReceiveAmaTasks, onReceiveAppealDetails } from '../QueueActions';
 import { requestPatch, showErrorMessage } from '../uiReducer/uiActions';
 import QueueFlowModal from './QueueFlowModal';
-import { taskActionData } from '../utils';
+import { taskActionData, prepareAppealForStore } from '../utils';
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import { setScheduledHearing } from '../../components/common/actions';
+
+import ApiUtil from '../../util/ApiUtil';
 
 import RadioField from '../../components/RadioField';
 import AssignHearingForm from '../../hearings/components/modalForms/AssignHearingForm';
@@ -205,6 +207,10 @@ class PostponeHearingModal extends React.Component {
         (resp) => {
           this.setState({ isPosting: false });
           this.props.onReceiveAmaTasks(resp.body.tasks.data);
+          // Reload the appeal so updated hearing details display
+          ApiUtil.get(`/appeals/${this.props.appealId}`).then((response) => {
+            this.props.onReceiveAppealDetails(prepareAppealForStore([response?.body?.appeal]));
+          });
         },
         () => {
           this.setState({ isPosting: false });
@@ -270,6 +276,7 @@ PostponeHearingModal.propTypes = {
     externalId: PropTypes.string,
     veteranFullName: PropTypes.string,
   }),
+  appealId: PropTypes.string,
   assignHearing: PropTypes.shape({
     apiFormattedValues: PropTypes.shape({
       scheduled_time_string: PropTypes.string,
@@ -299,7 +306,8 @@ PostponeHearingModal.propTypes = {
   task: PropTypes.shape({
     taskId: PropTypes.string,
   }),
-  userCanScheduleVirtualHearings: PropTypes.bool
+  userCanScheduleVirtualHearings: PropTypes.bool,
+  onReceiveAppealDetails: PropTypes.func,
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -316,7 +324,8 @@ const mapDispatchToProps = (dispatch) =>
       setScheduledHearing,
       requestPatch,
       onReceiveAmaTasks,
-      showErrorMessage
+      showErrorMessage,
+      onReceiveAppealDetails
     },
     dispatch
   );

--- a/client/app/queue/components/PostponeHearingModal.jsx
+++ b/client/app/queue/components/PostponeHearingModal.jsx
@@ -6,14 +6,12 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 
 import { taskById, appealWithDetailSelector } from '../selectors';
-import { onReceiveAmaTasks, onReceiveAppealDetails } from '../QueueActions';
+import { onReceiveAmaTasks } from '../QueueActions';
 import { requestPatch, showErrorMessage } from '../uiReducer/uiActions';
 import QueueFlowModal from './QueueFlowModal';
-import { taskActionData, prepareAppealForStore } from '../utils';
+import { taskActionData } from '../utils';
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
 import { setScheduledHearing } from '../../components/common/actions';
-
-import ApiUtil from '../../util/ApiUtil';
 
 import RadioField from '../../components/RadioField';
 import AssignHearingForm from '../../hearings/components/modalForms/AssignHearingForm';
@@ -207,10 +205,6 @@ class PostponeHearingModal extends React.Component {
         (resp) => {
           this.setState({ isPosting: false });
           this.props.onReceiveAmaTasks(resp.body.tasks.data);
-          // Reload the appeal so updated hearing details display
-          ApiUtil.get(`/appeals/${this.props.appealId}`).then((response) => {
-            this.props.onReceiveAppealDetails(prepareAppealForStore([response?.body?.appeal]));
-          });
         },
         () => {
           this.setState({ isPosting: false });
@@ -276,7 +270,6 @@ PostponeHearingModal.propTypes = {
     externalId: PropTypes.string,
     veteranFullName: PropTypes.string,
   }),
-  appealId: PropTypes.string,
   assignHearing: PropTypes.shape({
     apiFormattedValues: PropTypes.shape({
       scheduled_time_string: PropTypes.string,
@@ -306,8 +299,7 @@ PostponeHearingModal.propTypes = {
   task: PropTypes.shape({
     taskId: PropTypes.string,
   }),
-  userCanScheduleVirtualHearings: PropTypes.bool,
-  onReceiveAppealDetails: PropTypes.func,
+  userCanScheduleVirtualHearings: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => ({
@@ -324,8 +316,7 @@ const mapDispatchToProps = (dispatch) =>
       setScheduledHearing,
       requestPatch,
       onReceiveAmaTasks,
-      showErrorMessage,
-      onReceiveAppealDetails
+      showErrorMessage
     },
     dispatch
   );

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -132,12 +132,12 @@ const actionableTasksForAppeal = createSelector(
   [getAllTasksForAppeal], (tasks) => _.filter(tasks, (task) => task.availableActions.length)
 );
 
-export const scheduleHearingTasksForAppeal = createSelector(
+export const openScheduleHearingTasksForAppeal = createSelector(
   [actionableTasksForAppeal],
   (tasks) => _.filter(incompleteTasksSelector(tasks), (task) => task.type === 'ScheduleHearingTask')
 );
 
-export const hearingTasksForAppeal = createSelector(
+export const allHearingTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
   (tasks) => _.filter(tasks, (task) => task.type === 'HearingTask')
 );

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -137,6 +137,11 @@ export const scheduleHearingTasksForAppeal = createSelector(
   (tasks) => _.filter(incompleteTasksSelector(tasks), (task) => task.type === 'ScheduleHearingTask')
 );
 
+export const hearingTasksForAppeal = createSelector(
+  [getAllTasksForAppeal],
+  (tasks) => _.filter(incompleteTasksSelector(tasks), (task) => task.type === 'HearingTask')
+);
+
 export const rootTasksForAppeal = createSelector(
   [actionableTasksForAppeal], (tasks) => _.filter(tasks, (task) => task.type === 'RootTask')
 );

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -139,7 +139,7 @@ export const scheduleHearingTasksForAppeal = createSelector(
 
 export const hearingTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
-  (tasks) => _.filter(incompleteTasksSelector(tasks), (task) => task.type === 'HearingTask')
+  (tasks) => _.filter(tasks, (task) => task.type === 'HearingTask')
 );
 
 export const rootTasksForAppeal = createSelector(

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -289,7 +289,8 @@ export const prepareAppealHearingsForStore = (appeal) =>
     externalId: hearing.external_id,
     disposition: hearing.disposition,
     isVirtual: hearing.is_virtual,
-    notes: hearing.notes
+    notes: hearing.notes,
+    createdAt: hearing.created_at
   }));
 
 const prepareAppealAvailableHearingLocationsForStore = (appeal) =>

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -134,7 +134,12 @@ const taskAttributesFromRawTask = (task) => {
       requestedAt: task.attributes.latest_informal_hearing_presentation_task?.requested_at,
       receivedAt: task.attributes.latest_informal_hearing_presentation_task?.received_at
     },
-    canMoveOnDocketSwitch: task.attributes.can_move_on_docket_switch
+    canMoveOnDocketSwitch: task.attributes.can_move_on_docket_switch,
+    unscheduledHearingNotes: {
+      updatedAt: task.attributes.unscheduled_hearing_notes?.updated_at,
+      updatedByCssId: task.attributes.unscheduled_hearing_notes?.updated_by_css_id,
+      notes: task.attributes.unscheduled_hearing_notes?.notes
+    }
   };
 };
 

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -628,6 +628,15 @@ export const taskActionData = ({ task, match }) => {
   return null;
 };
 
+export const parentTasks = (childrenTasks, allTasks) => {
+  const parentTaskIds = _.map(childrenTasks, 'parentId')
+  const parentTasks = parentTaskIds.map((parentId) => {
+    return _.find(allTasks, ['taskId', parentId.toString()]);
+  })
+
+  return parentTasks
+}
+
 export const nullToFalse = (key, obj) => {
   if (obj[key] === null) {
     obj[key] = false;

--- a/client/test/app/hearings/components/EditUnscheduledNotesModal.test.js
+++ b/client/test/app/hearings/components/EditUnscheduledNotesModal.test.js
@@ -1,0 +1,59 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { generateAmaTask } from 'test/data/tasks';
+import { amaAppeal } from 'test/data/appeals';
+
+import { EditUnscheduledNotesModal } from 'app/hearings/components/EditUnscheduledNotesModal';
+
+describe('EditUnscheduledNotesModal', () => {
+  const onCancel = jest.fn();
+  const hearingTask = generateAmaTask({
+    uniqueId: '3',
+    type: 'HearingTask',
+    status: 'on_hold'
+  })
+  const defaultProps = {
+    task: hearingTask,
+    appeal: amaAppeal,
+    onCancel: onCancel
+  }
+
+  it('renders correctly', () => {
+    const { container } = render(<EditUnscheduledNotesModal {...defaultProps} />);
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('passes a11y testing', async () => {
+    const { container } = render(<EditUnscheduledNotesModal {...defaultProps} />);
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('displays pre filled data', () => {
+    const maxCharLimit = 1000
+    const notes = "Pre filled notes"
+    const hearingTaskWithNotesData = {
+      ...hearingTask,
+      unscheduledHearingNotes: {
+        updatedAt: '2020-09-08T10:03:49.210-04:00',
+        updatedByCssId: 'BVASYELLOW',
+        notes: notes
+      }
+    }
+    render(
+      <EditUnscheduledNotesModal {...defaultProps} task={hearingTaskWithNotesData}/>
+    );
+
+    expect(screen.getByLabelText('Notes')).toBeInTheDocument()
+    expect(screen.getByText(notes)).toBeInTheDocument()
+    const charLimitMessage = `${maxCharLimit - notes.length} characters left`
+    expect(screen.getByText(charLimitMessage)).toBeInTheDocument()
+    expect(screen.getByText('Last updated by BVASYELLOW on 09/08/2020'))
+      .toBeInTheDocument()
+  })
+})

--- a/client/test/app/hearings/components/UnscheduledNotes.test.js
+++ b/client/test/app/hearings/components/UnscheduledNotes.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { axe } from 'jest-axe';
 import userEvent from '@testing-library/user-event';
 
@@ -49,9 +49,15 @@ describe('UnscheduledNotes', () => {
   });
 
   it('displays character limit info when notes is present', () => {
-    const container = render(<UnscheduledNotes {...defaultProps} />);
+    render(<UnscheduledNotes {...defaultProps} />);
 
     const charLimitMessage = `${maxCharLimit - inputText.length} characters left`
-    expect(container.getByText(charLimitMessage)).toBeInTheDocument()
+    expect(screen.getByText(charLimitMessage)).toBeInTheDocument()
   });
+
+  it('does not display textfield when readonly is passed as prop', () => {
+    render(<UnscheduledNotes {...defaultProps} readonly/>);
+
+    expect(screen.queryByLabelText('Notes')).not.toBeInTheDocument()
+  })
 })

--- a/client/test/app/hearings/components/__snapshots__/EditUnscheduledNotesModal.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/EditUnscheduledNotesModal.test.js.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EditUnscheduledNotesModal renders correctly 1`] = `
+<div>
+  <section
+    aria-describedby="modal_id-desc"
+    aria-labelledby="modal_id-title"
+    aria-modal="true"
+    class="cf-modal active "
+    id="modal_id"
+    role="alertdialog"
+  >
+    <div
+      class="cf-modal-body"
+      id=""
+    >
+      <button
+        class="cf-modal-close"
+        id="Edit-Notes-button-id-close"
+        type="button"
+      >
+        <span
+          class="usa-sr-only"
+        >
+          Close
+        </span>
+        <svg
+          class="cf-icon-close"
+          height="55"
+          viewBox="0 0 55 55"
+          width="55"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <title>
+            close
+          </title>
+          <path
+            d="M52.6 46.9l-6 6c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-13-13-13 13c-.8.8-1.9 1.2-3 1.2s-2.2-.4-3-1.2l-6-6c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l13-13-13-13c-.8-.8-1.2-1.9-1.2-3s.4-2.2 1.2-3l6-6c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l13 13 13-13c.8-.8 1.9-1.2 3-1.2s2.2.4 3 1.2l6 6c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3l-13 13 13 13c.8.8 1.2 1.9 1.2 3s-.4 2.2-1.2 3z"
+          />
+        </svg>
+      </button>
+      <div
+        style="display: flex;"
+      >
+        <div
+          data-css-1gs0ko2=""
+        >
+          <h1
+            id="modal_id-title"
+          >
+            Edit Notes
+          </h1>
+          <div
+            data-css-o98ubo=""
+          >
+            <div>
+              <div
+                class="cf-form-textarea"
+                data-css-jz0ijb=""
+              >
+                <label
+                  class="question-label"
+                  data-css-42cjjw=""
+                  for="null-unscheduled-notes"
+                >
+                  <strong>
+                    <span>
+                      Notes
+                    </span>
+                  </strong>
+                </label>
+                <textarea
+                  id="null-unscheduled-notes"
+                  maxlength="1000"
+                  name="null-unscheduled-notes"
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        class="cf-modal-divider"
+      />
+      <div
+        class="cf-modal-controls"
+      >
+        <div>
+          <span
+            class="cf-push-right"
+          >
+            <span>
+              <button
+                class="cf-submit usa-button"
+                type="button"
+              >
+                Save
+              </button>
+            </span>
+          </span>
+          <span
+            class="cf-push-left"
+          >
+            <span>
+              <button
+                class="cf-submit cf-btn-link usa-button"
+                type="button"
+              >
+                Cancel
+              </button>
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/client/test/app/hearings/components/__snapshots__/UnscheduledNotes.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/UnscheduledNotes.test.js.snap
@@ -2,44 +2,46 @@
 
 exports[`UnscheduledNotes renders correctly 1`] = `
 <div>
-  <div
-    class="cf-form-textarea"
-    data-css-jz0ijb=""
-  >
-    <label
-      class="question-label"
-      data-css-42cjjw=""
-      for="undefined-unscheduled-notes"
+  <div>
+    <div
+      class="cf-form-textarea"
+      data-css-jz0ijb=""
     >
-      <strong>
-        <span>
-          Notes
-        </span>
-      </strong>
-    </label>
-    <p
-      style="float: right; margin-bottom: 0px;"
+      <label
+        class="question-label"
+        data-css-42cjjw=""
+        for="undefined-unscheduled-notes"
+      >
+        <strong>
+          <span>
+            Notes
+          </span>
+        </strong>
+      </label>
+      <p
+        style="float: right; margin-bottom: 0px;"
+      >
+        <i>
+          985
+           
+          characters
+           
+          left
+        </i>
+      </p>
+      <textarea
+        id="undefined-unscheduled-notes"
+        maxlength="1000"
+        name="undefined-unscheduled-notes"
+      >
+        Type notes here
+      </textarea>
+    </div>
+    <span
+      style="color: rgb(91, 97, 107);"
     >
-      <i>
-        985
-         
-        characters
-         
-        left
-      </i>
-    </p>
-    <textarea
-      id="undefined-unscheduled-notes"
-      maxlength="1000"
-      name="undefined-unscheduled-notes"
-    >
-      Type notes here
-    </textarea>
+      Last updated by VACOUSER on 09/08/2020
+    </span>
   </div>
-  <span
-    style="color: rgb(91, 97, 107);"
-  >
-    Last updated by VACOUSER on 09/08/2020
-  </span>
 </div>
 `;

--- a/client/test/app/queue/CaseHearingsDetail.test.js
+++ b/client/test/app/queue/CaseHearingsDetail.test.js
@@ -1,0 +1,118 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { within } from '@testing-library/dom'
+
+import { generateAmaTask } from 'test/data/tasks';
+import { openHearingAppeal, amaAppealHearingData } from 'test/data/appeals';
+import { queueWrapper } from '../../data/stores/queueStore';
+import COPY from '../../../COPY.json'
+import CaseHearingsDetail from 'app/queue/CaseHearingsDetail';
+
+describe('CaseHearingDetail', () => {
+  const hearingTask = generateAmaTask({
+    taskId: '3',
+    type: 'HearingTask',
+    status: 'on_hold'
+  })
+  const defaultProps = {
+    hearingTasks: [hearingTask],
+    appeal: openHearingAppeal,
+    title: 'Hearings'
+  }
+
+  it('renders correctly', () => {
+    const { container } = render(
+      <CaseHearingsDetail {...defaultProps} />, { wrapper: queueWrapper }
+    );
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('passes a11y testing', async () => {
+    const { container } = render(
+      <CaseHearingsDetail {...defaultProps} />,
+      { wrapper: queueWrapper }
+    );
+
+    const results = await axe(container);
+
+    expect(results).toHaveNoViolations();
+  });
+
+  it('displays Unscheduled Hearings', async () => {
+    const notes = 'Prefilled notes'
+    const hearingTaskWithNotesData = {
+      ...hearingTask,
+      unscheduledHearingNotes: {
+        updatedAt: '2020-09-08T10:03:49.210-04:00',
+        updatedByCssId: 'BVASYELLOW',
+        notes: notes
+      }
+    }
+    render(
+      <CaseHearingsDetail {...defaultProps} hearingTasks={[hearingTaskWithNotesData]} />,
+      { wrapper: queueWrapper }
+    );
+
+    expect(screen.getByText(`${COPY.UNSCHEDULED_HEARING_TITLE}:`)).toBeInTheDocument()
+    expect(screen.getByText(`${COPY.UNSCHEDULED_HEARING_TITLE}:`)).toBeInTheDocument()
+
+    expect(screen.getByText('Notes:')).toBeInTheDocument()
+    expect(screen.getByText('Edit')).toBeInTheDocument()
+    expect(screen.getByText(notes)).toBeInTheDocument()
+    expect(screen.getByText('Last updated by BVASYELLOW on 09/08/2020'))
+      .toBeInTheDocument()
+  })
+
+  it('displays both Unscheduled Hearing and Scheduled Hearing', () => {
+    render(
+      <CaseHearingsDetail {...defaultProps} appeal={openHearingAppeal} />,
+      { wrapper: queueWrapper }
+    );
+
+    expect(screen.getByText(`${COPY.UNSCHEDULED_HEARING_TITLE}:`)).toBeInTheDocument()
+    expect(screen.getByText('Hearing:')).toBeInTheDocument()
+  })
+
+  it('displays multiple hearings in correct order', () => {
+    const appealWithTwoHearings = {
+      ...openHearingAppeal,
+      hearings: [
+        openHearingAppeal.hearings[0],
+        {
+          ...amaAppealHearingData,
+          date: '2020-10-07T03:30:00.000-04:00',
+          createdAt: '2020-09-07T03:30:00.000-04:00',
+          externalId: 'b5790483-f10f-4d52-b82a-2ae67a5ad4a8'
+        }
+      ]
+    }
+
+    const c = render(
+      <CaseHearingsDetail {...defaultProps} appeal={appealWithTwoHearings} />,
+      { wrapper: queueWrapper }
+    );
+
+    expect(
+      screen.getByText(`${COPY.CASE_DETAILS_HEARING_LIST_LABEL}:`)
+    ).toBeInTheDocument()
+
+    const hearingOne = screen.getByText('Hearing 2:').closest('div')
+    expect(within(hearingOne).getByText('10/7/20')).toBeInTheDocument()
+    const hearingTwo = screen.getByText('Hearing 1:').closest('div')
+    expect(within(hearingTwo).getByText('8/7/20')).toBeInTheDocument()
+  })
+
+  it('displays two Unscheduled hearing if there are two Hearing Tasks', () => {
+    render(
+      <CaseHearingsDetail
+        {...defaultProps}
+        hearingTasks={[hearingTask, generateAmaTask({...hearingTask, taskId: '4'})]} />,
+      { wrapper: queueWrapper }
+    );
+
+    expect(screen.getByText(`${COPY.UNSCHEDULED_HEARING_TITLE} 1:`)).toBeInTheDocument()
+    expect(screen.getByText(`${COPY.UNSCHEDULED_HEARING_TITLE} 2:`)).toBeInTheDocument()
+  })
+})

--- a/client/test/app/queue/__snapshots__/CaseHearingsDetail.test.js.snap
+++ b/client/test/app/queue/__snapshots__/CaseHearingsDetail.test.js.snap
@@ -1,0 +1,224 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CaseHearingDetail renders correctly 1`] = `
+<div>
+  <div
+    id="hearing-details"
+  >
+    <div
+      data-css-aga5w7=""
+      data-css-lvj3zo=""
+    >
+      <span
+        data-css-l6c9n4=""
+      >
+        Unscheduled hearing
+        
+        :
+      </span>
+      <ul
+        class="cf-bare-list"
+        data-css-vguy8r=""
+      >
+        <li
+          data-css-1yjr6ry=""
+        >
+          <span
+            data-css-l6c9n4=""
+          >
+            Type
+            :
+          </span>
+           
+          Video
+        </li>
+        <li
+          data-css-1yjr6ry=""
+        >
+          <span
+            data-css-l6c9n4=""
+          >
+            Notes
+            :
+          </span>
+           
+          <span>
+            <button
+              class="cf-submit cf-btn-link usa-button"
+              data-css-1a24qct=""
+              type="button"
+            >
+              <span
+                data-css-1qcxu9b=""
+              >
+                <svg
+                  height="25px"
+                  version="1.1"
+                  viewBox="0 0 25 25"
+                  width="25px"
+                >
+                  <g
+                    fill="none"
+                    fill-rule="evenodd"
+                    stroke="none"
+                    stroke-width="1"
+                  >
+                    <g
+                      fill="#0071BC"
+                      fill-rule="nonzero"
+                      transform="translate(-729.000000, -307.000000)"
+                    >
+                      <g
+                        transform="translate(6.000000, 253.000000)"
+                      >
+                        <g
+                          transform="translate(0.000000, 29.000000)"
+                        >
+                          <path
+                            d="M738.522827,27 L736.791876,28.7078716 L740.228508,32.0986824 L741.959459,30.3908108 L738.522827,27 Z M736.216998,29.2750845 L728.503527,36.8857095 L731.940159,40.2765203 L739.653631,32.6658953 L736.216998,29.2750845 Z M727.979188,37.5027872 L727,41.76 L731.314743,40.7938682 L727.979188,37.5027872 Z"
+                            id="Shape"
+                          />
+                        </g>
+                      </g>
+                    </g>
+                  </g>
+                </svg>
+              </span>
+              <span
+                data-css-1kz462l=""
+              >
+                Edit
+              </span>
+            </button>
+          </span>
+          <br />
+        </li>
+      </ul>
+    </div>
+    <ul
+      class="cf-bare-list"
+      data-css-aga5w7=""
+    >
+      <li
+        data-css-dxjmvv=""
+      >
+        
+         
+        <div
+          data-css-ix5cpv=""
+        >
+          <span
+            data-css-l6c9n4=""
+          >
+            Hearing
+            
+            :
+          </span>
+          <ul
+            class="cf-bare-list"
+            data-css-vguy8r=""
+          >
+            <li
+              data-css-1yjr6ry=""
+            >
+              <span
+                data-css-l6c9n4=""
+              >
+                Type
+                :
+              </span>
+               
+              Central
+            </li>
+            <li
+              data-css-1yjr6ry=""
+            >
+              <span
+                data-css-l6c9n4=""
+              >
+                Disposition
+                :
+              </span>
+               
+              None
+            </li>
+            <li
+              data-css-1yjr6ry=""
+            >
+              
+               
+              <span
+                aria-describedby="hearing-worksheet-tip"
+                currentitem="false"
+                data-event="focus mouseenter"
+                data-event-off="keydown mouseleave"
+                data-for="hearing-worksheet-tip"
+                data-tip="true"
+                role="tooltip"
+                tabindex="0"
+              >
+                <a
+                  href="/hearings/worksheet/print?keep_open=true&hearing_ids=29e88a5d-8f00-47ea-b178-95a01d912b96"
+                  target="_blank"
+                >
+                  View VLJ Hearing Worksheet
+                </a>
+              </span>
+              <span
+                data-css-wlp5bi=""
+              >
+                <div
+                  class="__react_component_tooltip place-top type-dark "
+                  data-id="tooltip"
+                  id="hearing-worksheet-tip"
+                >
+                  This link opens a PDF copy of the Hearing Worksheet
+                </div>
+              </span>
+            </li>
+            <li
+              data-css-1yjr6ry=""
+            >
+              <span
+                data-css-l6c9n4=""
+              >
+                Date
+                :
+              </span>
+               
+              <span
+                data-css-qela1j=""
+              >
+                8/7/20
+              </span>
+            </li>
+            <li
+              data-css-1yjr6ry=""
+            >
+              <span
+                data-css-l6c9n4=""
+              >
+                Judge
+                :
+              </span>
+               
+              
+            </li>
+            <li
+              data-css-1yjr6ry=""
+            >
+              
+               
+              <a
+                href="/hearings/29e88a5d-8f00-47ea-b178-95a01d912b96/details"
+              >
+                View Hearing Details
+              </a>
+            </li>
+          </ul>
+        </div>
+      </li>
+    </ul>
+  </div>
+</div>
+`;

--- a/client/test/data/appeals.js
+++ b/client/test/data/appeals.js
@@ -164,7 +164,8 @@ export const openHearingAppeal = {
       type: 'Central',
       externalId: '29e88a5d-8f00-47ea-b178-95a01d912b96',
       disposition: null,
-      isVirtual: false
+      isVirtual: false,
+      createdAt: '2020-04-07T03:30:00.000-04:00'
     }
   ],
 };
@@ -216,5 +217,15 @@ export const scheduleHearingDetails = {
       facility_type: 'va_health_facility'
     }
   }
+};
+
+export const amaAppealHearingData = {
+  heldBy: 'Stacy Yellow',
+  viewedByJudge: false,
+  date: '2020-08-07T03:30:00.000-04:00',
+  createdAt: '2020-04-07T03:30:00.000-04:00',
+  type: 'Central',
+  externalId: '29e88a5d-8f00-47ea-b178-95a01d912b96',
+  disposition: null,
+  isVirtual: false
 }
-;

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1799,4 +1799,66 @@ RSpec.feature "Case details", :all_dbs do
       end
     end
   end
+
+  describe "Unscheduled hearing notes" do
+    let!(:current_user) do
+      user = create(:user, css_id: "BVASYELLOW", roles: ["Build HearSched"])
+      User.authenticate!(user: user)
+    end
+    let(:fill_in_notes) { "Fill in notes" }
+
+    before do
+      HearingsManagement.singleton.add_user(current_user)
+    end
+
+    shared_examples "edit unscheduled notes" do
+      it "edits unscheduled successully" do
+        id = appeal.external_id
+
+        visit("/queue/appeals/#{id}")
+
+        within("div#hearing-details") do
+          expect(page).to have_content(COPY::UNSCHEDULED_HEARING_TITLE)
+          expect(page).to have_content("Type: #{appeal.readable_current_hearing_request_type}")
+          click_button("Edit", exact: true)
+          fill_in "Notes", with: fill_in_notes
+          click_button("Save", exact: true)
+          expect(page).to have_content(fill_in_notes)
+          expect(page).to have_content("Last updated by BVASYELLOW on #{Time.zone.now.strftime('%m/%d/%Y')}")
+        end
+
+        expect(page).to have_content(
+          COPY::SAVE_UNSCHEDULED_NOTES_SUCCESS_MESSAGE % veteran_name
+        )
+      end
+    end
+
+    context "ama appeal" do
+      let!(:appeal) do
+        create(:appeal, :hearing_docket, closest_regional_office: "C")
+      end
+      let(:veteran_name) { appeal.veteran.name }
+      let!(:schedule_hearing_task) do
+        create(:schedule_hearing_task, appeal: appeal, assigned_to: current_user)
+      end
+
+      include_examples "edit unscheduled notes"
+    end
+
+    context "legacy appeal" do
+      let!(:appeal) do
+        create(
+          :legacy_appeal,
+          vacols_case: create(
+            :case,
+            :travel_board_hearing
+          )
+        )
+      end
+      let(:veteran_name) { appeal.veteran_full_name }
+      let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal) }
+
+      include_examples "edit unscheduled notes"
+    end
+  end
 end

--- a/spec/models/tasks/hearing_task_spec.rb
+++ b/spec/models/tasks/hearing_task_spec.rb
@@ -156,4 +156,89 @@ describe HearingTask, :postgres do
       end
     end
   end
+
+  describe ".update_from_params" do
+    let(:hearings_management_user) { create(:hearings_coordinator) }
+    let(:notes) { "New notes" }
+    let(:hearing_task) { create(:hearing_task, appeal: appeal) }
+    let(:update_params) do
+      {
+        business_payloads: {
+          values: {
+            notes: notes
+          }
+        }
+      }
+    end
+
+    before { HearingsManagement.singleton.add_user(hearings_management_user) }
+
+    subject { hearing_task.update_from_params(update_params, hearings_management_user) }
+
+    context "with notes as param" do
+      context "for ama appeal" do
+        let(:appeal) { create(:appeal) }
+
+        it "updates value correctly", :aggregate_failures do
+          expect(subject.count).to eq(1)
+          expect(hearing_task.reload.instructions).to match_array([notes])
+          expect(hearing_task.versions.count).to eq(1)
+        end
+      end
+
+      context "for legacy appeal", :aggregate_failures do
+        let(:appeal) { create(:legacy_appeal)}
+
+        it "updates value correctly" do
+          expect(subject.count).to eq(1)
+          expect(hearing_task.reload.instructions).to match_array([notes])
+          expect(hearing_task.versions.count).to eq(1)
+        end
+      end
+    end
+  end
+
+  describe ".unscheduled_hearing_notes" do
+    let(:appeal) { create(:appeal) }
+    let(:instructions) { ["Notes"] }
+    let(:hearing_task) { create(:hearing_task, instructions: instructions, appeal: appeal) }
+
+    subject { hearing_task.unscheduled_hearing_notes }
+
+    context "with no paper trail versions but a value for instructions" do
+      it "returns correct value" do
+        expect(subject).to eq({
+          notes: instructions.first,
+          updated_at: nil,
+          updated_by_css_id: nil
+        })
+      end
+    end
+
+    context "with a paper trail version and value for instructions" do
+      before do
+        hearing_task.update!(instructions: ["New notes"])
+      end
+
+      it "returns correct value" do
+        expect(subject).to eq({
+          notes: "New notes",
+          updated_at: hearing_task.reload.versions.first.created_at,
+          updated_by_css_id: nil
+        })
+      end
+    end
+
+    context "with neither paper trail version and nor value for instructions" do
+      let(:instructions) { nil }
+
+      it "returns correct value" do
+        expect(subject).to eq({
+          notes: nil,
+          updated_at: nil,
+          updated_by_css_id: nil
+        })
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-500

Part 1 of stack - proceeds https://github.com/department-of-veterans-affairs/caseflow/pull/16164
Note: Jest failures are fixed in following PR.

### Description
- Create a new component `EditUnscheduledNotesModal` 
- Update `UnscheduledNotes` component to display readonly notes in Case Details
- Update `CaseDetailsView` to pass hearingTasks as prop to `CaseHearingsDetails`
- Update logic in `CaseHearingsDetails` to display unscheduled hearings as well as update the order for scheduled hearings to be in desc order

### Acceptance Criteria
- [x] For any appeal with an open HearingTask, on the Case Details page the Hearings section appears even if there is no scheduled hearing yet
- [x]  If the appeal has an open schedule hearing task, display at the top of the Hearings section 
  - [x] Unscheduled Hearing header
  - [x] "Type:" and hearing type 
  - [x] "Notes:" label and Edit button
- [x] If the hearing does not have an open schedule hearing task, only displayed any scheduled hearings
- [x] If the appeal has an open schedule hearing task and previously scheduled hearings, show both the Unscheduled Hearing header and notes as well as the previously scheduled hearing info
- [x] Previously scheduled hearings should be ordered in descending order of hearing dates (i.e., most recent first)
- [x] When a user clicks the Edit button, display a modal where a user can enter notes (CASEFLOW-499) and save their notes
- [x] When a user clicks Save
   - [x] They're returned to the Case Details page
   - [x] A success or error alert is displayed at the top of the page
   - [x] The added/edited notes are shown under the Notes label and Edit button
   - [x] The following Google Analytics event is sent
- [x] If a user has previously entered notes
  - [x] They're shown under the Notes label and Edit button when a user first loads the Case Details page
  - [x] They populate the modal that opens when a user clicks the edit button 
 
### Testing Plan
1. Login as `BVASYELLOW`
2. Go to http://localhost:3000/hearings/schedule/assign or https://hearings.caseflowdemo.com/hearings/schedule/assign
3. Pick an appeal from any RO and go to Case details page for it
4. Scroll down to the hearing section and ensure that there exists an unscheduled hearing section. Interact with it.
5. If the appeal does not have a previously scheduled hearing, you can create one by scheduling the veteran for hearing and refreshing the page.  Notice that the unscheduled hearing section no longer displays. 
6. Postpone the hearing by clicking on `Postpone Hearing` in the actions menu but instead of rescheduling, click `Send to Schedule Veteran list` and hit enter. Scroll down to the hearing section and ensure that you can see both Unscheduled and and Scheduled hearings section.


### User Facing Changes
<img width="580" alt="Screen Shot 2021-04-23 at 11 12 14 AM" src="https://user-images.githubusercontent.com/20735998/115892031-c4a72b80-a424-11eb-97f7-16083dad332d.png">|<img width="569" alt="Screen Shot 2021-04-23 at 10 50 13 AM" src="https://user-images.githubusercontent.com/20735998/115892081-d25cb100-a424-11eb-837f-a512e23e12dd.png">
--|--

