### PR TITLE
Make use of_type scope

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -195,7 +195,7 @@ class Appeal < DecisionReview
   end
 
   def reviewing_judge_name
-    task = tasks.not_cancelled.where(type: JudgeDecisionReviewTask.name).order(created_at: :desc).first
+    task = tasks.not_cancelled.of_type(:JudgeDecisionReviewTask).order(created_at: :desc).first
     task ? task.assigned_to.try(:full_name) : ""
   end
 
@@ -236,11 +236,11 @@ class Appeal < DecisionReview
   end
 
   def active?
-    tasks.open.where(type: RootTask.name).any?
+    tasks.open.of_type(:RootTask).any?
   end
 
   def ready_for_distribution?
-    tasks.active.where(type: DistributionTask.name).any?
+    tasks.active.of_type(:DistributionTask).any?
   end
 
   def ready_for_distribution_at

--- a/app/workflows/complete_case_review.rb
+++ b/app/workflows/complete_case_review.rb
@@ -51,7 +51,7 @@ class CompleteCaseReview
   end
 
   def open_qr_tasks?
-    case_review.task.appeal.tasks.open.where(type: :QualityReviewTask).blank?
+    case_review.task.appeal.tasks.open.of_type(:QualityReviewTask).blank?
   end
 
   def response_errors

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -3,7 +3,7 @@
 FactoryBot.define do
   module FactoryBotHelper
     def self.find_first_task_or_create(appeal, task_type, **kwargs)
-      (appeal.tasks.open.where(type: task_type.name).first if appeal) ||
+      (appeal.tasks.open.of_type(task_type.name).first if appeal) ||
         FactoryBot.create(task_type.name.underscore.to_sym, appeal: appeal, **kwargs) { |t| yield(t) if block_given? }
     end
   end

--- a/spec/feature/queue/cavc_task_queue_spec.rb
+++ b/spec/feature/queue/cavc_task_queue_spec.rb
@@ -896,7 +896,7 @@ RSpec.feature "CAVC-related tasks queue", :all_dbs do
         end
 
         step "reassign to another user" do
-          timed_hold_task = task.appeal.tasks.open.where(type: :TimedHoldTask).first
+          timed_hold_task = task.appeal.tasks.open.of_type(:TimedHoldTask).first
           expect(timed_hold_task.parent.assigned_to).to eq org_nonadmin
 
           click_dropdown(text: Constants.TASK_ACTIONS.REASSIGN_TO_PERSON.label)

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -92,7 +92,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       expect(page).to have_content(COPY::JUDGE_CHECKOUT_DISPATCH_SUCCESS_MESSAGE_TITLE % appeal.veteran_full_name)
 
       # The bug was that a BvaDispatchTask is created while the QualityReviewTask is open. It should not be created.
-      expect(appeal.tasks.open.where(type: :BvaDispatchTask).count).to eq 0
+      expect(appeal.tasks.open.of_type(:BvaDispatchTask).count).to eq 0
     end
   end
 

--- a/spec/fixes/fixing_dispatched_appeal_spec.rb
+++ b/spec/fixes/fixing_dispatched_appeal_spec.rb
@@ -50,7 +50,7 @@ describe "Fixing dispatched appeals" do
 
       # Close out appeal
       appeal.root_task.completed!
-      appeal.tasks.where(type: :TrackVeteranTask).map(&:completed!)
+      appeal.tasks.of_type(:TrackVeteranTask).map(&:completed!)
 
       # 5. Recreate and reattach the decision document to the appeal because it was sent to the Veteran
       # and no edits have been made

--- a/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
+++ b/spec/models/tasks/cavc_remand_processed_letter_response_window_task_spec.rb
@@ -32,7 +32,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
 
         expect(appeal.tasks).to include new_task
         expect(parent_task.children).to include new_task
