### PR TITLE
Move method to public method

### DIFF
--- a/app/models/power_of_attorney.rb
+++ b/app/models/power_of_attorney.rb
@@ -68,11 +68,11 @@ class PowerOfAttorney
     @bgs_power_of_attorney = nil
   end
 
-  private
-
   def bgs_power_of_attorney
     @bgs_power_of_attorney ||= fetch_bgs_power_of_attorney || BgsPowerOfAttorney.new(file_number: file_number)
   end
+
+  private
 
   def fetch_bgs_power_of_attorney
     if claimant_participant_id.present?


### PR DESCRIPTION
### Description
Makes the PowerOfAttorney bgs_power_of_attorney method public, because it's now being used for delegation in LegacyAppeal.