### PR TITLE
Parse hearingTime on correct date to fix hearing/slot ordering issue

### DIFF
--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -547,7 +547,7 @@ const calculateAvailableTimeslots = ({ numberOfSlots, beginsAt, roTimezone, sche
  * @param {string} availableSlots    -- Array of unfilled slots
  * @param {string} scheduledHearings -- Array of hearings
  **/
-const combineSlotsAndHearings = ({ roTimezone, availableSlots, scheduledHearings }) => {
+const combineSlotsAndHearings = ({ roTimezone, availableSlots, scheduledHearings, hearingDayDate }) => {
   const slots = availableSlots.map((slot) => ({
     ...slot,
     key: `${slot?.slotId}-${slot?.time_string}`,
@@ -557,7 +557,7 @@ const combineSlotsAndHearings = ({ roTimezone, availableSlots, scheduledHearings
   }));
 
   const formattedHearings = scheduledHearings.map((hearing) => {
-    const time = moment.tz(hearing?.hearingTime, 'HH:mm', roTimezone).clone().
+    const time = moment.tz(`${hearing?.hearingTime} ${hearingDayDate}`, 'HH:mm YYYY-MM-DD', roTimezone).clone().
       tz('America/New_York');
 
     return {
@@ -661,7 +661,8 @@ export const setTimeSlots = ({
   const slotsAndHearings = combineSlotsAndHearings({
     roTimezone,
     availableSlots,
-    scheduledHearings
+    scheduledHearings,
+    hearingDayDate
   });
 
   return displaySelectedTimeAsSlot({ selected, slotsAndHearings });


### PR DESCRIPTION
Resolves [CASEFLOW-1570](https://vajira.max.gov/browse/CASEFLOW-1570)

### Description
This PR fixes an ordering issue where all scheduled hearings would appear before all timeslots in the timeslot listing for any HearingDay that isn't on the current date.

### Acceptance Criteria
- [ ] Scheduled hearings appear correctly in the list of timeslots for future virtual HearingDays.
- [ ] Scheduled hearings appear correctly in the list of timeslots for a virtual HearingDay on the current date.

### Testing Plan
- Create a virtual HearingDay for today, and one for 14 days in the future
```
# Code that's going to be useful for the next week until
# there's an easy way to make a virtual day in the UI
def create_virtual_hearing_day(date)
  HearingDay.create(
    request_type: "R",
    regional_office: "RO43", # Oakland
    created_by: User.first,
    scheduled_for: date,
    updated_by: User.first
  )
end

# Create the two virtual hearing days
date = Date.today
create_virtual_hearing_day(date)
date = Date.today + 14
create_virtual_hearing_day(date)
```
- In the UI find a veteran to schedule, choose "Schedule Veteran" from the dropdown.
- Find the second virtual day you created, **the one that is 14 days in the future**.
- Schedule this veteran, either by clicking a timeslot or using a custom time.
- Find another veteran to schedule, choose the same hearing day.
- You should see the hearing you scheduled previously in the correct place in the timeslot listing.
- Repeat these same steps, but for the hearing day on the current date.