### PR TITLE
Use plain JS to get the last element of vetName

### DIFF
--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import moment from 'moment';
 import pluralize from 'pluralize';
-import { _, isEmpty } from 'lodash';
+import { isEmpty } from 'lodash';
 import { css } from 'glamor';
 
 import DocketTypeBadge from '../../components/DocketTypeBadge';

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -104,7 +104,7 @@ export const detailsColumn = (tasks, requireDasRecord, userRole) => {
       const vetName = task.appeal.veteranFullName.split(' ');
       // only take last, first names. ignore middle names/initials
 
-      return `${_.last(vetName)} ${vetName[0]}`;
+      return `${vetName[vetName.length - 1]} ${vetName[0]}`;
     }
   };
 };


### PR DESCRIPTION
### Description
Using lodash's `_last.()` is failing, using plain JavaScript isn't failing. JC in the Frontend Workgroup said that this would be a valid fix, "if using plain JS works, it's probably best to just switch to that."

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Queue sorts successfully on sortable columns