### PR TITLE
Correctly handle "reschedule hearing" action on transcription tasks that aren't descendants of hearing tasks

### DIFF
--- a/app/models/tasks/hearing_task.rb
+++ b/app/models/tasks/hearing_task.rb
@@ -11,6 +11,8 @@ class HearingTask < Task
   delegate :hearing, to: :hearing_task_association, allow_nil: true
   before_validation :set_assignee
 
+  class ExistingOpenHearingTaskOnAppeal < StandardError; end
+
   def self.label
     "All hearing-related tasks"
   end

--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -44,7 +44,7 @@ class TranscriptionTask < Task
       verify_user_can_update!(current_user)
 
       if params[:status] == Constants.TASK_STATUSES.cancelled
-        recreate_hearing
+        create_new_hearing_task_tree
       else
         super(params, current_user)
       end
@@ -55,7 +55,7 @@ class TranscriptionTask < Task
 
   private
 
-  def recreate_hearing
+  def create_new_hearing_task_tree
     hearing_task_ancestor = ancestor_task_of_type(HearingTask)
     open_hearing_task_count = appeal.tasks.open.count { |task| task.type == HearingTask.name }
 

--- a/app/models/tasks/transcription_task.rb
+++ b/app/models/tasks/transcription_task.rb
@@ -57,7 +57,7 @@ class TranscriptionTask < Task
 
   def recreate_hearing
     hearing_task_ancestor = ancestor_task_of_type(HearingTask)
-    open_hearing_task_count = appeal.tasks.open.count { |t| t.type == HearingTask.name }
+    open_hearing_task_count = appeal.tasks.open.count { |task| task.type == HearingTask.name }
 
     # don't allow multiple open hearing tasks
     if hearing_task_ancestor.nil? && open_hearing_task_count > 0

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -449,6 +449,7 @@
   "HEARING_TASK_ASSOCIATION_NOT_UNIQUE_MESSAGE": "that is not closed already exists for %s %s",
   "HEARING_TASK_ASSOCIATION_MISSING_MESASAGE": "Hearing task (%s) is missing an associated hearing. This means that either the hearing was deleted in VACOLS or the hearing association has been deleted.",
   "HEARING_TASK_DEFAULT_INSTRUCTIONS": "This task will be auto-completed when all hearing-related tasks have been completed.",
+  "OPEN_HEARING_TASK_EXISTS_ON_APPEAL_MESSAGE": "There's already an open hearing task on this appeal.",
 
   "CAVC_TASK_LABEL": "All CAVC-related tasks",
   "CAVC_TASK_DEFAULT_INSTRUCTIONS": "This task will be auto-completed when all CAVC-related tasks have been closed.",

--- a/spec/models/tasks/transcription_task_spec.rb
+++ b/spec/models/tasks/transcription_task_spec.rb
@@ -66,29 +66,58 @@ describe TranscriptionTask, :postgres do
           status: Constants.TASK_STATUSES.cancelled
         }
       end
-      let(:appeal) { create(:appeal) }
-      let!(:root_task) { create(:root_task, appeal: appeal) }
-      let!(:hearing_task) { create(:hearing_task, parent: root_task) }
-      let!(:schedule_hearing_task) { create(:schedule_hearing_task, parent: hearing_task) }
-      let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task.reload) }
-      let!(:transcription_task) { create(:transcription_task, parent: disposition_task) }
 
-      it "cancels all tasks in the hierarchy and creates a new schedule_hearing_task" do
-        transcription_task.update_from_params(update_params, transcription_user)
+      context "with a HearingTask ancestor" do
+        let(:appeal) { create(:appeal) }
+        let!(:root_task) { create(:root_task, appeal: appeal) }
+        let!(:distribution_task) { create(:distribution_task, parent: root_task) }
+        let!(:hearing_task) { create(:hearing_task, parent: distribution_task) }
+        let!(:schedule_hearing_task) { create(:schedule_hearing_task, parent: hearing_task) }
+        let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task.reload) }
+        let!(:transcription_task) { create(:transcription_task, parent: disposition_task) }
 
