### PR TITLE
Explain page: ignore HLRs and SCs associated with the appeal

### DIFF
--- a/app/assets/stylesheets/explain_appeal.css
+++ b/app/assets/stylesheets/explain_appeal.css
@@ -11,6 +11,10 @@
  * file per style scope.
  */
 
+.show_pii_true {
+  color: red;
+}
+
 li,
 li ul {
   margin-bottom: 0px
@@ -18,7 +22,7 @@ li ul {
 
 summary {
   display: list-item;
- }
+}
 
 #events_table {
   margin: 5px;

--- a/app/controllers/explain_controller.rb
+++ b/app/controllers/explain_controller.rb
@@ -58,7 +58,7 @@ class ExplainController < ApplicationController
     ].compact.join("\n\n")
   end
 
-  DEFAULT_TREEE_FIELDS = [:id, :status, :ASGN_BY, :ASGN_TO, :ASGN_DATE, :UPD_DATE, :CRE_DATE, :CLO_DATE].freeze
+  DEFAULT_TREEE_FIELDS = [:id, :status, :ASGN_BY, :ASGN_TO, :CRE_DATE, :ASGN_DATE, :UPD_DATE, :CLO_DATE].freeze
 
   def treee_fields
     return DEFAULT_TREEE_FIELDS unless fields_query_param

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -18,7 +18,7 @@
   <h3>Appeal <%=appeal.id%> (<%=appeal.uuid%>)</h3>
   <ul id="appeal_info">
     <li>status: <%= appeal_status.to_s %></li>
-    <li>priority: <%= appeal.aod? && appeal.cavc? %> (AOD: <%= appeal.aod? %>, CAVC: <%= appeal.cavc? %>)</li>
+    <li>priority: <%= appeal.aod? || appeal.cavc? %> (AOD: <%= appeal.aod? %>, CAVC: <%= appeal.cavc? %>)</li>
     <% if sje.records_hash["appeals"].length > 1 %>
     <li>Related Appeals:
       <ul>

--- a/app/views/explain/show.html.erb
+++ b/app/views/explain/show.html.erb
@@ -6,7 +6,7 @@
 <% end %>
 
 <div style="font-size:0.875em; padding:10px">
-  Currently, <code>show_pii = <%= show_pii_query_param %></code>.
+  <code class="show_pii_<%=show_pii_query_param%>">show_pii = <%= show_pii_query_param %></code>.
   To toggle PII, click <%= link_to('toggle show_pii', {action: 'show', show_pii: !show_pii_query_param}) %>.
   (Other formats:
   <%= link_to((show_pii_query_param ? "text showing PII" : "sanitized text"),
@@ -56,7 +56,7 @@
   </details>
   <hr/>
 
-  <h3>Intake (<%= show_pii_query_param ? "showing PII" : "no PII" %>)</h3>
+  <h3>Intake (<span class="show_pii_<%=show_pii_query_param%>"><%= show_pii_query_param ? "showing PII" : "no PII" %></span>)</h3>
   <code style="color: green">
     puts IntakeRenderer.render(Appeal.find(<%= appeal.id %>),
       show_pii: <%= show_pii_query_param ? "true" : "false" %>)
@@ -64,7 +64,7 @@
   <pre style="font-size:0.9em; padding:10px"><code><%= intake_as_text %></code></pre>
   <hr/>
 
-  <h3>Hearing (<%= show_pii_query_param ? "showing PII" : "no PII" %>)</h3>
+  <h3>Hearing (<span class="show_pii_<%=show_pii_query_param%>"><%= show_pii_query_param ? "showing PII" : "no PII" %></span>)</h3>
   <code style="color: green">
     puts HearingRenderer.render(Appeal.find(<%= appeal.id %>),
       show_pii: <%= show_pii_query_param ? "true" : "false" %>)
@@ -72,7 +72,7 @@
   <pre style="font-size:0.9em; padding:10px"><code><%= hearing_as_text %></code></pre>
   <hr/>
 
-  <h3>Appeal Narrative (contains PII)</h3>
+  <h3>Appeal Narrative (<span class="show_pii_true">contains PII</span>)</h3>
   
   <details>
     <summary id="narrative_table" style="color: purple">Narrative table</summary>

--- a/lib/helpers/sanitized_json_configuration.rb
+++ b/lib/helpers/sanitized_json_configuration.rb
@@ -240,10 +240,15 @@ class SanitizedJsonConfiguration
     [
       appeal.cavc_remand&.source_appeal,
       appeal.appellant_substitution&.source_appeal,
-      appeal.request_issues.includes(:contested_decision_issue).map do |rqi|
-        rqi.contested_decision_issue&.decision_review
-      end
+      decision_reviews_associated_with(appeal)[Appeal]
     ].flatten.compact
+  end
+
+  # To-do: export other decision_reviews, i.e., HLRs and SCs
+  def self.decision_reviews_associated_with(appeal)
+    appeal.request_issues.includes(:contested_decision_issue).map do |rqi|
+      rqi.contested_decision_issue&.decision_review
+    end.compact.group_by(&:class)
   end
 
   def before_sanitize(record, obj_hash)

--- a/lib/helpers/sanitized_json_configuration.rb
+++ b/lib/helpers/sanitized_json_configuration.rb
@@ -142,7 +142,7 @@ class SanitizedJsonConfiguration
       }
     }.each do |clazz, class_configuration|
       class_configuration[:sanitize_fields] ||= self.class.select_sanitize_fields(clazz).tap do |fields|
