### PR TITLE
Upgrade to latest version of puma

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -1,5 +1,3 @@
 CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
-  CVE-2021-28965: 2021-05-03 # snoozing until we can upgrade ruby
-  CVE-2021-29509: 2021-05-24

--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem "pg", platforms: :ruby
 # Puma was chosen because it handles load of 40+ concurrent users better than Unicorn and Passenger
 # Discussion: https://github.com/18F/college-choice/issues/597#issuecomment-139034834
 # We are not yet at version 4.x because we have not tested.
-gem "puma", "~> 3.12.6"
+gem "puma"
 gem "rack", "~> 2.2.3"
 gem "rails", "5.2.4.6"
 # Used to colorize output for rake tasks

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -440,7 +440,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.10)
     public_suffix (3.1.1)
-    puma (3.12.6)
+    puma (5.3.2)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-contrib (2.1.0)
@@ -723,7 +724,7 @@ DEPENDENCIES
   pg
   pry
   pry-byebug
-  puma (~> 3.12.6)
+  puma
   rack (~> 2.2.3)
   rails (= 5.2.4.6)
   rails-erd


### PR DESCRIPTION
Resolves CVE-2021-29509

Resolves [CASEFLOW-1574](https://vajira.max.gov/browse/CASEFLOW-1574).

### Description
Also removes the .security.yml override for this, and for an already-expired entry for rexml.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
This is upgrading puma, our Ruby application server, from version 3 to version 5. We should really hammer on this in UAT before merging!