### PR TITLE
Adjust validation in SubstituteAppellantBasicsForm to enforce substitution date after both NOD date & date of death

### DIFF
--- a/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsForm.stories.js
+++ b/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsForm.stories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { format, sub } from 'date-fns';
 
 import { SubstituteAppellantBasicsForm } from './SubstituteAppellantBasicsForm';
 
@@ -14,6 +15,8 @@ export default {
   parameters: {},
   args: {
     relationships,
+    nodDate: format(sub(new Date(), { months: 1 }), 'yyyy-MM-dd'),
+    dateOfDeath: format(sub(new Date(), { days: 15 }), 'yyyy-MM-dd'),
   },
   argTypes: {
     onCancel: { action: 'cancel' },

--- a/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsView.jsx
+++ b/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsView.jsx
@@ -3,6 +3,7 @@ import { useHistory, useParams } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
 import { format } from 'date-fns';
 
+import { appealWithDetailSelector } from 'app/queue/selectors';
 import { SubstituteAppellantBasicsForm } from './SubstituteAppellantBasicsForm';
 
 import {
@@ -17,6 +18,10 @@ export const SubstituteAppellantBasicsView = () => {
   const { appealId } = useParams();
   const dispatch = useDispatch();
   const history = useHistory();
+
+  const appeal = useSelector((state) =>
+    appealWithDetailSelector(state, { appealId })
+  );
 
   const {
     formData: existingValues,
@@ -70,6 +75,8 @@ export const SubstituteAppellantBasicsView = () => {
       onCancel={handleCancel}
       onSubmit={handleSubmit}
       relationships={relationships}
+      nodDate={appeal.nodDate}
+      dateOfDeath={appeal.veteranDateOfDeath}
       loadingRelationships={loadingRelationships}
     />
   );


### PR DESCRIPTION
Connects [CASEFLOW-1540](https://vajira.max.gov/browse/CASEFLOW-1540)

### Description
This adjusts the validation in `SubstituteAppellantBasicsForm` to ensure that selected substitution date cannot be before NOD date or date of death.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
#### Storybook
1. Go to story for `SubstituteAppellantBasicsForm`
2. Enter a date prior to either the value for `nodDate` or `dateOfDeath` args
3. Click Continue/Submit button and ensure proper error message appears

#### Demo
1. Log in as COB_USER and search for cases for `54545454` file number
2. Select Evidence Submission or Direct Review case
3. Note the NOD and veteran's date of death
4. Click button to start substitution
5. Set an invalid substitution date and click submit button
6. Ensure proper error message appears

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

BEFORE | AFTER
---|---
![Screen Shot 2021-06-17 at 11 19 47](https://user-images.githubusercontent.com/2581274/122426089-f7216080-cf5d-11eb-9685-23109d5014f0.png) | ![Screen Shot 2021-06-17 at 11 19 13](https://user-images.githubusercontent.com/2581274/122426189-0a343080-cf5e-11eb-8513-f6382aaa2d94.png)

