### PR TITLE
Annotate PII columns in schema

### DIFF
--- a/db/migrate/20210615221829_add_pii_comment_on_pii_columns.rb
+++ b/db/migrate/20210615221829_add_pii_comment_on_pii_columns.rb
@@ -1,0 +1,43 @@
+class AddPiiCommentOnPiiColumns < Caseflow::Migration
+  def up
+    change_column_comment :veterans, :first_name, "PII. Veteran's first name"
+    change_column_comment :veterans, :middle_name, "PII. Veteran's middle name"
+    change_column_comment :veterans, :last_name, "PII. Veteran's last name"
+    change_column_comment :veterans, :file_number, "PII. Veteran's file_number"
+    change_column_comment :veterans, :ssn, "PII. The cached Social Security Number"
+
+    change_column_comment :appeals, :veteran_file_number, "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :available_hearing_locations, :veteran_file_number, "PII. The VBA corporate file number of the Veteran for the appeal"
+    change_column_comment :end_product_establishments, :veteran_file_number, "PII. The file number of the Veteran submitted when establishing the end product."
+    change_column_comment :higher_level_reviews, :veteran_file_number, "PII. The file number of the Veteran that the Higher Level Review is for."
+    change_column_comment :supplemental_claims, :veteran_file_number, "PII. The file number of the Veteran that the Supplemental Claim is for."
+    change_column_comment :intakes, :veteran_file_number, "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :ramp_elections, :veteran_file_number, "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :ramp_refilings, :veteran_file_number, "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+
+    change_column_comment :bgs_power_of_attorneys, :file_number, "PII. Claimant file number"
+    change_column_comment :documents, :file_number, "PII"
+    change_column_comment :form8s, :file_number, "PII"
+  end
+
+  def down
+    change_column_comment :veterans, :first_name, nil
+    change_column_comment :veterans, :middle_name, nil
+    change_column_comment :veterans, :last_name, nil
+    change_column_comment :veterans, :file_number, nil
+    change_column_comment :veterans, :ssn, "The cached Social Security Number"
+
+    change_column_comment :appeals, :veteran_file_number, "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :available_hearing_locations, :veteran_file_number, "The VBA corporate file number of the Veteran for the appeal"
+    change_column_comment :end_product_establishments, :veteran_file_number, "The file number of the Veteran submitted when establishing the end product."
+    change_column_comment :higher_level_reviews, :veteran_file_number, "The file number of the Veteran that the Higher Level Review is for."
+    change_column_comment :supplemental_claims, :veteran_file_number, "The file number of the Veteran that the Supplemental Claim is for."
+    change_column_comment :intakes, :veteran_file_number, "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :ramp_elections, :veteran_file_number, "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    change_column_comment :ramp_refilings, :veteran_file_number, "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+
+    change_column_comment :bgs_power_of_attorneys, :file_number, "Claimant file number"
+    change_column_comment :documents, :file_number, nil
+    change_column_comment :form8s, :file_number, nil  
+  end
+end

--- a/db/migrate/20210615221829_add_pii_comment_on_pii_columns.rb
+++ b/db/migrate/20210615221829_add_pii_comment_on_pii_columns.rb
@@ -18,6 +18,14 @@ class AddPiiCommentOnPiiColumns < Caseflow::Migration
     change_column_comment :bgs_power_of_attorneys, :file_number, "PII. Claimant file number"
     change_column_comment :documents, :file_number, "PII"
     change_column_comment :form8s, :file_number, "PII"
+
+    change_column_comment :people, :date_of_birth, "PII"
+    change_column_comment :people, :email_address, "PII. Person email address, cached from BGS"
+    change_column_comment :people, :first_name, "PII. Person first name, cached from BGS"
+    change_column_comment :people, :last_name, "PII. Person last name, cached from BGS"
+    change_column_comment :people, :middle_name, "PII. Person middle name, cached from BGS"
+    change_column_comment :people, :name_suffix, "PII. Person name suffix, cached from BGS"
+    change_column_comment :people, :ssn, "PII. Person Social Security Number, cached from BGS"
   end
 
   def down
