### PR TITLE
Speed up query that filters out unrecognized appellants from Docket

### DIFF
--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -86,9 +86,8 @@ class Docket
 
   def docket_appeals
     Appeal.joins(:claimants)
-      .joins("left join unrecognized_appellants on claimants.id = unrecognized_appellants.claimant_id")
       .where(docket_type: docket_type)
-      .where("unrecognized_appellants.id is null")
+      .where("claimants.type <> 'OtherClaimant'")
       .extending(Scopes)
   end
 

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -56,7 +56,7 @@ describe Docket, :all_dbs do
     let!(:unrecognized_appellant_appeal) do
       create(:appeal,
              :with_post_intake_tasks,
-             claimants: [create(:claimant, :with_unrecognized_appellant_detail)],
+             claimants: [create(:claimant, :with_unrecognized_appellant_detail, type: "OtherClaimant")],
              docket_type: Constants.AMA_DOCKETS.direct_review)
     end
 


### PR DESCRIPTION
Follow up to #16352 to speed up the database query.