### PR TITLE
Revert "Bump rexml from 3.2.4 to 3.2.5"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
-    rexml (3.2.5)
+    rexml (3.2.4)
     roo (2.8.2)
       nokogiri (~> 1)
       rubyzip (>= 1.2.1, < 2.0.0)


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#16190

https://www.ruby-lang.org/en/news/2021/04/05/xml-round-trip-vulnerability-in-rexml-cve-2021-28965/

> You cannot use gem update rexml for Ruby 2.5.8 or prior.