### PR TITLE
Block grants/remands for unrecognized appellants

### DIFF
--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -55,6 +55,8 @@ class DecisionDocument < CaseflowRecord
     upload_to_vbms!
 
     if appeal.is_a?(Appeal)
+      fail NotImplementedError if appeal.claimant.is_a?(OtherClaimant)
+
       create_board_grant_effectuations!
       process_board_grant_effectuations!
       appeal.create_remand_supplemental_claims!

--- a/spec/models/decision_document_spec.rb
+++ b/spec/models/decision_document_spec.rb
@@ -180,6 +180,18 @@ describe DecisionDocument, :postgres do
         end
       end
 
+      context "when appellant is unrecognized" do
+        let(:claimant) { create(:claimant, type: "OtherClaimant") }
+
+        it "uploads the document and then gets blocked" do
+          expect { subject }.to raise_error(NotImplementedError)
+
+          expect(VBMSService).to have_received(:upload_document_to_vbms).with(
+            decision_document.appeal, decision_document
+          )
+        end
+      end
+
       it "uploads document" do
         subject
 


### PR DESCRIPTION
### Description
When an appeal with an unrecognized appellant gets granted or remanded, any EPs that get created in VBMS will be incorrectly created with the veteran's participant ID. This PR blocks decision documents from processing completely -- the document will still be uploaded to VBMS, but downstream EPs won't be created.

### Testing Plan
1. Added a new test