### PR TITLE
Fixed sort/filter table announcements by JAWS

### DIFF
--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -178,6 +178,7 @@ class ListSchedule extends React.Component {
         name: 'Date',
         align: 'left',
         valueName: 'scheduledFor',
+        columnName: 'date',
         valueFunction: (row) => <Link to={`/schedule/docket/${row.id}`}>
           {moment(row.scheduledFor).format('ddd M/DD/YYYY')}
         </Link>,
@@ -215,6 +216,7 @@ class ListSchedule extends React.Component {
         name: 'Room',
         align: 'left',
         valueName: 'room',
+        columnName: 'room',
         tableData: hearingScheduleRows,
         getSortValue: (hearingDay) => {
           return hearingDay.room;

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -178,7 +178,7 @@ export const HeaderRow = (props) => {
           return (
             <th
               {...sortProps}
-              {...(column?.sortProps || {})}
+              {...(column?.sortProps || sortProps)}
               {...(ariaLabel ? { 'aria-labelledby': ariaLabel } : {})}
               role="columnheader"
               scope="col"


### PR DESCRIPTION
Resolves [CASEFLOW-1015](https://vajira.max.gov/browse/CASEFLOW-1015)

Part 4 of the [508 compliance stack](https://github.com/department-of-veterans-affairs/caseflow/pull/16374)

### Description
Resolves the issue where JAWS was reading sort/filter by on each cell instead of just the headings

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] JAWS no longer reads the sort/filter by on each cell

### Testing Plan
1. First setup your environment to use JAWS following [these steps](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/Engineering/accessibility-jaws-setup.md)
2. Once you are at the screen to select a user, choose `BVASYELLOW` and navigate to the hearings schedule: http://localhost:3000/hearings/schedule
3. Focus JAWS on the table using "T" on the keyboard
4. Use Ctrl+Alt+Left Arrow to navigate to the one of the sortable column header cells
5. click space bar to change the sort order and ensure JAWS announces it
6. Use Ctrl+Alt+Down Arrow to move to the first cell and ensure JAWS does not announce sort order
7. Repeat the steps applying the filter to one of the columns instead and ensure that when focused the cell does not get announced with the sort order
