### PR TITLE
Explain page: narrative table: make attribute details clickable

### DIFF
--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -13,7 +13,7 @@
         <th>event type</th>
         <th style="width: 60%;">narrative</th>
         <th style="width: 20%;">relevant data</th>
-        <th>attribute count</th>
+        <th>details</th>
       </tr>
       <% event_table_data.each do |event| %>
         <tr class="<%=event["category"]+'_'+event['event_type']%> <%=event["category"]%>">
@@ -42,7 +42,16 @@
               %></pre>
             <% end %>
           </td>
-          <td style="padding: 2px" class="details"><%= event["details"]&.size %></td>
+          <td style="padding: 2px; font-size:0.8em" class="details">
+            <% if event["details"] %>
+              <details>
+                <summary>(<%= event["details"]&.size %>)</summary>
+                <pre style="margin: 0px; width: 300px;"><%=
+                  JSON.pretty_generate(event["details"]).sub("{\n","").sub("\n}","").gsub(/^  /,"")
+                %></pre>
+              </details>
+            <% end %>
+          </td>
         </tr>
       <% end %>
     </table>


### PR DESCRIPTION
### Description
For the narrative table at the `explain` page, make attribute details clickable. When clicked, it shows attributes about the event.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] When attribute details is clicked, it shows attributes about the event.

### Testing Plan
Uncomment `binding.pry` in the `spec/fixes/investigate_duplicate_judge_assign_task_spec.rb` RSpec and click on the "Narrative table" link in the browser tabs with the `explain` page. In the 'details' column, click on any of the numbers to expand the attributes (the number indicates the number of attributes).

### User Facing Changes

![image](https://user-images.githubusercontent.com/55255674/123149529-fb022680-d426-11eb-9c02-f03cdcee0bf5.png)
