### PR TITLE
Put death dismissal streamline behind a feature toggle

### DIFF
--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -39,7 +39,7 @@ class InitialTasksFactory
       # create tasks based on appellant_substitution form
     elsif @appeal.cavc?
       create_cavc_subtasks
-    elsif @appeal.veteran.date_of_death.present?
+    elsif @appeal.veteran.date_of_death.present? && FeatureToggle.enabled?(:death_dismissal_streamlining)
       distribution_task.ready_for_distribution!
     elsif @appeal.evidence_submission_docket?
       EvidenceSubmissionWindowTask.create!(appeal: @appeal, parent: distribution_task)

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -66,6 +66,9 @@ describe InitialTasksFactory, :postgres do
         end
 
         context "on veteran date of death present" do
+          before { FeatureToggle.enable!(:death_dismissal_streamlining) }
+          after { FeatureToggle.disable!(:death_dismissal_streamlining) }
+
           context "on the evidence submission docket is created" do
             let(:appeal) do
               create(


### PR DESCRIPTION
Follow-up to #16212 

### Description
Add the `death_dismissal_streamlining` feature toggle for CASEFLOW-895

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Affected tests from #16212 updated with before/after blocks to toggle/untoggle