@@ -38,6 +46,14 @@ class AddPiiCommentOnPiiColumns < Caseflow::Migration
 
     change_column_comment :bgs_power_of_attorneys, :file_number, "Claimant file number"
     change_column_comment :documents, :file_number, nil
-    change_column_comment :form8s, :file_number, nil  
+    change_column_comment :form8s, :file_number, nil
+
+    change_column_comment :people, :date_of_birth, nil
+    change_column_comment :people, :email_address, "Person email address, cached from BGS"
+    change_column_comment :people, :first_name, "Person first name, cached from BGS"
+    change_column_comment :people, :last_name, "Person last name, cached from BGS"
+    change_column_comment :people, :middle_name, "Person middle name, cached from BGS"
+    change_column_comment :people, :name_suffix, "Person name suffix, cached from BGS"
+    change_column_comment :people, :ssn, "Person Social Security Number, cached from BGS"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_170300) do
+ActiveRecord::Schema.define(version: 2021_06_15_221829) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,7 +118,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.date "target_decision_date", comment: "If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
     t.datetime "updated_at"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."
-    t.string "veteran_file_number", null: false, comment: "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    t.string "veteran_file_number", null: false, comment: "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
     t.boolean "veteran_is_not_claimant", comment: "Selected by the user during intake, indicates whether the Veteran is the claimant, or if the claimant is someone else such as a dependent. Must be TRUE if Veteran is deceased."
     t.index ["aod_based_on_age"], name: "index_appeals_on_aod_based_on_age"
     t.index ["docket_type"], name: "index_appeals_on_docket_type"
@@ -173,7 +173,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "name", comment: "Name of location; i.e 'Chicago Regional Benefit Office', 'Jennings VA Clinic', etc"
     t.string "state", comment: "State in abbreviated form; i.e 'NY', 'CA', etc"
     t.datetime "updated_at", null: false, comment: "Automatic timestamp of when hearing location was updated"
-    t.string "veteran_file_number", comment: "The VBA corporate file number of the Veteran for the appeal"
+    t.string "veteran_file_number", comment: "PII. The VBA corporate file number of the Veteran for the appeal"
     t.string "zip_code"
     t.index ["appeal_id", "appeal_type"], name: "index_available_hearing_locations_on_appeal_id_and_appeal_type"
     t.index ["updated_at"], name: "index_available_hearing_locations_on_updated_at"
@@ -199,7 +199,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "authzn_poa_access_ind", comment: "Authorization for POA access"
     t.string "claimant_participant_id", null: false, comment: "Claimant participant ID -- use as FK to claimants"
     t.datetime "created_at", null: false, comment: "Standard created_at/updated_at timestamps"
-    t.string "file_number", comment: "Claimant file number"
+    t.string "file_number", comment: "PII. Claimant file number"
     t.datetime "last_synced_at", comment: "The last time BGS was checked"
     t.string "legacy_poa_cd", comment: "Legacy POA code"
     t.string "poa_participant_id", null: false, comment: "POA participant ID -- use as FK to people"
@@ -549,7 +549,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.boolean "category_procedural"
     t.datetime "created_at"
     t.string "description"
-    t.string "file_number"
+    t.string "file_number", comment: "PII"
     t.integer "previous_document_version_id"
     t.date "received_at"
     t.string "series_id"
@@ -601,7 +601,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "synced_status", comment: "The status of the end product, which is synced by a job. Once and end product is cleared (CLR) or canceled (CAN) the status is final and the end product will not continue being synced."
     t.datetime "updated_at"
     t.integer "user_id", comment: "The ID of the user who performed the decision review intake."
-    t.string "veteran_file_number", null: false, comment: "The file number of the Veteran submitted when establishing the end product."
+    t.string "veteran_file_number", null: false, comment: "PII. The file number of the Veteran submitted when establishing the end product."
     t.index ["source_type", "source_id"], name: "index_end_product_establishments_on_source_type_and_source_id"
     t.index ["updated_at"], name: "index_end_product_establishments_on_updated_at"
     t.index ["user_id"], name: "index_end_product_establishments_on_user_id"
