### PR TITLE
Caseflow 1497: add substitute button only for veteran appeals

### DIFF
--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -147,6 +147,7 @@ export const CaseDetailsView = (props) => {
 
   const supportSubstituteAppellant =
     currentUserOnClerkOfTheBoard &&
+    !appeal.appellantIsNotVeteran &&
     props.featureToggles.recognized_granted_substitution_after_dd &&
     appeal.caseType === 'Original' &&
     // Substitute appellants for hearings will be supported later, but aren't yet:

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1874,6 +1874,13 @@ RSpec.feature "Case details", :all_dbs do
         let(:disposition) { "dismissed_death" }
 
         it_behaves_like "the button is shown"
+
+        context "but the claimant is not a veteran" do
+          before {
+            appeal.update(veteran_is_not_claimant: true)
+          }
+          it_behaves_like "the button is not shown"
+        end
       end
 
       context "when the disposition is something else" do

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1875,7 +1875,7 @@ RSpec.feature "Case details", :all_dbs do
 
           it_behaves_like "the button is shown"
 
-          context "but the claimant is not a veteran" do
+          context "but if the claimant is not a veteran" do
             before { appeal.update(veteran_is_not_claimant: true) }
             it_behaves_like "the button is not shown"
           end

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1873,15 +1873,13 @@ RSpec.feature "Case details", :all_dbs do
       context "when the disposition is 'Dismissed, Death'" do
         let(:disposition) { "dismissed_death" }
 
-        it_behaves_like "the button is shown"
+          it_behaves_like "the button is shown"
 
-        context "but the claimant is not a veteran" do
-          before {
-            appeal.update(veteran_is_not_claimant: true)
-          }
-          it_behaves_like "the button is not shown"
+          context "but the claimant is not a veteran" do
+            before { appeal.update(veteran_is_not_claimant: true) }
+            it_behaves_like "the button is not shown"
+          end
         end
-      end
 
       context "when the disposition is something else" do
         context "when the user is an admin" do


### PR DESCRIPTION
Resolves #{1497}

### Description
This qualifies the availability of the "add substitute" button additionally, so that one cannot do so for appeals in which the claimant is not a veteran.

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan (shamelessly inspired by [this pr](https://github.com/department-of-veterans-affairs/caseflow/pull/16184)
1. We're going to want two new appeals to test different cases. Pull up a Rails terminal (`make c`) and run the following.
```ruby
# In case you don't just instinctively do this anyway...
RequestStore[:current_user] = User.system_user

# This should be visible to COB admins *and* non-admins
appeal1 = FactoryBot.create(:appeal, :dispatched_with_decision_issue,
               docket_type: "evidence_submission",
               stream_type: "original",
               disposition: "dismissed_death")

appeal2 = FactoryBot.create(:appeal, :dispatched_with_decision_issue,
               docket_type: "evidence_submission",
               stream_type: "original",
               disposition: "dismissed_death",
               veteran_is_not_claimant: true) # <- this should make the button disappear

Then, just for your reference, note the UUIDs:
[appeal1.uuid, appeal2.uuid]
```
1. (Ensure the veteran has a date of death: `appeal1.veteran.update(date_of_death: 1.month.ago))`
2. Confirm, at /test/users, that you have the recognized_granted_substitution_after_dd feature flag enabled. (Enable it if it's not already on.)
3. If you haven't already, create the 2 appeals above.
4. Log in as COB_USER, which is a non-admin Clerk of the Board user. Note that appeal1 at `/queue/appeals/APPEAL_UUID` shows an "+ Add Substitute" button.
5. Navigate to appeal2 by copying in the UUID to the url, and note that the button is absent.
6. Also review the feature test I added.

