### PR TITLE
Do not raise InvalidCountryNameError for nil appellant_address country

### DIFF
--- a/app/models/concerns/appeal_concern.rb
+++ b/app/models/concerns/appeal_concern.rb
@@ -114,12 +114,12 @@ module AppealConcern
     address_obj = addr.is_a?(Hash) ? Address.new(addr) : addr
 
     # Some appellant addresses have empty country values but valid city, state, and zip codes.
-    # If the address has a zip code and a state value then we make the best guess that the address
-    # is within the US (TimezoneService.address_to_timezone will raise an error if this guess is
-    # wrong and the zip code is not a valid US zip code), otherwise we return nil without attempting
-    # to get the timezone identifier.
+    # If the address has a zip code then we make the best guess that the address is within the US
+    # (TimezoneService.address_to_timezone will raise an error if this guess is wrong and the zip
+    # code is not a valid US zip code), otherwise we return nil without attempting to get
+    # thetimezone identifier.
     if address_obj.country.blank?
-      return if address_obj.zip.blank? || address_obj.state.blank?
+      return if address_obj.zip.blank?
 
       new_address_hash = address_obj.as_json.symbolize_keys.merge(country: "USA")
       address_obj = Address.new(**new_address_hash)

--- a/app/models/concerns/appeal_concern.rb
+++ b/app/models/concerns/appeal_concern.rb
@@ -118,8 +118,8 @@ module AppealConcern
     # is within the US (TimezoneService.address_to_timezone will raise an error if this guess is
     # wrong and the zip code is not a valid US zip code), otherwise we return nil without attempting
     # to get the timezone identifier.
-    if address_obj.country.nil?
-      return if address_obj.zip.nil? || address_obj.state.nil?
+    if address_obj.country.blank?
+      return if address_obj.zip.blank? || address_obj.state.blank?
 
       new_address_hash = address_obj.as_json.symbolize_keys.merge(country: "USA")
       address_obj = Address.new(**new_address_hash)

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -23,16 +23,16 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
 
     context "When all properties of the appellant_address are nil" do
       let(:address) do
-          {
-            addrs_one_txt: nil,
-            addrs_two_txt: nil,
-            addrs_three_txt: nil,
-            city_nm: nil,
-            cntry_nm: nil,
-            postal_cd: nil,
-            zip_prefix_nbr: nil,
-            ptcpnt_addrs_type_nm: nil,
-          }
+        {
+          addrs_one_txt: nil,
+          addrs_two_txt: nil,
+          addrs_three_txt: nil,
+          city_nm: nil,
+          cntry_nm: nil,
+          postal_cd: nil,
+          zip_prefix_nbr: nil,
+          ptcpnt_addrs_type_nm: nil,
+        }
       end
       let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }
 
@@ -52,7 +52,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
           cntry_nm: nil,
           postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
           zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,
-          ptcpnt_addrs_type_nm: "Mailing"
+          ptcpnt_addrs_type_nm: "Mailing",
         }
       end
       let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -42,7 +42,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
       end
     end
 
-    context "When appellant_address country is nil but zip and state are provided" do
+    context "When appellant_address country is nil but zip is provided" do
       let(:address) do
         {
           addrs_one_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1].sample,
@@ -50,7 +50,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
           addrs_three_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_3].sample,
           city_nm: [nil, FakeConstants.BGS_SERVICE.DEFAULT_CITY].sample,
           cntry_nm: nil,
-          postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
+          postal_cd: [nil, FakeConstants.BGS_SERVICE.DEFAULT_STATE].sample,
           zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,
           ptcpnt_addrs_type_nm: "Mailing"
         }

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -42,7 +42,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
       end
     end
 
-    context "When appellant_address country is nil" do
+    context "When appellant_address country is nil but zip and state are provided" do
       let(:address) do
         {
           addrs_one_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1].sample,

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -45,10 +45,10 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
     context "When appellant_address country is nil" do
       let(:address) do
         {
-          addrs_one_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1,
-          addrs_two_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_2,
-          addrs_three_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_3,
-          city_nm: FakeConstants.BGS_SERVICE.DEFAULT_CITY,
+          addrs_one_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1].sample,
+          addrs_two_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_2].sample,
+          addrs_three_txt: [nil, FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_3].sample,
+          city_nm: [nil, FakeConstants.BGS_SERVICE.DEFAULT_CITY].sample,
           cntry_nm: nil,
           postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
           zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -20,5 +20,47 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
 
       expect(subject.serializable_hash[:data][:attributes][:appellant_address]).to eq serialized_appellant_address
     end