@@ -651,7 +651,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "contested_claims_procedures_applicable"
     t.string "contested_claims_requirements_followed"
     t.datetime "created_at", null: false
-    t.string "file_number"
+    t.string "file_number", comment: "PII"
     t.date "form9_date"
     t.string "form_646_not_of_record_explanation"
     t.string "form_646_of_record"
@@ -840,7 +840,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.boolean "same_office", comment: "Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review."
     t.datetime "updated_at"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the Higher Level Review. Can be used to link to the claim after it is completed."
-    t.string "veteran_file_number", null: false, comment: "The file number of the Veteran that the Higher Level Review is for."
+    t.string "veteran_file_number", null: false, comment: "PII. The file number of the Veteran that the Higher Level Review is for."
     t.boolean "veteran_is_not_claimant", comment: "Indicates whether the Veteran is the claimant on the Higher Level Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
     t.index ["updated_at"], name: "index_higher_level_reviews_on_updated_at"
     t.index ["uuid"], name: "index_higher_level_reviews_on_uuid"
@@ -871,7 +871,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "type", comment: "The class name of the intake."
     t.datetime "updated_at"
     t.integer "user_id", null: false, comment: "The ID of the user who created the intake."
-    t.string "veteran_file_number", comment: "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    t.string "veteran_file_number", comment: "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
     t.index ["detail_type", "detail_id"], name: "index_intakes_on_detail_type_and_detail_id"
     t.index ["type", "veteran_file_number"], name: "unique_index_to_avoid_duplicate_intakes", unique: true, where: "(completed_at IS NULL)"
     t.index ["type"], name: "index_intakes_on_type"
@@ -1133,7 +1133,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "option_selected", comment: "Indicates whether the Veteran selected for their RAMP election to be processed as a higher level review (with or without a hearing), a supplemental claim, or a board appeal."
     t.date "receipt_date", comment: "The date that the RAMP form was received by central mail."
     t.datetime "updated_at"
-    t.string "veteran_file_number", null: false, comment: "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    t.string "veteran_file_number", null: false, comment: "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
     t.index ["updated_at"], name: "index_ramp_elections_on_updated_at"
     t.index ["veteran_file_number"], name: "index_ramp_elections_on_veteran_file_number"
   end
@@ -1160,7 +1160,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.string "option_selected", comment: "Which lane the RAMP refiling is for, between appeal, higher level review, and supplemental claim."
     t.date "receipt_date", comment: "Receipt date of the RAMP form."
     t.datetime "updated_at"
-    t.string "veteran_file_number", null: false, comment: "The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
+    t.string "veteran_file_number", null: false, comment: "PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran."
     t.index ["updated_at"], name: "index_ramp_refilings_on_updated_at"
     t.index ["veteran_file_number"], name: "index_ramp_refilings_on_veteran_file_number"
   end
@@ -1357,7 +1357,7 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.date "receipt_date", comment: "The date that the Supplemental Claim form was received by central mail. Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established. Supplemental Claims do not have the same timeliness restriction on contestable issues as Appeals and Higher Level Reviews."
     t.datetime "updated_at"
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false, comment: "The universally unique identifier for the Supplemental Claim. Can be used to link to the claim after it is completed."
-    t.string "veteran_file_number", null: false, comment: "The file number of the Veteran that the Supplemental Claim is for."
+    t.string "veteran_file_number", null: false, comment: "PII. The file number of the Veteran that the Supplemental Claim is for."
     t.boolean "veteran_is_not_claimant", comment: "Indicates whether the Veteran is the claimant on the Supplemental Claim form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
     t.index ["decision_review_remanded_type", "decision_review_remanded_id"], name: "index_decision_issues_on_decision_review_remanded"
     t.index ["updated_at"], name: "index_supplemental_claims_on_updated_at"
@@ -1537,13 +1537,13 @@ ActiveRecord::Schema.define(version: 2021_06_15_170300) do
     t.datetime "created_at"
     t.date "date_of_death", comment: "Date of Death reported by BGS, cached locally"
     t.datetime "date_of_death_reported_at", comment: "The datetime that date_of_death last changed for veteran."
