### PR TITLE
Extend snooze on CVE-2021-29509 one more day

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -2,4 +2,4 @@ CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
   CVE-2021-28965: 2021-05-03 # snoozing until we can upgrade ruby
-  CVE-2021-29509: 2021-05-24
+  CVE-2021-29509: 2021-05-25


### PR DESCRIPTION
### Description
There's a PR up for this that's been looked at, but all test runs
are failing due to this CVE at the moment. Extend through the end
of today so others aren't blocked as we test this.