### PR TITLE
Add intake form generator

### DIFF
--- a/client/app/intake/pages/appeal/review.jsx
+++ b/client/app/intake/pages/appeal/review.jsx
@@ -1,153 +1,19 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
 import * as yup from 'yup';
-import RadioField from '../../../components/RadioField';
-import { Redirect } from 'react-router-dom';
-import SelectClaimant, { selectClaimantValidations } from '../../components/SelectClaimant';
-import LegacyOptInApproved from '../../components/LegacyOptInApproved';
-import { setDocketType } from '../../actions/appeal';
-import {
-  setVeteranIsNotClaimant,
-  setClaimant,
-  setPayeeCode,
-  setLegacyOptInApproved
-} from '../../actions/decisionReview';
-import { setReceiptDate } from '../../actions/intake';
-import { PAGE_PATHS, INTAKE_STATES, FORM_TYPES, GENERIC_FORM_ERRORS } from '../../constants';
-import { getIntakeStatus } from '../../selectors';
-import ErrorAlert from '../../components/ErrorAlert';
-import PropTypes from 'prop-types';
-import ReceiptDateInput, { receiptDateInputValidation } from '../receiptDateInput';
+import { selectClaimantValidations } from '../../components/SelectClaimant';
+import { FORM_TYPES, GENERIC_FORM_ERRORS } from '../../constants';
+import { receiptDateInputValidation } from '../receiptDateInput';
+
+const appealFormHeader = (veteranName) => (
+  <h1>Review { veteranName }'s { FORM_TYPES.APPEAL.name }</h1>
+);
 
 const reviewAppealSchema = yup.object().shape({
+  ...receiptDateInputValidation(true),
   'docket-type': yup.string().required(GENERIC_FORM_ERRORS.blank),
-  'legacy-opt-in': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'different-claimant-option': yup.string().required(GENERIC_FORM_ERRORS.blank),
-  ...selectClaimantValidations(),
-  ...receiptDateInputValidation(true)
+  'legacy-opt-in': yup.string().required(GENERIC_FORM_ERRORS.blank),
+  ...selectClaimantValidations()
 });
 