-    t.string "file_number", null: false
-    t.string "first_name"
-    t.string "last_name"
-    t.string "middle_name"
+    t.string "file_number", null: false, comment: "PII. Veteran's file_number"
+    t.string "first_name", comment: "PII. Veteran's first name"
+    t.string "last_name", comment: "PII. Veteran's last name"
+    t.string "middle_name", comment: "PII. Veteran's middle name"
     t.string "name_suffix"
     t.string "participant_id"
-    t.string "ssn", comment: "The cached Social Security Number"
+    t.string "ssn", comment: "PII. The cached Social Security Number"
     t.datetime "updated_at"
     t.index ["file_number"], name: "index_veterans_on_file_number", unique: true
     t.index ["participant_id"], name: "index_veterans_on_participant_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1077,14 +1077,14 @@ ActiveRecord::Schema.define(version: 2021_06_15_221829) do
 
   create_table "people", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.date "date_of_birth"
-    t.string "email_address", comment: "Person email address, cached from BGS"
-    t.string "first_name", comment: "Person first name, cached from BGS"
-    t.string "last_name", comment: "Person last name, cached from BGS"
-    t.string "middle_name", comment: "Person middle name, cached from BGS"
-    t.string "name_suffix", comment: "Person name suffix, cached from BGS"
+    t.date "date_of_birth", comment: "PII"
+    t.string "email_address", comment: "PII. Person email address, cached from BGS"
+    t.string "first_name", comment: "PII. Person first name, cached from BGS"
+    t.string "last_name", comment: "PII. Person last name, cached from BGS"
+    t.string "middle_name", comment: "PII. Person middle name, cached from BGS"
+    t.string "name_suffix", comment: "PII. Person name suffix, cached from BGS"
     t.string "participant_id", null: false
-    t.string "ssn", comment: "Person Social Security Number, cached from BGS"
+    t.string "ssn", comment: "PII. Person Social Security Number, cached from BGS"
     t.datetime "updated_at", null: false
     t.index ["participant_id"], name: "index_people_on_participant_id", unique: true
     t.index ["ssn"], name: "index_people_on_ssn"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -68,7 +68,7 @@ appeals,stream_type,string,,,,,,"When multiple appeals have the same docket numb
 appeals,target_decision_date,date,,,,,,"If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
 appeals,updated_at,datetime,,,,,x,
 appeals,uuid,uuid ∗,x,,,,x,"The universally unique identifier for the appeal, which can be used to navigate to appeals/appeal_uuid. This allows a single ID to determine an appeal whether it is a legacy appeal or an AMA appeal."
-appeals,veteran_file_number,string ∗,x,,,,x,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+appeals,veteran_file_number,string ∗,x,,,,x,PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
 appeals,veteran_is_not_claimant,boolean,,,,,,"Selected by the user during intake, indicates whether the Veteran is the claimant, or if the claimant is someone else such as a dependent. Must be TRUE if Veteran is deceased."
 appeal_series,,,,,,,,
 appeal_series,created_at,datetime,,,,,,
@@ -129,7 +129,7 @@ available_hearing_locations,id,integer (8) PK,x,x,,,,
 available_hearing_locations,name,string,,,,,,"Name of location; i.e 'Chicago Regional Benefit Office', 'Jennings VA Clinic', etc"
 available_hearing_locations,state,string,,,,,,"State in abbreviated form; i.e 'NY', 'CA', etc"
 available_hearing_locations,updated_at,datetime ∗,x,,,,x,Automatic timestamp of when hearing location was updated
-available_hearing_locations,veteran_file_number,string,,,,,x,The VBA corporate file number of the Veteran for the appeal
+available_hearing_locations,veteran_file_number,string,,,,,x,PII. The VBA corporate file number of the Veteran for the appeal
 available_hearing_locations,zip_code,string,,,,,,
 bgs_attorneys,,,,,,,,Cache of unique BGS attorney data — used for adding claimants to cases pulled from POA data
 bgs_attorneys,created_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
