### PR TITLE
Add date of birth column to unrecognized party details

### DIFF
--- a/db/migrate/20210629174248_add_birthdate_to_unrecognized_party.rb
+++ b/db/migrate/20210629174248_add_birthdate_to_unrecognized_party.rb
@@ -1,0 +1,6 @@
+class AddBirthdateToUnrecognizedParty < Caseflow::Migration
+  def change
+    add_column :unrecognized_party_details, :date_of_birth, :date,
+      comment: "PII"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_28_174527) do
+ActiveRecord::Schema.define(version: 2021_06_29_174248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1460,6 +1460,7 @@ ActiveRecord::Schema.define(version: 2021_06_28_174527) do
     t.string "city", null: false
     t.string "country", null: false
     t.datetime "created_at", null: false
+    t.date "date_of_birth", comment: "PII"
     t.string "email_address"
     t.string "last_name"
     t.string "middle_name"

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1116,6 +1116,7 @@ unrecognized_party_details,address_line_3,string,,,,,,
 unrecognized_party_details,city,string ∗,x,,,,,
 unrecognized_party_details,country,string ∗,x,,,,,
 unrecognized_party_details,created_at,datetime ∗,x,,,,,
+unrecognized_party_details,date_of_birth,date,,,,,,PII
 unrecognized_party_details,email_address,string,,,,,,
 unrecognized_party_details,id,integer (8) PK,x,x,,,,
 unrecognized_party_details,last_name,string,,,,,,


### PR DESCRIPTION
Resolves [CASEFLOW-1824](https://vajira.max.gov/browse/CASEFLOW-1824)

### Description
When intaking unrecognized appellant was originally built out, the 10182 form's date of birth field was omitted because users did not have the practice of storing it (and in general, Board adjudication does not use it). However, for unrecognized appellants, DoB is essential for identifying the appellant, since the 10182 doesn't ask for SSN. This PR adds the column to the database schema.

### Database Changes
*Only for Schema Changes*

* [x] Update column comments
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb`
* [x] Run `make docs` (after running `make migrate`) to update DB schema docs
* [x] Post this PR in #appeals-schema with a summary