### PR TITLE
Snooze rexml warning

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -1,3 +1,4 @@
 CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
+  CVE-2021-28965: 2021-05-03 # snoozing until we can upgrade ruby


### PR DESCRIPTION
Snoozes security warning for rexml gem until we can get a Ruby upgrade going
