### PR TITLE
Added aria labels to make documents/comments tabs accessible

### DIFF
--- a/client/app/components/ToggleButton.jsx
+++ b/client/app/components/ToggleButton.jsx
@@ -29,6 +29,7 @@ export default class ToggleButton extends React.Component {
 }
 
 ToggleButton.propTypes = {
+  onClick: PropTypes.func,
   active: PropTypes.string,
   children: PropTypes.node
 };

--- a/client/app/components/ToggleButton.jsx
+++ b/client/app/components/ToggleButton.jsx
@@ -18,12 +18,13 @@ export default class ToggleButton extends React.Component {
     const mappedChildren = React.Children.map(children, (child) => {
       return React.cloneElement(child, {
         classNames: active === child.props.name ? ['usa-button'] : ['usa-button-secondary'],
-        onClick: this.handleClick(child.props.name)
+        onClick: this.handleClick(child.props.name),
+        role: 'tab'
       }
       );
     });
 
-    return <div className="cf-toggle-button">{mappedChildren}</div>;
+    return <div className="cf-toggle-button" role="tablist">{mappedChildren}</div>;
   }
 }
 

--- a/client/app/reader/DocumentsCommentsButton.jsx
+++ b/client/app/reader/DocumentsCommentsButton.jsx
@@ -7,27 +7,53 @@ import { setViewingDocumentsOrComments } from '../reader/DocumentList/DocumentLi
 import { DOCUMENTS_OR_COMMENTS_ENUM } from './DocumentList/actionTypes';
 
 class DocumentsCommentsButton extends PureComponent {
-  render = () => <div className="cf-documents-comments-control">
-    <span className="cf-show-all-label">Show all:</span>
-    <ToggleButton
-      active={this.props.viewingDocumentsOrComments}
-      onClick={this.props.setViewingDocumentsOrComments}>
-
-      <Button name={DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS}>
-        Documents
-      </Button>
-      <Button name={DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS}>
-        Comments
-      </Button>
-    </ToggleButton>
-  </div>;
+  render = () => (
+    <div className="cf-documents-comments-control">
+      <span id="toggle-label" className="cf-show-all-label" aria-label="Show all">Show all:</span>
+      <ToggleButton
+        active={this.props.viewingDocumentsOrComments}
+        onClick={this.props.setViewingDocumentsOrComments}
+      >
+        <Button
+          id="show-documents-view"
+          ariaLabel={DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS}
+          name={DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS}
+          styling={{
+            'aria-labelledby': 'toggle-label show-documents-view',
+            'aria-selected':
+              this.props.viewingDocumentsOrComments ===
+              DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS,
+          }}
+        >
+          Documents
+        </Button>
+        <Button
+          id="show-comments-view"
+          ariaLabel={DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS}
+          name={DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS}
+          styling={{
+            'aria-labelledby': 'toggle-label show-comments-view',
+            'aria-selected':
+              this.props.viewingDocumentsOrComments ===
+              DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS,
+          }}
+        >
+          Comments
+        </Button>
+      </ToggleButton>
+    </div>
+  );
 }
 
 export default connect(
   (state) => ({
-    viewingDocumentsOrComments: state.documentList.viewingDocumentsOrComments
+    viewingDocumentsOrComments: state.documentList.viewingDocumentsOrComments,
   }),
-  (dispatch) => bindActionCreators({
-    setViewingDocumentsOrComments
-  }, dispatch)
+  (dispatch) =>
+    bindActionCreators(
+      {
+        setViewingDocumentsOrComments,
+      },
+      dispatch
+    )
 )(DocumentsCommentsButton);

--- a/client/app/reader/DocumentsCommentsButton.jsx
+++ b/client/app/reader/DocumentsCommentsButton.jsx
@@ -1,4 +1,5 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import ToggleButton from '../components/ToggleButton';
 import Button from '../components/Button';
@@ -15,11 +16,11 @@ class DocumentsCommentsButton extends PureComponent {
         onClick={this.props.setViewingDocumentsOrComments}
       >
         <Button
-          id="show-documents-view"
+          id="button-documents"
           ariaLabel={DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS}
           name={DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS}
           styling={{
-            'aria-labelledby': 'toggle-label show-documents-view',
+            'aria-labelledby': 'toggle-label button-documents',
             'aria-selected':
               this.props.viewingDocumentsOrComments ===
               DOCUMENTS_OR_COMMENTS_ENUM.DOCUMENTS,
@@ -28,11 +29,11 @@ class DocumentsCommentsButton extends PureComponent {
           Documents
         </Button>
         <Button
-          id="show-comments-view"
+          id="button-comments"
           ariaLabel={DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS}
           name={DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS}
           styling={{
-            'aria-labelledby': 'toggle-label show-comments-view',
+            'aria-labelledby': 'toggle-label button-comments',
             'aria-selected':
               this.props.viewingDocumentsOrComments ===
               DOCUMENTS_OR_COMMENTS_ENUM.COMMENTS,
@@ -57,3 +58,8 @@ export default connect(
       dispatch
     )
 )(DocumentsCommentsButton);
+
+DocumentsCommentsButton.propTypes = {
+  setViewingDocumentsOrComments: PropTypes.func.isRequired,
+  viewingDocumentsOrComments: PropTypes.string
+};


### PR DESCRIPTION
Resolves [CASEFLOW-1010](https://vajira.max.gov/browse/CASEFLOW-1010)

Part 3 of the [508 compliance stack](https://github.com/department-of-veterans-affairs/caseflow/pull/16374)

### Description
Resolves the issue where JAWS was reading the documents/comments view tab incorrectly on reader

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] JAWS reads the state of the documents/comments tab view correctly

### Testing Plan
1. First setup your environment to use JAWS following [these steps](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/Engineering/accessibility-jaws-setup.md)
2. Once you are at the screen to select a user, choose `BVAAABSHIRE` and navigate to the reader: by clicking the document list link
3. Focus on the documents tab and ensure that the state is read correctly
4. Tab to the comments tab and press enter to select and make sure the state is read correctly
5. Repeat the steps above changing back and forth a few times to be sure that everything is accurate