### PR TITLE
Paula/Caseflow 1394 - Document ID update for Judges Queue tabs

### DIFF
--- a/app/models/queue_tabs/assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/assigned_tasks_tab.rb
@@ -29,6 +29,7 @@ class AssignedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    # check for attorney_in_vacols? first so that acting-VLJs will continue to see their attorney columns
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
     return QueueTab.judge_column_names if assignee.judge_in_vacols?
 

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -21,7 +21,7 @@ class CompletedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
-    # acting VLJs are both judge_in_vacols and attorney_in_vacols and should see the attorney columns
+    # check for attorney_in_vacols? first so that acting-VLJs will continue to see their attorney columns
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
     return QueueTab.judge_column_names if assignee.judge_in_vacols?
 

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -21,7 +21,9 @@ class CompletedTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    # acting VLJs are both judge_in_vacols and attorney_in_vacols and should see the attorney columns
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.judge_column_names if assignee.judge_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -45,7 +45,9 @@ class OnHoldTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
+    # acting VLJs are both judge_in_vacols and attorney_in_vacols and should see the attorney columns
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
+    return QueueTab.judge_column_names if assignee.judge_in_vacols?
 
     [
       Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,

--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -45,7 +45,7 @@ class OnHoldTasksTab < QueueTab
 
   # rubocop:disable Metrics/AbcSize
   def column_names
-    # acting VLJs are both judge_in_vacols and attorney_in_vacols and should see the attorney columns
+    # check for attorney_in_vacols? first so that acting-VLJs will continue to see their attorney tabs
     return QueueTab.attorney_column_names if assignee.attorney_in_vacols?
     return QueueTab.judge_column_names if assignee.judge_in_vacols?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -359,14 +359,22 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     FeatureToggle.enabled?(:user_queue_pagination, user: self)
   end
 
-  def queue_tabs
-    return [assigned_tasks_tab] if judge_in_vacols? && !attorney_in_vacols?
-
+  def combined_tabs
     [
       assigned_tasks_tab,
       on_hold_tasks_tab,
       completed_tasks_tab
     ]
+  end
+
+  def queue_tabs
+    # acting VLJs are both judge_in_vacols and attorney_in_vacols and should see the attorney columns
+    if FeatureToggle.enabled?(:judge_queue_tabs, user: self)
+      combined_tabs
+    else
+      return [assigned_tasks_tab] if judge_in_vacols? && !attorney_in_vacols?
+      combined_tabs
+    end
   end
 
   def self.default_active_tab

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -70,6 +70,10 @@ export const documentIdColumn = () => {
 
       const nameAbbrev = `${preparer.firstName.substring(0, 1)}. ${preparer.lastName}`;
 
+      if (!task.documentId) {
+        return;
+      }
+
       return <React.Fragment>
         {task.documentId}<br />from {nameAbbrev}
       </React.Fragment>;

--- a/spec/feature/queue/judge_queue_spec.rb
+++ b/spec/feature/queue/judge_queue_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.feature "Judge queue", :all_dbs do
+    let(:judge) { create(:user) }
+    let!(:vacols_judge) { create(:staff, :judge_role, user: judge) }
+  
+    let(:attorney) { create(:user) }
+    let!(:vacols_attorney) { create(:staff, :attorney_role, user: attorney) }
+  
+    let!(:judge_team) do
+      JudgeTeam.create_for_judge(judge).tap { |jt| jt.add_user(attorney) }
+    end
+
+    let(:root_task) { create(:root_task, appeal: appeal) }
+  
+    before do
+      User.authenticate!(user: judge)
+      FeatureToggle.enable!(:judge_queue_tabs)
+    end
+    after { FeatureToggle.disable!(:judge_queue_tabs) }
+
+    describe "judge tabs display" do
+        context "with assigned case" do
+            let(:appeal) { create(:appeal) }
+            let(:root_task) { create(:root_task, appeal: appeal) }
+            let(:judge_task) do
+                create(
+                    :ama_judge_decision_review_task,
+                    appeal: appeal,
+                    assigned_to: judge,
+                    parent: root_task
+                )
+            end
+            
+            it "displays all three judge's tabs" do
+                visit("/queue")
+                expect(page).to have_content(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, 1)
+                expect(page).to have_content(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 0)
+                expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
+            end
+        end
+
+        context "with on-hold tasks" do
+            let!(:judge_active_tasks) { create_list(:ama_task, 2, :assigned, assigned_to: judge) }
+            let!(:judge_onhold_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
+
+            before do
+                judge_onhold_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.on_hold) }
+            end
+
+            it "displays on-hold tasks" do
+                visit("/queue")
+                find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE,4)).click
+                expect(find("tbody").find_all("tr").length).to eq(4)
+            end
+        end
+
+        context "with 3 completed tasks" do
+            let!(:judge_active_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
+            let!(:judge_closed_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: judge) }
+
+            before do
+                judge_closed_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.completed) }
+            end
+
+            it "displays completed tasks" do
+                visit("/queue")
+                find("button", text: format(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)).click
+                expect(find("tbody").find_all("tr").length).to eq(3)
+            end
+        end
+    end
+  end
+  