-        puts "  Inferring #{clazz} sanitize_fields: #{fields}" unless fields.blank?
+        Rails.logger.info "  Inferring #{clazz} sanitize_fields: #{fields}" unless fields.blank?
       end
     end
   end

--- a/spec/feature/explain_spec.rb
+++ b/spec/feature/explain_spec.rb
@@ -116,7 +116,7 @@ RSpec.feature "Explain JSON" do
       expect(page).to have_content("show_pii: false")
       expect(page).to have_content("Appeal Narrative (contains PII)")
 
-      click_link('toggle show_pii')
+      click_link("toggle show_pii")
       expect(page).to have_content("show_pii = true")
       expect(page).to have_content("Intake (showing PII)")
       expect(page).to have_content("Hearing (showing PII)")

--- a/spec/feature/explain_spec.rb
+++ b/spec/feature/explain_spec.rb
@@ -108,6 +108,20 @@ RSpec.feature "Explain JSON" do
     end
     it "present realistic appeal events" do
       visit "explain/appeals/#{real_appeal.uuid}"
+      expect(page).to have_content("show_pii = false")
+      expect(page).to have_content("status: dispatched")
+      expect(page).to have_content("priority: false (AOD: false, CAVC: false)")
+      expect(page).to have_content("Intake (no PII)")
+      expect(page).to have_content("Hearing (no PII)")
+      expect(page).to have_content("show_pii: false")
+      expect(page).to have_content("Appeal Narrative (contains PII)")
+
+      click_link('toggle show_pii')
+      expect(page).to have_content("show_pii = true")
+      expect(page).to have_content("Intake (showing PII)")
+      expect(page).to have_content("Hearing (showing PII)")
+      expect(page).to have_content("show_pii: true")
+      expect(page).to have_content("Appeal Narrative (contains PII)")
       page.find("#narrative_table").click
       task = real_appeal.tasks.sample
       expect(page).to have_content("#{task.type}_#{task.id}")

--- a/spec/feature/explain_spec.rb
+++ b/spec/feature/explain_spec.rb
@@ -51,7 +51,7 @@ RSpec.feature "Explain JSON" do
 
   # 3 appeals are involved: `source_appeal` goes through CAVC remand to create `cavc_remand.remand_appeal`,
   # which goes through appellant substitution to create `appellant_substitution.target_appeal`.
-  let(:source_appeal) { create(:appeal, :dispatched, :type_cavc_remand, :advanced_on_docket_due_to_motion) }
+  let(:source_appeal) { create(:appeal, :dispatched, :type_cavc_remand) }
   let(:created_by) { create(:user) }
   let(:substitute) { create(:claimant) }
   let(:poa_participant_id) { "13579" }
@@ -87,6 +87,16 @@ RSpec.feature "Explain JSON" do
   scenario "admin visits explain page for appellant_substitution CAVC-remanded appeal" do
     visit "explain/appeals/#{appellant_substitution.target_appeal.uuid}"
     expect(page).to have_content("Appeal.find(#{appellant_substitution.target_appeal.id})")
+    expect(page).to have_content("priority: true (AOD: false, CAVC: true)")
+
+    visit "explain/appeals/#{appellant_substitution.source_appeal.uuid}"
+    expect(page).to have_content("Appeal.find(#{appellant_substitution.source_appeal.id})")
+    expect(page).to have_content("priority: true (AOD: false, CAVC: true)")
+
+    cavc_remand = appellant_substitution.source_appeal.cavc_remand
+    visit "explain/appeals/#{cavc_remand.source_appeal.uuid}"
+    expect(page).to have_content("Appeal.find(#{cavc_remand.source_appeal.id})")
+    expect(page).to have_content("priority: false (AOD: false, CAVC: false)")
   end
 
   context "for a realistic appeal" do


### PR DESCRIPTION
Resolves [Sentry alert](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18685)

### Description
Ignore associated HLRs and SCs when loading decision reviews associated with the appeal.

Also fix appeal priority calculation: should have used `||` not `&&`.

When `show_pii = true`, make it obvious on the page by coloring the text red.

### Acceptance Criteria
- [ ] HLRs and SCs associated with the appeal do not break the page
- [ ] appeal priority is correct

### Testing Plan
Insert a `binding.pry` into the modified RSpec and playing around on the `explain` page.