-        child_timed_hold_tasks = new_task.children.where(type: :TimedHoldTask)
+        child_timed_hold_tasks = new_task.children.of_type(:TimedHoldTask)
         expect(child_timed_hold_tasks.count).to eq 1
         expect(child_timed_hold_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
@@ -51,7 +51,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
       context "while window task is on-hold" do
         context "window task assigned to org" do
           it "returns on-hold actions available to org" do
-            child_timed_hold_task = window_task.children.where(type: :TimedHoldTask).active.first
+            child_timed_hold_task = window_task.children.of_type(:TimedHoldTask).active.first
             expect(child_timed_hold_task.status).to eq Constants.TASK_STATUSES.assigned
 
             expect(window_task.reload.status).to eq Constants.TASK_STATUSES.on_hold
@@ -68,7 +68,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
           end
 
           it "returns on-hold actions available to user" do
-            child_timed_hold_task = user_window_task.children.where(type: :TimedHoldTask).active.first
+            child_timed_hold_task = user_window_task.children.of_type(:TimedHoldTask).active.first
             expect(child_timed_hold_task.status).to eq Constants.TASK_STATUSES.assigned
 
             expect(user_window_task.reload.status).to eq Constants.TASK_STATUSES.on_hold
@@ -83,7 +83,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
       context "after timed-hold window ends (due to cancellation or time passed)" do
         context "window task assigned to org" do
           it "returns actions available to org" do
-            child_timed_hold_task = window_task.children.where(type: :TimedHoldTask).active.first
+            child_timed_hold_task = window_task.children.of_type(:TimedHoldTask).active.first
             expect(child_timed_hold_task.status).to eq Constants.TASK_STATUSES.assigned
 
             Timecop.travel(Time.zone.now + 90.days + 1.hour)
@@ -104,7 +104,7 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
           end
 
           it "returns actions available to user" do
-            child_timed_hold_task = user_window_task.children.where(type: :TimedHoldTask).active.first
+            child_timed_hold_task = user_window_task.children.of_type(:TimedHoldTask).active.first
             expect(child_timed_hold_task.status).to eq Constants.TASK_STATUSES.assigned
 
             Timecop.travel(Time.zone.now + 80.days + 1.hour)
@@ -157,17 +157,17 @@ describe CavcRemandProcessedLetterResponseWindowTask, :postgres do
     context "when assigning task to person" do
       context "open TimedHoldTask child exists" do
         it "has open TimedHoldTask child under newly created child task" do
-          timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
+          timed_hold_task = subject.children.open.of_type(:TimedHoldTask).first
           expect(timed_hold_task.status).to eq "assigned"
         end
       end
       context "no open TimedHoldTask child exists" do
         before do
-          timed_hold_task = window_task.children.open.where(type: :TimedHoldTask).first
+          timed_hold_task = window_task.children.open.of_type(:TimedHoldTask).first
           timed_hold_task.cancelled!
         end
         it "does not have TimedHoldTask child under newly created child task" do
-          timed_hold_task = subject.children.open.where(type: :TimedHoldTask).first
+          timed_hold_task = subject.children.open.of_type(:TimedHoldTask).first
           expect(timed_hold_task).to eq nil
         end
       end

--- a/spec/models/tasks/mandate_hold_task_spec.rb
+++ b/spec/models/tasks/mandate_hold_task_spec.rb
@@ -9,7 +9,7 @@ describe MandateHoldTask, :postgres do
   let(:decision_date) { 5.days.ago.to_date }
   let(:cavc_remand) { create(:cavc_remand, decision_date: decision_date) }
   let(:appeal) { cavc_remand.remand_appeal }
-  let(:cavc_task) { appeal.tasks.open.where(type: :CavcTask).last }
+  let(:cavc_task) { appeal.tasks.open.of_type(:CavcTask).last }
 
   describe ".create" do
     subject { described_class.create(parent: parent_task, appeal: appeal) }
@@ -36,7 +36,7 @@ describe MandateHoldTask, :postgres do
 
         expect(appeal.tasks).to include new_task
         expect(parent_task.children).to include new_task
-        child_timed_hold_tasks = new_task.children.where(type: :TimedHoldTask)
+        child_timed_hold_tasks = new_task.children.of_type(:TimedHoldTask)
         expect(child_timed_hold_tasks.count).to eq 1
         expect(child_timed_hold_tasks.first.assigned_to).to eq CavcLitigationSupport.singleton
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
@@ -54,7 +54,7 @@ describe MandateHoldTask, :postgres do
     context "immediately after MandateHoldTask is created" do
       it "returns available actions when MandateHoldTask is on hold" do
         expect(mandate_task.reload.status).to eq Constants.TASK_STATUSES.on_hold
-        child_timed_hold_tasks = mandate_task.children.where(type: :TimedHoldTask)
+        child_timed_hold_tasks = mandate_task.children.of_type(:TimedHoldTask)
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.assigned
 
         expect(mandate_task.available_actions(org_admin)).to include Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
@@ -73,7 +73,7 @@ describe MandateHoldTask, :postgres do
       end
       it "marks MandateHoldTask as assigned" do
         expect(mandate_task.reload.status).to eq Constants.TASK_STATUSES.assigned
-        child_timed_hold_tasks = mandate_task.children.where(type: :TimedHoldTask)
+        child_timed_hold_tasks = mandate_task.children.of_type(:TimedHoldTask)
         expect(child_timed_hold_tasks.first.status).to eq Constants.TASK_STATUSES.completed
       end
 

--- a/spec/models/tasks/schedule_hearing_task_spec.rb
+++ b/spec/models/tasks/schedule_hearing_task_spec.rb
@@ -271,10 +271,10 @@ describe ScheduleHearingTask, :all_dbs do
         expect(task.reload.status).to eq Constants.TASK_STATUSES.cancelled
         expect(task.cancelled_by).to eq hearings_management_user
         expect(task.closed_at).to_not be_nil
-        new_hearing_tasks = appeal.tasks.open.where(type: HearingTask.name)
+        new_hearing_tasks = appeal.tasks.open.of_type(:HearingTask)
         expect(new_hearing_tasks.count).to eq 1
         expect(new_hearing_tasks.first.hearing).to eq hearing
-        new_change_tasks = appeal.tasks.open.where(type: ChangeHearingDispositionTask.name)
+        new_change_tasks = appeal.tasks.open.of_type(:ChangeHearingDispositionTask)
         expect(new_change_tasks.count).to eq 1
         expect(new_change_tasks.first.parent).to eq new_hearing_tasks.first
       end

--- a/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
+++ b/spec/models/tasks/special_case_movement/blocked_special_case_movement_task_spec.rb
@@ -24,7 +24,7 @@ describe BlockedSpecialCaseMovementTask do
 
       shared_examples "cancelled distribution children" do
         it "cancel any open distribution descendants" do
-          dist_task = appeal.tasks.open.where(type: DistributionTask.name).first
+          dist_task = appeal.tasks.open.of_type(:DistributionTask).first
           open_tasks = dist_task.descendants.select(&:open?) - [dist_task]
           expect { subject }.not_to raise_error
           open_tasks.each do |task|
@@ -40,7 +40,7 @@ describe BlockedSpecialCaseMovementTask do
                  :with_post_intake_tasks,
                  docket_type: Constants.AMA_DOCKETS.direct_review)
         end
