### PR TITLE
WIP | Add Admin Tasks Form to SubstituteAppellantTasksForm

### DIFF
--- a/client/app/queue/substituteAppellant/substituteAppellant.slice.js
+++ b/client/app/queue/substituteAppellant/substituteAppellant.slice.js
@@ -28,6 +28,7 @@ const initialState = {
   formData: {
     substitutionDate: null,
     participantId: null,
+    newTasks: []
   },
 
   /**

--- a/client/app/queue/substituteAppellant/tasks/SubstituteAppellantTasksForm.jsx
+++ b/client/app/queue/substituteAppellant/tasks/SubstituteAppellantTasksForm.jsx
@@ -1,22 +1,28 @@
-/* eslint-disable */
-// REMOVE ABOVE LINE BEFORE CONTINUING WORK ON THIS FILE
-
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useForm } from 'react-hook-form';
+import { FormProvider, useFieldArray, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
 import { css } from 'glamor';
 
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
+import { AddAdminTaskForm } from 'app/queue/colocatedTasks/AddAdminTaskForm/AddAdminTaskForm';
 import {
   SUBSTITUTE_APPELLANT_CREATE_TASKS_TITLE,
   SUBSTITUTE_APPELLANT_SELECT_APPELLANT_SUBHEAD,
 } from 'app/../COPY';
 import CheckoutButtons from 'app/queue/docketSwitch/grant/CheckoutButtons';
+import Button from 'app/components/Button';
 import { KeyDetails } from './KeyDetails';
 
-const schema = yup.object().shape({});
+const schema = yup.object().shape({
+  newTasks: yup.array(
+    yup.object().shape({
+      type: yup.string().required(),
+      instructions: yup.string().required(),
+    })
+  ),
+});
 
 const sectionStyle = css({ marginBottom: '24px' });
 
@@ -29,45 +35,84 @@ export const SubstituteAppellantTasksForm = ({
   onCancel,
   onSubmit,
 }) => {
-  const {
-    errors,
-    formState: { touched },
-    handleSubmit,
-    register,
-  } = useForm({
+  const methods = useForm({
     // Use this for repopulating form from redux when user navigates back
-    defaultValues: { ...existingValues },
+    defaultValues: {
+      ...existingValues,
+      newTasks: existingValues?.newTasks ?? [],
+    },
     resolver: yupResolver(schema),
+  });
+  const { control, handleSubmit } = methods;
+
+  const { fields, append, remove } = useFieldArray({
+    control,
+    name: 'newTasks',
   });
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)}>
-      <AppSegment filledBackground>
-        <h1>{SUBSTITUTE_APPELLANT_CREATE_TASKS_TITLE}</h1>
-        <div {...sectionStyle}>
-          {SUBSTITUTE_APPELLANT_SELECT_APPELLANT_SUBHEAD}
+    <FormProvider {...methods}>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <AppSegment filledBackground>
+          <h1>{SUBSTITUTE_APPELLANT_CREATE_TASKS_TITLE}</h1>
+          <div {...sectionStyle}>
+            {SUBSTITUTE_APPELLANT_SELECT_APPELLANT_SUBHEAD}
+          </div>
+          <KeyDetails
+            nodDate={nodDate}
+            dateOfDeath={dateOfDeath}
+            substitutionDate={substitutionDate}
+          />
+
+          <React.Fragment>
+            <h3 {...css({ marginBottom: '0' })}>
+              <br />
+              <strong>Would you like to add any additional tasks?</strong>
+              <br />
+            </h3>
+            <div>
+              {fields.map((item, idx) => (
+                <AddAdminTaskForm
+                  key={item.id}
+                  item={item}
+                  baseName={`newTasks[${idx}]`}
+                  onRemove={() => remove(idx)}
+                />
+              ))}
+            </div>
+            <Button
+              willNeverBeLoading
+              dangerStyling
+              styling={css({ marginTop: '1rem' })}
+              name="+ Add task"
+              onClick={() => append({ type: null, instructions: '' })}
+            />
+          </React.Fragment>
+        </AppSegment>
+        <div className="controls cf-app-segment">
+          <CheckoutButtons
+            onCancel={onCancel}
+            onBack={onBack}
+            onSubmit={handleSubmit(onSubmit)}
+            submitText="Continue"
+          />
         </div>
-        <KeyDetails
-          nodDate={nodDate}
-          dateOfDeath={dateOfDeath}
-          substitutionDate={substitutionDate}
-        />
-      </AppSegment>
-      <div className="controls cf-app-segment">
-        <CheckoutButtons
-          onCancel={onCancel}
-          onBack={onBack}
-          onSubmit={onSubmit}
-          submitText="Continue"
-        />
-      </div>
-    </form>
+      </form>
+    </FormProvider>
   );
 };
 SubstituteAppellantTasksForm.propTypes = {
   existingValues: PropTypes.shape({}),
+  nodDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.string]),
+  dateOfDeath: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string,
+  ]),
+  substitutionDate: PropTypes.oneOfType([
+    PropTypes.instanceOf(Date),
+    PropTypes.string,
+  ]),
   onBack: PropTypes.func,
   onCancel: PropTypes.func,
   onSubmit: PropTypes.func,
 };
