### PR TITLE
Strip leading/trailing whitespace from country names in TimezoneService

### DIFF
--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -76,7 +76,9 @@ class TimezoneService
 
     # Finds the ISO 3166 country code corresponding to the given country name, or fails
     # with an error if not found.
-    def iso3166_alpha2_code_from_name(country_name)
+    def iso3166_alpha2_code_from_name(orig_country_name)
+      country_name = orig_country_name&.strip
+
       iso3166_code = ISO3166::Country.find_country_by_name(country_name)
       iso3166_code = ISO3166::Country.find_country_by_alpha3(country_name) if iso3166_code.blank?
 

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -189,6 +189,7 @@ describe TimezoneService do
     include_examples "it resolves to a valid ISO 3166 country code", "Switzerland", "CH"
     include_examples "it resolves to a valid ISO 3166 country code", "Taiwan", "TW"
     include_examples "it resolves to a valid ISO 3166 country code", "United Kingdom", "GB"
+    include_examples "it resolves to a valid ISO 3166 country code", "United Kingdom ", "GB"
 
     shared_examples "it throws an error if not a valid country name" do |country_name|
       it "#{country_name.inspect} raises InvalidCountryNameError" do


### PR DESCRIPTION
Resolves `TimezoneService::InvalidCountryNameError: no ISO 3166 country code found for "USA "` category of error we see occasionally (like [this example](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18565/events/2390b17c04844cc58ac9041b3854e53b/)).