### PR TITLE
Consistently use 'hearing' and not 'hearings' as docket name

### DIFF
--- a/client/app/hearings/components/assignHearings/TimeSlotCard.stories.js
+++ b/client/app/hearings/components/assignHearings/TimeSlotCard.stories.js
@@ -56,7 +56,7 @@ Basic.args = {
   veteranFirstName: 'John',
   veteranLastName: 'Doe',
   veteranFileNumber: '987654321',
-  docketName: 'hearings',
+  docketName: 'hearing',
   caseType: 'Original',
   poaName: 'American Legion',
   docketNumber: '1800000A',
@@ -88,5 +88,5 @@ Basic.argTypes = {
     },
   },
   currentIssueCount: { control: { type: 'number' } },
-  docketName: { control: { type: 'select', options: ['', 'legacy', 'hearings'] } },
+  docketName: { control: { type: 'select', options: ['', 'legacy', 'hearing'] } },
 };

--- a/client/app/hearings/components/scheduleHearing/AppealInformation.stories.js
+++ b/client/app/hearings/components/scheduleHearing/AppealInformation.stories.js
@@ -62,6 +62,6 @@ Basic.args = {
 Basic.argTypes = {
   issueCount: { control: { type: 'number' } },
   caseType: { control: { type: 'select', options: ['Original', LEGACY_APPEAL_TYPES.CAVC_REMAND] } },
-  docketName: { control: { type: 'select', options: ['', 'legacy', 'hearings'] } },
+  docketName: { control: { type: 'select', options: ['', 'legacy', 'hearing'] } },
   veteranDateOfDeath: { control: { type: 'date' } }
 };

--- a/client/app/hearings/components/scheduleHearing/Timeslot.stories.js
+++ b/client/app/hearings/components/scheduleHearing/Timeslot.stories.js
@@ -20,7 +20,7 @@ export default {
       },
     },
     roTimezone: { control: { type: 'select', options: roTimezones() } },
-    docketName: { control: { type: 'select', options: ['', 'legacy', 'hearings'] } },
+    docketName: { control: { type: 'select', options: ['', 'legacy', 'hearing'] } },
     issueCount: { control: { type: 'number' } },
     poaName: { control: { type: 'select', options: ['', 'American Legion'] } }
   }

--- a/client/app/hearings/components/scheduleHearing/TimeslotDetail.stories.js
+++ b/client/app/hearings/components/scheduleHearing/TimeslotDetail.stories.js
@@ -8,7 +8,7 @@ export default {
   title: 'Hearings/Components/Schedule Hearing/TimeSlot Detail',
   component: TimeSlotDetail,
   argTypes: {
-    docketName: { control: { type: 'select', options: ['', 'legacy', 'hearings'] } },
+    docketName: { control: { type: 'select', options: ['', 'legacy', 'hearing'] } },
     issueCount: { control: { type: 'number' } },
     poaName: { control: { type: 'select', options: ['', 'American Legion'] } },
   }

--- a/db/seeds/substitutions.rb
+++ b/db/seeds/substitutions.rb
@@ -45,7 +45,7 @@ module Seeds
     def create_deceased_vet_and_dismissed_appeals
       ActiveRecord::Base.transaction do
         # Create appeals for each docket type
-        %w[direct_review evidence_submission hearings].each do |docket_type|
+        %w[direct_review evidence_submission hearing].each do |docket_type|
           create_appeal_with_death_dismissal(veteran: deceased_vet, docket_type: docket_type)
         end
 


### PR DESCRIPTION
### Description
I ran into a "bug" that was actually bad seed data; we had an appeal's docket_name set to 'hearings' instead of the correct 'hearing'. This was on our end and I fixed it in the console.

While looking, I found a few storybook stories that also had "hearings" for docketName. They weren't directly causing a problem, but I wanted to rid the code of incorrect instances of it.

### Acceptance Criteria
- [ ] Tests pass
- [ ] Someone who works on the Hearings code approves of this change
