### PR TITLE
CASEFLOW-1415 Ensure new substitution appeal retains source appeal history

### DIFF
--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -36,7 +36,8 @@ class InitialTasksFactory
     distribution_task # ensure distribution_task exists
 
     if @appeal.appellant_substitution?
-      # create tasks based on appellant_substitution form
+      # copy task tree from source appeal
+      # To-do create tasks based on appellant_substitution form
     elsif @appeal.cavc?
       create_cavc_subtasks
     elsif @appeal.evidence_submission_docket?


### PR DESCRIPTION
Resolves [CASEFLOW-1415](https://vajira.max.gov/browse/CASEFLOW-1415)

### Description
For appellant substitution, copy the task tree of the source appeal to the new appeal so that the user can see the appeal's history in the timeline.

Enabler for this story: Based on the tasks selected by the user, we need to reopen not just those tasks, but also any parent tasks that should now be on-hold

### Acceptance Criteria
- [ ] Backend code to duplicate the existing task tree for the source appeal

### Testing Plan
1. Go to ...

### User Facing Changes

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.
