### PR TITLE
Don’t show : after updating POA to no POA

### DIFF
--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -120,6 +120,8 @@ export const PowerOfAttorneyDetailUnconnected = ({ powerOfAttorney, appealId, po
     });
   }
 
+  const show_poa_details = poa.representative_type && poa.representative_name
+
   return (
     <React.Fragment>
       <div>
@@ -127,9 +129,11 @@ export const PowerOfAttorneyDetailUnconnected = ({ powerOfAttorney, appealId, po
           <em>{ COPY.CASE_DETAILS_UNRECOGNIZED_POA }</em> :
           <PoaRefresh powerOfAttorney={poa} appealId={appealId} {...detailListStyling} />}
         </p>
-        <ul {...detailListStyling}>
-          <BareList ListElementComponent="ul" items={details.map(getDetailField)} />
-        </ul>
+        { show_poa_details && (
+          <ul {...detailListStyling}>
+            <BareList ListElementComponent="ul" items={details.map(getDetailField)} />
+          </ul>
+        )}
         <p><em>{ COPY.CASE_DETAILS_POA_EXPLAINER }</em></p>
         { poaAlert.message && poaAlert.alertType && (
           <div>


### PR DESCRIPTION
### Description
When refreshing POA, sometimes there is no POA, when this happens a single colon would be left on the page. This PR makes it so that colon isn't displayed in this scenario.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests continue to pass