### PR TITLE
Unidentified issues switch to nonrating EP get nonrating EP calculated and remain unidentified

### DIFF
--- a/app/models/nonrating_request_issue.rb
+++ b/app/models/nonrating_request_issue.rb
@@ -4,4 +4,8 @@ class NonratingRequestIssue < RequestIssue
   def rating?
     false
   end
+
+  def nonrating?
+    true
+  end
 end

--- a/app/workflows/end_product_code_selector.rb
+++ b/app/workflows/end_product_code_selector.rb
@@ -271,7 +271,7 @@ class EndProductCodeSelector
 
   attr_reader :request_issue
 
-  delegate :remanded?, :remand_type, :correction?, :correction_type, :rating?, :is_unidentified?,
+  delegate :remanded?, :remand_type, :correction?, :correction_type, :rating?, :nonrating?, :is_unidentified?,
            :decision_review, :decision_review_type, :benefit_type, to: :request_issue
 
   def call
@@ -287,7 +287,7 @@ class EndProductCodeSelector
   end
 
   def issue_type
-    (rating? || is_unidentified?) ? :rating : :nonrating
+    nonrating? ? :nonrating : :rating
   end
 
   def review_type


### PR DESCRIPTION
Partially Resolves [INC18151043](https://dsva.slack.com/archives/CHX8FMP28/p1622040768124600)

### Description
This is from a batteam report, where someone submitted a claim label edit. It looks like the edit was successful, and the data was updated properly, although a success status was not stored, the successful response is in the logs (see logs in [batteam thread](https://dsva.slack.com/archives/CHX8FMP28/p1622040768124600)).  The request issue was an unidentified issue that got moved from a rating to a nonrating EP.  The request_issue.end_product_code was still calculating a rating end product, although the EPE was correct. This may have caused problems on the front-end.

Unidentified issues don't have a decision date and aren't supposed to be decided in VBMS, they're supposed to be replaced with an identified issue, or in this case possibly through the nonrating issue modal.  They get a placeholder contention text in VBMS instructing the user to edit in Caseflow. We want to maintain this property of the unidentified issue.

This uses the new NonratingRequestIssue type to force issues changed to this type to return true as nonrating, and utilizes that in the EndProductCodeSelector. The issues still have is_unidentified set to true and the same contention text in VBMS.

### Acceptance Criteria
- [ ] After an unidentified issue on a rating EP has it's claim label edited to a nonrating EP, it's end_product_code should accurately reflect the non-rating EP
- [ ] The unidentified issue is still treated as an unidentified issue and maintains the UNIDENTIFIED_ISSUE contention text in VBMS.

### Testing Plan
1. Automated tests
2. Testing in UAT - note this does not seem like a higher risk change, but it would be good to test in UAT to understand the previous behavior

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.