### PR TITLE
Remove sentry alert from BgsPowerOfAttorney#update_ihp_enabled

### DIFF
--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -243,12 +243,7 @@ class BgsPowerOfAttorney < CaseflowRecord
   end
 
   def update_ihp_enabled?
-    toggle_on = FeatureToggle.enabled?(:poa_auto_ihp_update, user: RequestStore.store[:current_user])
-    Raven.capture_message("Checking if IHP should be updated..." \
-    "Is feature toggle enabled for this user?: #{toggle_on}" \
-    "Was there a POA participant ID change?: #{saved_change_to_poa_participant_id?}" \
-    "POA participant ID: #{poa_participant_id}" \
-    "File number: #{file_number}")
-    toggle_on && saved_change_to_poa_participant_id?
+    FeatureToggle.enabled?(:poa_auto_ihp_update, user: RequestStore.store[:current_user]) &&
+      saved_change_to_poa_participant_id?
   end
 end


### PR DESCRIPTION
### Description
A sentry alert to `BgsPowerOfAttorney#update_ihp_enabled?` had been added temporarily to capture information on the method's execution.  We've obtained what we needed to so now removing the alert.

### Acceptance Criteria
- [ ] Code compiles correctly