### PR TITLE
Fix alert type on POA response

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -259,13 +259,13 @@ class AppealsController < ApplicationController
     poa = appeal.bgs_power_of_attorney
 
     if poa.blank?
-      ["Successfully refreshed. No power of attorney information was found at this time.", "not found"]
+      ["Successfully refreshed. No power of attorney information was found at this time.", "success"]
     elsif poa.bgs_record == :not_found
       poa.destroy!
-      ["Successfully refreshed. No power of attorney information was found at this time.", "deleted"]
+      ["Successfully refreshed. No power of attorney information was found at this time.", "success"]
     else
       poa.save_with_updated_bgs_record!
-      ["POA Updated Successfully", "updated"]
+      ["POA Updated Successfully", "success"]
     end
   end
 


### PR DESCRIPTION
### Description
Uses "success" alert type available in the Alert component for successful POA responses.

### Acceptance Criteria
- [ ] Shows success alert type when the POA update request succeeds

### Testing Plan
1. N/A

 BEFORE|AFTER
 ---|---
<img width="783" alt="Screen Shot 2021-06-23 at 6 32 30 PM" src="https://user-images.githubusercontent.com/6589610/123194957-30753700-d45c-11eb-8ef5-809ba9d992c0.png"> | ![Screen Shot 2021-06-24 at 12 55 02 PM](https://user-images.githubusercontent.com/6589610/123324286-7f1de200-d4eb-11eb-98e4-aae0ff4623f6.png)

