### PR TITLE
Do not distribute cases with an unrecognized appellant

### DIFF
--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -85,7 +85,11 @@ class Docket
   private
 
   def docket_appeals
-    Appeal.where(docket_type: docket_type).extending(Scopes)
+    Appeal.joins(:claimants)
+      .joins("left join unrecognized_appellants on claimants.id = unrecognized_appellants.claimant_id")
+      .where(docket_type: docket_type)
+      .where("unrecognized_appellants.id is null")
+      .extending(Scopes)
   end
 
   def assign_judge_tasks_for_appeals(appeals, judge)

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -53,17 +53,24 @@ describe Docket, :all_dbs do
              :cavc_ready_for_distribution,
              docket_type: Constants.AMA_DOCKETS.direct_review)
     end
+    let!(:unrecognized_appellant_appeal) do
+      create(:appeal,
+             :with_post_intake_tasks,
+             claimants: [create(:claimant, :with_unrecognized_appellant_detail)],
+             docket_type: Constants.AMA_DOCKETS.direct_review)
+    end
 
     context "appeals" do
       context "when no options given" do
         subject { DirectReviewDocket.new.appeals }
-        it "returns all appeals if no option given" do
+        it "returns all appeals except for unrecognized_appellant appeals if no option given" do
           expect(subject).to include appeal
           expect(subject).to include denied_aod_motion_appeal
           expect(subject).to include inapplicable_aod_motion_appeal
           expect(subject).to include aod_age_appeal
           expect(subject).to include aod_motion_appeal
           expect(subject).to include cavc_appeal
+          expect(subject).to_not include unrecognized_appellant_appeal
         end
       end
 
@@ -76,6 +83,7 @@ describe Docket, :all_dbs do
           expect(subject).to include aod_age_appeal
           expect(subject).to include aod_motion_appeal
           expect(subject).to include cavc_appeal
+          expect(subject).to_not include unrecognized_appellant_appeal
         end
       end
 
@@ -88,6 +96,7 @@ describe Docket, :all_dbs do
           expect(subject).to_not include aod_age_appeal
           expect(subject).to_not include aod_motion_appeal
           expect(subject).to_not include cavc_appeal
+          expect(subject).to_not include unrecognized_appellant_appeal
         end
       end
 


### PR DESCRIPTION
We have begun intaking appeals for unrecognized appellants, and some of those appeals have already been distributed. The Board should not be working on decisions for unrecognized appellants, so this PR prevents those appeals from being distributed.

See [this Slack thread](https://dsva.slack.com/archives/C7P7M26QM/p1623342865191400) for more context on the decision to prevent distribution for unrecognized appellants.