### PR TITLE
Add foreign key to EndProductCodeUpdate table

### DIFF
--- a/db/migrate/20210602145220_add_foreign_key_for_end_product_code_update.rb
+++ b/db/migrate/20210602145220_add_foreign_key_for_end_product_code_update.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyForEndProductCodeUpdate < Caseflow::Migration
+  def change
+    add_foreign_key "end_product_code_updates", "end_product_establishments", validate: false
+  end
+end

--- a/db/migrate/20210602145330_validate_foreign_key_for_end_product_code_update.rb
+++ b/db/migrate/20210602145330_validate_foreign_key_for_end_product_code_update.rb
@@ -1,0 +1,5 @@
+class ValidateForeignKeyForEndProductCodeUpdate < Caseflow::Migration
+  def change
+  	validate_foreign_key "end_product_code_updates", "end_product_establishments"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_01_143622) do
+ActiveRecord::Schema.define(version: 2021_06_02_145330) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1662,6 +1662,7 @@ ActiveRecord::Schema.define(version: 2021_06_01_143622) do
   add_foreign_key "docket_switches", "appeals", column: "old_docket_stream_id"
   add_foreign_key "docket_switches", "tasks"
   add_foreign_key "document_views", "users"
+  add_foreign_key "end_product_code_updates", "end_product_establishments"
   add_foreign_key "end_product_establishments", "users"
   add_foreign_key "end_product_updates", "end_product_establishments"
   add_foreign_key "end_product_updates", "users"


### PR DESCRIPTION
### Description
Adding a foreign key to the `EndProductCodeUpdate` table for `end_product_establishments`

This is phase 7c of a multi-phase plan to add missing foreign keys.
Phase 7b PR #16304
Phase 7 PR #16277
Phase 5c PR #16263
Phase 5b PR #16281
Phase 4 PR #16137
Phase 3 PR #16120
Phase 2 PR #16114
Phase 1 PR #16034 has more details.

### Testing Plan
Verify in Prod, Preprod, and UAT environments
```ruby
EndProductCodeUpdate.unscoped.includes(:end_product_establishment).where.not(end_product_establishment_id: nil).select{|r| r.end_product_establishment == nil}.pluck(:id)
=> []
```

### Database Changes
*Only for Schema Changes*



* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] #appeals-schema notified with summary and link to this PR
* [ ] Any non-obvious semantics or logic useful for interpreting database data is documented at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

