### PR TITLE
Define default and maximum time slots separately

### DIFF
--- a/app/models/hearing_day.rb
+++ b/app/models/hearing_day.rb
@@ -40,9 +40,9 @@ class HearingDay < CaseflowRecord
   REQUEST_TYPES = Constants::HEARING_REQUEST_TYPES.with_indifferent_access.freeze
 
   SLOTS_BY_REQUEST_TYPE = {
-    REQUEST_TYPES[:virtual] => 8,
-    REQUEST_TYPES[:central] => 10,
-    REQUEST_TYPES[:video] => 12
+    REQUEST_TYPES[:virtual] => { default: 8, maximum: 12 },
+    REQUEST_TYPES[:central] => { default: 10, maximum: 10 },
+    REQUEST_TYPES[:video] => { default: 12, maximum: 12 }
   }.freeze
 
   DEFAULT_SLOT_LENGTH = 60 # in minutes
@@ -145,7 +145,7 @@ class HearingDay < CaseflowRecord
     # Check if we have a stored value
     return number_of_slots unless number_of_slots.nil?
 
-    SLOTS_BY_REQUEST_TYPE[request_type]
+    SLOTS_BY_REQUEST_TYPE[request_type][:default]
   end
 
   def slot_length_minutes

--- a/app/services/hearing_schedule/validate_ro_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_ro_spreadsheet.rb
@@ -205,7 +205,7 @@ class HearingSchedule::ValidateRoSpreadsheet
   def filter_invalid_number_of_slots
     @allocation_spreadsheet_data.select do |row|
       begin
-        row["number_of_slots"] > HearingDay::SLOTS_BY_REQUEST_TYPE["R"] ||
+        row["number_of_slots"] > HearingDay::SLOTS_BY_REQUEST_TYPE[HearingDay::REQUEST_TYPES[:virtual]][:maximum] ||
           row["number_of_slots"] < 0 ||
           (row["allocated_days_without_room"] > 0 && row["number_of_slots"] == 0)
       rescue StandardError => error


### PR DESCRIPTION
Resolves [CASEFLOW-1559](https://vajira.max.gov/browse/CASEFLOW-1559)

### Description
Defines default and maximum slots on hearing days separately.