### PR TITLE
Revert "Allow sending Docket Switches to OCB VLJs only (#16087)" (#16110)" (#16140)"

### DIFF
--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -177,10 +177,7 @@ class TaskActionRepository
 
     def docket_switch_send_to_judge_data(_task, _user = nil)
       {
-        type: DocketSwitchRulingTask.name,
-        options: ClerkOfTheBoard.singleton.users.select(&:judge?).map do |judge|
-          { value: judge.id, label: judge.display_name }
-        end
+        type: DocketSwitchRulingTask.name
       }
     end
 

--- a/spec/feature/queue/docket_switch_spec.rb
+++ b/spec/feature/queue/docket_switch_spec.rb
@@ -7,7 +7,6 @@ RSpec.feature "Docket Switch", :all_dbs do
     cotb_org.add_user(cotb_attorney)
     cotb_org.add_user(cotb_non_attorney)
     create(:staff, :judge_role, sdomainid: judge.css_id)
-    cotb_org.add_user(judge)
   end
   after { FeatureToggle.disable!(:docket_switch) }
 
@@ -85,8 +84,8 @@ RSpec.feature "Docket Switch", :all_dbs do
       find("label[for=disposition_#{disposition}]").click
       fill_in("hyperlink", with: hyperlink)
 
-      find(".cf-select__control", text: "Select judge").click
-      find("div", class: "cf-select__option", text: judge.display_name).click
+      # The previously assigned judge should be selected
+      expect(page).to have_content(judge_assign_task.assigned_to.display_name)
 
       click_button(text: "Submit")
 


### PR DESCRIPTION
It looks like we finally have the official green light to release Docket Switch to all VLJs. Third time (and fifth PR)'s the charm.

This reverts commit a5ad4c1590ccc7ef2897b1e9e9f46156c404f06b.