@@ -144,7 +144,7 @@ bgs_power_of_attorneys,authzn_change_clmant_addrs_ind,string,,,,,,Authorization 
 bgs_power_of_attorneys,authzn_poa_access_ind,string,,,,,,Authorization for POA access
 bgs_power_of_attorneys,claimant_participant_id,string ∗,x,,,,x,Claimant participant ID -- use as FK to claimants
 bgs_power_of_attorneys,created_at,datetime ∗,x,,,,x,Standard created_at/updated_at timestamps
-bgs_power_of_attorneys,file_number,string,,,,,x,Claimant file number
+bgs_power_of_attorneys,file_number,string,,,,,x,PII. Claimant file number
 bgs_power_of_attorneys,id,integer (8) PK,x,x,,,,
 bgs_power_of_attorneys,last_synced_at,datetime,,,,,x,The last time BGS was checked
 bgs_power_of_attorneys,legacy_poa_cd,string,,,,,,Legacy POA code
@@ -402,7 +402,7 @@ documents,category_other,boolean,,,,,,
 documents,category_procedural,boolean,,,,,,
 documents,created_at,datetime,,,,,,
 documents,description,string,,,,,,
-documents,file_number,string,,,,,x,
+documents,file_number,string,,,,,x,PII
 documents,id,integer PK,x,x,,,,
 documents,previous_document_version_id,integer,,,,,,
 documents,received_at,date,,,,,,
@@ -453,7 +453,7 @@ end_product_establishments,station,string,,,,,,The station ID of the end product
 end_product_establishments,synced_status,string,,,,,,"The status of the end product, which is synced by a job. Once and end product is cleared (CLR) or canceled (CAN) the status is final and the end product will not continue being synced."
 end_product_establishments,updated_at,datetime,,,,,x,
 end_product_establishments,user_id,integer FK,,,x,,x,The ID of the user who performed the decision review intake.
-end_product_establishments,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran submitted when establishing the end product.
+end_product_establishments,veteran_file_number,string ∗,x,,,,x,PII. The file number of the Veteran submitted when establishing the end product.
 end_product_updates,,,,,,,,Updates the claim label for end products established from Caseflow
 end_product_updates,active_request_issue_ids,integer (8) ∗,x,,,,,A list of active request issue IDs when a user has finished editing a decision review. Used to keep track of which request issues may have been impacted by the update.
 end_product_updates,created_at,datetime ∗,x,,,,,
@@ -493,7 +493,7 @@ form8s,certifying_username,string,,,,,,
 form8s,contested_claims_procedures_applicable,string,,,,,,
 form8s,contested_claims_requirements_followed,string,,,,,,
 form8s,created_at,datetime ∗,x,,,,,
-form8s,file_number,string,,,,,,
+form8s,file_number,string,,,,,,PII
 form8s,form9_date,date,,,,,,
 form8s,form_646_not_of_record_explanation,string,,,,,,
 form8s,form_646_of_record,string,,,,,,
@@ -646,7 +646,7 @@ higher_level_reviews,receipt_date,date ∗,x,,,,,The date that the Higher Leve
 higher_level_reviews,same_office,boolean,,,,,,Whether the Veteran wants their issues to be reviewed by the same office where they were previously reviewed. This creates a special issue on all of the contentions created on this Higher Level Review.
 higher_level_reviews,updated_at,datetime,,,,,x,
 higher_level_reviews,uuid,uuid ∗,x,,,,x,The universally unique identifier for the Higher Level Review. Can be used to link to the claim after it is completed.
-higher_level_reviews,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran that the Higher Level Review is for.
+higher_level_reviews,veteran_file_number,string ∗,x,,,,x,PII. The file number of the Veteran that the Higher Level Review is for.
 higher_level_reviews,veteran_is_not_claimant,boolean,,,,,,"Indicates whether the Veteran is the claimant on the Higher Level Review form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
 ihp_drafts,,,,,,,,
 ihp_drafts,appeal_id,integer ∗ FK,x,,x,,x,Appeal id the IHP was written for
@@ -671,7 +671,7 @@ intakes,started_at,datetime,,,,,,"Timestamp for when the intake was created, whi
 intakes,type,string,,,,,x,The class name of the intake.
 intakes,updated_at,datetime,,,,,x,
 intakes,user_id,integer ∗ FK,x,,x,,x,The ID of the user who created the intake.