-/* eslint-enable */

--- a/client/app/queue/substituteAppellant/tasks/SubstituteAppellantTasksView.jsx
+++ b/client/app/queue/substituteAppellant/tasks/SubstituteAppellantTasksView.jsx
@@ -48,6 +48,7 @@ export const SubstituteAppellantTasksView = () => {
     history.push(`/queue/appeals/${appealId}`);
   };
   const handleSubmit = async (formData) => {
+    console.log('handleSubmit', formData);
     // Here we'll dispatch updateData action to update Redux store with our form data
     dispatch(updateData(formData));
 

--- a/client/test/app/queue/substituteAppellant/__snapshots__/SubstituteAppellantTasksForm.test.js.snap
+++ b/client/test/app/queue/substituteAppellant/__snapshots__/SubstituteAppellantTasksForm.test.js.snap
@@ -50,6 +50,24 @@ exports[`SubstituteAppellantTasksForm with blank form renders default state corr
           </tbody>
         </table>
       </section>
+      <h3
+        data-css-1m1s8ka=""
+      >
+        <br />
+        <strong>
+          Would you like to add any additional tasks?
+        </strong>
+        <br />
+      </h3>
+      <div />
+      <button
+        class="cf-submit usa-button-secondary"
+        data-css-byo489=""
+        id="button-+-Add-task"
+        type="button"
+      >
+        + Add task
+      </button>
     </section>
     <div
       class="controls cf-app-segment"
@@ -130,6 +148,24 @@ exports[`SubstituteAppellantTasksForm with existing form data renders default st
           </tbody>
         </table>
       </section>
+      <h3
+        data-css-1m1s8ka=""
+      >
+        <br />
+        <strong>
+          Would you like to add any additional tasks?
+        </strong>
+        <br />
+      </h3>
+      <div />
+      <button
+        class="cf-submit usa-button-secondary"
+        data-css-byo489=""
+        id="button-+-Add-task"
+        type="button"
+      >
+        + Add task
+      </button>
     </section>
     <div
       class="controls cf-app-segment"

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -78,6 +78,17 @@ RSpec.shared_examples("fill substitution form") do
       expect(page).to have_content("Veteran date of death")
       expect(page).to have_content("Substitution granted by the RO")
 
+      # Add admin action
+      page.find("button", text: "+ Add task").click
+      # Ensure all admin actions are available and select "AOJ"
+      click_dropdown(text: "AOJ") do
+        visible_options = page.find_all(".cf-select__option")
+        expect(visible_options.length).to eq Constants::CO_LOCATED_ADMIN_ACTIONS.length
+      end
+
+      fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: admin_action_instructions
+      # End filling admin action
+
       page.find("button", text: "Continue").click
     end
 

--- a/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
+++ b/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
@@ -8,6 +8,7 @@ RSpec.feature "granting substitute appellant for appeals", :all_dbs do
     let(:appeal) { create(:appeal, :dispatched, veteran: veteran) }
     let(:substitution_date) { Time.zone.today - 5.days }
     let(:user) { create(:user) }
+    let(:admin_action_instructions) { "Lorem ipsum dolor sit amet" }
 
     context "as COTB user" do
       include_context "with Clerk of the Board user"


### PR DESCRIPTION
Connects [CASEFLOW-1080](https://vajira.max.gov/browse/CASEFLOW-1080)

### Description
This adds `AddAdminTaskForm` to `SubsituteAppellantTasksForm`

Stack:
- #16157 (Base)
   - #16159 (Refactor `AddAdminTaskForm`)
     - #16175 (This one)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `AddAdminTaskForm` functional within `SubstituteAppellantTasksForm`

### Testing Plan
1. Go to ...

