### PR TITLE
Add benefit type to issues list on intake

### DIFF
--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { filter, find } from 'lodash';
 
 import INELIGIBLE_REQUEST_ISSUES from '../../../constants/INELIGIBLE_REQUEST_ISSUES';
+import BENEFIT_TYPES from '../../../constants/BENEFIT_TYPES';
 import COPY from '../../../COPY';
 
 import { legacyIssue } from '../util/issues';
@@ -82,6 +83,7 @@ class AddedIssue extends React.PureComponent {
 
   render() {
     const { issue, issueIdx, legacyAppeals } = this.props;
+
     let eligibleState = {
       errorMsg: '',
       cssKlasses: ['issue-desc']
@@ -114,6 +116,7 @@ class AddedIssue extends React.PureComponent {
             <em>(Originally: {issue.text})</em>
           </div>
         )}
+        {issue.benefitType && <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
         {issue.date && <span className="issue-date">Decision date: {formatDateStr(issue.date)}</span>}
         {issue.notes && <span className="issue-notes">Notes:&nbsp;{issue.notes}</span>}
         {issue.untimelyExemptionNotes && (
@@ -141,6 +144,7 @@ AddedIssue.propTypes = {
   formType: PropTypes.string.isRequired,
   issue: PropTypes.shape({
     beforeAma: PropTypes.bool,
+    benefitType: PropTypes.string,
     correctionType: PropTypes.string,
     date: PropTypes.string,
     decisionReviewTitle: PropTypes.string,


### PR DESCRIPTION
Resolves #1686

### Description
Display the benefit type on the issues list component on the review intake page
https://dsva.slack.com/archives/C3AQSB4LA/p1624389305102000

### Acceptance Criteria
- The Benefit type of the added issue is displayed on the intake review page

### Testing Plan
1. Go to the intake review page
2. Add an issue
3. Verify that the correct Benefit Type is displayed for that issue

 BEFORE|AFTER
![image](https://user-images.githubusercontent.com/23530352/122987131-41e01580-d36e-11eb-9e33-1c66ce006993.png)
|
![image](https://user-images.githubusercontent.com/23530352/122987183-4e646e00-d36e-11eb-9840-11aa392a20a7.png)
