### PR TITLE
Send OpenTasksWithClosedAtChecker messages to Echo Slack channel

### DIFF
--- a/app/services/open_tasks_with_closed_at_checker.rb
+++ b/app/services/open_tasks_with_closed_at_checker.rb
@@ -17,6 +17,10 @@ class OpenTasksWithClosedAtChecker < DataIntegrityChecker
     end
   end
 
+  def slack_channel
+    "#appeals-echo"
+  end
+
   private
 
   def open_tasks_with_closed_at_defined


### PR DESCRIPTION
Routes `OpenTasksWithClosedAtChecker` to team Echo's Slack channel. These messages had previously been sent to the `#appeals-job-alerts` channel (the [default channel for `DataIntegrityChecker` alerts](https://github.com/department-of-veterans-affairs/caseflow/blob/5f61fdbeea37e3822621270104d6dce1b42808e2/app/services/data_integrity_checker.rb#L34)), but now that Echo will start whittling away at these tasks it may make sense to send these messages to team Echo's Slack channel.