### PR TITLE
Set application to queue on :update_power_of_attorney

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -2,7 +2,7 @@
 
 class AppealsController < ApplicationController
   before_action :react_routed
-  before_action :set_application, only: [:document_count, :power_of_attorney]
+  before_action :set_application, only: [:document_count, :power_of_attorney, :update_power_of_attorney]
   # Only whitelist endpoints VSOs should have access to.
   skip_before_action :deny_vso_access, only: [
     :index,


### PR DESCRIPTION
### Description
`AppealsController#update_power_of_attorney` didn't set the `RecordStore[:application]` to be `queue`, which resulted in the VACOLS data being returned after refreshing POA instead of BGS. Which means the POA was being updated, but the information displayed to the user was stale.

### Acceptance Criteria
- [ ] Code compiles correctly
