### PR TITLE
Narrative: improve presentation of events table

### DIFF
--- a/app/assets/stylesheets/explain_appeal.css
+++ b/app/assets/stylesheets/explain_appeal.css
@@ -11,22 +11,47 @@
  * file per style scope.
  */
 
-.clock {
-  color: rgb(146, 146, 146);
+#events_table tr.clock {
+  color: rgb(173, 173, 173);
+  font-size: 0.7em;
 }
 
-.milestone {
-  color: rgb(0, 8, 126);
+#events_table tr.milestone {
+  border-style: outset;
 }
 
-.task_assigned {
+#events_table tr.issue {
+  border-style: dotted;
+}
+
+#events_table tr.document {
+  border-style: dotted;
+}
+
+#events_table tr.hearing {
+  border-style: dashed;
+}
+
+#events_table .milestone .event_type,
+#events_table .milestone .category,
+#events_table .milestone .narrative {
+  color: blue;
+}
+
+#events_table .task_assigned .event_type,
+#events_table .task_assigned .category,
+#events_table .task_assigned .narrative {
   color: rgb(134, 132, 1)
 }
 
-.task_cancelled {
+#events_table .task_cancelled .event_type,
+#events_table .task_cancelled .category,
+#events_table .task_cancelled .narrative {
   color: rgb(143, 80, 80)
 }
 
-.task_completed {
+#events_table .task_completed .event_type,
+#events_table .task_completed .category,
+#events_table .task_completed .narrative {
   color: rgb(0, 90, 0)
 }

--- a/app/controllers/concerns/explain/appeal_record_event_mapper.rb
+++ b/app/controllers/concerns/explain/appeal_record_event_mapper.rb
@@ -26,7 +26,7 @@ class Explain::AppealRecordEventMapper < Explain::RecordEventMapper
       next if count == 0
 
       current_time = receipt_date + count.month
-      events << new_event(current_time, "month", category: "clock", object_id: "month_#{count}")
+      events << new_event(current_time, "month", category: "clock", object_id: "month #{count}")
     end
   end
 

--- a/app/controllers/concerns/explain/appeal_record_event_mapper.rb
+++ b/app/controllers/concerns/explain/appeal_record_event_mapper.rb
@@ -25,8 +25,8 @@ class Explain::AppealRecordEventMapper < Explain::RecordEventMapper
     number_of_months.times.each_with_object([]) do |count, events|
       next if count == 0
 
-      current_time = receipt_date + count.month
-      events << new_event(current_time, "month", category: "clock", object_id: "month #{count}")
+      month_timestamp = receipt_date + count.month
+      events << AppealEventData.new(month_timestamp, @default_context_id, "clock", "month #{count}", "month")
     end
   end
 

--- a/app/controllers/concerns/explain/hearing_record_event_mapper.rb
+++ b/app/controllers/concerns/explain/hearing_record_event_mapper.rb
@@ -42,7 +42,7 @@ class Explain::HearingRecordEventMapper < Explain::RecordEventMapper
   end
 
   def hearing_as_word
-    "#{@hearing_day['scheduled_for']} #{hearing_type} hearing (with judge #{user(record['judge_id'])})"
+    "#{@hearing_day['scheduled_for']} #{hearing_type} hearing with judge #{user(record['judge_id'])}"
   end
 
   RELEVANT_DATA_KEYS = %w[scheduled_time military_service representative_name bva_poc room].freeze

--- a/app/controllers/concerns/explain/record_event_mapper.rb
+++ b/app/controllers/concerns/explain/record_event_mapper.rb
@@ -110,7 +110,7 @@ class Explain::RecordEventMapper
       # row_order is an ordering based on event_type
       return row_order <=> other.row_order unless row_order == other.row_order
 
-      if details.key?("id") && other.details.key?("id")
+      if details&.key?("id") && other.details&.key?("id")
         # sort by id in reverse ordering to close child tasks first
         return other.details["id"] <=> details["id"] if CLOSED_STATUSES.include?(event_type)
 

--- a/app/controllers/explain_controller.rb
+++ b/app/controllers/explain_controller.rb
@@ -31,8 +31,12 @@ class ExplainController < ApplicationController
                 :show_pii_query_param, :treee_fields,
                 :available_fields,
                 :task_tree_as_text, :intake_as_text,
-                :event_table_data,
+                :event_table_data, :appeal_object_id,
                 :sje
