### PR TITLE
Override the default outline for focused elements

### DIFF
--- a/client/app/styles/_commons.scss
+++ b/client/app/styles/_commons.scss
@@ -26,6 +26,10 @@ a:visited {
   color: $color-primary; // Override USWDS
 }
 
+*:focus, a:focus {
+  outline: 2px dotted $color-gray-medium; // Override the light gray dotted outline default
+}
+
 abbr {
   border: 0;
   text-decoration: none;


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1020

### Description
Override the default light grey dotted outline.
The light grey outline aspect ratio to the background is 2.4:1 which is failing for objects and UI components.
The medium grey outline aspect ration to the background is 4.37:1 which according to https://webaim.org/resources/contrastchecker/ is passing for objects and UI components. This is the subtlest darkening that passes the contrast check.

### Acceptance Criteria
- Ensure that the focus outline has a strong enough contrast to meet 508 compliance

### Testing Plan
1. Go to any page of the application and focus on an element. 
2. Check that the outline color is now #757575 

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - The outline on focused elements will now be slightly darker

 BEFORE|AFTER


### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

