### PR TITLE
Prevent the creation of BvaDispatchTasks for unrecognized appellants

### DIFF
--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -5,6 +5,8 @@
 # This indicates that an appeal is decided and the appellant is about to be notified of the decision.
 
 class BvaDispatchTask < Task
+  before_create :prevent_dispatch_task_creation_for_unrecognized_appellants
+
   def available_actions(user)
     return [] unless user
 
@@ -44,5 +46,11 @@ class BvaDispatchTask < Task
         LegacyAppealDispatch.new(appeal: appeal, params: params).call
       end
     end
+  end
+
+  private
+
+  def prevent_dispatch_task_creation_for_unrecognized_appellants
+      fail NotImplementedError if appeal.claimant.is_a?(OtherClaimant)
   end
 end

--- a/app/models/tasks/bva_dispatch_task.rb
+++ b/app/models/tasks/bva_dispatch_task.rb
@@ -51,6 +51,6 @@ class BvaDispatchTask < Task
   private
 
   def prevent_dispatch_task_creation_for_unrecognized_appellants
-      fail NotImplementedError if appeal.claimant.is_a?(OtherClaimant)
+    fail NotImplementedError if appeal.claimant.is_a?(OtherClaimant)
   end
 end

--- a/spec/models/tasks/bva_dispatch_task_spec.rb
+++ b/spec/models/tasks/bva_dispatch_task_spec.rb
@@ -52,6 +52,20 @@ describe BvaDispatchTask, :all_dbs do
         expect(subject).to be_nil
       end
     end
+
+    context "when case belongs to an unrecognized appellant" do
+      let(:claimant) { create(:claimant, :with_unrecognized_appellant_detail, type: "OtherClaimant") }
+      let(:appeal) { create(:appeal, claimants: [claimant]) }
+      let(:root_task) { create(:root_task, appeal: appeal) }
+
+      before do
+        BvaDispatch.singleton.add_user(create(:user))
+      end
+
+      it "should raise an error" do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+    end
   end
 
   describe ".outcode" do


### PR DESCRIPTION
We have begun intaking appeals for unrecognized appellants, and some of those appeals have already been distributed with attorneys drafting decisions on them. [Previous changes prevented the code from updating VBMS with grants/remands](https://github.com/department-of-veterans-affairs/caseflow/pull/16345), however the Board requires that the Decision Management Team not send out letters for those cases as well.

This change makes it so that we do not create `BvaDispatchTask`s for cases with unrecognized appellants, thereby preventing these cases from showing up in the Decision Management Team queue.

### Restarting

The task trees for these appeals will display completed `AttorneyTask` and `JudgeDecisionReviewTask`s but no `BvaDispatchTask`. We are tracking all appeals [in this document](https://docs.google.com/spreadsheets/d/13EbrYFLJwZVZhmBJCm_9Zvt8jm-y5-0oDwlVBLbhRV4/edit#gid=0), but we can also use the following query to find these appeals directly in the database whenever the time comes to create `BvaDispatchTask`s for these cases:

```sql
select distinct t.appeal_id
from unrecognized_appellants ua
join claimants cl
  on cl.id = ua.claimant_id
join tasks t
  on cl.decision_review_id = t.appeal_id
  and t.type = 'JudgeDecisionReviewTask'
left join tasks disptask
  on cl.decision_review_id = disptask.appeal_id
  and disptask.type = 'BvaDispatchTask'
where t.status = 'completed'
  and disptask.id is null;
```

See [this Slack thread](https://dsva.slack.com/archives/C7P7M26QM/p1623342865191400) for more context on the decision to prevent distribution for unrecognized appellants.