### PR TITLE
Show all nonrating comp issue categories with nonVeteranClaimants toggle

### DIFF
--- a/client/app/intake/components/NonratingRequestIssueModal.jsx
+++ b/client/app/intake/components/NonratingRequestIssueModal.jsx
@@ -240,7 +240,7 @@ class NonratingRequestIssueModal extends React.Component {
   }
 
   render() {
-    const { formType, intakeData, onCancel, featureToggles: { attorneyFees } } = this.props;
+    const { formType, intakeData, onCancel, featureToggles: { attorneyFees, nonVeteranClaimants } } = this.props;
     const { benefitType, category, selectedNonratingIssueId } = this.state;
 
     const issueNumber = (intakeData.addedIssues || []).length + 1;
@@ -255,7 +255,7 @@ class NonratingRequestIssueModal extends React.Component {
     // remove this logic when attorney_fee featureToggle is turned on
     // and instead call nonratingRequestIssueCategories(benefitType)
     const compensationCategories = nonratingRequestIssueCategories(
-      benefitType === 'compensation' && attorneyFees ? 'compensation_all' : benefitType);
+      benefitType === 'compensation' && (attorneyFees || nonVeteranClaimants) ? 'compensation_all' : benefitType);
 
     const benefitTypeElement =
       formType === 'appeal' ? <BenefitType value={benefitType} onChange={this.benefitTypeOnChange} asDropdown /> : null;


### PR DESCRIPTION
### Description
This PR ensures that all `attorney_fees`-related issue categories (for non-rating compensation issues) are still available under the `non_veteran_claimants` feature toggle, since we had to turn off `attorney_fees` due to a conflict elsewhere.

Once the `non_veteran_claimants` release is stabilized we should remove the `attorney_fees` toggle immediately.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Ensure that `attorney_fees` is off and `non_veteran_claimants` is on
2. Start any intake
3.  On the add issues screen, ensure that when adding a non-rating compensation issue, categories such as `Contested Claims - Apportionment` and `Contested Claims - Attorney fees` are available.

### User Facing Changes
<img width="715" src="https://user-images.githubusercontent.com/282869/118979218-3d2ada80-b946-11eb-953c-f079f4461f42.png">
