### PR TITLE
Hide `HearingTask` during Substitution

### DIFF
--- a/client/app/queue/substituteAppellant/tasks/utils.js
+++ b/client/app/queue/substituteAppellant/tasks/utils.js
@@ -1,7 +1,7 @@
 import { formatISO } from 'date-fns';
 import parseISO from 'date-fns/parseISO';
 
-const automatedTasks = [
+export const automatedTasks = [
   'QualityReviewTask',
   'JudgeQualityReviewTask',
   'AttorneyQualityReviewTask',
@@ -11,7 +11,8 @@ const automatedTasks = [
   'AttorneyRewriteTask',
   'BvaDispatchTask',
   'JudgeDispatchReturnTask',
-  'AttorneyDispatchReturnTask'
+  'AttorneyDispatchReturnTask',
+  'HearingTask'
 ];
 
 // Generic function to determine if a task (`current`) is a descendent of another task (`target`)

--- a/client/test/app/queue/substituteAppellant/tasks/utils.test.js
+++ b/client/test/app/queue/substituteAppellant/tasks/utils.test.js
@@ -1,6 +1,7 @@
 import { uniq } from 'lodash';
 
 import {
+  automatedTasks,
   calculateEvidenceSubmissionEndDate,
   filterTasks,
   prepTaskDataForUi,
@@ -122,8 +123,21 @@ describe('utility functions for task manipulation', () => {
       });
     });
 
-    describe('tasks with a type in the automatedTasks array', () => {
-      const userTaskInfo = { taskId: 1, hideFromCaseTimeline: false, type: 'JudgeDecisionReviewTask', assignedTo: { isOrganization: false } };
+    describe('tasks in automatedTasks array', () => {
+      it.each(automatedTasks)('should hide %s', (type) => {
+        const task = { id: 1, type, assignedTo: { isOrganization: false } };
+
+        expect(shouldHide(task, type, [])).toBe(true);
+      });
+    });
+
+    describe('tasks with a type in the automatedTasks array by poaType', () => {
+      const userTaskInfo = {
+        taskId: 1,
+        hideFromCaseTimeline: false,
+        type: 'JudgeDecisionReviewTask',
+        assignedTo: { isOrganization: false },
+      };
       const allTasks = [userTaskInfo, otherOrgTask, otherUserTask];
       const poaTypes = ['Attorney', 'Agent', null];
 

--- a/client/test/app/queue/substituteAppellant/tasks/utils.test.js
+++ b/client/test/app/queue/substituteAppellant/tasks/utils.test.js
@@ -127,7 +127,7 @@ describe('utility functions for task manipulation', () => {
       it.each(automatedTasks)('should hide %s', (type) => {
         const task = { id: 1, type, assignedTo: { isOrganization: false } };
 
-        expect(shouldHide(task, type, [])).toBe(true);
+        expect(shouldHide(task, null, [])).toBe(true);
       });
     });
 


### PR DESCRIPTION
Connects [CASEFLOW-1500](https://vajira.max.gov/browse/CASEFLOW-1500)

### Description
This adds `HearingTask` to the list of tasks that get automatically hidden when performing appellant substitution. 

### Acceptance Criteria
- [x] Code compiles correctly
- [x] "All Hearing-Related Tasks" does not appear in task selection during substitution

### Testing Plan
1. Log in as COB_USER
2. Search for veteran `54545454` and choose the Hearing-docket appeal
3. Go through substitution process, and ensure "All hearing-related tasks" does not display during task selection


### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![Screen Shot 2021-07-01 at 16 17 35](https://user-images.githubusercontent.com/2581274/124185925-9596e100-da89-11eb-9327-1229c7476b85.png) | ![Screen Shot 2021-07-01 at 16 17 59](https://user-images.githubusercontent.com/2581274/124185947-9d568580-da89-11eb-9134-b61be10e8f81.png)


