### PR TITLE
Explain endpoint: don't fail on legacy appeal

### DIFF
--- a/app/controllers/concerns/explain/appeal_record_event_mapper.rb
+++ b/app/controllers/concerns/explain/appeal_record_event_mapper.rb
@@ -20,6 +20,8 @@ class Explain::AppealRecordEventMapper < Explain::RecordEventMapper
   end
 
   def timing_events(last_timestamp)
+    return [] if last_timestamp.nil?
+
     number_of_months = (last_timestamp.year * 12 + last_timestamp.month) -
                        (receipt_date.year * 12 + receipt_date.month) + 2
     number_of_months.times.each_with_object([]) do |count, events|

--- a/app/controllers/concerns/explain_appeal_events_concern.rb
+++ b/app/controllers/concerns/explain_appeal_events_concern.rb
@@ -13,7 +13,7 @@ module ExplainAppealEventsConcern
   # :reek:FeatureEnvy
   def event_table_data
     task_events = tasks_as_event_data
-    events = appeal_as_event_data(task_events.last.timestamp) +
+    events = appeal_as_event_data(task_events.last&.timestamp) +
              task_events +
              request_issues_as_event_data +
              hearings_as_event_data
@@ -21,14 +21,14 @@ module ExplainAppealEventsConcern
   end
 
   def appeal_as_event_data(last_timestamp)
-    all_events = sje.records_hash[Appeal.table_name].map do |appeal|
+    all_events = exported_records(Appeal).map do |appeal|
       mapper = Explain::AppealRecordEventMapper.new(appeal)
       mapper.events + mapper.timing_events(last_timestamp)
     end
-    all_events += sje.records_hash[Intake.table_name].map do |intake|
+    all_events += exported_records(Intake).map do |intake|
       Explain::IntakeRecordEventMapper.new(intake, object_id_cache).events
     end
-    all_events += sje.records_hash[DecisionDocument.table_name].map do |decis_doc|
+    all_events += exported_records(DecisionDocument).map do |decis_doc|
       Explain::DecisionDocumentRecordEventMapper.new(decis_doc).events
     end
     # To-do: judge_case_reviews, attorney_case_reviews
@@ -36,18 +36,18 @@ module ExplainAppealEventsConcern
   end
 
   def tasks_as_event_data
-    sje.records_hash[Task.table_name].map do |task|
+    exported_records(Task).map do |task|
       Explain::TaskRecordEventMapper.new(task, object_id_cache).events
     end.flatten.compact.sort
   end
 
   # rubocop:disable Metrics/AbcSize
   def request_issues_as_event_data
-    req_issues = sje.records_hash[RequestIssue.table_name].index_by { |req| req["id"] }
-    dec_issues = sje.records_hash[DecisionIssue.table_name].index_by { |dec| dec["id"] }
+    req_issues = exported_records(RequestIssue).index_by { |req| req["id"] }
+    dec_issues = exported_records(DecisionIssue).index_by { |dec| dec["id"] }
 
     events = []
-    sje.records_hash[RequestDecisionIssue.table_name].each do |req_dec_issue|
+    exported_records(RequestDecisionIssue).each do |req_dec_issue|
       req_issue = req_issues[req_dec_issue["request_issue_id"]]
       dec_issue = dec_issues[req_dec_issue["decision_issue_id"]]
       events += Explain::RequestIssueRecordEventMapper.new(req_issue).events
@@ -56,7 +56,7 @@ module ExplainAppealEventsConcern
 
     # Remove records after processing them.
     # Don't remove them while processing because multiple request_issues can map to same decision_issue.
-    sje.records_hash[RequestDecisionIssue.table_name].each do |req_dec_issue|
+    exported_records(RequestDecisionIssue).each do |req_dec_issue|
       req_issues.delete(req_dec_issue["request_issue_id"])
       dec_issues.delete(req_dec_issue["decision_issue_id"])
     end
@@ -72,9 +72,9 @@ module ExplainAppealEventsConcern
   # rubocop:enable Metrics/AbcSize
 
   def hearings_as_event_data
-    hearing_days = sje.records_hash[HearingDay.table_name].index_by { |req| req["id"] }
-    virtual_hearings = sje.records_hash[VirtualHearing.table_name].index_by { |req| req["hearing_id"] }
-    sje.records_hash[Hearing.table_name].map do |hearing|
+    hearing_days = exported_records(HearingDay).index_by { |req| req["id"] }
+    virtual_hearings = exported_records(VirtualHearing).index_by { |req| req["hearing_id"] }
+    exported_records(Hearing).map do |hearing|
       hearing_day = hearing_days[hearing["hearing_day_id"]]
       virtual_hearing = virtual_hearings[hearing["id"]]
       Explain::HearingRecordEventMapper.new(hearing, hearing_day, virtual_hearing, object_id_cache).events
@@ -83,9 +83,13 @@ module ExplainAppealEventsConcern
 
   private
 
+  def exported_records(klass)
+    sje.records_hash[klass.table_name] || []
+  end
+
   # # :reek:NestedIterators
   # def records_hash_for(appeal)
-  #   sje.records_hash.map do |table_name, records|
+  #   exported_records(map)|table_name, records|
   #     next unless records.is_a?(Array)
 
   #     filtered_records = records.select do |record|
@@ -99,10 +103,10 @@ module ExplainAppealEventsConcern
 
   def object_id_cache
     @object_id_cache ||= {
-      # appeals: sje.records_hash[Appeal.table_name].map { |appeal| [appeal["id"], appeal["name"]] }.to_h,
-      orgs: sje.records_hash[Organization.table_name].map { |org| [org["id"], org["name"]] }.to_h,
-      users: sje.records_hash[User.table_name].map { |user| [user["id"], user["css_id"]] }.to_h,
-      tasks: sje.records_hash[Task.table_name].map { |task| [task["id"], "#{task['type']}_#{task['id']}"] }.to_h
+      # appeals: exported_records(Appeal).map { |appeal| [appeal["id"], appeal["name"]] }.to_h,
+      orgs: exported_records(Organization).map { |org| [org["id"], org["name"]] }.to_h,
+      users: exported_records(User).map { |user| [user["id"], user["css_id"]] }.to_h,
+      tasks: exported_records(Task).map { |task| [task["id"], "#{task['type']}_#{task['id']}"] }.to_h
     }
   end
 end

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -21,7 +21,7 @@
             if event["category"] == "clock"
               event["timestamp"]
             else
-              DateTime.parse(event["timestamp"]).strftime("%F %T") rescue event["timestamp"]
+              DateTime.parse(event["timestamp"]).strftime("%F %T.%L") rescue event["timestamp"]
             end
           %></td>
           <td style="padding: 2px" class="category"><%= event["category"] %></td>


### PR DESCRIPTION
Resolves [Sentry alert](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18619)

### Description
Handle missing exported records so that the `explain` endpoint does not fail for legacy appeals.

The `explain` endpoint relies on `SanitizedJsonExporter`, which doesn't currently support legacy appeals and hence does not export `Task` records.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] the `explain` endpoint does not fail for legacy appeals

### Testing Plan
Go to the `explain` endpoint for a legacy appeal, e.g. http://localhost:3000/explain/appeals/2226048
Narrative table should be minimally populated.
