### PR TITLE
Add foreign keys for hearings tables (Phase 5b) 

### DIFF
--- a/db/migrate/20210520211935_add_hearings_related_foreign_keys.rb
+++ b/db/migrate/20210520211935_add_hearings_related_foreign_keys.rb
@@ -1,0 +1,10 @@
+class AddHearingsRelatedForeignKeys < Caseflow::Migration
+  def change
+    add_foreign_key "hearing_issue_notes", "request_issues", validate: false
+    add_foreign_key "hearing_issue_notes", "hearings", validate: false
+
+    add_foreign_key "hearings", "hearing_days", validate: false
+    add_foreign_key "transcriptions", "hearings", validate: false
+    add_foreign_key "virtual_hearing_establishments", "virtual_hearings", validate: false
+  end
+end

--- a/db/migrate/20210520212147_validate_hearings_related_foreign_keys.rb
+++ b/db/migrate/20210520212147_validate_hearings_related_foreign_keys.rb
@@ -1,0 +1,10 @@
+class ValidateHearingsRelatedForeignKeys < Caseflow::Migration
+  def change
+    validate_foreign_key "hearing_issue_notes", "request_issues"
+    validate_foreign_key "hearing_issue_notes", "hearings"
+
+    validate_foreign_key "hearings", "hearing_days"
+    validate_foreign_key "transcriptions", "hearings"
+    validate_foreign_key "virtual_hearing_establishments", "virtual_hearings"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1671,7 +1671,6 @@ ActiveRecord::Schema.define(version: 2021_05_20_212147) do
   add_foreign_key "hearing_issue_notes", "request_issues"
   add_foreign_key "hearing_task_associations", "tasks", column: "hearing_task_id"
   add_foreign_key "hearing_views", "users"
-  add_foreign_key "hearings", "appeals"
   add_foreign_key "hearings", "hearing_days"
   add_foreign_key "hearings", "users", column: "created_by_id"
   add_foreign_key "hearings", "users", column: "judge_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_152437) do
+ActiveRecord::Schema.define(version: 2021_05_20_212147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1667,8 +1667,12 @@ ActiveRecord::Schema.define(version: 2021_05_07_152437) do
   add_foreign_key "hearing_days", "users", column: "created_by_id"
   add_foreign_key "hearing_days", "users", column: "judge_id"
   add_foreign_key "hearing_days", "users", column: "updated_by_id"
+  add_foreign_key "hearing_issue_notes", "hearings"
+  add_foreign_key "hearing_issue_notes", "request_issues"
   add_foreign_key "hearing_task_associations", "tasks", column: "hearing_task_id"
   add_foreign_key "hearing_views", "users"
+  add_foreign_key "hearings", "appeals"
+  add_foreign_key "hearings", "hearing_days"
   add_foreign_key "hearings", "users", column: "created_by_id"
   add_foreign_key "hearings", "users", column: "judge_id"
   add_foreign_key "hearings", "users", column: "updated_by_id"
@@ -1699,10 +1703,12 @@ ActiveRecord::Schema.define(version: 2021_05_07_152437) do
   add_foreign_key "tasks", "tasks", column: "parent_id"
   add_foreign_key "tasks", "users", column: "assigned_by_id"
   add_foreign_key "tasks", "users", column: "cancelled_by_id"
+  add_foreign_key "transcriptions", "hearings"
   add_foreign_key "unrecognized_appellants", "claimants"
   add_foreign_key "unrecognized_appellants", "unrecognized_party_details"
   add_foreign_key "unrecognized_appellants", "unrecognized_party_details", column: "unrecognized_power_of_attorney_id"
   add_foreign_key "user_quotas", "users"
+  add_foreign_key "virtual_hearing_establishments", "virtual_hearings"
   add_foreign_key "virtual_hearings", "users", column: "created_by_id"
   add_foreign_key "virtual_hearings", "users", column: "updated_by_id"
   add_foreign_key "vso_configs", "organizations"

--- a/spec/services/etl/hearing_syncer_spec.rb
+++ b/spec/services/etl/hearing_syncer_spec.rb
@@ -31,25 +31,5 @@ describe ETL::HearingSyncer, :etl, :all_dbs do
         expect(etl_regional_hearing.hearing_location_zip_code).to be_nil
       end
     end
-
-    context "orphaned Hearing" do
-      let!(:orphaned_hearing) { create(:hearing) }
-      let(:etl_build_table) { ETL::BuildTable.where(table_name: "hearings").last }
-
-      before do
-        orphaned_hearing.appeal.delete # not destroy, to avoid callbacks
-      end
-
-      it "skips orphans" do
-        subject
-
-        expect(Hearing.count).to eq(3)
-        expect(ETL::Hearing.count).to eq(2)
-        expect(etl_build_table).to be_complete
-        expect(etl_build_table.rows_rejected).to eq(1)
-        expect(etl_build_table.rows_inserted).to eq(2)
-        expect(etl_build_table.rows_updated).to eq(0)
-      end
-    end
   end
 end


### PR DESCRIPTION
Bumps #14732
* This is phase 5b of a [multi-phase plan](https://hackmd.io/wum2LtUfSHC-1o6-peBseQ) to add missing foreign keys.
  * (This is a redo of Phase 6, which was inadvertently deployed with Phase 5 changes.)
* Phase 4 PR #16137.
* Phase 3 PR #16120.
* Phase 2 PR #16114.
* Phase 1 PR #16034 has more details.

### Description
Add foreign keys for hearings-related tables, i.e., `hearing_issue_notes`, `hearings`, `virtual_hearing_establishments`, and `transcriptions` tables. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
```ruby
hins=HearingIssueNote.includes(:request_issue).where.not(request_issue_id: nil).select{|r| r.request_issue == nil};
hins.count
=> 0

hinhs=HearingIssueNote.includes(:hearing).where.not(hearing_id: nil).select{|r| r.hearing == nil};
hinhs.count
=> 0

hhds=Hearing.includes(:hearing_day).where.not(hearing_day_id: nil).select{|r| r.hearing_day == nil};
hhds.count
=> 0

ths=Transcription.includes(:hearing).where.not(hearing_id: nil).select{|r| r.hearing == nil};
ths.count
=> 0

vhes=VirtualHearingEstablishment.includes(:virtual_hearing).where.not(virtual_hearing_id: nil).select{|r| r.virtual_hearing == nil};
vhes.count
=> 0
```

Also check records in UAT as well.

### Database Changes

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] DB schema docs updated with `make docs` (after running `make migrate`)
* [x] #appeals-schema notified with summary and link to this PR