### PR TITLE
Remove poa_refresh feature toggle

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -34,7 +34,6 @@
       fnod_banner: FeatureToggle.enabled?(:fnod_banner, user: current_user),
       view_nod_date_updates: FeatureToggle.enabled?(:view_nod_date_updates, user: current_user),
       poa_button_refresh: FeatureToggle.enabled?(:poa_button_refresh, user: current_user),
-      poa_refresh: FeatureToggle.enabled?(:poa_refresh, user: current_user),
       poa_auto_refresh: FeatureToggle.enabled?(:poa_auto_refresh, user: current_user),
       poa_auto_ihp_update: FeatureToggle.enabled?(:poa_auto_ihp_update, user: current_user),
       recognized_granted_substitution_after_dd: FeatureToggle.enabled?(:recognized_granted_substitution_after_dd, user: current_user)


### PR DESCRIPTION
### Description
Removed the broader and outdated `poa_refresh` feature toggle from the index.html.erb file (since replaced with `poa_button_refresh`, `poa_auto_refresh` & `poa_auto_ihp_update`)

### Acceptance Criteria
- [ ] Code compiles correctly