-class Review extends React.PureComponent {
-  render() {
-    const {
-      appealStatus,
-      veteranName,
-      docketType,
-      docketTypeError,
-      legacyOptInApproved,
-      legacyOptInApprovedError,
-      reviewIntakeError,
-      errors
-    } = this.props;
-
-    switch (appealStatus) {
-    case INTAKE_STATES.NONE:
-      return <Redirect to={PAGE_PATHS.BEGIN} />;
-    case INTAKE_STATES.COMPLETED:
-      return <Redirect to={PAGE_PATHS.COMPLETED} />;
-    default:
-    }
-
-    const docketTypeRadioOptions = [
-      { value: 'direct_review',
-        displayText: 'Direct Review' },
-      { value: 'evidence_submission',
-        displayText: 'Evidence Submission' },
-      { value: 'hearing',
-        displayText: 'Hearing' }
-    ];
-
-    return <div>
-      <h1>Review { veteranName }'s { FORM_TYPES.APPEAL.name }</h1>
-
-      { reviewIntakeError && <ErrorAlert {...reviewIntakeError} /> }
-
-      <ReceiptDateInput
-        {...this.props}
-      />
-
-      <RadioField
-        name="docket-type"
-        label="Which review option did the Veteran request?"
-        strongLabel
-        vertical
-        options={docketTypeRadioOptions}
-        onChange={this.props.setDocketType}
-        errorMessage={docketTypeError || errors?.['docket-type']?.message}
-        value={docketType}
-        inputRef={this.props.register}
-      />
-
-      <SelectClaimantConnected
-        register={this.props.register}
-        errors={this.props.errors}
-      />
-
-      <LegacyOptInApproved
-        value={legacyOptInApproved}
-        onChange={this.props.setLegacyOptInApproved}
-        errorMessage={legacyOptInApprovedError || errors?.['legacy-opt-in']?.message}
-        register={this.props.register}
-      />
-    </div>;
-  }
-}
-
-Review.propTypes = {
-  veteranName: PropTypes.string,
-  receiptDate: PropTypes.string,
-  receiptDateError: PropTypes.string,
-  docketType: PropTypes.string,
-  docketTypeError: PropTypes.string,
-  legacyOptInApproved: PropTypes.bool,
-  legacyOptInApprovedError: PropTypes.string,
-  reviewIntakeError: PropTypes.object,
-  setDocketType: PropTypes.func,
-  setReceiptDate: PropTypes.func,
-  setLegacyOptInApproved: PropTypes.func,
-  appealStatus: PropTypes.string,
-  register: PropTypes.func,
-  errors: PropTypes.array
-};
-
-const SelectClaimantConnected = connect(
-  ({ appeal, intake, featureToggles }) => ({
-    isVeteranDeceased: intake.veteran.isDeceased,
-    veteranIsNotClaimant: appeal.veteranIsNotClaimant,
-    veteranIsNotClaimantError: appeal.veteranIsNotClaimantError,
-    claimant: appeal.claimant,
-    claimantError: appeal.claimantError,
-    payeeCode: appeal.payeeCode,
-    relationships: appeal.relationships,
-    benefitType: appeal.benefitType,
-    formType: intake.formType,
-    featureToggles
-  }),
-  (dispatch) => bindActionCreators({
-    setVeteranIsNotClaimant,
-    setClaimant,
-    setPayeeCode
-  }, dispatch)
-)(SelectClaimant);
-
-export default connect(
-  (state) => ({
-    veteranName: state.intake.veteran.name,
-    appealStatus: getIntakeStatus(state),
-    receiptDate: state.appeal.receiptDate,
-    receiptDateError: state.appeal.receiptDateError,
-    docketType: state.appeal.docketType,
-    docketTypeError: state.appeal.docketTypeError,
-    legacyOptInApproved: state.appeal.legacyOptInApproved,
-    legacyOptInApprovedError: state.appeal.legacyOptInApprovedError,
-    reviewIntakeError: state.appeal.requestStatus.reviewIntakeError
-  }),
-  (dispatch) => bindActionCreators({
-    setDocketType,
-    setReceiptDate,
-    setLegacyOptInApproved
-  }, dispatch)
-)(Review);
-
-export { reviewAppealSchema };
+export { reviewAppealSchema, appealFormHeader };

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -11,8 +11,10 @@ import {
   setVeteranIsNotClaimant,
   setClaimant,
   setPayeeCode,
-  setLegacyOptInApproved
+  setLegacyOptInApproved,
+  setBenefitType,
 } from '../actions/decisionReview';
+import { setInformalConference, setSameOffice } from '../actions/higherLevelReview';
 import { bindActionCreators } from 'redux';
 import { getIntakeStatus } from '../selectors';
 import SelectClaimant from '../components/SelectClaimant';
@@ -170,6 +172,9 @@ export default connect(
   (dispatch) => bindActionCreators({
     setDocketType,
     setReceiptDate,
-    setLegacyOptInApproved
+    setLegacyOptInApproved,
+    setInformalConference,
+    setSameOffice,
+    setBenefitType,
   }, dispatch)
 )(FormGenerator);

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -146,8 +146,8 @@ const SelectClaimantConnected = connect(
 )(SelectClaimant);
 
 FormGenerator.propTypes = {
-  formHeader: PropTypes.string,
-  schema: PropTypes.object,
+  schema: PropTypes.object.isRequired,
+  formHeader: PropTypes.func.isRequired,
   veteranName: PropTypes.string,
   receiptDate: PropTypes.string,
   receiptDateError: PropTypes.string,

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -19,8 +19,9 @@ import { bindActionCreators } from 'redux';
 import { getIntakeStatus } from '../selectors';
 import SelectClaimant from '../components/SelectClaimant';
 import BenefitType from '../components/BenefitType';
-import { BOOLEAN_RADIO_OPTIONS, INTAKE_STATES, PAGE_PATHS } from '../constants';
+import { BOOLEAN_RADIO_OPTIONS, INTAKE_STATES, PAGE_PATHS, VBMS_BENEFIT_TYPES } from '../constants';
 import { convertStringToBoolean } from '../util';
+import ErrorAlert from '../components/ErrorAlert';
 
 const docketTypeRadioOptions = [
   { value: 'direct_review',
@@ -71,7 +72,9 @@ const formFieldMapping = (props) => {
         props.setInformalConference(convertStringToBoolean(value));
       }}
       errorMessage={props.informalConferenceError || props.errors?.['informal-conference']?.message}
-      value={props.informalConference === null ? null : props.informalConference.toString()}
+      // eslint-disable-next-line no-undefined
+      value={props.informalConference === null || props.informalConference === undefined ?
+        null : props.informalConference.toString()}
       inputRef={props.register}
     />,
     'same-office': <RadioField
@@ -84,7 +87,8 @@ const formFieldMapping = (props) => {
         props.setSameOffice(convertStringToBoolean(value));
       }}
       errorMessage={props.sameOfficeError || props.errors?.['same-office']?.message}
-      value={props.sameOffice === null ? null : props.sameOffice.toString()}
+      // eslint-disable-next-line no-undefined
+      value={props.sameOffice === null || props.sameOffice === undefined ? null : props.sameOffice.toString()}
       inputRef={props.register}
     />
   });
