### PR TITLE
Fixes `make reset` and `make docs` and avoid warning messages

### DIFF
--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -5,6 +5,8 @@ require "csv"
 
 # required for ERD diagrams
 require "ruby-graphviz"
+require "tasks/support/erd_record_associations.rb"
+require "tasks/support/erd_graph_styling.rb"
 
 namespace :doc do
   desc "prepare environment"

--- a/lib/tasks/support/erd_graph_styling.rb
+++ b/lib/tasks/support/erd_graph_styling.rb
@@ -22,7 +22,7 @@ module ErdGraphStyling
 
   private
 
-  DECISION_REVIEW_POLYTYPES = %w[
+  DECISION_REVIEW_POLYTYPES ||= %w[
     decision_review_type review_type decision_review_remanded_type
     appeal_type
     original_decision_review_type
@@ -31,7 +31,7 @@ module ErdGraphStyling
 
   # Records that can act as join tables (has foreign keys to exactly 2 other tables)
   # Would be great to automatically identify these
-  JOIN_TABLE_RECORDS = %w[
+  JOIN_TABLE_RECORDS ||= %w[
     OrganizationsUser
     RequestDecisionIssue
     IhpDraft
@@ -43,7 +43,7 @@ module ErdGraphStyling
     Message
   ].freeze
 
-  NODE_STYLES = {
+  NODE_STYLES ||= {
     abstract_records: {
       node_names: %w[DecisionReview ClaimReview],
       attribs: {
@@ -78,7 +78,7 @@ module ErdGraphStyling
   }.freeze
 
   # Records that indicate completion of a significant step
-  COMPLETION_RECORDS = %w[
+  COMPLETION_RECORDS ||= %w[
     JudgeCaseReview AttorneyCaseReview
     DecisionDocument VbmsUploadedDocument
     DecisionIssue

--- a/lib/tasks/support/erd_record_associations.rb
+++ b/lib/tasks/support/erd_record_associations.rb
@@ -29,7 +29,7 @@ module ErdRecordAssociations
     end
   end
 
-  POLYMORPHIC_COLOR = "#0000ff" # blue
+  POLYMORPHIC_COLOR ||= "#0000ff" # blue
 
   #:reek:UtilityFunction
   def add_polymorphic_node(graph, node_name, subclasses)
@@ -60,7 +60,7 @@ module ErdRecordAssociations
 
   private
 
-  SUBCLASS_COLOR = "#000099" # dark blue
+  SUBCLASS_COLOR ||= "#000099" # dark blue
 
   def add_subclass_edges_for(graph, klass)
     (klass.subclasses & record_classes).each do |subclass|
@@ -108,7 +108,7 @@ module ErdRecordAssociations
     end
   end
 
-  DECISION_REVIEW_TYPES = %w[Appeal SupplementalClaim HigherLevelReview].freeze
+  DECISION_REVIEW_TYPES ||= %w[Appeal SupplementalClaim HigherLevelReview].freeze
 
   def polymorphic_nodes_config
     @polymorphic_nodes_config ||= {
@@ -197,7 +197,7 @@ module ErdRecordAssociations
   end
 
   # for custom edges
-  CUSTOM_POLYMORPHIC_EDGE_COLORS = {
+  CUSTOM_POLYMORPHIC_EDGE_COLORS ||= {
     color: "#6600cc",
     fontcolor: "#6600cc"
   }.freeze


### PR DESCRIPTION
### Description
Fixes `make reset` and `make docs` and avoid warning messages.

Problem: support modules (`tasks/support/erd_record_associations.rb` and `tasks/support/erd_graph_styling.rb`) are being loaded multiple times, which causes "warning: already initialized constant".

[Rakefile](https://github.com/department-of-veterans-affairs/caseflow/blob/57e746e91b91c82c9b5f4edac343bde9688b68d9/Rakefile#L9) loads these modules, so I thought [removing the `require`s in PR #16442](https://github.com/department-of-veterans-affairs/caseflow/pull/16442/files#diff-faf9971a389ff22a7638216daf4683d292ce419fe84517cdcbd8451577feb782L8) would eliminate the warning. It did but it also broke `make reset` and `make docs`. Why? Because the `Rakefile` only runs when calling `bundle exec rake ...`. It is not called for other `bundle` commands like `bundle exec erd ...` (run during `make docs`) or `bundle exec rails runner scripts/enable_features_dev.rb` (run at the end `make reset`).

Due to many `require`s used in `config/environment.rb`, `app/controllers/test/users_controller.rb`, and elsewhere (`bootsnap`?), it looks like [dependency hell](https://en.wikipedia.org/wiki/Dependency_hell) and loading Ruby files multiple times seems unavoidable. Ruby's `require` [should already prevents multiple includes](https://www.ruby-forum.com/t/how-can-i-prevent-require-duplicate-files/156901/2).

Following [examples](https://stackoverflow.com/questions/7953611/solutions-to-the-annoying-warning-already-initialized-constant-message) from others, this PR will not try to set constants that are already set.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
`make docs` works with no failure messages.
`make reset` works.