-intakes,veteran_file_number,string,,,,,x,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+intakes,veteran_file_number,string,,,,,x,PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
 job_notes,,,,,,,,
 job_notes,created_at,datetime ∗,x,,,,,Default created_at/updated_at
 job_notes,id,integer (8) PK,x,x,,,,
@@ -818,15 +818,15 @@ organizations_users,updated_at,datetime,,,,,x,
 organizations_users,user_id,integer FK,,,x,,x,
 people,,,,,,,,
 people,created_at,datetime ∗,x,,,,,
-people,date_of_birth,date,,,,,,
-people,email_address,string,,,,,,"Person email address, cached from BGS"
-people,first_name,string,,,,,,"Person first name, cached from BGS"
+people,date_of_birth,date,,,,,,PII
+people,email_address,string,,,,,,"PII. Person email address, cached from BGS"
+people,first_name,string,,,,,,"PII. Person first name, cached from BGS"
 people,id,integer (8) PK,x,x,,,,
-people,last_name,string,,,,,,"Person last name, cached from BGS"
-people,middle_name,string,,,,,,"Person middle name, cached from BGS"
-people,name_suffix,string,,,,,,"Person name suffix, cached from BGS"
+people,last_name,string,,,,,,"PII. Person last name, cached from BGS"
+people,middle_name,string,,,,,,"PII. Person middle name, cached from BGS"
+people,name_suffix,string,,,,,,"PII. Person name suffix, cached from BGS"
 people,participant_id,string ∗,x,,,,x,
-people,ssn,string,,,,,x,"Person Social Security Number, cached from BGS"
+people,ssn,string,,,,,x,"PII. Person Social Security Number, cached from BGS"
 people,updated_at,datetime ∗,x,,,,x,
 post_decision_motions,,,,,,,,"Stores the disposition and associated task of post-decisional motions handled by the Litigation Support Team: Motion for Reconsideration, Motion to Vacate, and Clear and Unmistakeable Error."
 post_decision_motions,appeal_id,integer (8) FK,,,x,,,
@@ -854,7 +854,7 @@ ramp_elections,notice_date,date,,,,,,The date that the Veteran was notified of t
 ramp_elections,option_selected,string ∗,x,,,,,"Indicates whether the Veteran selected for their RAMP election to be processed as a higher level review (with or without a hearing), a supplemental claim, or a board appeal."
 ramp_elections,receipt_date,date ∗,x,,,,,The date that the RAMP form was received by central mail.
 ramp_elections,updated_at,datetime,,,,,x,
-ramp_elections,veteran_file_number,string ∗,x,,,,x,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+ramp_elections,veteran_file_number,string ∗,x,,,,x,PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
 ramp_election_rollbacks,,,,,,,,"If a RAMP election needs to get rolled back, for example if the EP is canceled, it is tracked here. Also any VACOLS issues that were closed in the legacy system and opted into RAMP are re-opened in the legacy system."
 ramp_election_rollbacks,created_at,datetime ∗,x,,,,,Timestamp for when the rollback was created.
 ramp_election_rollbacks,id,integer (8) PK,x,x,,,,
@@ -883,7 +883,7 @@ ramp_refilings,id,integer PK,x,x,,,,
 ramp_refilings,option_selected,string ∗,x,,,,,"Which lane the RAMP refiling is for, between appeal, higher level review, and supplemental claim."
 ramp_refilings,receipt_date,date ∗,x,,,,,Receipt date of the RAMP form.
 ramp_refilings,updated_at,datetime,,,,,x,
-ramp_refilings,veteran_file_number,string ∗,x,,,,x,The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
+ramp_refilings,veteran_file_number,string ∗,x,,,,x,PII. The VBA corporate file number of the Veteran for this review. There can sometimes be more than one file number per Veteran.
 record_synced_by_jobs,,,,,,,,
 record_synced_by_jobs,created_at,datetime,,,,,,
 record_synced_by_jobs,error,string,,,,,,
