### PR TITLE
Use .pop, not .sample, for populating "random" names

### DIFF
--- a/spec/models/task_sorter_spec.rb
+++ b/spec/models/task_sorter_spec.rb
@@ -272,8 +272,8 @@ describe TaskSorter, :all_dbs do
 
         before do
           tasks.each do |task|
-            first_name = fake_names.sample
-            last_name = "#{fake_names.sample} #{fake_names.sample}"
+            first_name = fake_names.pop
+            last_name = "#{fake_names.pop} #{fake_names.pop}"
             task.appeal.veteran.update!(first_name: first_name, last_name: last_name)
             create(
               :cached_appeal,


### PR DESCRIPTION
### Description
I think this solves a particularly vexing flake, where every once in a blue moon we'd get [this](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/44259/workflows/d55beb18-03e6-48aa-b761-312936f14c00/jobs/173431/tests#failed-test-0) headache of a test failure:

```
Failure/Error: expect(subject.map(&:appeal_id)).to eq(expected_order.map(&:appeal_id)), ordered_vets.to_s
  ["BPBDPXAG (YRXPLJRO BPBDPXAG), CTACHKAX", "BPBDPXAG (QMODOFDX BPBDPXAG), CTACHKAX", "CTACHKAX (CTACHKAX CTACHKAX), WPBXAHLJ", "CTACHKAX (LCVCQDUD CTACHKAX), XFIUWQBA", "CXJHREVA (PPEPIOYI CXJHREVA), PQGCPYXU", "FVOVCKPP (LYVTKDWA FVOVCKPP), TXOCOQXR", "KKFACQQD (LHAYGRWX KKFACQQD), VNXGHDPG", "KMYGIMDP (PRRNSXOY KMYGIMDP), QMODOFDX", "LCVCQDUD (FFYOIPIO LCVCQDUD), LHAYGRWX", "PFLBDOEY (IUXJCXCV PFLBDOEY), CTACHKAX", "QLIPHMXG (KKFACQQD QLIPHMXG), RFBOWXOG", "TVTSKJMM (GUSBVOAJ TVTSKJMM), YPHHPRHV", "VNOJIUNT (CUUMWGVW VNOJIUNT), KOONRNOW", "WIIPIHQA (CXJHREVA WIIPIHQA), MJAVKCUU"]
./spec/models/task_sorter_spec.rb:295:in `block (5 levels) in <top (required)>'
```

Trying to reason about it feels like solving a Zodiac cipher, but I realized that names are being repeated. That feels extraordinarily improbable when we're generating 100 8-character strings; 26^8 = 208827064576 so getting multiple repeats in a set of 100 is... odd.

I'm pretty sure I figured out what's going on. `Array#sample` makes this promise:

> The elements are chosen by using random and unique indices into the array in order to ensure that an element doesn't repeat itself unless the array already contained duplicate elements.

But I believe that's true only for _an_ invocation of `sample`; no state is kept on the array for which have already been `sample`d. I was pretty easily able to reproduce this:

```
irb(main):015:0> x = (1...100).to_a
=> [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]
irb(main):016:0> x.sample
=> 9
irb(main):017:0> x.sample
=> 46
irb(main):018:0> x.sample
=> 29
irb(main):019:0> x.sample
=> 48
irb(main):020:0> x.sample
=> 61
irb(main):021:0> x.sample
=> 31
irb(main):022:0> x.sample
=> 61
```

Seven calls on an array of 99 elements (oops) and I drew 61 twice.

So it's not that we're generating the same 8-character string repeatedly by miracle; we're just picking 1 of 100 names out of a hat, _throwing it back in the hat_, and then drawing again&mdash;42 times.

I _think_ the remaining part of the bug is something to do with which names we consider when there are two surnames?

So, use `.pop` so the drawn names aren't put back in the hat.

### Acceptance Criteria
- [ ] This test doesn't flake

### Testing Plan
1. Maybe check this test out and run it a handful of times locally