### PR TITLE
IP PI: eager loading - optimize checking for children on tasks for appeal

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -136,7 +136,7 @@ class TasksController < ApplicationController
 
     tasks = TasksForAppeal.new(appeal: appeal, user: current_user, user_role: user_role).call
 
-    render json: { tasks: json_tasks(tasks)[:data] }
+    render json: { tasks: json_tasks(tasks.with_children_existence)[:data] }
   end
 
   def reschedule


### PR DESCRIPTION
Resolves #{github issue number}

### Description
This preloads the has_children question per task using a scope.  Here's one of the bullet logs this eliminates:
```
15:12:33 rails.1  | [localhost] [8197e9ca-c978-4fdc-bb14-d4ee307c3071] [localhost] [BVAAABSHIRE ] user: barshirtcliff
15:12:33 rails.1  | GET /appeals/23d38b51-8135-4c70-b2db-fcca569ffe2b/tasks?role=Judge
15:12:33 rails.1  | USE eager loading detected
15:12:33 rails.1  |   TrackVeteranTask => [:children]
15:12:33 rails.1  |   Add to your finder: :includes => [:children]
15:12:33 rails.1  | Call stack
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/models/task.rb:324:in `open_with_no_children?'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/models/task.rb:578:in `can_move_on_docket_switch?'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/models/serializers/work_queue/task_serializer.rb:160:in `block in <class:TaskSerializer>'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/serializers/ama_and_legacy_task_serializer.rb:19:in `call'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/controllers/tasks_controller.rb:273:in `json_tasks'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/controllers/tasks_controller.rb:139:in `for_appeal'
15:12:33 rails.1  |   /Users/barshirtcliff/caseflow/app/controllers/application_controller.rb:227:in `set_timezone'
15:12:33 rails.1  |
```
It may be beneficial to use this scope in more than one place.
I got the idea for doing it this way from [here](https://dev.to/johncip/understanding-rails-eager-loading-3n6j)

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. Unit tests pass

