### PR TITLE
StuckAppealsChecker: notify Team Echo in Slack

### DIFF
--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 class StuckAppealsChecker < DataIntegrityChecker
+  def slack_channel
+    "#appeals-echo"
+  end
+
   def call
     return if stuck_appeals.count == 0 && appeals_maybe_not_closed.count == 0
 
+    add_to_report "To resolve, see https://github.com/department-of-veterans-affairs/caseflow/wiki/Resolving-Background-Job-Alerts#stuckappealschecker\n"
     add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
     add_to_report "AppealsWithClosedRootTaskOpenChildrenQuery: #{appeals_maybe_not_closed.count}"
   end


### PR DESCRIPTION
[Slack](https://dsva.slack.com/archives/CJL810329/p1624990986271300?thread_ts=1624962561.259600&cid=CJL810329)

### Description
StuckAppealsChecker: notify Team Echo in Slack instead of #appeals-job-alerts.
Also add a link to the resolution/investigation instructions.

### Acceptance Criteria
- [ ] Code compiles correctly