@@ -99,11 +103,17 @@ const FormGenerator = (props) => {
   default:
   }
 
+  const showInvalidVeteranError = !props.veteranValid && VBMS_BENEFIT_TYPES.includes(props.benefitType);
+
   return (
     <div>
       <h1>
         {props.formHeader(props.veteranName)}
       </h1>
+
+      { props.reviewIntakeError && <ErrorAlert {...props.reviewIntakeError} /> }
+      { showInvalidVeteranError && <ErrorAlert errorCode="veteran_not_valid" errorData={props.veteranInvalidFields} /> }
+
       {Object.keys(props.schema.fields).map((field) => formFieldMapping(props)[field])}
     </div>
   );
@@ -145,6 +155,9 @@ FormGenerator.propTypes = {
   setLegacyOptInApproved: PropTypes.func,
   appealStatus: PropTypes.string,
   intakeStatus: PropTypes.string,
+  veteranValid: PropTypes.bool,
+  veteranInvalidFields: PropTypes.object,
+  benefitType: PropTypes.string,
   register: PropTypes.func,
   errors: PropTypes.array
 };

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import RadioField from '../../components/RadioField';
+import ReceiptDateInput from './receiptDateInput';
+import { setDocketType } from '../actions/appeal';
+import { setReceiptDate } from '../actions/intake';
+import LegacyOptInApproved from '../components/LegacyOptInApproved';
+import {
+  setVeteranIsNotClaimant,
+  setClaimant,
+  setPayeeCode,
+  setLegacyOptInApproved
+} from '../actions/decisionReview';
+import { bindActionCreators } from 'redux';
+import { getIntakeStatus } from '../selectors';
+import SelectClaimant from '../components/SelectClaimant';
+
+const FormGenerator = (props) => {
+  return(
+    <div>
+      <h1>
+        {props.formHeader(props.veteranName)}
+      </h1>
+      {Object.keys(props.schema.fields).map((field) => formFieldMapping(props)[field])}
+    </div>
+  )
+}
+
+const docketTypeRadioOptions = [
+  { value: 'direct_review',
+    displayText: 'Direct Review' },
+  { value: 'evidence_submission',
+    displayText: 'Evidence Submission' },
+  { value: 'hearing',
+    displayText: 'Hearing' }
+];
+
+const formFieldMapping = (props) => ({
+  'receipt-date': <ReceiptDateInput {...props} />,
+  'docket-type': <RadioField
+    name="docket-type"
+    label="Which review option did the Veteran request?"
+    strongLabel
+    vertical
+    options={docketTypeRadioOptions}
+    onChange={props.setDocketType}
+    errorMessage={props.docketTypeError || props.errors?.['docket-type']?.message}
+    value={props.docketType}
+    inputRef={props.register}
+  />,
+  'legacy-opt-in': <LegacyOptInApproved
+    value={props.legacyOptInApproved}
+    onChange={props.setLegacyOptInApproved}
+    errorMessage={props.legacyOptInApprovedError || props.errors?.['legacy-opt-in']?.message}
+    register={props.register}
+  />,
+  'different-claimant-option': <SelectClaimantConnected
+    register={props.register}
+    errors={props.errors}
+  />
+})
+
+const SelectClaimantConnected = connect(
+  ({ appeal, intake, featureToggles }) => ({
+    isVeteranDeceased: intake.veteran.isDeceased,
+    veteranIsNotClaimant: appeal.veteranIsNotClaimant,
+    veteranIsNotClaimantError: appeal.veteranIsNotClaimantError,
+    claimant: appeal.claimant,
+    claimantError: appeal.claimantError,
+    payeeCode: appeal.payeeCode,
+    relationships: appeal.relationships,
+    benefitType: appeal.benefitType,
+    formType: intake.formType,
+    featureToggles
+  }),
+  (dispatch) => bindActionCreators({
+    setVeteranIsNotClaimant,
+    setClaimant,
+    setPayeeCode
+  }, dispatch)
+)(SelectClaimant);
+
+FormGenerator.propTypes = {
+  formHeader: PropTypes.string,
+  schema: PropTypes.object
+}
+
+export default connect(
+  (state) => console.log(state) || ({
+    veteranName: state.intake.veteran.name,
+    appealStatus: getIntakeStatus(state),
+    receiptDate: state.appeal.receiptDate,
+    receiptDateError: state.appeal.receiptDateError,
+    docketType: state.appeal.docketType,
+    docketTypeError: state.appeal.docketTypeError,
+    legacyOptInApproved: state.appeal.legacyOptInApproved,
+    legacyOptInApprovedError: state.appeal.legacyOptInApprovedError,
+    reviewIntakeError: state.appeal.requestStatus.reviewIntakeError
+  }),
+  (dispatch) => bindActionCreators({
+    setDocketType,
+    setReceiptDate,
+    setLegacyOptInApproved
+  }, dispatch)
+)(FormGenerator);

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -55,6 +55,7 @@ const formFieldMapping = (props) => {
     'different-claimant-option': <SelectClaimantConnected
       register={props.register}
       errors={props.errors}
+      formName={props.formName}
     />,
     'benefit-type-options': <BenefitType
       value={props.benefitType}
@@ -120,17 +121,17 @@ const FormGenerator = (props) => {
 };
 
 const SelectClaimantConnected = connect(
-  ({ higherLevelReview, appeal, intake, featureToggles }) => ({
-    isVeteranDeceased: intake.veteran.isDeceased,
-    veteranIsNotClaimant: higherLevelReview.veteranIsNotClaimant || appeal.veteranIsNotClaimant,
-    veteranIsNotClaimantError: higherLevelReview.veteranIsNotClaimantError || appeal.veteranIsNotClaimantError,
-    claimant: higherLevelReview.claimant || appeal.claimant,
-    claimantError: higherLevelReview.claimantError || appeal.claimantError,
-    payeeCode: higherLevelReview.payeeCode || appeal.payeeCode,
-    relationships: higherLevelReview.relationships || appeal.relationships,
-    benefitType: higherLevelReview.benefitType || appeal.benefitType,
-    formType: intake.formType,
-    featureToggles
+  (state, props) => ({
+    isVeteranDeceased: state.intake.veteran.isDeceased,
+    veteranIsNotClaimant: state[props.formName].veteranIsNotClaimant,
+    veteranIsNotClaimantError: state[props.formName].veteranIsNotClaimantError,
+    claimant: state[props.formName].claimant,
+    claimantError: state[props.formName].claimantError,
+    payeeCode: state[props.formName].payeeCode,
+    relationships: state[props.formName].relationships,
+    benefitType: state[props.formName].benefitType,
+    formType: state.intake.formType,
+    ...state.featureToggles
   }),
   (dispatch) => bindActionCreators({
     setVeteranIsNotClaimant,

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -121,18 +121,22 @@ const FormGenerator = (props) => {
 };
 
 const SelectClaimantConnected = connect(
-  (state, props) => ({
-    isVeteranDeceased: state.intake.veteran.isDeceased,
-    veteranIsNotClaimant: state[props.formName].veteranIsNotClaimant,
-    veteranIsNotClaimantError: state[props.formName].veteranIsNotClaimantError,
-    claimant: state[props.formName].claimant,
-    claimantError: state[props.formName].claimantError,
-    payeeCode: state[props.formName].payeeCode,
-    relationships: state[props.formName].relationships,
-    benefitType: state[props.formName].benefitType,
-    formType: state.intake.formType,
-    ...state.featureToggles
-  }),
+  (state, props) => {
+    const { featureToggles } = state;
+
+    return ({
+      isVeteranDeceased: state.intake.veteran.isDeceased,
+      veteranIsNotClaimant: state[props.formName].veteranIsNotClaimant,
+      veteranIsNotClaimantError: state[props.formName].veteranIsNotClaimantError,
+      claimant: state[props.formName].claimant,
+      claimantError: state[props.formName].claimantError,
+      payeeCode: state[props.formName].payeeCode,
+      relationships: state[props.formName].relationships,
+      benefitType: state[props.formName].benefitType,
+      formType: state.intake.formType,
+      featureToggles
+    });
+  },
   (dispatch) => bindActionCreators({
     setVeteranIsNotClaimant,
     setClaimant,

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { Redirect } from 'react-router-dom';
 import RadioField from '../../components/RadioField';
 import ReceiptDateInput from './receiptDateInput';
 import { setDocketType } from '../actions/appeal';
@@ -16,7 +17,7 @@ import { bindActionCreators } from 'redux';
 import { getIntakeStatus } from '../selectors';
 import SelectClaimant from '../components/SelectClaimant';
 import BenefitType from '../components/BenefitType';
-import { BOOLEAN_RADIO_OPTIONS } from '../constants';
+import { BOOLEAN_RADIO_OPTIONS, INTAKE_STATES, PAGE_PATHS } from '../constants';
 import { convertStringToBoolean } from '../util';
 
 const docketTypeRadioOptions = [
@@ -88,6 +89,14 @@ const formFieldMapping = (props) => {
 };
 
 const FormGenerator = (props) => {
+  switch (props.intakeStatus) {
+  case INTAKE_STATES.NONE:
+    return <Redirect to={PAGE_PATHS.BEGIN} />;
+  case INTAKE_STATES.COMPLETED:
+    return <Redirect to={PAGE_PATHS.COMPLETED} />;
+  default:
+  }
+
   return (
     <div>
       <h1>
@@ -133,6 +142,7 @@ FormGenerator.propTypes = {
   setReceiptDate: PropTypes.func,
   setLegacyOptInApproved: PropTypes.func,
   appealStatus: PropTypes.string,
+  intakeStatus: PropTypes.string,
   register: PropTypes.func,
   errors: PropTypes.array
 };
@@ -140,8 +150,7 @@ FormGenerator.propTypes = {
 export default connect(
   (state, props) => ({
     veteranName: state.intake.veteran.name,
-    appealStatus: getIntakeStatus(state),
-    higherLevelReviewStatus: getIntakeStatus(state),
+    intakeStatus: getIntakeStatus(state),
     receiptDate: state[props.formName].receiptDate,
     receiptDateError: state[props.formName].receiptDateError,
     docketType: state[props.formName].docketType,

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -131,6 +131,7 @@ const SelectClaimantConnected = connect(
       claimant: state[props.formName].claimant,
       claimantError: state[props.formName].claimantError,
       payeeCode: state[props.formName].payeeCode,
+      payeeCodeError: state[props.formName].payeeCodeError,
       relationships: state[props.formName].relationships,
       benefitType: state[props.formName].benefitType,
       formType: state.intake.formType,

--- a/client/app/intake/pages/higherLevelReview/review.jsx
+++ b/client/app/intake/pages/higherLevelReview/review.jsx
@@ -1,199 +1,21 @@
 import React from 'react';
-import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import { Redirect } from 'react-router-dom';
 import * as yup from 'yup';
-import RadioField from '../../../components/RadioField';
-import BenefitType from '../../components/BenefitType';
-import LegacyOptInApproved from '../../components/LegacyOptInApproved';
-import SelectClaimant, { selectClaimantValidations } from '../../components/SelectClaimant';
-import { setInformalConference, setSameOffice } from '../../actions/higherLevelReview';
-import {
-  setBenefitType,
-  setVeteranIsNotClaimant,
-  setClaimant,
-  setPayeeCode,
-  setLegacyOptInApproved
-} from '../../actions/decisionReview';
-import { setReceiptDate } from '../../actions/intake';
-import { PAGE_PATHS, INTAKE_STATES, BOOLEAN_RADIO_OPTIONS,
-  FORM_TYPES, VBMS_BENEFIT_TYPES, GENERIC_FORM_ERRORS } from '../../constants';
-import { convertStringToBoolean } from '../../util';
-import { getIntakeStatus } from '../../selectors';
-import ErrorAlert from '../../components/ErrorAlert';
-import PropTypes from 'prop-types';
-import ReceiptDateInput, { receiptDateInputValidation } from '../receiptDateInput';
+import { selectClaimantValidations } from '../../components/SelectClaimant';
+import { FORM_TYPES, GENERIC_FORM_ERRORS } from '../../constants';
+import { receiptDateInputValidation } from '../receiptDateInput';
+
+const higherLevelReviewFormHeader = (veteranName) => (
+  <h1>Review { veteranName }'s { FORM_TYPES.HIGHER_LEVEL_REVIEW.name }</h1>
+);
 
 const reviewHigherLevelReviewSchema = yup.object().shape({
   'benefit-type-options': yup.string().required(GENERIC_FORM_ERRORS.blank),
+  ...receiptDateInputValidation(true),
   'informal-conference': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'same-office': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'different-claimant-option': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'legacy-opt-in': yup.string().required(GENERIC_FORM_ERRORS.blank),
-  ...selectClaimantValidations(),
-  ...receiptDateInputValidation(true)
+  ...selectClaimantValidations()
 });
 
-class Review extends React.PureComponent {
-  render() {
-    const {
-      higherLevelReviewStatus,
-      veteranName,
-      benefitType,
-      benefitTypeError,
-      informalConference,
-      informalConferenceError,
-      sameOffice,
-      sameOfficeError,
-      legacyOptInApproved,
-      legacyOptInApprovedError,
-      reviewIntakeError,
-      veteranValid,
-      veteranInvalidFields,
-      errors
-    } = this.props;
-
-    switch (higherLevelReviewStatus) {
-    case INTAKE_STATES.NONE:
-      return <Redirect to={PAGE_PATHS.BEGIN} />;
-    case INTAKE_STATES.COMPLETED:
-      return <Redirect to={PAGE_PATHS.COMPLETED} />;
-    default:
-    }
-
-    const showInvalidVeteranError = !veteranValid && VBMS_BENEFIT_TYPES.includes(benefitType);
-
-    return <div>
-      <h1>Review { veteranName }'s { FORM_TYPES.HIGHER_LEVEL_REVIEW.name }</h1>
-
-      { reviewIntakeError && <ErrorAlert {...reviewIntakeError} /> }
-      { showInvalidVeteranError && <ErrorAlert errorCode="veteran_not_valid" errorData={veteranInvalidFields} /> }
-
-      <BenefitType
-        value={benefitType}
-        onChange={this.props.setBenefitType}
-        errorMessage={benefitTypeError || errors?.['benefit-type-options']?.message}
-        register={this.props.register}
-      />
-
-      <ReceiptDateInput
-        {...this.props}
-      />
-
-      <RadioField
-        name="informal-conference"
-        label="Was an informal conference requested?"
-        strongLabel
-        vertical
-        options={BOOLEAN_RADIO_OPTIONS}
-        onChange={(value) => {
-          this.props.setInformalConference(convertStringToBoolean(value));
-        }}
-        errorMessage={informalConferenceError || errors?.['informal-conference']?.message}
-        value={informalConference === null ? null : informalConference.toString()}
-        inputRef={this.props.register}
-      />
-
-      <RadioField
-        name="same-office"
-        label="Was an interview by the same office requested?"
-        strongLabel
-        vertical
-        options={BOOLEAN_RADIO_OPTIONS}
-        onChange={(value) => {
-          this.props.setSameOffice(convertStringToBoolean(value));
-        }}
-        errorMessage={sameOfficeError || errors?.['same-office']?.message}
-        value={sameOffice === null ? null : sameOffice.toString()}
-        inputRef={this.props.register}
-      />
-
-      <SelectClaimantConnected
-        register={this.props.register}
-        errors={this.props.errors}
-      />
-
-      <LegacyOptInApproved
-        value={legacyOptInApproved}
-        onChange={this.props.setLegacyOptInApproved}
-        errorMessage={legacyOptInApprovedError || errors?.['legacy-opt-in']?.message}
-        register={this.props.register}
-      />
-    </div>;
-  }
-}
-
-Review.propTypes = {
-  veteranName: PropTypes.string,
-  receiptDate: PropTypes.string,
-  receiptDateError: PropTypes.string,
-  benefitType: PropTypes.string,
-  benefitTypeError: PropTypes.string,
-  informalConference: PropTypes.bool,
-  informalConferenceError: PropTypes.string,
-  sameOffice: PropTypes.string,
-  sameOfficeError: PropTypes.string,
-  legacyOptInApproved: PropTypes.string,
-  legacyOptInApprovedError: PropTypes.string,
-  reviewIntakeError: PropTypes.object,
-  veteranValid: PropTypes.bool,
-  veteranInvalidFields: PropTypes.object,
-  setBenefitType: PropTypes.func,
-  setReceiptDate: PropTypes.func,
-  setInformalConference: PropTypes.func,
-  setSameOffice: PropTypes.func,
-  setLegacyOptInApproved: PropTypes.func,
-  higherLevelReviewStatus: PropTypes.string,
-  register: PropTypes.func,
-  errors: PropTypes.array
-};
-
-const SelectClaimantConnected = connect(
-  ({ higherLevelReview, intake, featureToggles }) => ({
-    isVeteranDeceased: intake.veteran.isDeceased,
-    veteranIsNotClaimant: higherLevelReview.veteranIsNotClaimant,
-    veteranIsNotClaimantError: higherLevelReview.veteranIsNotClaimantError,
-    claimant: higherLevelReview.claimant,
-    claimantError: higherLevelReview.claimantError,
-    payeeCode: higherLevelReview.payeeCode,
-    payeeCodeError: higherLevelReview.payeeCodeError,
-    relationships: higherLevelReview.relationships,
-    benefitType: higherLevelReview.benefitType,
-    formType: intake.formType,
-    featureToggles
-  }),
-  (dispatch) => bindActionCreators({
-    setVeteranIsNotClaimant,
-    setClaimant,
-    setPayeeCode
-  }, dispatch)
-)(SelectClaimant);
-
-export default connect(
-  (state) => ({
-    veteranName: state.intake.veteran.name,
-    higherLevelReviewStatus: getIntakeStatus(state),
-    receiptDate: state.higherLevelReview.receiptDate,
-    receiptDateError: state.higherLevelReview.receiptDateError,
-    benefitType: state.higherLevelReview.benefitType,
-    benefitTypeError: state.higherLevelReview.benefitTypeError,
-    legacyOptInApproved: state.higherLevelReview.legacyOptInApproved,
-    legacyOptInApprovedError: state.higherLevelReview.legacyOptInApprovedError,
-    informalConference: state.higherLevelReview.informalConference,
-    informalConferenceError: state.higherLevelReview.informalConferenceError,
-    sameOffice: state.higherLevelReview.sameOffice,
-    sameOfficeError: state.higherLevelReview.sameOfficeError,
-    reviewIntakeError: state.higherLevelReview.requestStatus.reviewIntakeError,
-    veteranValid: state.higherLevelReview.veteranValid,
-    veteranInvalidFields: state.higherLevelReview.veteranInvalidFields
-  }),
-  (dispatch) => bindActionCreators({
-    setInformalConference,
-    setSameOffice,
-    setReceiptDate,
-    setBenefitType,
-    setLegacyOptInApproved
-  }, dispatch)
-)(Review);
-
-export { reviewHigherLevelReviewSchema };
+export { reviewHigherLevelReviewSchema, higherLevelReviewFormHeader };

--- a/client/app/intake/pages/review.jsx
+++ b/client/app/intake/pages/review.jsx
@@ -13,7 +13,7 @@ import { PAGE_PATHS, FORM_TYPES, REQUEST_STATE, VBMS_BENEFIT_TYPES } from '../co
 import RampElectionPage, { reviewRampElectionSchema } from './rampElection/review';
 import RampRefilingPage, { reviewRampRefilingSchema } from './rampRefiling/review';
 import SupplementalClaimPage, { reviewSupplementalClaimSchema } from './supplementalClaim/review';
-import HigherLevelReviewPage, { reviewHigherLevelReviewSchema } from './higherLevelReview/review';
+import { higherLevelReviewFormHeader, reviewHigherLevelReviewSchema } from './higherLevelReview/review';
 import { appealFormHeader, reviewAppealSchema } from './appeal/review';
 
 import Button from '../../components/Button';
@@ -91,8 +91,15 @@ const Review = (props) => {
           ramp_election: <RampElectionPage {...formProps} />,
           ramp_refiling: <RampRefilingPage {...formProps} />,
           supplemental_claim: <SupplementalClaimPage featureToggles={props.featureToggles} {...formProps} />,
-          higher_level_review: <HigherLevelReviewPage featureToggles={props.featureToggles} {...formProps} />,
+          higher_level_review: <FormGenerator
+            formName={selectedForm.formName}
+            formHeader={higherLevelReviewFormHeader}
+            schema={schemaMappings.higher_level_review}
+            featureToggles={props.featureToggles}
+            {...formProps}
+          />,
           appeal: <FormGenerator
+            formName={selectedForm.formName}
             formHeader={appealFormHeader}
             schema={schemaMappings.appeal}
             featureToggles={props.featureToggles}

--- a/client/app/intake/pages/review.jsx
+++ b/client/app/intake/pages/review.jsx
@@ -92,14 +92,14 @@ const Review = (props) => {
           ramp_refiling: <RampRefilingPage {...formProps} />,
           supplemental_claim: <SupplementalClaimPage featureToggles={props.featureToggles} {...formProps} />,
           higher_level_review: <FormGenerator
-            formName={selectedForm.formName}
+            formName={selectedForm?.formName}
             formHeader={higherLevelReviewFormHeader}
             schema={schemaMappings.higher_level_review}
             featureToggles={props.featureToggles}
             {...formProps}
           />,
           appeal: <FormGenerator
-            formName={selectedForm.formName}
+            formName={selectedForm?.formName}
             formHeader={appealFormHeader}
             schema={schemaMappings.appeal}
             featureToggles={props.featureToggles}

--- a/client/app/intake/pages/review.jsx
+++ b/client/app/intake/pages/review.jsx
@@ -14,7 +14,7 @@ import RampElectionPage, { reviewRampElectionSchema } from './rampElection/revie
 import RampRefilingPage, { reviewRampRefilingSchema } from './rampRefiling/review';
 import SupplementalClaimPage, { reviewSupplementalClaimSchema } from './supplementalClaim/review';
 import HigherLevelReviewPage, { reviewHigherLevelReviewSchema } from './higherLevelReview/review';
-import AppealReviewPage, { reviewAppealSchema } from './appeal/review';
+import { appealFormHeader, reviewAppealSchema } from './appeal/review';
 
 import Button from '../../components/Button';
 import CancelButton from '../components/CancelButton';
@@ -25,6 +25,7 @@ import { setReceiptDateError } from '../actions/intake';
 import { toggleIneligibleError } from '../util';
 
 import SwitchOnForm from '../components/SwitchOnForm';
+import FormGenerator from './formGenerator';
 
 const textAlignRightStyling = css({
   textAlign: 'right',
@@ -91,7 +92,12 @@ const Review = (props) => {
           ramp_refiling: <RampRefilingPage {...formProps} />,
           supplemental_claim: <SupplementalClaimPage featureToggles={props.featureToggles} {...formProps} />,
           higher_level_review: <HigherLevelReviewPage featureToggles={props.featureToggles} {...formProps} />,
-          appeal: <AppealReviewPage featureToggles={props.featureToggles} {...formProps} />
+          appeal: <FormGenerator
+            formHeader={appealFormHeader}
+            schema={schemaMappings.appeal}
+            featureToggles={props.featureToggles}
+            {...formProps}
+          />
         }}
         componentForNoFormSelected={<Redirect to={PAGE_PATHS.BEGIN} />}
       />


### PR DESCRIPTION
Resolves  #16316

### Description
Implement Form Generator first pass. Definitely lots of room to improve, just hoping to get some eyes on and a discussion going on best ways to go about implementing this.

The idea here for this first pass, is to keep the separate files for each of the sub review forms, but reduce their complexity significantly by only having them export their yup schema (and a custom form header). The parent review page then just uses the FormGenerator to convert each of the yup schemas into a usable form. Ideally, the FormGenerator and the parent review page should have no specific knowledge of the individual sub forms (this isn't quite the case, but should be the goal). 

### Acceptance Criteria
- All of the intake process works exactly the same as it previously did

### Testing Plan
1. Go to intake
2. File an NOD appeal and verify form validation works
3. Make sure you are able to submit
4. File a Higher Level Review and verify form validation works
5. Make sure you are able to submit

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

 BEFORE|AFTER
No UI changes

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

