### PR TITLE
Fixed sort/filter table announcements by JAWS

### DIFF
--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -20,7 +20,7 @@
   <%= stylesheet_link_tag 'application', media: 'all' %>
 
   <%= env_javascript_include_tag(static: ['webpack-bundle'],
-                                 hot: ['http://localhost:3500/webpack-bundle.js']) %>
+                                 hot: ['http://10.0.2.2:3500/webpack-bundle.js']) %>
 
   <%= csrf_meta_tags %>
 

--- a/app/views/layouts/_head.html.erb
+++ b/app/views/layouts/_head.html.erb
@@ -20,7 +20,7 @@
   <%= stylesheet_link_tag 'application', media: 'all' %>
 
   <%= env_javascript_include_tag(static: ['webpack-bundle'],
-                                 hot: ['http://10.0.2.2:3500/webpack-bundle.js']) %>
+                                 hot: ['http://localhost:3500/webpack-bundle.js']) %>
 
   <%= csrf_meta_tags %>
 

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -99,7 +99,7 @@ const HeaderRow = (props) => {
           </span>;
         }
 
-        return <th scope="col" key={columnNumber} className={cellClasses(column)}>
+        return <th scope="col" key={columnNumber} className={cellClasses(column)} {...column?.sortProps}>
           { column.tooltip ?
             <Tooltip id={`tooltip-${columnNumber}`} text={column.tooltip}>{columnContent}</Tooltip> :
             <React.Fragment>{columnContent}</React.Fragment>

--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -218,6 +218,7 @@ class DocumentsTable extends React.Component {
           'receivedAt' && { 'aria-sort': sortDirectionAriaLabel },
         header: (
           <Button
+            styling={{ 'aria-roledescription': 'sort button' }}
             name="Receipt Date"
             id="receipt-date-header"
             classNames={['cf-document-list-button-header']}
@@ -244,6 +245,7 @@ class DocumentsTable extends React.Component {
         header: (
           <Button
             id="type-header"
+            styling={{ 'aria-roledescription': 'sort button' }}
             name="Document Type"
             classNames={['cf-document-list-button-header']}
             onClick={() => this.props.changeSortState('type')}


### PR DESCRIPTION
Resolves [CASEFLOW-1008](https://vajira.max.gov/browse/CASEFLOW-1008) and [CASEFLOW-1011](https://vajira.max.gov/browse/CASEFLOW-1011)

Part 2 of the [508 compliance stack](https://github.com/department-of-veterans-affairs/caseflow/pull/16374)

### Description
Resolves the issue where JAWS was reading sort/filter by on each cell instead of just the headings

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] JAWS no longer reads the sort/filter by on each cell

### Testing Plan
1. First setup your environment to use JAWS following [these steps](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/Engineering/accessibility-jaws-setup.md)
2. Once you are at the screen to select a user, choose `BVAAABSHIRE` and navigate to the reader: by clicking the document list link
3. Focus JAWS on the table using "T" on the keyboard
4. Use Ctrl+Alt+Left Arrow to navigate to the "Receipt Date" header cell
5. click space bar to change the sort order and ensure JAWS announces it
6. Use Ctrl+Alt+Down Arrow to move to the first cell and ensure JAWS does not announce sort order
7. Repeat the steps applying the filter to one of the columns instead and ensure that when focused the cell does not get announced with the sort order
