### PR TITLE
Show unlisted claimant option for veterans without relations

### DIFF
--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -304,7 +304,9 @@ export const SelectClaimant = (props) => {
 
       {showDeceasedVeteranAlert && deceasedVeteranAlert()}
       {showClaimants && (
-        (hasRelationships || newClaimant) ? claimantOptions() : noClaimantsCopy()
+        (nonVeteranClaimants || hasRelationships || newClaimant) ?
+          claimantOptions() :
+          noClaimantsCopy()
       )}
 
       {enableAddClaimantModal && !newClaimant && (

--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -93,15 +93,16 @@ export const SelectClaimant = (props) => {
   const [showClaimantModal, setShowClaimantModal] = useState(false);
   const [newClaimant, setNewClaimant] = useState(null);
   const openAddClaimantModal = () => setShowClaimantModal(true);
+  const isAppeal = (formType === 'appeal');
 
   const enableAddClaimantModal = useMemo(
-    () => formType === 'appeal' && attorneyFees && veteranIsNotClaimant && !nonVeteranClaimants,
-    [formType, veteranIsNotClaimant, attorneyFees, nonVeteranClaimants]
+    () => isAppeal && attorneyFees && veteranIsNotClaimant && !nonVeteranClaimants,
+    [isAppeal, veteranIsNotClaimant, attorneyFees, nonVeteranClaimants]
   );
 
   const enableAddClaimant = useMemo(
-    () => formType === 'appeal' && nonVeteranClaimants && veteranIsNotClaimant,
-    [formType, veteranIsNotClaimant, nonVeteranClaimants]
+    () => isAppeal && nonVeteranClaimants && veteranIsNotClaimant,
+    [isAppeal, veteranIsNotClaimant, nonVeteranClaimants]
   );
 
   const radioOpts = useMemo(() => {
@@ -119,7 +120,7 @@ export const SelectClaimant = (props) => {
   );
   const shouldShowPayeeCode = useMemo(() => {
     return (
-      formType !== 'appeal' &&
+      !isAppeal &&
       (benefitType === 'compensation' ||
         benefitType === 'pension' ||
         allowFiduciary)
@@ -206,7 +207,7 @@ export const SelectClaimant = (props) => {
 
         <br />
         <br />
-        {enableAddClaimantModal && formType === 'appeal' && !(claimant || claimantNotes) ?
+        {enableAddClaimantModal && !(claimant || claimantNotes) ?
           ADD_CLAIMANT_TEXT :
           ''}
       </p>
@@ -222,7 +223,7 @@ export const SelectClaimant = (props) => {
         {CLAIMANT_NOT_FOUND_END}
         <br />
         <br />
-        {enableAddClaimantModal && formType === 'appeal' ? ADD_CLAIMANT_TEXT : ''}
+        {enableAddClaimantModal ? ADD_CLAIMANT_TEXT : ''}
       </p>
     );
   };
@@ -275,7 +276,7 @@ export const SelectClaimant = (props) => {
   };
 
   let veteranClaimantOptions = BOOLEAN_RADIO_OPTIONS;
-  const allowDeceasedAppellants = deceasedAppellants && formType === 'appeal';
+  const allowDeceasedAppellants = deceasedAppellants && isAppeal;
   const showDeceasedVeteranAlert = isVeteranDeceased && veteranIsNotClaimant === false && allowDeceasedAppellants;
 
   if (isVeteranDeceased && !allowDeceasedAppellants) {
@@ -304,7 +305,7 @@ export const SelectClaimant = (props) => {
 
       {showDeceasedVeteranAlert && deceasedVeteranAlert()}
       {showClaimants && (
-        (nonVeteranClaimants || hasRelationships || newClaimant) ?
+        (enableAddClaimant || hasRelationships || newClaimant) ?
           claimantOptions() :
           noClaimantsCopy()
       )}

--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -303,8 +303,11 @@ export const SelectClaimant = (props) => {
       />
 
       {showDeceasedVeteranAlert && deceasedVeteranAlert()}
-      {showClaimants && (hasRelationships || newClaimant) && claimantOptions()}
-      {showClaimants && !hasRelationships && !newClaimant && noClaimantsCopy()}
+      {showClaimants && (
+        (nonVeteranClaimants || hasRelationships || newClaimant)
+          ? claimantOptions()
+          : noClaimantsCopy()
+      )}
 
       {enableAddClaimantModal && !newClaimant && (
         <>

--- a/client/app/intake/components/SelectClaimant.jsx
+++ b/client/app/intake/components/SelectClaimant.jsx
@@ -304,9 +304,7 @@ export const SelectClaimant = (props) => {
 
       {showDeceasedVeteranAlert && deceasedVeteranAlert()}
       {showClaimants && (
-        (nonVeteranClaimants || hasRelationships || newClaimant)
-          ? claimantOptions()
-          : noClaimantsCopy()
+        (hasRelationships || newClaimant) ? claimantOptions() : noClaimantsCopy()
       )}
 
       {enableAddClaimantModal && !newClaimant && (

--- a/spec/feature/intake/non_veteran_claimants_spec.rb
+++ b/spec/feature/intake/non_veteran_claimants_spec.rb
@@ -372,6 +372,28 @@ feature "Non-veteran claimants", :postgres do
       # Re-routes back to Review page
       expect(page).to have_current_path("/intake/review_request")
     end
+
+    context "when the veteran has no dependent relations" do
+      it "allows selecting claimant not listed" do
+        allow(veteran).to receive(:relationships).and_return([])
+        start_appeal(veteran)
+        visit "/intake"
+
+        expect(page).to have_current_path("/intake/review_request")
+
+        within_fieldset("Is the claimant someone other than the Veteran?") do
+          find("label", text: "Yes", match: :prefer_exact).click
+        end
+
+        expect(page).to have_selector("label[for=claimant-options_claimant_not_listed]")
+
+        within_fieldset(COPY::SELECT_CLAIMANT_LABEL) do
+          find("label", text: "Claimant not listed", match: :prefer_exact).click
+        end
+
+        expect(page).to have_button("Continue to next step", disabled: false)
+      end
+    end
   end
 
   def add_existing_attorney(attorney)

--- a/spec/feature/intake/non_veteran_claimants_spec.rb
+++ b/spec/feature/intake/non_veteran_claimants_spec.rb
@@ -375,7 +375,7 @@ feature "Non-veteran claimants", :postgres do
 
     context "when the veteran has no dependent relations" do
       it "allows selecting claimant not listed" do
-        allow(veteran).to receive(:relationships).and_return([])
+        allow_any_instance_of(Veteran).to receive(:relationships).and_return([])
         start_appeal(veteran)
         visit "/intake"
 


### PR DESCRIPTION
Resolves [CASEFLOW-1550](https://vajira.max.gov/browse/CASEFLOW-1550)

### Description
This PR allows intake users with `non_veteran_claimants` enabled to select the "Claimant not listed" option when the veteran has no known dependent relationships.

Rutvi has provided an alternate design with new copy, that makes this read less awkwardly, which I'll defer to a later PR in the interest of getting this one deployed to unblock users.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. New feature test added

### User Facing Changes

Before:
<img width="683" src="https://user-images.githubusercontent.com/282869/118517886-9e17a000-b705-11eb-946a-687cdf38a2da.png">

After:
<img width="633" src="https://user-images.githubusercontent.com/282869/118517539-4bd67f00-b705-11eb-82ad-3822fe293bb8.png">
