### PR TITLE
Reset Redux Store after Substitution

### DIFF
--- a/client/app/queue/substituteAppellant/review/SubstituteAppellantReviewContainer.jsx
+++ b/client/app/queue/substituteAppellant/review/SubstituteAppellantReviewContainer.jsx
@@ -6,7 +6,7 @@ import { showSuccessMessage, showErrorMessage } from 'app/queue/uiReducer/uiActi
 import { SubstituteAppellantReview } from './SubstituteAppellantReview';
 import { calculateEvidenceSubmissionEndDate } from '../tasks/utils';
 
-import { cancel, stepBack, completeSubstituteAppellant } from '../substituteAppellant.slice';
+import { cancel, reset, stepBack, completeSubstituteAppellant } from '../substituteAppellant.slice';
 import { getAllTasksForAppeal, appealWithDetailSelector } from 'app/queue/selectors';
 
 import COPY from 'app/../COPY';
@@ -97,6 +97,11 @@ export const SubstituteAppellantReviewContainer = () => {
           detail: COPY.SUBSTITUTE_APPELLANT_SUCCESS_DETAIL,
         })
       );
+
+      // Reset Redux store
+      dispatch(reset());
+
+      // Route to new appeal stream
       history.push(`/queue/appeals/${res.payload.targetAppeal.uuid}`);
     } catch (error) {
       console.error('Error during substitute appellant appeal creation', error);

--- a/client/app/queue/substituteAppellant/review/SubstituteAppellantReviewContainer.jsx
+++ b/client/app/queue/substituteAppellant/review/SubstituteAppellantReviewContainer.jsx
@@ -39,7 +39,7 @@ export const SubstituteAppellantReviewContainer = () => {
 
   const { relationships } = useSelector((state) => state.substituteAppellant);
   const relationship = useMemo(() => {
-    return relationships.find((rel) => String(rel.value) === String(existingValues.participantId));
+    return relationships?.find((rel) => String(rel.value) === String(existingValues.participantId)) ?? null;
   }, [relationships, existingValues?.participantId]);
 
   const evidenceSubmissionEndDate = calculateEvidenceSubmissionEndDate(
@@ -98,11 +98,11 @@ export const SubstituteAppellantReviewContainer = () => {
         })
       );
 
-      // Reset Redux store
-      dispatch(reset());
-
       // Route to new appeal stream
       history.push(`/queue/appeals/${res.payload.targetAppeal.uuid}`);
+
+      // Reset Redux store after route transition begins to avoid rendering errors
+      dispatch(reset());
     } catch (error) {
       console.error('Error during substitute appellant appeal creation', error);
       dispatch(

--- a/client/app/queue/substituteAppellant/substituteAppellant.slice.js
+++ b/client/app/queue/substituteAppellant/substituteAppellant.slice.js
@@ -61,6 +61,7 @@ const substituteAppellantSlice = createSlice({
   initialState,
   reducers: {
     cancel: () => ({ ...initialState }),
+    reset: () => ({ ...initialState }),
     stepForward: (state) => ({ ...state, step: state.step + 1 }),
     stepBack: (state) => ({ ...state, step: state.step ? state.step - 1 : 0 }),
     updateData: (state, action) => {

--- a/client/app/queue/substituteAppellant/substituteAppellant.slice.js
+++ b/client/app/queue/substituteAppellant/substituteAppellant.slice.js
@@ -56,12 +56,14 @@ const initialState = {
   poa: null
 };
 
+const resetState = () => ({ ...initialState });
+
 const substituteAppellantSlice = createSlice({
   name: 'substituteAppellant',
   initialState,
   reducers: {
-    cancel: () => ({ ...initialState }),
-    reset: () => ({ ...initialState }),
+    cancel: resetState,
+    reset: resetState,
     stepForward: (state) => ({ ...state, step: state.step + 1 }),
     stepBack: (state) => ({ ...state, step: state.step ? state.step - 1 : 0 }),
     updateData: (state, action) => {

--- a/client/app/queue/substituteAppellant/substituteAppellant.slice.js
+++ b/client/app/queue/substituteAppellant/substituteAppellant.slice.js
@@ -120,6 +120,7 @@ export const completeSubstituteAppellant = createAsyncThunk(
 
 export const {
   cancel,
+  reset,
   stepForward,
   stepBack,
   updateData,


### PR DESCRIPTION
Connects [CASEFLOW-1609](https://vajira.max.gov/browse/CASEFLOW-1609)

### Description
This adds a bit of cleanup by resetting the relevant portion fo the Redux store after appellant substitution process

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `substituteAppellant` slice is reset to defaults upon successful confirmation/submission

### Testing Plan
1. Go to a dispatched appeal with a deceased veteran as a COB user
2. Open up Redux devtools and observe the `substituteAppellant` portion of the `queue` store
3. Perform substitution, but  prior to confirming, observe Redux state
4. After submission, confirm that `substituteAppellant` Redux state has been reset to defaults