### PR TITLE
Revert Video total_slots default to 12 and Central total_slots default to 10

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -39,7 +39,12 @@ class HearingDay < CaseflowRecord
 
   REQUEST_TYPES = Constants::HEARING_REQUEST_TYPES.with_indifferent_access.freeze
 
-  DEFAULT_SLOT_COUNT = 8
+  SLOTS_BY_REQUEST_TYPE = {
+    REQUEST_TYPES[:virtual] => 8,
+    REQUEST_TYPES[:central] => 10,
+    REQUEST_TYPES[:video] => 12
+  }.freeze
+
   DEFAULT_SLOT_LENGTH = 60 # in minutes
 
   before_create :assign_created_by_user
@@ -140,7 +145,7 @@ class HearingDay < CaseflowRecord
     # Check if we have a stored value
     return number_of_slots unless number_of_slots.nil?
 
-    DEFAULT_SLOT_COUNT
+    SLOTS_BY_REQUEST_TYPE[request_type]
   end
 
   def slot_length_minutes

--- a/app/services/hearing_schedule/validate_ro_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_ro_spreadsheet.rb
@@ -205,7 +205,7 @@ class HearingSchedule::ValidateRoSpreadsheet
   def filter_invalid_number_of_slots
     @allocation_spreadsheet_data.select do |row|
       begin
-        row["number_of_slots"] > HearingDay::DEFAULT_SLOT_COUNT ||
+        row["number_of_slots"] > HearingDay::SLOTS_BY_REQUEST_TYPE["R"] ||
           row["number_of_slots"] < 0 ||
           (row["allocated_days_without_room"] > 0 && row["number_of_slots"] == 0)
       rescue StandardError => error

--- a/spec/models/hearing_day_spec.rb
+++ b/spec/models/hearing_day_spec.rb
@@ -268,8 +268,8 @@ describe HearingDay, :all_dbs do
       context "a central day" do
         let(:regional_office_key) { nil }
         let(:request_type) { HearingDay::REQUEST_TYPES[:central] }
-        it "has 8 slots" do
-          expect(subject).to be(8)
+        it "has 10 slots" do
+          expect(subject).to be(10)
         end
       end
 
@@ -277,8 +277,8 @@ describe HearingDay, :all_dbs do
         context "a video day at RO (#{ro})" do
           let(:regional_office_key) { ro }
           let(:request_type) { HearingDay::REQUEST_TYPES[:video] }
-          it "has 8 slots" do
-            expect(subject).to be(8)
+          it "has 12 slots" do
+            expect(subject).to be(12)
           end
         end
       end


### PR DESCRIPTION
### Description
This PR reverts a misunderstanding (that video and central should also have 8 slots by default) in [this PR](https://github.com/department-of-veterans-affairs/caseflow/pull/16243).

As per the comment [here](https://github.com/department-of-veterans-affairs/caseflow/pull/16243#issuecomment-841402928), Central and Video HearingDays should continue to have 10 and 12 slots by default. This PR sets that and corrects the tests that depend on that.

### Acceptance Criteria
For HearingDays that have `number_of_slots == nil` nothing stored in the db.
- Central HearingDays (`request_type: "C"`) should have 10 `total_slots`.
- Video HearingDays (`request_type: "V"`) should have 12 `total_slots`. 
- Also, Virtual HearingDays (`request_type: "R"`) should continue to have 8 `total_slots`.

### Testing Plan
```
# See the request_type and total_slots for every hearing day, assuming you have not set
# any `number_of_slots` you should get this output
# [[10, "C"], [12, "V"], [8, "R"]]
HearingDay.all.map { |h| [h.total_slots, h.request_type] }.uniq
```