### PR TITLE
Fixed undefined label for Louisville RO

### DIFF
--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -261,6 +261,15 @@ export const getOptionsFromObject = (object, noneOption, transformer) =>
   _.concat(_.map(_.values(object), transformer), [noneOption]);
 
 /**
+ * Method to normalize the Regional Office Timezone names
+ * @param {string} name -- Name of the Regional Office timezone
+ */
+export const getFriendlyZoneName = (name) => {
+  // There is not a friendly name for some of the Regional Office zones, choose the city name instead for those
+  return Object.keys(REGIONAL_OFFICE_ZONE_ALIASES).includes(name) ? REGIONAL_OFFICE_ZONE_ALIASES[name] : name;
+};
+
+/**
  * Method to get the Timezone label of a Timezone value
  * @param {string} time -- The time to which the zone is being added
  * @param {string} name -- Name of the zone, defaults to New York
@@ -268,7 +277,7 @@ export const getOptionsFromObject = (object, noneOption, transformer) =>
  */
 export const zoneName = (time, name, format) => {
   // Default to using America/New_York
-  const timezone = name ? name : COMMON_TIMEZONES[3];
+  const timezone = name ? getFriendlyZoneName(name) : COMMON_TIMEZONES[3];
 
   // Filter the zone name
   const [zone] = Object.keys(TIMEZONES).filter((tz) => TIMEZONES[tz] === timezone);
@@ -310,15 +319,6 @@ export const hearingTimeOptsWithZone = (options, local) =>
       [label]: local && localTime !== time ? `${localTime} / ${time}` : time
     };
   });
-
-/**
- * Method to normalize the Regional Office Timezone names
- * @param {string} name -- Name of the Regional Office timezone
- */
-export const getFriendlyZoneName = (name) => {
-  // There is not a friendly name for some of the Regional Office zones, choose the city name instead for those
-  return Object.keys(REGIONAL_OFFICE_ZONE_ALIASES).includes(name) ? REGIONAL_OFFICE_ZONE_ALIASES[name] : name;
-};
 
 /**
  * Method to return a list of Regional Office Timezones sorted with common timezones at the top


### PR DESCRIPTION
Resolves [CASEFLOW-1588](https://vajira.max.gov/browse/CASEFLOW-1588)

### Description

Fixes the label for the Louisville RO to display the correct timezone instead of the word "undefined"

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Time zone label resolves appropriately (likely to "Eastern", "EST", or "EDT")

### Testing Plan

1. Shadow user `BVASYELLOW`: http://localhost:3000/test/users
2. Navigate to the hearing schedule: http://localhost:3000/hearings/schedule
3. Click the “Schedule Veteran” button at the top left
4. Select the St. Petersburg, FL RO from the dropdown
5. Click the “AMA Veterans Waiting” tab and click the name of one of the Veterans
6. On the Case Details page, click the “Schedule Veteran” option from the task list
7. Change the RO to "Louisville, KY" and select a hearing day
8. Ensure that the timezone shows only Eastern time instead of undefined
