### PR TITLE
Syncing Decision copy text removed from UI for claims closed with no decision

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -366,7 +366,7 @@ class EndProductEstablishment < CaseflowRecord
   def sync_status
     if request_issues.all.any?(&:decision_sync_error)
       COPY::OTHER_REVIEWS_TABLE_SYNCING_DECISIONS_ERROR
-    elsif request_issues.all.any?(&:submitted_not_processed?)
+    elsif request_issues.all.any?(&:submitted_not_processed?) && !request_issues.all.any?(&:closed?)
       COPY::OTHER_REVIEWS_TABLE_SYNCING_DECISIONS
     end
   end

--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -364,9 +364,9 @@ class EndProductEstablishment < CaseflowRecord
   end
 
   def sync_status
-    if request_issues.all.any?(&:decision_sync_error)
+    if request_issues.any?(&:decision_sync_error)
       COPY::OTHER_REVIEWS_TABLE_SYNCING_DECISIONS_ERROR
-    elsif request_issues.all.any?(&:submitted_not_processed?) && !request_issues.all.any?(&:closed?)
+    elsif request_issues.any?(&:submitted_not_processed?) && request_issues.any?(&:open?)
       COPY::OTHER_REVIEWS_TABLE_SYNCING_DECISIONS
     end
   end

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1366,6 +1366,27 @@ describe EndProductEstablishment, :postgres do
               end
             end
           end
+
+          context "when there are closed request issues with no decision" do
+              let!(:closed_request_issue) do
+                create(
+                  :request_issue,
+                  decision_review: epe.source,
+                  end_product_establishment: epe,
+                  decision_sync_submitted_at: Time.zone.now,
+                  decision_sync_processed_at: nil,
+                  closed_status: "no_decision",
+                  closed_at: Time.zone.now
+                )
+              end
+
+              it do
+                is_expected.to eq(
+                  ep_code: "037 Higher-Level Review Rating",
+                  ep_status: "Cleared"
+                )
+              end
+            end
         end
       end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1322,7 +1322,7 @@ describe EndProductEstablishment, :postgres do
         context "when there is a status" do
           let(:synced_status) { "CLR" }
 
-          let!(:pending_request_issue) do
+          let(:pending_request_issue) do
             create(
               :request_issue,
               decision_review: epe.source,
@@ -1342,10 +1342,10 @@ describe EndProductEstablishment, :postgres do
               )
             end
 
-            it {
+            it do
               is_expected.to eq(ep_code: "037 Higher-Level Review Rating",
                                 ep_status: "Cleared, Syncing decisions...")
-            }
+            end
 
             context "when there are pending request issues to sync with errors" do
               let!(:errored_request_issue) do
@@ -1368,25 +1368,26 @@ describe EndProductEstablishment, :postgres do
           end
 
           context "when there are closed request issues with no decision" do
-              let!(:closed_request_issue) do
-                create(
-                  :request_issue,
-                  decision_review: epe.source,
-                  end_product_establishment: epe,
-                  decision_sync_submitted_at: Time.zone.now,
-                  decision_sync_processed_at: nil,
-                  closed_status: "no_decision",
-                  closed_at: Time.zone.now
-                )
-              end
-
-              it do
-                is_expected.to eq(
-                  ep_code: "037 Higher-Level Review Rating",
-                  ep_status: "Cleared"
-                )
-              end
+            let!(:closed_request_issue) do
+              create(
+                :request_issue,
+                decision_review: epe.source,
+                end_product_establishment: epe,
+                decision_sync_submitted_at: Time.zone.now,
+                decision_sync_processed_at: nil,
+                closed_status: "no_decision",
+                closed_at: Time.zone.now
+              )
             end
+
+            it do
+              binding.pry
+              is_expected.to eq(
+                ep_code: "037 Higher-Level Review Rating",
+                ep_status: "Cleared"
+              )
+            end
+          end
         end
       end
 

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -1381,7 +1381,6 @@ describe EndProductEstablishment, :postgres do
             end
 
             it do
-              binding.pry
               is_expected.to eq(
                 ep_code: "037 Higher-Level Review Rating",
                 ep_status: "Cleared"


### PR DESCRIPTION
### Description
In the UI, claims would show a status of "Cleared. Syncing decisions..." even when all issues on the claim had been closed and would not be receiving a decision
