### PR TITLE
Snooze puma CVE until next week, and upgrade nokogiri

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -2,3 +2,4 @@ CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
   CVE-2021-28965: 2021-05-03 # snoozing until we can upgrade ruby
+  CVE-2021-29509: 2021-05-24

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -410,7 +410,7 @@ GEM
     newrelic_rpm (6.5.0.357)
     nio4r (2.5.7)
     no_proxy_fix (0.1.2)
-    nokogiri (1.11.3)
+    nokogiri (1.11.4)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
     nori (2.6.0)


### PR DESCRIPTION
Snooze CVE-2021-29509 until next week 5/24 to unblock merges in the meantime