-        let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
+        let(:dist_task) { appeal.tasks.active.of_type(:DistributionTask).first }
 
         context "with no blocking tasks" do
           it_behaves_like "successful creation"
@@ -79,7 +79,7 @@ describe BlockedSpecialCaseMovementTask do
                  :with_post_intake_tasks,
                  docket_type: Constants.AMA_DOCKETS.evidence_submission)
         end
-        let(:dist_task) { appeal.tasks.open.where(type: DistributionTask.name).first }
+        let(:dist_task) { appeal.tasks.open.of_type(:DistributionTask).first }
 
         context "with distribution task on_hold" do
           it_behaves_like "successful creation"

--- a/spec/models/tasks/special_case_movement_shared_examples.rb
+++ b/spec/models/tasks/special_case_movement_shared_examples.rb
@@ -29,7 +29,7 @@ end
 
 shared_examples "wrong parent task type provided" do
   context "with the evidence window task as parent" do
-    let(:evidence_window_task) { appeal.tasks.open.where(type: EvidenceSubmissionWindowTask.name).first }
+    let(:evidence_window_task) { appeal.tasks.open.of_type(:EvidenceSubmissionWindowTask).first }
 
     subject do
       described_class.create!(appeal: appeal,
@@ -76,7 +76,7 @@ shared_examples "non Case Movement user provided" do
              :with_post_intake_tasks,
              docket_type: Constants.AMA_DOCKETS.direct_review)
     end
-    let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
+    let(:dist_task) { appeal.tasks.active.of_type(:DistributionTask).first }
 
     subject do
       described_class.create!(appeal: appeal,

--- a/spec/models/tasks/special_case_movement_spec.rb
+++ b/spec/models/tasks/special_case_movement_spec.rb
@@ -24,7 +24,7 @@ describe SpecialCaseMovementTask do
                  :with_post_intake_tasks,
                  docket_type: Constants.AMA_DOCKETS.direct_review)
         end
-        let(:dist_task) { appeal.tasks.active.where(type: DistributionTask.name).first }
+        let(:dist_task) { appeal.tasks.active.of_type(:DistributionTask).first }
 
         context "with no blocking tasks" do
           it_behaves_like "successful creation"
@@ -52,7 +52,7 @@ describe SpecialCaseMovementTask do
                  :with_post_intake_tasks,
                  docket_type: Constants.AMA_DOCKETS.evidence_submission)
         end
-        let(:dist_task) { appeal.tasks.open.where(type: DistributionTask.name).first }
+        let(:dist_task) { appeal.tasks.open.of_type(:DistributionTask).first }
 
         context "with distribution task on_hold" do
           it "should error with appeal not ready" do

--- a/spec/models/tasks/translation_task_spec.rb
+++ b/spec/models/tasks/translation_task_spec.rb
@@ -22,7 +22,7 @@ describe TranslationTask, :postgres do
 
   describe ".create_from_parent" do
     let(:appeal) { create(:appeal, :with_post_intake_tasks, docket_type: Constants.AMA_DOCKETS.direct_review) }
-    let(:distribution_task) { appeal.tasks.open.where(type: DistributionTask.name).first }
+    let(:distribution_task) { appeal.tasks.open.of_type(:DistributionTask).first }
 
     subject { TranslationTask.create_from_parent(distribution_task) }
 


### PR DESCRIPTION
Connects #16169. Found some more code that can be replaced.

### Description
Replace commonly used queries with scopes `of_type` for consistency.

### Acceptance Criteria
- [ ] Code compiles correctly