+
+    context "When all properties of the appellant_address are nil" do
+      let(:address) do
+          {
+            addrs_one_txt: nil,
+            addrs_two_txt: nil,
+            addrs_three_txt: nil,
+            city_nm: nil,
+            cntry_nm: nil,
+            postal_cd: nil,
+            zip_prefix_nbr: nil,
+            ptcpnt_addrs_type_nm: nil,
+          }
+      end
+      let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }
+
+      it "Time zone is nil" do
+        expect(subject.serializable_hash[:data][:attributes][:appellant_address][:country]).to eq(nil)
+        expect(subject.serializable_hash[:data][:attributes][:appellant_tz]).to eq(nil)
+      end
+    end
+
+    context "When appellant_address country is nil" do
+      let(:address) do
+        {
+          addrs_one_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_1,
+          addrs_two_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_2,
+          addrs_three_txt: FakeConstants.BGS_SERVICE.DEFAULT_ADDRESS_LINE_3,
+          city_nm: FakeConstants.BGS_SERVICE.DEFAULT_CITY,
+          cntry_nm: nil,
+          postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
+          zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,
+          ptcpnt_addrs_type_nm: "Mailing"
+        }
+      end
+      let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }
+
+      it "Time zone is determined from zip code" do
+        expect(subject.serializable_hash[:data][:attributes][:appellant_address][:country]).to eq(nil)
+        expect(subject.serializable_hash[:data][:attributes][:appellant_tz]).to eq("America/Los_Angeles")
+      end
+    end
   end
 end

--- a/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/legacy_appeal_serializer_spec.rb
@@ -31,7 +31,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
           cntry_nm: nil,
           postal_cd: nil,
           zip_prefix_nbr: nil,
-          ptcpnt_addrs_type_nm: nil,
+          ptcpnt_addrs_type_nm: nil
         }
       end
       let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }
@@ -52,7 +52,7 @@ describe WorkQueue::LegacyAppealSerializer, :all_dbs do
           cntry_nm: nil,
           postal_cd: FakeConstants.BGS_SERVICE.DEFAULT_STATE,
           zip_prefix_nbr: FakeConstants.BGS_SERVICE.DEFAULT_ZIP,
-          ptcpnt_addrs_type_nm: "Mailing",
+          ptcpnt_addrs_type_nm: "Mailing"
         }
       end
       let(:legacy_appeal) { create(:legacy_appeal, vacols_case: create(:case), veteran_address: address) }


### PR DESCRIPTION
Resolves the remaining [2 of 3 common `TimezoneService::InvalidCountryNameError`s](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18565/) we have been seeing lately that were not address by the previous PR (#16399): 
```
TimezoneService::InvalidCountryNameError: no ISO 3166 country code found for ""
```

This PR handles the two scenarios in different ways:

### 1️⃣ Addresses with all `nil` fields

Some `LegacyAppeal`s (for example, 1357514 and 1357515) have an `appellant_address` with all fields present but with `nil` values:
```ruby
{
  :address_line_1=>nil,
  :address_line_2=>nil,
  :address_line_3=>nil,
  :city=>nil,
  :state=>nil,
  :country=>nil,
  :zip=>nil
}
``` 

Behaviour before this change | After
--- | ---
As written, the code creates an `Address` object for addresses like these and calls `TimezoneService.address_to_timezone()` which [fails when trying to determine the country](https://github.com/department-of-veterans-affairs/caseflow/blob/8e547951af3d4ff727fac940aead741f55f5b796/app/services/timezone_service.rb#L30) from the input `Address` and sends an `InvalidCountryNameError` above to Sentry and returns a `nil` value to the serializer. | With this change we will still return a `nil` value, but [will avoid making the call](https://github.com/department-of-veterans-affairs/caseflow/pull/16403/files#diff-a5e27a49cf3fe80cb3770494bcba425adb7cf58295545d808a108bf10ffaadffR122) to `TimezoneService.address_to_timezone()` if the address does not have a country, zip code, and state. We will stop seeing these errors, but these errors are not actionable since the addresses are coming from BGS and developers do not attempt to correct those addresses in BGS. 

### 2️⃣ Addresses with a `nil` country field

Some `LegacyAppeal`s (for example, 615504, 896697, and 1110864) have `appellant_address` with all fields and values present except for a `nil` value for the country field:
```ruby
{
  :address_line_1=>"1200 Mike Fahey St",
  :address_line_2=>nil,
  :address_line_3=>nil,
  :city=>"Omaha",
  :state=>"NE",
  :country=>nil,
  :zip=>"68102"
}
``` 

Behaviour before this change | After
--- | ---
As written, the code creates an `Address` object for addresses like these and calls `TimezoneService.address_to_timezone()` which [fails when trying to determine the country](https://github.com/department-of-veterans-affairs/caseflow/blob/8e547951af3d4ff727fac940aead741f55f5b796/app/services/timezone_service.rb#L30) from the input `Address` and sends an `InvalidCountryNameError` above to Sentry and returns a `nil` value to the serializer. | With this change we are using the presence of a zip code as an indication that the country is the "US" and [creating a new `Address` object](https://github.com/department-of-veterans-affairs/caseflow/pull/16403/files#diff-a5e27a49cf3fe80cb3770494bcba425adb7cf58295545d808a108bf10ffaadffR124) before we make the call to `TimezoneService.address_to_timezone()`. If the zip code is not a valid US address that method will raise an error (as it does now), but if the zip code is valid then we will return the timezone identifier instead of `nil` value as we did before.