### PR TITLE
Fixing legacy appeal claimant participant ID

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -312,12 +312,8 @@ class AppealsController < ApplicationController
   end
 
   def clear_poa_not_found_cache
-    Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.veteran.file_number}") if appeal.veteran&.file_number
-    Rails.cache.delete("bgs-participant-poa-not-found-#{claimant_participant_id}") if claimant_participant_id
-  end
-
-  def claimant_participant_id
-    appeal.is_a?(Appeal) ? appeal.claimant&.participant_id : appeal.claimant_participant_id
+    Rails.cache.delete("bgs-participant-poa-not-found-#{appeal&.veteran&.file_number}")
+    Rails.cache.delete("bgs-participant-poa-not-found-#{appeal&.claimant_participant_id}")
   end
 
   def cooldown_period_remaining

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -62,6 +62,8 @@ class AppealsController < ApplicationController
   end
 
   def update_power_of_attorney
+    clear_poa_not_found_cache
+
     if cooldown_period_remaining > 0
       message = "Information is current at this time. Please try again in #{cooldown_period_remaining} minutes"
       render json: {
@@ -72,7 +74,6 @@ class AppealsController < ApplicationController
       return
     end
 
-    clear_poa_not_found_cache
     if appeal.is_a?(Appeal)
       poa = BgsPowerOfAttorney.find(params[:poaId])
       render json: update_ama_poa(poa)
@@ -312,11 +313,11 @@ class AppealsController < ApplicationController
 
   def clear_poa_not_found_cache
     Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.veteran.file_number}") if appeal.veteran&.file_number
-    if appeal.claimant&.participant_id
-      Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.claimant&.participant_id}")
-    elsif claimant.is_a?(Hash)
-      Rails.cache.delete("bgs-participant-poa-not-found-#{appeal.claimant&.dig(:representative, :participant_id)}")
-    end
+    Rails.cache.delete("bgs-participant-poa-not-found-#{claimant_participant_id}") if claimant_participant_id
+  end
+
+  def claimant_participant_id
+    appeal.is_a?(Appeal) ? appeal.claimant&.participant_id : appeal.claimant_participant_id
   end
 
   def cooldown_period_remaining

--- a/app/controllers/concerns/explain/record_event_mapper.rb
+++ b/app/controllers/concerns/explain/record_event_mapper.rb
@@ -119,7 +119,6 @@ class Explain::RecordEventMapper
 
       0
     rescue StandardError => error
-      # binding.pry
       raise "#{error}:\n #{inspect}\n #{other.inspect}"
     end
     # rubocop:enable Metrics/CyclomaticComplexity, Metrics/AbcSize

--- a/app/controllers/explain_controller.rb
+++ b/app/controllers/explain_controller.rb
@@ -20,7 +20,6 @@ class ExplainController < ApplicationController
         format.json { render json: sanitized_json }
       end
     rescue StandardError => error
-      # binding.pry
       raise error.full_message
     end
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -403,12 +403,19 @@ class Appeal < DecisionReview
     claimants.map(&:power_of_attorney).compact
   end
 
-  def representatives
-    vso_participant_ids = power_of_attorneys.map(&:participant_id).compact.uniq
+  def representative_participant_ids
+    power_of_attorneys.map(&:participant_id).compact.uniq
+  end
+
+  def representative_organizations
     # Representatives are returned for Vso or PrivateBar POAs (i.e., subclasses of Representative)
     # and typically not for POAs with `BgsPowerOfAttorney.representative_type` = 'Agent' or 'Attorney'.
     # To get all POAs, call `power_of_attorneys`.
-    Representative.where(participant_id: vso_participant_ids)
+    Representative.where(participant_id: representative_participant_ids)
+  end
+
+  def representative_users
+    representative_organizations.map(&:users) + User.where(participant_id: representative_participant_ids)
   end
 
   def external_id

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -403,19 +403,12 @@ class Appeal < DecisionReview
     claimants.map(&:power_of_attorney).compact
   end
 
-  def representative_participant_ids
-    power_of_attorneys.map(&:participant_id).compact.uniq
-  end
-
-  def representative_organizations
+  def representatives
+    vso_participant_ids = power_of_attorneys.map(&:participant_id).compact.uniq
     # Representatives are returned for Vso or PrivateBar POAs (i.e., subclasses of Representative)
     # and typically not for POAs with `BgsPowerOfAttorney.representative_type` = 'Agent' or 'Attorney'.
     # To get all POAs, call `power_of_attorneys`.
-    Representative.where(participant_id: representative_participant_ids)
-  end
-
-  def representative_users
-    representative_organizations.map(&:users) + User.where(participant_id: representative_participant_ids)
+    Representative.where(participant_id: vso_participant_ids)
   end
 
   def external_id

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -898,6 +898,10 @@ class LegacyAppeal < CaseflowRecord
     vacols_case_review.valid_document_id?
   end
 
+  def claimant_participant_id
+    veteran_is_not_claimant ? person_for_appellant&.participant_id : veteran&.participant_id
+  end
+
   private
 
   def soc_eligible_for_opt_in?(receipt_date:, covid_flag: false)
