### PR TITLE
Explain endpoint: Replace jquery with non-jquery queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ npm-debug.log*
 node_modules
 
 # Generated js bundles
-/app/assets/javascripts/*
+/app/assets/javascripts/*webpack-bundle.js
 
 # Storybook
 /public/storybook/*

--- a/app/assets/javascripts/explain-appeal.js
+++ b/app/assets/javascripts/explain-appeal.js
@@ -1,0 +1,6 @@
+/**
+ * Support code for app/views/explain/show.html.erb,
+ * associated with app/controllers/explain_controller.rb.
+ * Also see accompanying app/assets/stylesheets/explain_appeal.css.
+ * These are added to the application in config/initializers/assets.rb.
+ */

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -93,11 +93,14 @@
   <script type="text/javascript">
     // Handle Task Tree field checkboxes
     function updateTaskTreeLink(){
-      var selected = $('#treeefields input:checked').map( (idx, elem) => elem.name ).get();
-      $('#task_tree_link').attr("href", window.location.href.split('?')[0]+"?fields="+selected.join(','));
+      const selected = Array.prototype.map.call(document.querySelectorAll('#treeefields input:checked'), elem => elem.name);
+      const newUrl = window.location.href.split('?')[0]+"?fields="+selected.join(',');
+      document.querySelector('#task_tree_link').setAttribute("href", newUrl);
     }
     updateTaskTreeLink();
-    $('#treeefields input').change( () => updateTaskTreeLink() );
+    document.querySelectorAll('#treeefields input').forEach((elem)=>{
+      elem.addEventListener('click', () => updateTaskTreeLink());
+    });
   </script>
 
   <% unless legacy_appeal? %>


### PR DESCRIPTION
Resolves [ReferenceError Sentry alerts](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/17008/?referrer=webhooks_plugin)

### Description
Replace jquery with basic javascript queries.

[Slack](https://dsva.slack.com/archives/C4JECDLSE/p1623098970035400?thread_ts=1623095733.032900&cid=C4JECDLSE)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] task tree checkboxes should update "Update task tree" URL link

### Testing Plan
Add `binding.pry` into `spec/feature/explain_spec.rb:87` and run the rspec. 

On the `explain` endpoint, 
- click the Help link
- mouse over the "Update task tree" link and examine the query string of the URL
- click on one or several checkboxes and check that the query string of the URL changes according to the checked items
