### PR TITLE
Don't error when veteran is nil in API hearing serializer

### DIFF
--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -16,7 +16,7 @@ class Api::V2::HearingSerializer
   attribute :first_name, &:veteran_first_name
   attribute :last_name, &:veteran_last_name
   attribute :participant_id do |hearing|
-    hearing.appeal.veteran.participant_id
+    hearing.appeal.veteran&.participant_id
   end
   attribute :hearing_location do |hearing|
     hearing.hearing_location_or_regional_office.name


### PR DESCRIPTION
Connects [CASEFLOW-1688](https://vajira.max.gov/browse/CASEFLOW-1688)

### Description
On certain cases with spina bifida claims, an appeal may have a nil veteran (see [CASEFLOW-1688](https://vajira.max.gov/browse/CASEFLOW-1688) for a full description). This is causing [an error](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/16864/) on our vettext hearings endpoint for one case in this state. This PR allows a nil veteran on an appeal in the `Api::V2::HearingSerializer` so that other hearings on the same day can be returned by the endpoint.
