### PR TITLE
Allow death dismissal streamlining only when deceased veteran is appellant

### DIFF
--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -40,7 +40,7 @@ class InitialTasksFactory
       create_selected_tasks
     elsif @appeal.cavc?
       create_cavc_subtasks
-    elsif @appeal.veteran.date_of_death.present? && FeatureToggle.enabled?(:death_dismissal_streamlining)
+    elsif should_streamline_death_dismissal?
       distribution_task.ready_for_distribution!
     else
       case @appeal.docket_type
@@ -155,5 +155,12 @@ class InitialTasksFactory
     else
       fail "Unsupported remand subtype: #{@cavc_remand.remand_subtype}"
     end
+  end
+
+  def should_streamline_death_dismissal?
+    return false if @appeal.appellant_is_not_veteran
+    return false if @appeal.veteran.date_of_death.nil?
+
+    FeatureToggle.enabled?(:death_dismissal_streamlining)
   end
 end

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -159,7 +159,7 @@ class InitialTasksFactory
 
   def should_streamline_death_dismissal?
     return false if @appeal.appellant_is_not_veteran
-    return false if @appeal.veteran.date_of_death.nil?
+    return false if @appeal.veteran.alive?
 
     FeatureToggle.enabled?(:death_dismissal_streamlining)
   end


### PR DESCRIPTION
Resolves [CASEFLOW-1676](https://vajira.max.gov/browse/CASEFLOW-1676)

### Description
This PR prevents death dismissal streamlining for deceased veterans when the appellant is not the veteran.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Added new test, which fails on old code