### PR TITLE
Fix flake: retrieve correct substitute claimant

### DIFF
--- a/app/models/appellant_substitution.rb
+++ b/app/models/appellant_substitution.rb
@@ -20,7 +20,7 @@ class AppellantSubstitution < CaseflowRecord
   after_create :initialize_tasks
 
   def substitute_claimant
-    Claimant.find_by(participant_id: substitute_participant_id)
+    target_appeal.claimant
   end
 
   def substitute_person

--- a/spec/models/appellant_substitution_spec.rb
+++ b/spec/models/appellant_substitution_spec.rb
@@ -31,7 +31,7 @@ describe AppellantSubstitution do
       expect(subject.target_appeal.appellant_substitution?).to eq true
       expect(subject.target_appeal.stream_type).to eq subject.source_appeal.stream_type
       expect(subject.target_appeal.docket_number).to eq subject.source_appeal.docket_number
-      expect(subject.substitute_claimant).to eq subject.target_appeal.claimant
+      expect(subject.target_appeal.claimant.participant_id).to eq subject.substitute_participant_id
       expect(subject.substitute_person).to eq subject.target_appeal.claimant.person
       expect(subject.substitute_person).not_to eq subject.source_appeal.claimant.person
 


### PR DESCRIPTION
Resolves flake https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/42513/workflows/1b5234f9-5b85-4b31-a704-322f0c15e80b/jobs/165038

### Description
`AppellantSubstitution#substitute_claimant` should return the claimant for the `target_appeal`, not the first claimant with a given `substitute_participant_id`.


### Acceptance Criteria
- [ ] Code compiles correctly