@@ -1043,7 +1043,7 @@ supplemental_claims,legacy_opt_in_approved,boolean,,,,,,"Indicates whether a Vet
 supplemental_claims,receipt_date,date ∗,x,,,,,The date that the Supplemental Claim form was received by central mail. Only issues decided prior to the receipt date will show up as contestable issues.  It is also the claim date for any associated end products that are established. Supplemental Claims do not have the same timeliness restriction on contestable issues as Appeals and Higher Level Reviews.
 supplemental_claims,updated_at,datetime,,,,,x,
 supplemental_claims,uuid,uuid ∗,x,,,,x,The universally unique identifier for the Supplemental Claim. Can be used to link to the claim after it is completed.
-supplemental_claims,veteran_file_number,string ∗,x,,,,x,The file number of the Veteran that the Supplemental Claim is for.
+supplemental_claims,veteran_file_number,string ∗,x,,,,x,PII. The file number of the Veteran that the Supplemental Claim is for.
 supplemental_claims,veteran_is_not_claimant,boolean,,,,,,"Indicates whether the Veteran is the claimant on the Supplemental Claim form, or if the claimant is someone else like a spouse or a child. Must be TRUE if the Veteran is deceased."
 tags,,,,,,,,
 tags,created_at,datetime ∗,x,,,,,
@@ -1168,14 +1168,14 @@ veterans,closest_regional_office,string,,,,,,
 veterans,created_at,datetime,,,,,,
 veterans,date_of_death,date,,,,,,"Date of Death reported by BGS, cached locally"
 veterans,date_of_death_reported_at,datetime,,,,,,The datetime that date_of_death last changed for veteran.
-veterans,file_number,string ∗,x,,,,x,
-veterans,first_name,string ∗,x,,,,,
+veterans,file_number,string ∗,x,,,,x,PII. Veteran's file_number
+veterans,first_name,string ∗,x,,,,,PII. Veteran's first name
 veterans,id,integer (8) PK,x,x,,,,
-veterans,last_name,string ∗,x,,,,,
-veterans,middle_name,string,,,,,,
+veterans,last_name,string ∗,x,,,,,PII. Veteran's last name
+veterans,middle_name,string,,,,,,PII. Veteran's middle name
 veterans,name_suffix,string,,,,,,
 veterans,participant_id,string,,,,,x,
-veterans,ssn,string,,,,,x,The cached Social Security Number
+veterans,ssn,string,,,,,x,PII. The cached Social Security Number
 veterans,updated_at,datetime,,,,,x,
 virtual_hearings,,,,,,,,
 virtual_hearings,alias,string,,,,,x,Alias for conference in Pexip

--- a/lib/helpers/sanitized_json_configuration.rb
+++ b/lib/helpers/sanitized_json_configuration.rb
@@ -138,12 +138,11 @@ class SanitizedJsonConfiguration
       },
       Person => {
         track_imported_ids: true,
-        sanitize_fields: %w[date_of_birth email_address first_name last_name middle_name ssn],
         retrieval: ->(records) { (records[Veteran] + records[Claimant]).map(&:person).uniq.compact }
       }
     }.each do |clazz, class_configuration|
       class_configuration[:sanitize_fields] ||= self.class.select_sanitize_fields(clazz).tap do |fields|
-        puts "  Inferring #{clazz}'s' sanitize_fields: #{fields}" unless fields.blank?
+        puts "  Inferring #{clazz} sanitize_fields: #{fields}" unless fields.blank?
       end
     end
   end

--- a/lib/helpers/sanitized_json_configuration.rb
+++ b/lib/helpers/sanitized_json_configuration.rb
@@ -7,6 +7,10 @@ require "helpers/sanitation_transforms.rb"
 # Needed by SanitizedJsonExporter and SanitizedJsonImporter.
 
 class SanitizedJsonConfiguration
+  def self.select_sanitize_fields(clazz)
+    clazz.columns.select { |column| column.comment&.starts_with?("PII") }.map(&:name)
+  end
+
   # For exporting, the :retrieval lambda is run according to the ordering in this hash.
   # Results of running each lambda are added to the `records` hash for use by later retrieval lambdas.
   # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
@@ -17,7 +21,6 @@ class SanitizedJsonConfiguration
         # i.e., DecisionReview has no table_name and hence cannot be used
         # when reassociating using polymorphic associations.
         track_imported_ids: true,