--- a/spec/feature/queue/judge_queue_spec.rb
+++ b/spec/feature/queue/judge_queue_spec.rb
@@ -1,74 +1,73 @@
 # frozen_string_literal: true
 
 RSpec.feature "Judge queue", :all_dbs do
-    let(:judge) { create(:user) }
-    let!(:vacols_judge) { create(:staff, :judge_role, user: judge) }
-  
-    let(:attorney) { create(:user) }
-    let!(:vacols_attorney) { create(:staff, :attorney_role, user: attorney) }
-  
-    let!(:judge_team) do
-      JudgeTeam.create_for_judge(judge).tap { |jt| jt.add_user(attorney) }
+  let(:judge) { create(:user) }
+  let!(:vacols_judge) { create(:staff, :judge_role, user: judge) }
+
+  let(:attorney) { create(:user) }
+  let!(:vacols_attorney) { create(:staff, :attorney_role, user: attorney) }
+
+  let!(:judge_team) do
+    JudgeTeam.create_for_judge(judge).tap { |jt| jt.add_user(attorney) }
+  end
+
+  let(:root_task) { create(:root_task, appeal: appeal) }
+
+  before do
+    User.authenticate!(user: judge)
+    FeatureToggle.enable!(:judge_queue_tabs)
+  end
+  after { FeatureToggle.disable!(:judge_queue_tabs) }
+
+  describe "judge tabs display" do
+    context "with assigned case" do
+      let(:appeal) { create(:appeal) }
+      let(:root_task) { create(:root_task, appeal: appeal) }
+      let(:judge_task) do
+        create(
+          :ama_judge_decision_review_task,
+          appeal: appeal,
+          assigned_to: judge,
+          parent: root_task
+        )
+      end
+
+      it "displays all three judge's tabs" do
+        visit("/queue")
+        expect(page).to have_content(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, 1)
+        expect(page).to have_content(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 0)
+        expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
+      end
     end
 
-    let(:root_task) { create(:root_task, appeal: appeal) }
-  
-    before do
-      User.authenticate!(user: judge)
-      FeatureToggle.enable!(:judge_queue_tabs)
+    context "with on-hold tasks" do
+      let!(:judge_active_tasks) { create_list(:ama_task, 2, :assigned, assigned_to: judge) }
+      let!(:judge_onhold_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
+
+      before do
+        judge_onhold_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.on_hold) }
+      end
+
+      it "displays on-hold tasks" do
+        visit("/queue")
+        find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 4)).click
+        expect(find("tbody").find_all("tr").length).to eq(4)
+      end
     end
-    after { FeatureToggle.disable!(:judge_queue_tabs) }
 
-    describe "judge tabs display" do
-        context "with assigned case" do
-            let(:appeal) { create(:appeal) }
-            let(:root_task) { create(:root_task, appeal: appeal) }
-            let(:judge_task) do
-                create(
-                    :ama_judge_decision_review_task,
-                    appeal: appeal,
-                    assigned_to: judge,
-                    parent: root_task
-                )
-            end
-            
-            it "displays all three judge's tabs" do
-                visit("/queue")
-                expect(page).to have_content(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, 1)
-                expect(page).to have_content(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE, 0)
-                expect(page).to have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
-            end
-        end
+    context "with 3 completed tasks" do
+      let!(:judge_active_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
+      let!(:judge_closed_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: judge) }
 
-        context "with on-hold tasks" do
-            let!(:judge_active_tasks) { create_list(:ama_task, 2, :assigned, assigned_to: judge) }
-            let!(:judge_onhold_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
+      before do
+        judge_closed_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.completed) }
+      end
 
-            before do
-                judge_onhold_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.on_hold) }
-            end
-
-            it "displays on-hold tasks" do
-                visit("/queue")
-                find("button", text: format(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE,4)).click
-                expect(find("tbody").find_all("tr").length).to eq(4)
-            end
-        end
-
-        context "with 3 completed tasks" do
-            let!(:judge_active_tasks) { create_list(:ama_task, 4, :assigned, assigned_to: judge) }
-            let!(:judge_closed_tasks) { create_list(:ama_task, 3, :assigned, assigned_to: judge) }
-
-            before do
-                judge_closed_tasks.each { |task| task.update!(status: Constants.TASK_STATUSES.completed) }
-            end
-
-            it "displays completed tasks" do
-                visit("/queue")
-                find("button", text: format(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)).click
-                expect(find("tbody").find_all("tr").length).to eq(3)
-            end
-        end
+      it "displays completed tasks" do
+        visit("/queue")
+        find("button", text: format(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)).click
+        expect(find("tbody").find_all("tr").length).to eq(3)
+      end
     end
   end
