### PR TITLE
Update KeyDetails test to use a non-dynamic date

### DIFF
--- a/client/test/app/queue/substituteAppellant/KeyDetails.test.js
+++ b/client/test/app/queue/substituteAppellant/KeyDetails.test.js
@@ -23,7 +23,13 @@ describe('KeyDetails', () => {
     );
 
   it('renders default state correctly', () => {
-    const { container } = setup();
+    // Choose a date so snapshot doesn't depend on todays date
+    const aprilFirst = new Date('2021-04-30');
+    const { container } = setup({
+      nodDate: sub(aprilFirst, { days: 30 }),
+      dateOfDeath: sub(aprilFirst, { days: 15 }),
+      substitutionDate: sub(aprilFirst, { days: 10 })
+    });
 
     expect(container).toMatchSnapshot();
   });

--- a/client/test/app/queue/substituteAppellant/KeyDetails.test.js
+++ b/client/test/app/queue/substituteAppellant/KeyDetails.test.js
@@ -24,11 +24,11 @@ describe('KeyDetails', () => {
 
   it('renders default state correctly', () => {
     // Choose a date so snapshot doesn't depend on todays date
-    const aprilFirst = new Date('2021-04-30');
+    const aprilThirty = new Date('2021-04-30');
     const { container } = setup({
-      nodDate: sub(aprilFirst, { days: 30 }),
-      dateOfDeath: sub(aprilFirst, { days: 15 }),
-      substitutionDate: sub(aprilFirst, { days: 10 })
+      nodDate: sub(aprilThirty, { days: 30 }),
+      dateOfDeath: sub(aprilThirty, { days: 15 }),
+      substitutionDate: sub(aprilThirty, { days: 10 })
     });
 
     expect(container).toMatchSnapshot();


### PR DESCRIPTION
Related to #[16157](https://github.com/department-of-veterans-affairs/caseflow/pull/16157)

### Description
This PR resolves a jest snapshot failure in master by changing the date used by KeyDetails.test.js to be non-dynamic so the snapshot will pass when the date returned by Date() changes.

KeyDetails.test.js was added in [this pr](https://github.com/department-of-veterans-affairs/caseflow/pull/16157). I'm now seeing errors about snapshot mismatches in CircleCI on an unrelated merge I'm attempting. The same snapshot error appears in CircleCI on another unrelated branch. Links to those errors:
- https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/41779/workflows/92ec3295-b9a3-4032-bce1-aafddc8e5d12/jobs/161457/tests#failed-test-0
- https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/41781/workflows/f42968a8-1d81-46e0-af0c-24ffbf8e7863/jobs/161463/tests#failed-test-0

To reproduce the issue I mimicked what would happen as the date changes:
- Checked out master
- Updated the jest snapshot so tests pass
- Changed all calls in KeyDetails.test.js to `new Date()` to `new Date('2021-04-29')`
- Saw that the snapshot failed.

### Acceptance Criteria
- [ ] Snapshot test passes for multiple dates.