-        sanitize_fields: %w[veteran_file_number],
         retrieval: lambda do |records|
           (records[Appeal] +
             records[Appeal].map { |appeal| self.class.appeals_associated_with(appeal) }.flatten.uniq.compact
@@ -26,11 +29,9 @@ class SanitizedJsonConfiguration
       },
       Veteran => {
         track_imported_ids: true,
-        sanitize_fields: %w[file_number first_name last_name middle_name ssn],
         retrieval: ->(records) { records[Appeal].map(&:veteran).sort_by(&:id) }
       },
       AppealIntake => {
-        sanitize_fields: %w[veteran_file_number],
         retrieval: ->(records) { records[Appeal].map(&:intake).compact.sort_by(&:id) }
       },
       DecisionDocument => {
@@ -140,7 +141,11 @@ class SanitizedJsonConfiguration
         sanitize_fields: %w[date_of_birth email_address first_name last_name middle_name ssn],
         retrieval: ->(records) { (records[Veteran] + records[Claimant]).map(&:person).uniq.compact }
       }
-    }
+    }.each do |clazz, class_configuration|
+      class_configuration[:sanitize_fields] ||= self.class.select_sanitize_fields(clazz).tap do |fields|
+        puts "  Inferring #{clazz}'s' sanitize_fields: #{fields}" unless fields.blank?
+      end
+    end
   end
   # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 

--- a/spec/lib/helpers/sanitized_json_exporter_spec.rb
+++ b/spec/lib/helpers/sanitized_json_exporter_spec.rb
@@ -296,6 +296,19 @@ describe "SanitizedJsonExporter/Importer" do
     end
   end
 
+  describe "SanitizedJsonConfiguration.select_sanitize_fields" do
+    let(:sjconfiguration) { SanitizedJsonConfiguration.new }
+    it "returns columns with 'PII' in its column comment" do
+      vets_sanitized_fields = %w[file_number first_name last_name middle_name ssn]
+      expect(SanitizedJsonConfiguration.select_sanitize_fields(Veteran)).to match_array vets_sanitized_fields
+
+      expect(sjconfiguration.configuration[Veteran][:sanitize_fields]).to match_array vets_sanitized_fields
+    end
+    it "doesn't override manually set sanitize_fields for Task" do
+      expect(sjconfiguration.configuration[Task][:sanitize_fields]).to match_array %w[instructions]
+    end
+  end
+
   let(:veteran) { create(:veteran, file_number: "111447777", middle_name: "Middle") }
   let(:appeal) do
     create(:appeal,

--- a/spec/lib/helpers/sanitized_json_exporter_spec.rb
+++ b/spec/lib/helpers/sanitized_json_exporter_spec.rb
@@ -301,8 +301,11 @@ describe "SanitizedJsonExporter/Importer" do
     it "returns columns with 'PII' in its column comment" do
       vets_sanitized_fields = %w[file_number first_name last_name middle_name ssn]
       expect(SanitizedJsonConfiguration.select_sanitize_fields(Veteran)).to match_array vets_sanitized_fields
-
       expect(sjconfiguration.configuration[Veteran][:sanitize_fields]).to match_array vets_sanitized_fields
+
+      people_sanitized_fields = %w[date_of_birth email_address first_name last_name middle_name name_suffix ssn]
+      expect(SanitizedJsonConfiguration.select_sanitize_fields(Person)).to match_array people_sanitized_fields
+      expect(sjconfiguration.configuration[Person][:sanitize_fields]).to match_array people_sanitized_fields
     end
     it "doesn't override manually set sanitize_fields for Task" do
       expect(sjconfiguration.configuration[Task][:sanitize_fields]).to match_array %w[instructions]


### PR DESCRIPTION
### Description
Make it obvious when columns contain PII by adding "PII" to the column comment.
This enables dynamically identifying columns that need to be sanitized when exporting by `SanitizedJsonExporter`.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
See new RSpec test

### Database Changes

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Run `make docs` (after running `make migrate`) to update DB schema docs
* [x] Post this PR in #appeals-schema with a summary