### PR TITLE
Ignore closed hearings in appeals API

### DIFF
--- a/app/decorators/appeal_status_api_decorator.rb
+++ b/app/decorators/appeal_status_api_decorator.rb
@@ -132,7 +132,7 @@ class AppealStatusApiDecorator < ApplicationDecorator
   def scheduled_hearing
     # Appeal Status api assumes that there can be multiple hearings that have happened in the past but only
     # one that is currently scheduled. Will get this by getting the hearing whose scheduled date is in the future.
-    @scheduled_hearing ||= hearings.find { |hearing| hearing.scheduled_for >= Time.zone.today }
+    @scheduled_hearing ||= hearings.where(disposition: nil).find { |hearing| hearing.scheduled_for >= Time.zone.today }
   end
 
   def api_scheduled_hearing_type

--- a/app/decorators/appeal_status_api_decorator.rb
+++ b/app/decorators/appeal_status_api_decorator.rb
@@ -132,7 +132,7 @@ class AppealStatusApiDecorator < ApplicationDecorator
   def scheduled_hearing
     # Appeal Status api assumes that there can be multiple hearings that have happened in the past but only
     # one that is currently scheduled. Will get this by getting the hearing whose scheduled date is in the future.
-    @scheduled_hearing ||= hearings.where(disposition: nil).find { |hearing| hearing.scheduled_for >= Time.zone.today }
+    @scheduled_hearing ||= hearings.with_no_disposition.find { |hearing| hearing.scheduled_for >= Time.zone.today }
   end
 
   def api_scheduled_hearing_type

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -70,6 +70,7 @@ class Hearing < CaseflowRecord
 
   attr_accessor :override_full_hearing_day_validation
 
+  scope :with_no_disposition, -> { where(disposition: nil) }
   scope :not_scheduled_in_error,
         lambda {
           where(

--- a/spec/decorators/appeal_status_api_decorator_spec.rb
+++ b/spec/decorators/appeal_status_api_decorator_spec.rb
@@ -395,4 +395,46 @@ describe AppealStatusApiDecorator, :all_dbs do
       end
     end
   end
+
+  context "#scheduled_hearing" do
+    subject { described_class.new(appeal).scheduled_hearing }
+    let(:receipt_date) { Time.zone.today - 10.days }
+    let!(:appeal) { create(:appeal, :hearing_docket, receipt_date: receipt_date) }
+
+    let(:hearing_scheduled_for) { Time.zone.today + 15.days }
+    let!(:hearing_day) do
+      create(:hearing_day,
+             request_type: HearingDay::REQUEST_TYPES[:video],
+             regional_office: "RO18",
+             scheduled_for: hearing_scheduled_for)
+    end
+
+    let!(:hearing) do
+      create(
+        :hearing,
+        appeal: appeal,
+        disposition: disposition,
+        evidence_window_waived: nil,
+        hearing_day: hearing_day
+      )
+    end
+
+    context "when a hearing scheduled for the future has not been held" do
+      let(:disposition) { nil }
+
+      it "returns that hearing" do
+        expect(subject).to eq(hearing)
+      end
+    end
+
+    context "when a hearing scheduled for the future has been cancelled" do
+      let(:disposition) { "cancelled" }
+
+      it "returns no hearing" do
+        expect(subject).to be_nil
+      end
+    end
+
+
+  end
 end

--- a/spec/decorators/appeal_status_api_decorator_spec.rb
+++ b/spec/decorators/appeal_status_api_decorator_spec.rb
@@ -434,7 +434,5 @@ describe AppealStatusApiDecorator, :all_dbs do
         expect(subject).to be_nil
       end
     end
-
-
   end
 end


### PR DESCRIPTION
Resolves `ArgumentError: comparison of Date with nil failed` errors [we've been seeing](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/16917) over the month.

These errors have been occurring because we're attempting to include [an alert for a hearing in the future](https://github.com/department-of-veterans-affairs/caseflow/blob/f4d4003111bf1ba42db8dd1fe7a0e2c5af205222/app/models/api_status_alerts.rb#L107) alongside post decision alerts, and [sorting them by the `decisionDate` field](https://github.com/department-of-veterans-affairs/caseflow/blob/f4d4003111bf1ba42db8dd1fe7a0e2c5af205222/app/decorators/appeal_status_api_decorator.rb#L181). However, since the scheduled hearing alert does not have a `decisionDate` field we are throwing an `ArgumentError: comparison of Date with nil failed`.

The hearing that is causing these errors (Hearing ID 11158) was postponed so it never should have been included in the list of alerts, however our status API logic does not take hearing disposition into account when looking for `scheduled_hearing`s. This PR updates the status API code to only return open hearings for `scheduled_hearing`s.