-  
+end

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -1015,6 +1015,14 @@ feature "Task queue", :all_dbs do
         expect(page).to have_content(COPY::USER_QUEUE_PAGE_TABLE_TITLE)
       end
 
+      it "should not display the on-hold and completed tabs if feature toggle is not enabled" do
+        # have not enabled :judge_queue_tabs feature toggle for this test
+        visit("/queue")
+        expect(page).to have_content(COPY::QUEUE_PAGE_ASSIGNED_TAB_TITLE, 2)
+        expect(page).to_not have_content(COPY::QUEUE_PAGE_ON_HOLD_TAB_TITLE)
+        expect(page).to_not have_content(COPY::QUEUE_PAGE_COMPLETE_TAB_TITLE)
+      end
+
       it "should be able to add admin actions from case details" do
         Colocated.singleton.add_user(create(:user))
         visit("/queue")


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1126
Resolves https://vajira.max.gov/browse/CASEFLOW-1394

###Description:
Judge Queue Tabs for 1126 were rolled back due to earlier than expected release.  

- A feature toggle was added (judge_queue_tabs) and will need to be enabled.
- For tasks/cases that do no have a decision document ID, we will no longer display the "from person123" information in the Document ID column.  Leaving it there is confusing because the ID number does not exist yet.


### Original Description from 1126:
Judges' individual queues only show a single table that is the equivalent of attorney and generic queues' "assigned" tabs. Judges can navigate to their "assign cases" view using the dropdown menu in the top right of their queue which provides a near-equivalent of the "on hold" tab. However, since judges now have the ability to assign admin actions directly to the VLJ support staff there are some on hold tasks that are not represented in the "assign cases" view.

This ticket exists to add tabs for "on hold" and "completed" tasks (in addition to the existing "assigned" table view they see now). Also confirmed that acting Judges that currently see the attorney queue tabs should continue to see the attorney queue tabs since the majority of their work is still attorney-centered activities.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Judges should now see "On Hold" and "Completed" tabs when signing into queue. Of Note: Attorney version of the queue tabs displays a "Veteran Documents" link that the Judges do not have; Judge version of the queue tabs displays a "Document ID" column that the Attorney version does not have.
- [x] Acting judges should still see the same Attorney-version of the queue tabs.

### Testing Plan
1. Login to queue as a judge (BVAAABSHIRE)
2. Notice that there are now 3 queue tabs under "Your cases":  Assigned (which they already had), On Hold, and Completed.
3. Notice that there is no column for "Veteran Documents" and that there is a column for "Document ID"
3. Login to queue as an attorney (BVASCASPER1)
4. Notice that there are also 3 tabs. No code was changed here.  Just observe that there is no "Document ID" column but there is a "Veterans Documents" column for comparing with an acting VLJ.
5. Login to queue as an acting VLJ (BVAACTING)
6. Notice that there are also 3 tabs.  Notice that the acting VLJ's columns are the same as those for an attorney.

### User Facing Changes
#### Judge Screenshots
**BEFORE**
<img width="590" alt="Judge Your Cases View - no tabs" src="https://user-images.githubusercontent.com/23639439/114941642-691be300-9e11-11eb-9525-fa10bc2167ba.png">

**AFTER**
_Assigned Tab_
<img width="590" alt="Jude Cases Assigned tab" src="https://user-images.githubusercontent.com/23639439/114941713-7f29a380-9e11-11eb-99a4-269db084c8bd.jpg">

_On Hold tab_
<img width="590" alt="Judge Cases On Hold tab" src="https://user-images.githubusercontent.com/23639439/114941724-8486ee00-9e11-11eb-9f34-ad1e1e7890e3.jpg">

_Completed tab_
<img width="590" alt="Judge Cases Completed tab" src="https://user-images.githubusercontent.com/23639439/114941753-8badfc00-9e11-11eb-8340-eca18f45bb8e.jpg">

####Acting VLJ Screenshot (no changes, just for reference)
<img width="590" alt="Acting Judge tabs" src="https://user-images.githubusercontent.com/23639439/114942374-71285280-9e12-11eb-8b2f-31ed6e6a5cf4.jpg">

####Attorney Screenshot (no changes, just for reference)
<img width ="590" alt="Attorney tabs" src="https://user-images.githubusercontent.com/23639439/114942507-a16ff100-9e12-11eb-8bf0-b14b5600158e.jpg">





### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.


