### PR TITLE
Replace poa_sync_date with poa_refresh feature toggle

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -31,7 +31,6 @@
       editNodDate: FeatureToggle.enabled?(:edit_nod_date, user: current_user),
       fnod_badge: FeatureToggle.enabled?(:fnod_badge, user: current_user),
       fnod_banner: FeatureToggle.enabled?(:fnod_banner, user: current_user),
-      poa_sync_date: FeatureToggle.enabled?(:poa_sync_date, user: current_user),
       view_nod_date_updates: FeatureToggle.enabled?(:view_nod_date_updates, user: current_user),
       poa_refresh: FeatureToggle.enabled?(:poa_refresh, user: current_user),
       recognized_granted_substitution_after_dd: FeatureToggle.enabled?(:recognized_granted_substitution_after_dd, user: current_user)

--- a/client/app/queue/components/PoaRefresh.jsx
+++ b/client/app/queue/components/PoaRefresh.jsx
@@ -30,7 +30,7 @@ export const PoaRefresh = ({ powerOfAttorney, appealId }) => {
   };
 
   const lastSyncedCopy = sprintf(COPY.CASE_DETAILS_POA_LAST_SYNC_DATE_COPY, poaSyncInfo);
-  const viewPoaRefresh = useSelector((state) => state.ui.featureToggles.poa_sync_date);
+  const viewPoaRefresh = useSelector((state) => state.ui.featureToggles.poa_refresh);
 
   return <React.Fragment>
     {viewPoaRefresh &&

--- a/client/app/queue/components/PoaRefresh.stories.js
+++ b/client/app/queue/components/PoaRefresh.stories.js
@@ -25,7 +25,7 @@ const Template = ({ poaSyncDateFeature, ...componentArgs }) => {
   const storeArgs = {
     ui: {
       featureToggles: {
-        poa_sync_date: poaSyncDateFeature
+        poa_refresh: poaSyncDateFeature
       }
     }
   };

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -407,8 +407,8 @@ RSpec.feature "Case details", :all_dbs do
       let(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "0000000000S")) }
       let!(:veteran) { create(:veteran, file_number: appeal.sanitized_vbms_id) }
 
-      before { FeatureToggle.disable!(:poa_sync_date) }
-      after { FeatureToggle.enable!(:poa_sync_date) }
+      before { FeatureToggle.disable!(:poa_refresh) }
+      after { FeatureToggle.enable!(:poa_refresh) }
 
       scenario "text isn't on the page" do
         visit "/queue/appeals/#{appeal.vacols_id}"
@@ -427,8 +427,8 @@ RSpec.feature "Case details", :all_dbs do
         )
       end
 
-      before { FeatureToggle.enable!(:poa_sync_date) }
-      after { FeatureToggle.disable!(:poa_sync_date) }
+      before { FeatureToggle.enable!(:poa_refresh) }
+      after { FeatureToggle.disable!(:poa_refresh) }
 
       scenario "text is on the page" do
         visit "/queue/appeals/#{appeal.uuid}"
@@ -440,8 +440,8 @@ RSpec.feature "Case details", :all_dbs do
       let!(:user) { User.authenticate!(roles: ["System Admin"]) }
       let(:appeal) { create(:appeal, veteran: create(:veteran)) }
 
-      before { FeatureToggle.enable!(:poa_sync_date) }
-      after { FeatureToggle.disable!(:poa_sync_date) }
+      before { FeatureToggle.enable!(:poa_refresh) }
+      after { FeatureToggle.disable!(:poa_refresh) }
 
       scenario "text is not on the page" do
         visit "/queue/appeals/#{appeal.uuid}"
@@ -456,11 +456,9 @@ RSpec.feature "Case details", :all_dbs do
 
       before do
         FeatureToggle.disable!(:poa_refresh)
-        FeatureToggle.disable!(:poa_sync_date)
       end
       after do
         FeatureToggle.enable!(:poa_refresh)
-        FeatureToggle.enable!(:poa_sync_date)
       end
 
       scenario "button isn't on the page" do
@@ -482,11 +480,9 @@ RSpec.feature "Case details", :all_dbs do
 
       before do
         FeatureToggle.enable!(:poa_refresh)
-        FeatureToggle.enable!(:poa_sync_date)
       end
       after do
         FeatureToggle.disable!(:poa_refresh)
-        FeatureToggle.disable!(:poa_sync_date)
       end
 
       scenario "button is on the page and is in cooldown" do
@@ -532,11 +528,9 @@ RSpec.feature "Case details", :all_dbs do
 
       before do
         FeatureToggle.enable!(:poa_refresh)
-        FeatureToggle.enable!(:poa_sync_date)
       end
       after do
         FeatureToggle.disable!(:poa_refresh)
-        FeatureToggle.disable!(:poa_sync_date)
       end
 
       scenario "attempts to refresh with no BGS data" do


### PR DESCRIPTION
### Description
The `poa_sync_date` feature toggle is no longer necessary as all user facing changes are hidden behind`poa_refresh` and [CASEFLOW-867](https://vajira.max.gov/browse/CASEFLOW-867) & [CASEFLOW-868](https://vajira.max.gov/browse/CASEFLOW-868) will be released at the same time.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass