### PR TITLE
correct syntax for Raven.capture_exception

### DIFF
--- a/app/jobs/virtual_hearings/create_conference_job.rb
+++ b/app/jobs/virtual_hearings/create_conference_job.rb
@@ -84,7 +84,7 @@ class VirtualHearings::CreateConferenceJob < VirtualHearings::ConferenceJob
     begin
       send_emails(email_type) if virtual_hearing.active?
     rescue StandardError => error
-      Raven.capture_exception(error: error, extra: { virtual_hearing_id: virtual_hearing.id, email_type: email_type })
+      Raven.capture_exception(error, extra: { virtual_hearing_id: virtual_hearing.id, email_type: email_type })
     end
 
     if virtual_hearing.can_be_established?


### PR DESCRIPTION
correct syntax for Raven.capture_exception (should be `Raven.capture_exception(error)` instead of `Raven.capture_exception(error: error)`)