### PR TITLE
Adds claim label for SCs with issues decided > 1 year ago to json file

### DIFF
--- a/client/constants/EP_CLAIM_TYPES.json
+++ b/client/constants/EP_CLAIM_TYPES.json
@@ -27,6 +27,13 @@
      "family": "040",
      "official_label": "Supplemental Claim Non-Rating"
    },
+   "040SCRGTY": {
+     "review_type": "supplemental_claim",
+     "benefit_type": "compensation",
+     "family": "040",
+     "issue_type": "rating",
+     "official_label": "Supplemental Claim Rating > Year"
+   },
    "030HLRR": {
      "review_type": "higher_level_review",
      "issue_type": "rating",


### PR DESCRIPTION
Resolves  https://vajira.max.gov/browse/CASEFLOW-1703

### Description
Adding claim label for SCs to EP_CLAIM_TYPES.json file 

### Acceptance Criteria

Given that an Intake User is submitting a Compensation Supplemental Claim...

- [ ] Verify that an EP Code 040SCRGT or subsequent code is added to the claim, when at least one of the claims rating issues decision date is greater than one year from the claim date (receipt date)
- [ ] Verify that an EP Code 040SCRGT or subsequent code is NOT ADDED to the claim, when there are no rating issues or the claims rating issues decision date is not greater than one year from the claim date (receipt date)


