### PR TITLE
Include cancelled cases in Quality Review team's monthly limit for AMA appeals

### DIFF
--- a/app/models/judge_case_review.rb
+++ b/app/models/judge_case_review.rb
@@ -27,7 +27,7 @@ class JudgeCaseReview < CaseflowRecord
   # LEGACY Limit and Probablity. See AMA at app/models/quality_review_case_selector.rb:5
   # As of Dec 2019, we want AMA and Legacy to use the same cap. The percentages may differ. The
   # goal is to get to the cap as steadily across the month as possible
-  MONTHLY_LIMIT_OF_QUAILITY_REVIEWS = 137
+  MONTHLY_LIMIT_OF_QUALITY_REVIEWS = 137
   QUALITY_REVIEW_SELECTION_PROBABILITY = 0.032
 
   def update_in_vacols!
@@ -90,7 +90,7 @@ class JudgeCaseReview < CaseflowRecord
     end
 
     def reached_monthly_limit_in_quality_reviews?
-      where(location: :quality_review).this_month.size >= MONTHLY_LIMIT_OF_QUAILITY_REVIEWS
+      where(location: :quality_review).this_month.size >= MONTHLY_LIMIT_OF_QUALITY_REVIEWS
     end
 
     def repository

--- a/app/models/quality_review_case_selector.rb
+++ b/app/models/quality_review_case_selector.rb
@@ -15,7 +15,6 @@ class QualityReviewCaseSelector
 
     def reached_monthly_limit_in_quality_reviews?
       QualityReviewTask
-        .not_cancelled
         .created_this_month
         .where(assigned_to_type: Organization.name)
         .size >= MONTHLY_LIMIT_OF_QUALITY_REVIEWS

--- a/app/models/quality_review_case_selector.rb
+++ b/app/models/quality_review_case_selector.rb
@@ -3,7 +3,7 @@
 class QualityReviewCaseSelector
   # AMA Limit and Probability. See Legacy numbers at app/models/judge_case_review.rb:28
   # This probability was selected by Josh Freeman, QR Director at BVA
-  MONTHLY_LIMIT_OF_QUAILITY_REVIEWS = 133
+  MONTHLY_LIMIT_OF_QUALITY_REVIEWS = 133
   QUALITY_REVIEW_SELECTION_PROBABILITY = 0.188
 
   class << self
@@ -18,7 +18,7 @@ class QualityReviewCaseSelector
         .not_cancelled
         .created_this_month
         .where(assigned_to_type: Organization.name)
-        .size >= MONTHLY_LIMIT_OF_QUAILITY_REVIEWS
+        .size >= MONTHLY_LIMIT_OF_QUALITY_REVIEWS
     end
   end
 end

--- a/spec/models/judge_case_review_spec.rb
+++ b/spec/models/judge_case_review_spec.rb
@@ -61,7 +61,7 @@ describe JudgeCaseReview, :all_dbs do
     end
 
     subject { JudgeCaseReview.reached_monthly_limit_in_quality_reviews? }
-    let(:limit) { JudgeCaseReview::MONTHLY_LIMIT_OF_QUAILITY_REVIEWS }
+    let(:limit) { JudgeCaseReview::MONTHLY_LIMIT_OF_QUALITY_REVIEWS }
 
     context "when more than monthly limit" do
       before do

--- a/spec/models/quality_review_case_selector_spec.rb
+++ b/spec/models/quality_review_case_selector_spec.rb
@@ -24,9 +24,9 @@ describe QualityReviewCaseSelector, :all_dbs do
     end
 
     context "after reaching the monthly limit" do
-      before { stub_const("QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUAILITY_REVIEWS", 5) }
+      before { stub_const("QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUALITY_REVIEWS", 5) }
 
-      let!(:qr_tasks) { create_list(:qr_task, QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUAILITY_REVIEWS) }
+      let!(:qr_tasks) { create_list(:qr_task, QualityReviewCaseSelector::MONTHLY_LIMIT_OF_QUALITY_REVIEWS) }
 
       it "returns true" do
         expect(subject).to be(true)

--- a/spec/models/quality_review_case_selector_spec.rb
+++ b/spec/models/quality_review_case_selector_spec.rb
@@ -32,11 +32,11 @@ describe QualityReviewCaseSelector, :all_dbs do
         expect(subject).to be(true)
       end
 
-      context "but some tasks are cancelled" do
+      context "some tasks are cancelled" do
         before { qr_tasks.last.update_columns(status: Constants.TASK_STATUSES.cancelled) }
 
-        it "returns false" do
-          expect(subject).to be(false)
+        it "returns true" do
+          expect(subject).to be(true)
         end
       end
 


### PR DESCRIPTION
Resolves Jira ticket [1268](https://vajira.max.gov/browse/CASEFLOW-1268), Update AMA QR code to include cancelled cases.

### Description
Previously, cancelled AMA cases did not count toward the quality review team's monthly limit of 133 AMA cases.  I removed one line in the `QualityReviewCaseSelector` model, and now cancelled AMA cases will count toward the monthly limit of 133.  I also updated the spec to reflect this new expectation.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Quality is spelled with one i