### PR TITLE
Fix test by prefixing single-digit month and day with '0'

### DIFF
--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -304,7 +304,7 @@ feature "Intake Add Issues Page", :all_dbs do
       add_intake_nonrating_issue(
         category: "Dependent Child - Biological",
         description: "test",
-        date: 30.days.ago.to_date.strftime("%-m/%-d/%Y")
+        date: 30.days.ago.to_date.strftime("%m/%d/%Y")
       )
       click_on "Establish appeal"
       expect(page).to have_content("correct the issues")


### PR DESCRIPTION
Resolves this flake: [Intake Add Issues Page show decision date on unidentified issues show correct the issues link on appeal](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/41851/workflows/27b22d68-e70b-420c-b231-44596309a53a/jobs/161804/tests#failed-test-0) that is happening pretty consistently across PRs: https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow

Filling in with date `4/3/2021' causes this problem:
![image](https://user-images.githubusercontent.com/55255674/116903342-e44b0a80-ac01-11eb-8f62-97227faa0bfb.png)

[Slack](https://dsva.slack.com/archives/CQGMLMWFK/p1620058250082800?thread_ts=1620057284.081700&cid=CQGMLMWFK)

### Description
Prefix single-digit month and day with '0' so that the date is properly filled in.

### Acceptance Criteria
- [ ] Code compiles correctly
