### PR TITLE
Fix Storybook for FnodBadge

### DIFF
--- a/client/app/queue/components/FnodBadge.stories.js
+++ b/client/app/queue/components/FnodBadge.stories.js
@@ -1,8 +1,4 @@
 import React from 'react';
-import { createStore, applyMiddleware } from 'redux';
-import rootReducer from '../../../app/queue/reducers';
-import thunk from 'redux-thunk';
-import { Provider } from 'react-redux';
 
 import FnodBadge from './FnodBadge';
 
@@ -13,24 +9,13 @@ export default {
     layout: 'centered',
   },
   args: {
-    appeal: {
-      veteranAppellantDeceased: true,
-      veteranDateOfDeath: '2019-03-17'
-    },
-    featureToggles: {
-      fnod_badge: true
-    },
+    veteranAppellantDeceased: true,
+    tooltipText: 'Content displayed in tooltip; can be string or any React element',
+    uniqueId: 'abc123'
   }
 };
 
-const getStore = () => createStore(rootReducer, applyMiddleware(thunk));
-const store = getStore();
-
-const Template = (args) => (
-  <Provider store={store}>
-    <FnodBadge {...args} />
-  </Provider>
-);
+const Template = (args) => <FnodBadge {...args} />;
 
 export const FNODBadge = Template.bind({});
 


### PR DESCRIPTION
### Description
The Storybook story for `FnodBadge` was broken due to what was likely a change in the props that it took. It no longer seems to have a dependency on Redux and instead is a straightforward presentational component.

Currently, badge doesn't display at all [in the story](https://www.caseflowdemo.com/storybook/?path=/story/commons-components-badges-fnod-badge--fnod-badge) due to the component returning `null` if `veteranAppellantDeceased` prop isn't present.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Story for `FnodBadge` displays correctly