-        expect(hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(schedule_hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(disposition_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(root_task.reload.status).to eq(Constants.TASK_STATUSES.on_hold)
+        it "cancels all tasks in the hierarchy and creates a new schedule_hearing_task" do
+          schedule_hearing_task.completed!
 
-        new_hearing_task = root_task.children.where.not(status: Constants.TASK_STATUSES.cancelled).first
-        new_schedule_hearing_task = new_hearing_task.children.first
+          transcription_task.update_from_params(update_params, transcription_user)
 
-        expect(new_hearing_task.open?).to eq(true)
-        expect(new_hearing_task.type).to eq(HearingTask.name)
-        expect(new_schedule_hearing_task.open?).to eq(true)
-        expect(new_schedule_hearing_task.type).to eq(ScheduleHearingTask.name)
+          expect(hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(schedule_hearing_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
+          expect(disposition_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(root_task.reload.status).to eq(Constants.TASK_STATUSES.on_hold)
+
+          new_hearing_task = distribution_task.children.open.detect { |t| t.type == HearingTask.name }
+          new_schedule_hearing_task = new_hearing_task.children.open.detect { |t| t.type == ScheduleHearingTask.name }
+
+          expect(new_hearing_task.open?).to eq(true)
+          expect(new_hearing_task.type).to eq(HearingTask.name)
+          expect(new_schedule_hearing_task.open?).to eq(true)
+          expect(new_schedule_hearing_task.type).to eq(ScheduleHearingTask.name)
+        end
+      end
+
+      context "without a HearingTask ancestor" do
+        # this legacy appeal tree with a parentless MissingHearingTranscriptsColocatedTask, is typical in production
+        let(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
+        let!(:root_task) { create(:root_task, appeal: appeal) }
+        let!(:parent_colocated_task) { create(:colocated_task, :missing_hearing_transcripts, appeal: appeal) }
+
+        it "cancels itself and creates a new schedule_hearing_task" do
+          # transcription task is created in MissingHearingTranscriptsColocatedTask after_create callback
+          transcription_task = parent_colocated_task.children.detect { |t| t.type == TranscriptionTask.name }
+          transcription_task.update_from_params(update_params, transcription_user)
+
+          expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+          expect(parent_colocated_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+
+          # the new hearing task is created as a child of the appeal's root task
+          new_hearing_task = root_task.children.open.detect { |t| t.type == HearingTask.name }
+          expect(new_hearing_task.present?).to eq(true)
+
+          new_schedule_hearing_task = new_hearing_task.children.open.detect { |t| t.type == ScheduleHearingTask.name }
+          expect(new_schedule_hearing_task.present?).to eq(true)
+        end
       end
     end
 
@@ -110,19 +139,6 @@ describe TranscriptionTask, :postgres do
 
         expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
       end
-    end
-  end
-
-  context "#hearing_task" do
-    let(:appeal) { create(:appeal) }
-    let!(:root_task) { create(:root_task, appeal: appeal) }
-    let!(:hearing_task) { create(:hearing_task, parent: root_task) }
-    let!(:schedule_hearing_task) { create(:schedule_hearing_task, parent: hearing_task) }
-    let!(:disposition_task) { create(:assign_hearing_disposition_task, parent: hearing_task) }
-    let!(:transcription_task) { create(:transcription_task, parent: disposition_task) }
-
-    it "returns the hearing task" do
-      expect(transcription_task.hearing_task).to eq(hearing_task)
     end
   end
 end


### PR DESCRIPTION
Resolves [CASEFLOW-986](https://vajira.max.gov/browse/CASEFLOW-986)

### Description
Correctly handles the "Mark as complete: Reschedule hearing" action on transcription tasks that aren't descendants of hearing tasks.

### Technical background
Here's the investigation I did to make sure I was covering all possible task trees, and as inspiration for the task trees in the test cases.
```ruby
#
#
# what types of parents do transcription tasks have?

TranscriptionTask.open.map { |t| t.parent.type }.reduce(Hash.new(0)) { |a, b| a[b] += 1; a }

{
 "TranscriptionTask"=>25,
 "MissingHearingTranscriptsColocatedTask"=>66,
 "AssignHearingDispositionTask"=>1403,
 "ChangeHearingDispositionTask"=>24
}

#
#
# what does a typical line of descent look like for tasks with each of those parents?

def minitrees(tasks)
  tasks.map do |t|
    parent = t.parent
    tree = [parent.type]
    grandparent = parent.parent
    while grandparent.present?
      tree.push(grandparent.type)
      grandparent = grandparent.parent
    end
    tree.join(" - ")
  end.reduce(Hash.new(0)) { |a, b| a[b] += 1; a }
end

#
# with TranscriptionTask parent

tts = TranscriptionTask.open.select { |t| t.parent.type == TranscriptionTask.name }
puts minitrees(tts)
{
  "TranscriptionTask - AssignHearingDispositionTask - HearingTask - DistributionTask - RootTask"=>25
}

#
# with ChangeHearingDispositionTask parent

tts = TranscriptionTask.open.select { |t| t.parent.type == ChangeHearingDispositionTask.name }
puts minitrees(tts)
{
  "ChangeHearingDispositionTask - HearingTask - DistributionTask - RootTask"=>24
}

#
# with MissingHearingTranscriptsColocatedTask parent

tts = TranscriptionTask.open.select do |t|
  t.parent.type == MissingHearingTranscriptsColocatedTask.name
end
puts minitrees(tts)
{
  "MissingHearingTranscriptsColocatedTask"=>57,
  "MissingHearingTranscriptsColocatedTask - JudgeAssignTask - RootTask"=>1,
  "MissingHearingTranscriptsColocatedTask - AttorneyTask - JudgeDecisionReviewTask - RootTask"=>8
}

# example of the most common tree (it's always a LegacyAppeal)
# appeals with this tree were causing the errors that inspired CASEFLOW-986
                                           ┌────────────────────┐
LegacyAppeal 1452175                       │ ID      │ STATUS   │
├── RootTask                               │ 1588742 │ assigned │
└── MissingHearingTranscriptsColocatedTask │ 1615520 │ on_hold  │
    └── TranscriptionTask                  │ 1615521 │ assigned │
                                           └────────────────────┘

#
# with AssignHearingDispositionTask parent

tts = TranscriptionTask.open.select { |t| t.parent.type == AssignHearingDispositionTask.name }
puts minitrees(tts)

{
  "AssignHearingDispositionTask - HearingTask - DistributionTask - RootTask"=>1401,
  "AssignHearingDispositionTask - HearingTask - RootTask"=>1
}

# example of the most common tree
                                             ┌─────────────────────┐
Appeal 77527                                 │ ID      │ STATUS    │
└── RootTask                                 │ 920164  │ on_hold   │
    └── DistributionTask                     │ 920166  │ on_hold   │
        └── HearingTask                      │ 920167  │ on_hold   │
            ├── ScheduleHearingTask          │ 920168  │ completed │
            └── AssignHearingDispositionTask │ 1478187 │ on_hold   │
                └── TranscriptionTask        │ 1691912 │ assigned  │
                                             └─────────────────────┘
```