### PR TITLE
Resolve INC18593851 by changing conditional order in shouldSupportSubstituteAppellant

### DIFF
--- a/client/app/queue/substituteAppellant/caseDetails/utils.js
+++ b/client/app/queue/substituteAppellant/caseDetails/utils.js
@@ -12,6 +12,7 @@ export const shouldSupportSubstituteAppellant = ({
 
   return (
     currentUserOnClerkOfTheBoard &&
+      !appeal.isLegacyAppeal &&
       !appeal.appellantIsNotVeteran &&
       featureToggles.recognized_granted_substitution_after_dd &&
       appeal.caseType === 'Original' &&
@@ -22,8 +23,7 @@ export const shouldSupportSubstituteAppellant = ({
       !hasSubstitution &&
       // Only admins can perform sub on cases w/o all issues having disposition `dismissed_death`
       (userIsCobAdmin ||
-        appeal.decisionIssues.some(decisionHasDismissedDeathDisposition)) &&
-      !appeal.isLegacyAppeal
+        appeal.decisionIssues.some(decisionHasDismissedDeathDisposition))
   );
 };
 

--- a/client/app/queue/substituteAppellant/caseDetails/utils.js
+++ b/client/app/queue/substituteAppellant/caseDetails/utils.js
@@ -11,8 +11,8 @@ export const shouldSupportSubstituteAppellant = ({
     decisionIssue.disposition === 'dismissed_death';
 
   return (
-    currentUserOnClerkOfTheBoard &&
-      !appeal.isLegacyAppeal &&
+    !appeal.isLegacyAppeal &&
+      currentUserOnClerkOfTheBoard &&
       !appeal.appellantIsNotVeteran &&
       featureToggles.recognized_granted_substitution_after_dd &&
       appeal.caseType === 'Original' &&


### PR DESCRIPTION
Resolves [INC18593851](https://dsva.slack.com/archives/CHX8FMP28/p1625238634209600).

Resolves an issue where a Caseflow user was presented with a blank page when trying to view case details for a legacy appeal. This was happening because [the `recognized_granted_substitution_after_dd` feature toggle](https://github.com/department-of-veterans-affairs/caseflow/blob/420bd28c6ae8ddf96f15263c84ea059d20798809/client/app/queue/substituteAppellant/caseDetails/utils.js#L16) was enabled for this user (`FeatureToggle.enabled?(:recognized_granted_substitution_after_dd, user: "CSS_ID")`) so more conditions were being checked than expected. Since this feature toggle must be active for a user to encounter this error this bug only affected a small subset of Caseflow users:
1. Non-admin Clerk of the Board users
2. with the `recognized_granted_substitution_after_dd` active
3. trying to access a non-hearing, original, Legacy appeal
4. where the appellant is the Veteran and there is no substitution.

This PR addresses the underlying problem ([attempting to access an attribute of a legacy appeal that does not exist](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18776/)) by changing the order of the conditions.