### PR TITLE
Write migration to fix poa participant id column comment in appellant_substitutions table

### DIFF
--- a/db/migrate/20210628174527_update_appellant_substitutions_poa_participant_id_comment.rb
+++ b/db/migrate/20210628174527_update_appellant_substitutions_poa_participant_id_comment.rb
@@ -1,5 +1,9 @@
 class UpdateAppellantSubstitutionsPoaParticipantIdComment < Caseflow::Migration[5.2]
-  def change
+  def up
     change_column_comment(:appellant_substitutions, :poa_participant_id, "Identifier of the appellant's POA, if they have a CorpDB participant_id. Null if the substitute appellant has no POA.")
+  end
+
+  def down
+    change_column_comment(:appellant_substitutions, :poa_participant_id, "Identifier of the appellant's POA, if they have a CorpDB participant_id")
   end
 end

--- a/db/migrate/20210628174527_update_appellant_substitutions_poa_participant_id_comment.rb
+++ b/db/migrate/20210628174527_update_appellant_substitutions_poa_participant_id_comment.rb
@@ -1,0 +1,5 @@
+class UpdateAppellantSubstitutionsPoaParticipantIdComment < Caseflow::Migration[5.2]
+  def change
+    change_column_comment(:appellant_substitutions, :poa_participant_id, "Identifier of the appellant's POA, if they have a CorpDB participant_id. Null if the substitute appellant has no POA.")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_22_145703) do
+ActiveRecord::Schema.define(version: 2021_06_28_174527) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -94,7 +94,7 @@ appellant_substitutions,claimant_type,string ∗,x,,,,,Claimant type of substi
 appellant_substitutions,created_at,datetime ∗,x,,,,,Standard created_at/updated_at timestamps
 appellant_substitutions,created_by_id,integer (8) ∗ FK,x,,x,,,User that created this record
 appellant_substitutions,id,integer (8) PK,x,x,,,,
-appellant_substitutions,poa_participant_id,string,,,,,,"Identifier of the appellant's POA, if they have a CorpDB participant_id"
+appellant_substitutions,poa_participant_id,string,,,,,,"Identifier of the appellant's POA, if they have a CorpDB participant_id. Null if the substitute appellant has no POA."
 appellant_substitutions,selected_task_ids,integer (8) ∗,x,,,,,User-selected task ids from source appeal
 appellant_substitutions,source_appeal_id,integer (8) ∗ FK,x,,x,,x,The relevant source appeal for this substitution
 appellant_substitutions,substitute_participant_id,string ∗,x,,,,,Participant ID of substitute appellant


### PR DESCRIPTION
### Description
I mistakenly directly edited the schema in PR #16389, rather than writing a migration to update the column comment.  This PR is meant to fix my previous mistake and prevent the db schema from getting out of sync for other developers.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Migration and rollback both run successfully
- [ ] Comment is clear

### Testing Plan
1. Locally run the migration and confirm that it runs successfully
2. Locally rollback the migration and confirm that it rolls back successfully

### Database Changes
*Only for Schema Changes*

* [x] Update column comments
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Run `make docs` (after running `make migrate`) to update DB schema docs
* [x] Post this PR in #appeals-schema with a summary