### PR TITLE
clarify confusing error message with appropriate action

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -366,7 +366,7 @@
   "ASSIGN_WIDGET_NO_TASK_DETAIL": "Please select a task.",
   "ASSIGN_WIDGET_SUCCESS": "%(verb)s %(numCases)s %(casePlural)s to %(assignee)s",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_TITLE": "Error assigning tasks",
-  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "Timeout Error while assigning tasks, please reload the page before proceeding.",
+  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "Timeout Error while assigning tasks; please reload the page before proceeding.",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL_LINK": "Please assign tasks to an attorney from your assign page.",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL": " Reassign tasks to a judge in the action dropdown",
   "ASSIGN_WIDGET_LOADING": "Loading...",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -366,7 +366,7 @@
   "ASSIGN_WIDGET_NO_TASK_DETAIL": "Please select a task.",
   "ASSIGN_WIDGET_SUCCESS": "%(verb)s %(numCases)s %(casePlural)s to %(assignee)s",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_TITLE": "Error assigning tasks",
-  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "One or more tasks couldn't be assigned. Reassign tasks to a judge on the case details screen",
+  "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL": "Timeout Error while assigning tasks, please reload the page before proceeding.",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL_LINK": "Please assign tasks to an attorney from your assign page.",
   "ASSIGN_WIDGET_ASSIGNMENT_ERROR_DETAIL_MODAL": " Reassign tasks to a judge in the action dropdown",
   "ASSIGN_WIDGET_LOADING": "Loading...",


### PR DESCRIPTION
Resolves #{1636}

### Description
This clarifies an error message that currently is worse than confusing - it's wrong.
This error happens when there's an error talking to VACOLS.  Unfortunately, the underlying problem is fairly complex and deserves 2 followup tickets (links coming up):

1. We should include VACOLS timeout handling with our vacols db client and standardize error handling in a centralized way instead [link to jira ticket](https://vajira.max.gov/browse/CASEFLOW-1770)
2. The rollback procedure for this transaction set may not be working correctly, leaving inconsistent state between caseflow's db and the vacols db, especially in situations where the call to vacols succeeds but too slowly, so caseflow treats it as an error and attempts to rollback, and then does that incompletely (I'll add log snippets to that ticket).

For now, just to diminish the user confusion, the updated error message advises users to reload the page before proceeding.

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. I was able to evoke this error by shutting down the local VACOLS db at exactly the right moment.  It is only used in one place in the entire code base.
