### PR TITLE
Handle legacy appeal claimant participant ID

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -312,11 +312,11 @@ class AppealsController < ApplicationController
 
   def clear_poa_not_found_cache
     Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.veteran.file_number}") if appeal.veteran&.file_number
-    if appeal.claimant&.participant_id
-      Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.claimant&.participant_id}")
-    elsif claimant.is_a?(Hash)
-      Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.claimant&.dig(:representative, :participant_id)}")
-    end
+    Rails.cache.delete("bgs-participant-poa-not-found-#{claimant_participant_id}") if claimant_participant_id
+  end
+
+  def claimant_participant_id
+    appeal.is_a?(Appeal) ? appeal.claimant&.participant_id : appeal.claimant&.dig(:representative, :participant_id)
   end
 
   def cooldown_period_remaining

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -316,6 +316,7 @@ class AppealsController < ApplicationController
   end
 
   def claimant_participant_id
+    # Checks whether the appeal is an AMA or Legacy appeal to find the claimant's participant ID
     appeal.is_a?(Appeal) ? appeal.claimant&.participant_id : appeal.claimant&.dig(:representative, :participant_id)
   end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -324,7 +324,7 @@ class LegacyAppeal < CaseflowRecord
   end
 
   def poa_last_synced_at
-    power_of_attorney.bgs_poa_last_synced_at
+    power_of_attorney&.bgs_poa_last_synced_at
   end
 
   def legacy_appeal_representative
@@ -898,6 +898,10 @@ class LegacyAppeal < CaseflowRecord
     vacols_case_review.valid_document_id?
   end
 
+  def claimant_participant_id
+    veteran_is_not_claimant ? person_for_appellant&.participant_id : veteran&.participant_id 
+  end
+
   private
 
   def soc_eligible_for_opt_in?(receipt_date:, covid_flag: false)
@@ -979,10 +983,6 @@ class LegacyAppeal < CaseflowRecord
       claimant_participant_id: claimant_participant_id,
       vacols_id: vacols_id
     )
-  end
-
-  def claimant_participant_id
-    person_for_appellant&.participant_id
   end
 
   class << self

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -605,17 +605,23 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
 
   describe "Get legacy appeal Power of Attorney" do
     let!(:user) { User.authenticate!(roles: ["System Admin"]) }
-    let(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "0000000000S")) }
-    let!(:veteran) { create(:veteran, file_number: appeal.sanitized_vbms_id) }
-    let(:get_params) { { appeal_id: appeal.vacols_id } }
-    let(:patch_params) { { appeal_id: appeal.vacols_id, poaId: appeal.power_of_attorney.id } }
-    let!(:poa) do
+    let!(:appellant) { create(:person, ssn: veteran.ssn, participant_id: veteran.participant_id) }
+    let(:appeal) do
       create(
-        :bgs_power_of_attorney,
-        :with_name_cached,
-        appeal: appeal
+        :legacy_appeal,
+        vacols_case: create(:case, bfcorlid: "0000000000S")
       )
     end
+    let!(:veteran) { create(:veteran, file_number: appeal.sanitized_vbms_id) }
+    let(:get_params) { { appeal_id: appeal.vacols_id } }
+    let(:patch_params) { { appeal_id: appeal.vacols_id, poaId: appeal.power_of_attorney&.bgs_id } }
+    # let!(:poa) do
+    #   create(
+    #     :bgs_power_of_attorney,
+    #     :with_name_cached,
+    #     appeal: appeal
+    #   )
+    # end
 
     context "get the appeals POA information" do
       subject do
@@ -634,18 +640,31 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
       end
     end
 
-    context do
+    context "when the POA was previously cached as not_found" do
+      let(:claimant_participant_id) { appeal.claimant_participant_id }
+      let(:patch_params) { { appeal_id: appeal.vacols_id } }
+      let!(:poa) do
+        create(
+          :bgs_power_of_attorney,
+          claimant_participant_id: veteran.participant_id
+        )
+      end
+      before do
+        Rails.cache.write("bgs-participant-poa-not-found-#{claimant_participant_id}", true)
+        # allow_any_instance_of(PowerOfAttorney).to receive(:bgs_power_of_attorney).and_return(nil)
+      end
+
       subject do
-        participant_id = appeal.claimant&.dig(:representative, :participant_id)
-        Rails.cache.write("bgs-participant-poa-not-found-#{participant_id}", true)
         patch :update_power_of_attorney, params: patch_params
       end
 
-      it "clears not_found cache when claimant is a hash" do
+      fit "clears not_found cache when claimant is a hash" do
+        binding.pry
+        subject
+        binding.pry
         expect(appeal.power_of_attorney).to_not eq(nil)
         expect(appeal.claimant.is_a?(Hash)).to eq(true)
-        participant_id = appeal.claimant&.dig(:representative, :participant_id)
-        expect(Rails.cache.read("bgs-participant-poa-not-found-#{participant_id}")).to eq(nil)
+        expect(Rails.cache.read("bgs-participant-poa-not-found-#{claimant_participant_id}")).to eq(nil)
       end
     end
   end

--- a/spec/factories/bgs_power_of_attorney.rb
+++ b/spec/factories/bgs_power_of_attorney.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     sequence(:poa_participant_id)
     representative_name { "POA Name" }
     representative_type { "VSO" }
+    # synced_at { 2.days.ago }
 
     trait :with_name_cached do
       transient do


### PR DESCRIPTION
Resolves [CASEFLOW-1742](https://vajira.max.gov/browse/CASEFLOW-1742)

### Description
When implementing a solution for CASEFLOW-1639 we inadvertently introduced a bug where Legacy appeals will fail when checking the participant_id on a claimant hash prior to when we check if the claimant is actually a hash.

This PR checks whether the appeal is an AMA appeal or a Legacy Appeal before getting the claimant's participant ID (from the claimant object, or hash, respectively).

### Acceptance Criteria
- [ ] A previously not_found POA for a legacy appeal is cleared from the cache and re-fetched when calling the update_power_of_attorney endpoint in the appeals controller

### Testing Plan
1. Controller spec

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)