### PR TITLE
Explain page: add hearing rendering for appeal

### DIFF
--- a/app/controllers/explain_controller.rb
+++ b/app/controllers/explain_controller.rb
@@ -29,7 +29,7 @@ class ExplainController < ApplicationController
   helper_method :legacy_appeal?, :appeal, :appeal_status,
                 :show_pii_query_param, :treee_fields,
                 :available_fields,
-                :task_tree_as_text, :intake_as_text,
+                :task_tree_as_text, :intake_as_text, :hearing_as_text,
                 :event_table_data, :appeal_object_id,
                 :sje
 
@@ -40,7 +40,8 @@ class ExplainController < ApplicationController
   def explain_as_text
     [
       task_tree_as_text,
-      intake_as_text
+      intake_as_text,
+      hearing_as_text
     ].join("\n\n")
   end
 
@@ -88,6 +89,10 @@ class ExplainController < ApplicationController
 
   def intake_as_text
     IntakeRenderer.render(appeal, show_pii: show_pii_query_param)
+  end
+
+  def hearing_as_text
+    HearingRenderer.render(appeal, show_pii: show_pii_query_param)
   end
 
   def sanitized_json

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -99,10 +99,18 @@
 
   <h3>Intake</h3>
   <code style="color: green">
-    puts IntakeRenderer.render(Appeal.find(<%= appeal.id %>), 
+    puts IntakeRenderer.render(Appeal.find(<%= appeal.id %>),
       show_pii: <%= show_pii_query_param ? "true" : "false" %>)
   </code>
   <pre style="font-size:0.84em; padding:10px"><code><%= intake_as_text %></code></pre>
+  <hr/>
+
+  <h3>Hearing</h3>
+  <code style="color: green">
+    puts HearingRenderer.render(Appeal.find(<%= appeal.id %>),
+      show_pii: <%= show_pii_query_param ? "true" : "false" %>)
+  </code>
+  <pre style="font-size:0.84em; padding:10px"><code><%= hearing_as_text %></code></pre>
   <hr/>
 
   <%= javascript_include_tag 'explain-appeal' %>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -102,7 +102,7 @@
     puts IntakeRenderer.render(Appeal.find(<%= appeal.id %>),
       show_pii: <%= show_pii_query_param ? "true" : "false" %>)
   </code>
-  <pre style="font-size:0.84em; padding:10px"><code><%= intake_as_text %></code></pre>
+  <pre style="font-size:0.9em; padding:10px"><code><%= intake_as_text %></code></pre>
   <hr/>
 
   <h3>Hearing</h3>
@@ -110,7 +110,7 @@
     puts HearingRenderer.render(Appeal.find(<%= appeal.id %>),
       show_pii: <%= show_pii_query_param ? "true" : "false" %>)
   </code>
-  <pre style="font-size:0.84em; padding:10px"><code><%= hearing_as_text %></code></pre>
+  <pre style="font-size:0.9em; padding:10px"><code><%= hearing_as_text %></code></pre>
   <hr/>
 
   <%= javascript_include_tag 'explain-appeal' %>

--- a/spec/controllers/explain_controller_spec.rb
+++ b/spec/controllers/explain_controller_spec.rb
@@ -3,6 +3,7 @@
 require "helpers/sanitized_json_configuration.rb"
 require "helpers/sanitized_json_exporter.rb"
 require "helpers/intake_renderer.rb"
+require "helpers/hearing_renderer.rb"
 
 describe ExplainController, :all_dbs, type: :controller do
   include TaskHelpers
@@ -84,6 +85,10 @@ describe ExplainController, :all_dbs, type: :controller do
         expect(response.body).to include "VeteranClaimant"
         expect(response.body).to include "breadcrumbs:"
         expect(response.body).to include "Veteran #{appeal.veteran.id}"
+
+        # hearing render output
+        sched_hearing_task_id = appeal.tasks.of_type(:ScheduleHearingTask).first.id
+        expect(response.body).to include "Unscheduled Hearing  (SCH Task ID: #{sched_hearing_task_id}"
       end
     end
 

--- a/spec/controllers/explain_controller_spec.rb
+++ b/spec/controllers/explain_controller_spec.rb
@@ -88,7 +88,7 @@ describe ExplainController, :all_dbs, type: :controller do
 
         # hearing render output
         sched_hearing_task_id = appeal.tasks.of_type(:ScheduleHearingTask).first.id
-        expect(response.body).to include "Unscheduled Hearing  (SCH Task ID: #{sched_hearing_task_id}"
+        expect(response.body).to include "Unscheduled Hearing (SCH Task ID: #{sched_hearing_task_id}"
       end
     end
 

--- a/spec/feature/explain_spec.rb
+++ b/spec/feature/explain_spec.rb
@@ -4,6 +4,7 @@ require "helpers/sanitized_json_configuration.rb"
 require "helpers/sanitized_json_exporter.rb"
 require "helpers/sanitized_json_importer.rb"
 require "helpers/intake_renderer.rb"
+require "helpers/hearing_renderer.rb"
 
 RSpec.feature "Explain JSON" do
   let(:user_roles) { ["System Admin"] }

--- a/spec/fixes/investigate_duplicate_judge_assign_task_spec.rb
+++ b/spec/fixes/investigate_duplicate_judge_assign_task_spec.rb
@@ -6,6 +6,7 @@ require "helpers/sanitized_json_importer.rb"
 # required to load `explain` endpoint in an RSpec
 require "helpers/sanitized_json_exporter.rb"
 require "helpers/intake_renderer.rb"
+require "helpers/hearing_renderer.rb"
 
 feature "duplicate JudgeAssignTask investigation" do
   before do

--- a/spec/lib/helpers/hearing_renderer_spec.rb
+++ b/spec/lib/helpers/hearing_renderer_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require "helpers/hearing_renderer.rb"
+
+describe "HearingRenderer" do
+  let(:show_pii) { false }
+  let(:renderer) { HearingRenderer.new(show_pii: show_pii) }
+  let(:vacols_case) { create(:case, bfcurloc: "CASEFLOW") }
+  let(:legacy_appeal) { create(:legacy_appeal, :with_veteran, vacols_case: vacols_case) }
+  let(:veteran) { legacy_appeal.veteran }
+  let!(:appeal) { create(:appeal, veteran: veteran, original_hearing_request_type: "central") }
+  let(:judge_last_name) { "Abshire" }
+  let!(:judge) do
+    create(:staff, :judge_role, sdomainid: "BVAAABSHIRE", snamel: judge_last_name, snamef: "Judge")
+    create(:user, css_id: "BVAAABSHIRE", full_name: "Judge #{judge_last_name}")
+  end
+  let(:ro) { "RO42" } # Cheyenne, WY
+  let!(:hearing_day) { create(:hearing_day, request_type: "R", regional_office: ro, room: "", judge_id: judge.id) }
+  let!(:hearing) { create(:hearing, appeal: appeal, hearing_day: hearing_day) }
+  let!(:user) { create(:user) }
+
+  before do
+    PaperTrail.request.whodunnit = user.id
+  end
+
+  describe ".readable_date" do
+    let(:include_time) { nil }
+    let(:date) { Time.use_zone("UTC") { Time.zone.parse("2021-02-01 09:30") } }
+
+    context "include time is true" do
+      let(:include_time) { true }
+
+      it "renders date with time" do
+        expect(renderer.readable_date(date, include_time)).to eq "02-01-2021 9:30AM UTC"
+      end
+    end
+
+    context "include time is false" do
+      let(:include_time) { false }
+
+      it "renders date without time" do
+        expect(renderer.readable_date(date, include_time)).to eq "02-01-2021"
+      end
+    end
+  end
+
+  describe ".veteran_children" do
+    it "includes all appeals associated with the veteran" do
+      output = renderer.veteran_children(veteran)
+      expect(output.length).to eq 2
+      expect(output.first.keys.first.to_s).to include "Appeal #{appeal.id}"
+      expect(output.second.keys.first.to_s).to include "LegacyAppeal #{legacy_appeal.id}"
+    end
+  end
+
+  describe ".hearing_day_details" do
+    it "includes expected hearing day details" do
+      output = renderer.hearing_day_details(hearing_day)
+      expect(output.length).to eq 1
+      expect(output.first).to eq "HearingDay #{hearing_day.id} (#{ro} - Cheyenne WY, Virtual, VLJ #{judge_last_name})"
+    end
+  end
+
+  describe ".hearing_day_children" do
+    it "has the expected number of hearing children" do
+      output = renderer.hearing_day_children(hearing_day.reload)
+      expect(output.length).to eq 1
+    end
+  end
+
+  describe ".appeal_type_conversions" do
+    it "includes expected information about a type conversion" do
+      appeal.update!(changed_hearing_request_type: "V")
+      output = renderer.appeal_type_conversions(appeal)
+      expect(output.length).to eq 1
+      expect(output.first["to_type"]).to eq "Video"
+      expect(output.first["converted_by"]).to eq user.css_id
+    end
+  end
+
+  describe ".format_original_and_current_type" do
+    context "no type change" do
+      it "shows only the original type" do
+        output = renderer.format_original_and_current_type(appeal)
+        expect(output.length).to eq 1
+        expect(output.first).to eq "Current type: Central"
+      end
+    end
+
+    context "with type change" do
+      it "shows the original and changed type" do
+        appeal.update!(changed_hearing_request_type: "V")
+        output = renderer.format_original_and_current_type(appeal)
+        expect(output.length).to eq 1
+        expect(output.first).to eq "Original Type: Central, current type: Video"
+      end
+    end
+  end
+
+  describe ".appeal_history" do
+    context "there have been no request type changes" do
+      it "describes the history" do
+        output = renderer.appeal_history(appeal)
+        expect(output.length).to eq 1
+        expect(output.first).to eq "Current type: Central"
+      end
+    end
+
+    context "there has been a request type change" do
+      it "describes the history" do
+        appeal.update!(changed_hearing_request_type: "V")
+        output = renderer.appeal_history(appeal)
+        expect(output.length).to eq 2
+        expect(output.first).to eq "Original Type: Central, current type: Video"
+        expect(output.second).to include "Converted to Video from Central by #{user.css_id}"
+      end
+    end
+  end
+
+  describe ".notes_or_include_pii_info" do
+    let(:notes) { "hello world" }
+
+    context "show_pii is false" do
+      it "asks the user to pass show_pii parameter" do
+        output = renderer.notes_or_include_pii_info(notes)
+        expect(output).to include "'show_pii: true'"
+      end
+    end
+
+    context "show_pii is true" do
+      let(:show_pii) { true }
+
+      it "shows the content of the note" do
+        output = renderer.notes_or_include_pii_info(notes)
+        expect(output).to eq notes
+      end
+
+      context "note contains a forward slash" do
+        let(:notes) { "hello / world" }
+
+        it "replaces it with a pipe symbol" do
+          output = renderer.notes_or_include_pii_info(notes)
+          expect(output).to eq "hello | world"
+        end
+      end
+
+      context "note is passed in list format" do
+        let(:notes) { %w[hello world] }
+
+        it "formats the list elements into a string" do
+          output = renderer.notes_or_include_pii_info(notes)
+          expect(output).to eq "hello world"
+        end
+      end
+    end
+  end
+
+  describe ".hearing_task_children" do
+    let(:show_pii) { true }
+    let!(:appeal) do
+      create(:appeal, :with_schedule_hearing_tasks, veteran: veteran, original_hearing_request_type: "central")
+    end
+
+    it "describes the hearing note and the children of the hearing task" do
+      h_task = appeal.tasks.find_by(type: HearingTask.name)
+      sh_task = appeal.tasks.find_by(type: ScheduleHearingTask.name)
+      h_task.update!(instructions: ["some instructions"])
+
+      output = renderer.hearing_task_children(h_task)
+      expect(output.length).to eq 2
+      expect(output.first).to include "some instructions"
+      expect(output.second).to include "ScheduleHearingTask #{sh_task.id}"
+      expect(output.second).to include "assigned"
+    end
+  end
+end


### PR DESCRIPTION
PR #16315 adds a hearing renderer.
This PR adds it to the `explain` page.

### Description
On the `explain` page, add hearing rendering for appeal.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `explain` page shows hearing rendering for appeal.

### Testing Plan
Insert a `binding.pry` in the `spec/feature/explain_spec.rb` RSpec around line 103 and check the page for the `HearingRenderer` output.

### User Facing Changes
![image](https://user-images.githubusercontent.com/55255674/123167736-8e922200-d43c-11eb-82a1-6a231ec43c3b.png)
