### PR TITLE
Update veteran date of death with correct date format

### DIFF
--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -331,7 +331,15 @@ class Veteran < CaseflowRecord
 
   def update_cached_attributes!
     CACHED_BGS_ATTRIBUTES.each do |local_attr, bgs_attr|
-      self[local_attr] = bgs_record[bgs_attr]
+      fetched_attr = bgs_record[bgs_attr]
+      if bgs_attr == :date_of_death && fetched_attr.present?
+        fetched_attr = begin
+                         Date.strptime(fetched_attr, "%m/%d/%Y")
+                       rescue ArgumentError
+                         nil
+                       end
+      end
+      self[local_attr] = fetched_attr
     end
     save!
   end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -341,6 +341,7 @@ class Veteran < CaseflowRecord
       end
       self[local_attr] = fetched_attr
     end
+    self.bgs_last_synced_at = Time.zone.now
     save!
   end
 

--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -95,7 +95,9 @@ class Generators::Veteran
     # rubocop:enable Metrics/MethodLength
 
     def build(attrs = {})
-      Fakes::BGSService.store_veteran_record(attrs[:file_number], default_attrs(attrs[:file_number]).merge(attrs))
+      record = default_attrs(attrs[:file_number]).merge(attrs)
+      record[:date_of_death] = record[:date_of_death].strftime("%m/%d/%Y") if record[:date_of_death].respond_to?(:strftime)
+      Fakes::BGSService.store_veteran_record(attrs[:file_number], record)
       Veteran.new(file_number: attrs[:file_number],
                   first_name: attrs[:first_name],
                   last_name: attrs[:last_name],

--- a/lib/generators/veteran.rb
+++ b/lib/generators/veteran.rb
@@ -96,7 +96,9 @@ class Generators::Veteran
 
     def build(attrs = {})
       record = default_attrs(attrs[:file_number]).merge(attrs)
-      record[:date_of_death] = record[:date_of_death].strftime("%m/%d/%Y") if record[:date_of_death].respond_to?(:strftime)
+      unless [NilClass, String].include?(record[:date_of_death].class)
+        record[:date_of_death] = record[:date_of_death].strftime("%m/%d/%Y")
+      end
       Fakes::BGSService.store_veteran_record(attrs[:file_number], record)
       Veteran.new(file_number: attrs[:file_number],
                   first_name: attrs[:first_name],

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -944,7 +944,7 @@ describe Veteran, :all_dbs do
         expect(veteran.bgs_last_synced_at).to be_nil
         subject
         expect(veteran[:date_of_death]).to eq(new_date_of_death)
-        expect(veteran.bgs_last_synced_at).to be_within(1.second).of Time.zone.now
+        expect(veteran.bgs_last_synced_at).to eq(Time.zone.now)
       end
     end
   end

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -941,8 +941,10 @@ describe Veteran, :all_dbs do
 
     context "when date of death is present" do
       it "saves date of death in the correct date format" do
+        expect(veteran.bgs_last_synced_at).to be_nil
         subject
         expect(veteran[:date_of_death]).to eq(new_date_of_death)
+        expect(veteran.bgs_last_synced_at).to be_within(1.second).of Time.zone.now
       end
     end
   end

--- a/spec/models/veteran_spec.rb
+++ b/spec/models/veteran_spec.rb
@@ -929,4 +929,21 @@ describe Veteran, :all_dbs do
       end
     end
   end
+
+  describe "#update_cached_attributes!" do
+    let(:new_date_of_death) { Date.new(2021, 3, 8) }
+    let(:bgs_date_of_death) { "03/08/2021" }
+    before do
+      allow(veteran).to receive(:fetch_bgs_record).and_return(date_of_death: bgs_date_of_death)
+    end
+
+    subject { veteran.update_cached_attributes! }
+
+    context "when date of death is present" do
+      it "saves date of death in the correct date format" do
+        subject
+        expect(veteran[:date_of_death]).to eq(new_date_of_death)
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Description
This PR fixes a bug in `Veteran#update_cached_attributes!` which incorrectly interprets the format of date of death from BGS.

The fix was cherry-picked from @bgantick's work on #16019 which provides a more holistic approach to dealing with the date of death caching.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Added new rspec for `Veteran#update_cached_attributes!`

When this test is run with the old version of `update_cached_attributes!`, the failure diff is given as

```
Veteran#update_cached_attributes! when date of death is present saves date of death in the correct date format
Failure/Error: expect(veteran[:date_of_death]).to eq(new_date_of_death)

  expected: Mon, 08 Mar 2021 
       got: Tue, 03 Aug 2021 

  (compared using ==)
```

which matches the data error we were seeing in the wild.