+
+  def appeal_object_id
+    @appeal_object_id ||= "#{appeal.class.name}_#{appeal.id}"
+  end
 
   def explain_as_text
     [

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -33,7 +33,7 @@
             <i>(<%= event["object_id"] %>)</i>
           </td>
           <td style="padding: 2px; font-size:0.8em">
-            <% if event["context_id"] != event["object_id"] && event["category"] != "clock" %>
+            <% if event["context_id"] != appeal_object_id && event["category"] != "clock" %>
               <i>context: <%= event["context_id"] %></i>
             <% end %>
             <% if event["relevant_data"] %>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -6,26 +6,42 @@
   <h2>Appeal Narrative</h2>
   <details open>
     <summary style="color: purple">Narrative table</summary>
-    <table>
+    <table style="width: 100%;">
       <tr>
         <th>timestamp</th>
-        <th>context</th>
         <th>category</th>
         <th>event type</th>
-        <th>object id</th>
-        <th>comment</th>
-        <th>relevant_data</th>
+        <th style="width: 60%;">narrative</th>
+        <th style="width: 20%;">relevant_data</th>
         <th>details count</th>
       </tr>
       <% event_table_data.each do |event| %>
         <tr class="<%=event["category"]+'_'+event['event_type']%> <%=event["category"]%>">
-          <td style="padding: 2px"><%= event["timestamp"] %></td>
-          <td style="padding: 2px"><%= event["context_id"] %></td>
+          <td style="padding: 2px"><%=
+            if event["category"] == "clock"
+              event["timestamp"]
+            else
+              DateTime.parse(event["timestamp"]).strftime("%F %T") rescue event["timestamp"]
+            end
+          %></td>
           <td style="padding: 2px"><%= event["category"] %></td>
           <td style="padding: 2px"><%= event["event_type"] %></td>
-          <td style="padding: 2px"><%= event["object_id"] %></td>
-          <td style="padding: 2px"><%= event["comment"] %></td>
-          <td style="padding: 2px"><%= event["relevant_data"] %></td>
+          <td style="padding: 2px">
+            <% if event["comment"] %>
+              <%= event["comment"] %><br/>
+            <% end %>
+            <i>(<%= event["object_id"] %>)</i>
+          </td>
+          <td style="padding: 2px; font-size:0.8em">
+            <% if event["context_id"] != event["object_id"] %>
+              <i>context: <%= event["context_id"] %></i>
+            <% end %>
+            <% if event["relevant_data"] %>
+              <pre style="margin: 0px; width: 300px;"><%=
+                JSON.pretty_generate(event["relevant_data"]).sub("{\n","").sub("\n}","").gsub(/^  /,"")
+              %></pre>
+            <% end %>
+          </td>
           <td style="padding: 2px"><%= event["details"]&.size %></td>
         </tr>
       <% end %>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -6,7 +6,7 @@
   <h2>Appeal Narrative</h2>
   <details open>
     <summary style="color: purple">Narrative table</summary>
-    <table style="width: 100%;">
+    <table id="events_table" style="width: 100%;">
       <tr>
         <th>timestamp</th>
         <th>category</th>
@@ -17,22 +17,22 @@
       </tr>
       <% event_table_data.each do |event| %>
         <tr class="<%=event["category"]+'_'+event['event_type']%> <%=event["category"]%>">
-          <td style="padding: 2px"><%=
+          <td style="padding: 2px" class="timestamp"><%=
             if event["category"] == "clock"
               event["timestamp"]
             else
               DateTime.parse(event["timestamp"]).strftime("%F %T") rescue event["timestamp"]
             end
           %></td>
-          <td style="padding: 2px"><%= event["category"] %></td>
-          <td style="padding: 2px"><%= event["event_type"] %></td>
-          <td style="padding: 2px">
+          <td style="padding: 2px" class="category"><%= event["category"] %></td>
+          <td style="padding: 2px" class="event_type"><%= event["event_type"] %></td>
+          <td style="padding: 2px" class="narrative">
             <% if event["comment"] %>
               <%= event["comment"] %><br/>
             <% end %>
             <i>(<%= event["object_id"] %>)</i>
           </td>
-          <td style="padding: 2px; font-size:0.8em">
+          <td style="padding: 2px; font-size:0.8em" class="rel_data">
             <% if event["context_id"] != appeal_object_id && event["category"] != "clock" %>
               <i>context: <%= event["context_id"] %></i>
             <% end %>
@@ -42,7 +42,7 @@
               %></pre>
             <% end %>
           </td>
-          <td style="padding: 2px"><%= event["details"]&.size %></td>
+          <td style="padding: 2px" class="details"><%= event["details"]&.size %></td>
         </tr>
       <% end %>
     </table>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -33,7 +33,7 @@
             <i>(<%= event["object_id"] %>)</i>
           </td>
           <td style="padding: 2px; font-size:0.8em">
-            <% if event["context_id"] != event["object_id"] %>
+            <% if event["context_id"] != event["object_id"] && event["category"] != "clock" %>
               <i>context: <%= event["context_id"] %></i>
             <% end %>
             <% if event["relevant_data"] %>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -12,8 +12,8 @@
         <th>category</th>
         <th>event type</th>
         <th style="width: 60%;">narrative</th>
-        <th style="width: 20%;">relevant_data</th>
-        <th>details count</th>
+        <th style="width: 20%;">relevant data</th>
+        <th>attribute count</th>
       </tr>
       <% event_table_data.each do |event| %>
         <tr class="<%=event["category"]+'_'+event['event_type']%> <%=event["category"]%>">

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -4,7 +4,7 @@
 
 <div style="font-size:0.875em; padding:10px">
   <h2>Appeal Narrative</h2>
-  <details open>
+  <details>
     <summary style="color: purple">Narrative table</summary>
     <table id="events_table" style="width: 100%;">
       <tr>


### PR DESCRIPTION
Innovation project: [Appeal Narrative](https://dsva.slack.com/archives/C022T6KSE6S/p1622571159006000)

### Description
Combine columns without losing information:
* context column value is prepended to relevant_data column only if the context is different than the current appeal
* object_id column value is appended to narrative column

Also, timestamp column is split into separate date and time so it is better word wrapped and more readable.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Table UI is more presentable without loss of information

### Testing Plan
Add `binding.pry` into `spec/feature/explain_spec.rb:100` and run the rspec. 
Should see something like this:
![image](https://user-images.githubusercontent.com/55255674/121265377-54425580-c87e-11eb-9c25-265fb4b45f7a.png)
