### PR TITLE
Don't exclude `Virtual Hearings` as a RO option when hearing type is virtual

### DIFF
--- a/client/app/hearings/components/ScheduleVeteranForm.jsx
+++ b/client/app/hearings/components/ScheduleVeteranForm.jsx
@@ -114,7 +114,7 @@ export const ScheduleVeteranForm = ({
           )}
           <RegionalOfficeDropdown
             errorMessage={errors?.regionalOffice}
-            excludeVirtualHearingsOption
+            excludeVirtualHearingsOption={!virtual}
             onChange={(regionalOffice) =>
               props.onChange('regionalOffice', regionalOffice)
             }


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1502

### Description
- determine `excludeVirtualHearingsOption` prop based on whether the type is virtual or not
- 
### Testing Plan
1. Go to ...

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---