@@ -979,10 +983,6 @@ class LegacyAppeal < CaseflowRecord
       claimant_participant_id: claimant_participant_id,
       vacols_id: vacols_id
     )
-  end
-
-  def claimant_participant_id
-    person_for_appellant&.participant_id
   end
 
   class << self

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -374,7 +374,7 @@ class Fakes::BGSService
                   legacy_poa_cd: "100",
                   nm: "Clarence Darrow",
                   org_type_nm: "POA Attorney",
-                  ptcpnt_id: "1234567"
+                  ptcpnt_id: "600153863"
                 }
               end
 

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -679,7 +679,7 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         assert_response(:success)
         expect(JSON.parse(subject.body)["power_of_attorney"]["representative_type"]).to eq "Attorney"
         expect(JSON.parse(subject.body)["power_of_attorney"]["representative_name"]).to eq "Clarence Darrow"
-        expected_email = "tom.brady@caseflow.gov"
+        expected_email = "clarence.darrow@caseflow.gov"
         expect(JSON.parse(subject.body)["power_of_attorney"]["representative_email_address"]).to eq expected_email
         expect(JSON.parse(subject.body)["power_of_attorney"]["representative_tz"]).to eq "America/Los_Angeles"
         expect(JSON.parse(subject.body)["power_of_attorney"]["representative_id"]).to eq appeal.power_of_attorney.id

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -608,7 +608,7 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
     let(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "0000000000S")) }
     let!(:veteran) { create(:veteran, file_number: appeal.sanitized_vbms_id) }
     let(:get_params) { { appeal_id: appeal.vacols_id } }
-    let(:patch_params) { { appeal_id: appeal.vacols_id, poaId: appeal.power_of_attorney.id } }
+    let(:patch_params) { { appeal_id: appeal.vacols_id, poaId: appeal.power_of_attorney&.bgs_id } }
     let!(:poa) do
       create(
         :bgs_power_of_attorney,

--- a/spec/feature/explain_spec.rb
+++ b/spec/feature/explain_spec.rb
@@ -97,7 +97,6 @@ RSpec.feature "Explain JSON" do
     end
     it "present realistic appeal events" do
       visit "explain/appeals/#{real_appeal.uuid}"
-      # binding.pry
       page.find("#narrative_table").click
       task = real_appeal.tasks.sample
       expect(page).to have_content("#{task.type}_#{task.id}")

--- a/spec/fixes/investigate_scm_cant_reassign_spec.rb
+++ b/spec/fixes/investigate_scm_cant_reassign_spec.rb
@@ -38,7 +38,6 @@ feature "CaseMovementTeam task actions" do
       # (and an error message in the DevTools console).
       click_on "Submit"
       expect(page).to have_content("Error assigning tasks")
-      # binding.pry # Uncomment this line to see error message
     end
   end
 end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -1891,7 +1891,7 @@ describe LegacyAppeal, :all_dbs do
       let(:vacols_case) { create(:case, :representative_american_legion, correspondent: correspondent) }
       let(:appellant_ssn) { "666001234" }
       let(:appellant_pid) { "1234" }
-      let(:poa_pid) { "1234567" } # defined in Fakes::BGSService
+      let(:poa_pid) { "600153863" } # defined in Fakes::BGSService
       let(:correspondent) do
         create(
           :correspondent,
@@ -2485,7 +2485,7 @@ describe LegacyAppeal, :all_dbs do
             name: "Attorney B Lawyer",
             type: "Attorney",
             code: "T",
-            participant_id: "1234567",
+            participant_id: "600153863",
             address: {
               address_line_1: "111 Magnolia St.",
               address_line_2: "Suite 222",

--- a/spec/workflows/ama_appeal_dispatch_spec.rb
+++ b/spec/workflows/ama_appeal_dispatch_spec.rb
@@ -8,7 +8,7 @@ describe AmaAppealDispatch, :postgres do
       appeal = create(:appeal, :advanced_on_docket_due_to_age)
       root_task = create(:root_task, appeal: appeal)
       BvaDispatchTask.create_from_root_task(root_task)
-      poa_participant_id = "1234567"
+      poa_participant_id = "600153863"
 
       bgs_poa = instance_double(BgsPowerOfAttorney)
       allow(BgsPowerOfAttorney).to receive(:find_or_create_by_file_number)


### PR DESCRIPTION
Resolves [CASEFLOW-1742](https://vajira.max.gov/browse/CASEFLOW-1742)

### Description
When implementing a solution for CASEFLOW-1639 we inadvertently introduced a bug where Legacy appeals will fail when checking the participant_id on a claimant hash prior to when we check if the claimant is actually a hash.

This PR checks whether the appeal is an AMA appeal or a Legacy Appeal before getting the claimant's participant ID, and get's the claimant's participant ID instead of the representative's participant ID. It also moves clearing the not_found cache to the beginning of the endpoint, because the `cooldown_period_remaining` could create a new BgsPowerOfAttorney that would trigger returning on the endpoint because the last_synced_at will be freshly populated.

### Acceptance Criteria
- [ ] A previously not_found POA for a legacy appeal is cleared from the cache and re-fetched when calling the update_power_of_attorney endpoint in the appeals controller

### Testing Plan
1. Tested code in Prod