### PR TITLE
Refactor Admin Actions Form

### DIFF
--- a/client/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.jsx
+++ b/client/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.jsx
@@ -24,7 +24,7 @@ const actionOptions = Object.entries(colocatedAdminActions).map(
 
 const { capitalizeFirst, snakeCaseToCamelCase, camelCaseToSnakeCase } = StringUtil;
 
-export const DocketSwitchAddAdminTaskForm = ({ baseName, item, onRemove }) => {
+export const AddAdminTaskForm = ({ baseName, item, onRemove }) => {
   const { control, errors, register } = useFormContext();
   const selectRef = useRef();
 
@@ -92,7 +92,7 @@ export const DocketSwitchAddAdminTaskForm = ({ baseName, item, onRemove }) => {
   );
 };
 
-DocketSwitchAddAdminTaskForm.propTypes = {
+AddAdminTaskForm.propTypes = {
   baseName: PropTypes.string.isRequired,
   item: PropTypes.shape({
     type: PropTypes.shape({ value: PropTypes.string, label: PropTypes.string }),

--- a/client/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.stories.js
+++ b/client/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.stories.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
-import { DocketSwitchAddAdminTaskForm } from './DocketSwitchAddAdminTaskForm';
+import { AddAdminTaskForm } from './AddAdminTaskForm';
 
 export default {
-  title: 'Queue/Docket Switch/DocketSwitchAddAdminTaskForm',
-  component: DocketSwitchAddAdminTaskForm,
+  title: 'Queue/Docket Switch/AddAdminTaskForm',
+  component: AddAdminTaskForm,
   decorators: [
     (storyFn) => {
       const methods = useForm();
@@ -21,7 +21,7 @@ export default {
     onRemove: { action: 'onRemove' },
   },
 };
-const Template = (args) => <DocketSwitchAddAdminTaskForm {...args} />;
+const Template = (args) => <AddAdminTaskForm {...args} />;
 
 export const Basic = Template.bind({});
 Basic.parameters = {

--- a/client/app/queue/docketSwitch/grant/DocketSwitchEditTasksForm.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchEditTasksForm.jsx
@@ -24,7 +24,7 @@ import CheckboxGroup from 'app/components/CheckboxGroup';
 import Button from 'app/components/Button';
 import StringUtil from 'app/util/StringUtil';
 import DocketSwitchRemoveTaskConfirmationModal from './DocketSwitchRemoveTaskModal';
-import { DocketSwitchAddAdminTaskForm } from './DocketSwitchAddAdminTaskForm';
+import { AddAdminTaskForm } from 'app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm';
 import tasksByDocketType from 'constants/DOCKET_SWITCH_TASKS_BY_DOCKET_TYPE';
 
 const sectionStyle = css({ marginBottom: '24px' });
@@ -228,7 +228,7 @@ export const DocketSwitchEditTasksForm = ({
             </h3>
             <div>
               {fields.map((item, idx) => (
-                <DocketSwitchAddAdminTaskForm
+                <AddAdminTaskForm
                   key={item.id}
                   item={item}
                   baseName={`newTasks[${idx}]`}

--- a/client/test/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.test.js
+++ b/client/test/app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { DocketSwitchAddAdminTaskForm } from 'app/queue/docketSwitch/grant/DocketSwitchAddAdminTaskForm';
+import { AddAdminTaskForm } from 'app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm';
 import { FormProvider, useForm } from 'react-hook-form';
 
 // eslint-disable-next-line react/prop-types
@@ -12,7 +12,7 @@ const Wrapper = ({ children }) => {
   return <FormProvider {...methods}>{children}</FormProvider>;
 };
 
-describe('DocketSwitchAddAdminTaskForm', () => {
+describe('AddAdminTaskForm', () => {
   const onRemove = jest.fn();
 
   const baseName = 'newTasks[0]';
@@ -21,7 +21,7 @@ describe('DocketSwitchAddAdminTaskForm', () => {
   const defaults = { baseName, item, onRemove };
 
   const setup = (props = {}) =>
-    render(<DocketSwitchAddAdminTaskForm {...defaults} {...props} />, {
+    render(<AddAdminTaskForm {...defaults} {...props} />, {
       wrapper: Wrapper,
     });
 

--- a/client/test/app/queue/colocatedTasks/AddAdminTaskForm/__snapshots__/AddAdminTaskForm.test.js.snap
+++ b/client/test/app/queue/colocatedTasks/AddAdminTaskForm/__snapshots__/AddAdminTaskForm.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DocketSwitchAddAdminTaskForm renders correctly 1`] = `
+exports[`AddAdminTaskForm renders correctly 1`] = `
 <div>
   <div
     class="css-78wbnw"


### PR DESCRIPTION
Connects [CASEFLOW-1080](https://vajira.max.gov/browse/CASEFLOW-1080)

### Description
This refactors the "Add Admin Actions" form used in Docket Switch workflow to be more generalizable (in preparation for using it for Substitute Appellant workflow).

This is part of a stacked PR that splits up the work for adding items to the "Create task" section of substitute appellant workflow

Stack:
- #16157 (Base)
   - #16159 (This one)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Everything works as before for Docket Switch workflow

### Testing Plan
Go to Storybook and ensure that `DocketSwitchEditTasksForm` works as before (it uses the refactored code)
