### PR TITLE
Add data integrity checker for appeals with more than one open hearing task

### DIFF
--- a/app/jobs/data_integrity_checks_job.rb
+++ b/app/jobs/data_integrity_checks_job.rb
@@ -7,6 +7,7 @@ class DataIntegrityChecksJob < CaseflowJob
   CHECKERS = %w[
     DecisionReviewTasksForInactiveAppealsChecker
     DecisionDateChecker
+    AppealsWithMoreThanOneOpenHearingTaskChecker
     ExpiredAsyncJobsChecker
     LegacyAppealsWithNoVacolsCase
     OpenHearingTasksWithoutActiveDescendantsChecker

--- a/app/services/appeals_with_more_than_one_open_hearing_task_checker.rb
+++ b/app/services/appeals_with_more_than_one_open_hearing_task_checker.rb
@@ -2,11 +2,6 @@
 
 # Data integrity checker for notifying when an appeal has multiple open HearingTask children
 class AppealsWithMoreThanOneOpenHearingTaskChecker < DataIntegrityChecker
-  #   AppealsWithMoreThanOneOpenHearingTaskChecker
-  #   appeals_with_more_than_one_open_hearing_task_checker
-  # For time_ago_in_words()
-  include ActionView::Helpers::DateHelper
-
   def call
     build_report(appeals_with_more_than_one_open_hearing_task)
   end

--- a/app/services/appeals_with_more_than_one_open_hearing_task_checker.rb
+++ b/app/services/appeals_with_more_than_one_open_hearing_task_checker.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Data integrity checker for notifying when an appeal has multiple open HearingTask children
+class AppealsWithMoreThanOneOpenHearingTaskChecker < DataIntegrityChecker
+  #   AppealsWithMoreThanOneOpenHearingTaskChecker
+  #   appeals_with_more_than_one_open_hearing_task_checker
+  # For time_ago_in_words()
+  include ActionView::Helpers::DateHelper
+
+  def call
+    build_report(appeals_with_more_than_one_open_hearing_task)
+  end
+
+  def slack_channel
+    "#appeals-tango"
+  end
+
+  private
+
+  HELP_DOCUMENT_LINK = "https://github.com/department-of-veterans-affairs/appeals-deployment/" \
+    "wiki/Resolving-Hearing-Data-Issues#appeals-with-more-than-one-open-hearing-task"
+
+  def appeals_with_more_than_one_open_hearing_task
+    HearingTask
+      .where("status IN (?)", Task.open_statuses)
+      .group(:appeal_id, :appeal_type)
+      .select("appeal_id, appeal_type, COUNT(*)")
+      .having("COUNT(*) > 1")
+      .map(&:appeal)
+      .uniq
+  end
+
+  def build_report(appeals)
+    return if appeals.empty?
+
+    appeals_count = appeals.count
+
+    add_to_report "Found #{appeals_count} #{'appeal'.pluralize(appeals_count)} with more than one open hearing task: "
+    appeals.each do |appeal|
+      add_to_report "`#{appeal.class.name}.find(#{appeal.id})` " \
+        "(#{appeal.tasks.open.where(type: HearingTask.name).length} open HearingTasks)"
+    end
+
+    add_to_report "Follow the instructions in *<#{HELP_DOCUMENT_LINK}|this document>* to resolve."
+  end
+end

--- a/spec/jobs/data_integrity_checks_job_spec.rb
+++ b/spec/jobs/data_integrity_checks_job_spec.rb
@@ -6,6 +6,7 @@ describe DataIntegrityChecksJob do
   let(:untracked_legacy_appeals_checker) { UntrackedLegacyAppealsChecker.new }
   let(:reviews_with_duplicate_ep_error_checker) { ReviewsWithDuplicateEpErrorChecker.new }
   let(:stuck_virtual_hearings_checker) { StuckVirtualHearingsChecker.new }
+  let(:appeals_with_more_than_one_open_hearing_task_checker) { AppealsWithMoreThanOneOpenHearingTaskChecker.new }
   let(:decision_date_checker) { DecisionDateChecker.new }
   let(:slack_service) { SlackService.new(url: "http://www.example.com") }
   let(:slack_messages) { [] }
@@ -18,6 +19,9 @@ describe DataIntegrityChecksJob do
     allow(UntrackedLegacyAppealsChecker).to receive(:new).and_return(untracked_legacy_appeals_checker)
     allow(ReviewsWithDuplicateEpErrorChecker).to receive(:new).and_return(reviews_with_duplicate_ep_error_checker)
     allow(StuckVirtualHearingsChecker).to receive(:new).and_return(stuck_virtual_hearings_checker)
+    allow(AppealsWithMoreThanOneOpenHearingTaskChecker).to receive(:new).and_return(
+      appeals_with_more_than_one_open_hearing_task_checker
+    )
     allow(DecisionDateChecker).to receive(:new).and_return(decision_date_checker)
     allow(SlackService).to receive(:new).and_return(slack_service)
     [
@@ -26,6 +30,7 @@ describe DataIntegrityChecksJob do
       untracked_legacy_appeals_checker,
       reviews_with_duplicate_ep_error_checker,
       stuck_virtual_hearings_checker,
+      appeals_with_more_than_one_open_hearing_task_checker,
       decision_date_checker
     ].each do |checker|
       allow(checker).to receive(:call).and_call_original
@@ -85,6 +90,10 @@ describe DataIntegrityChecksJob do
       expect(stuck_virtual_hearings_checker).to have_received(:call).once
       expect(stuck_virtual_hearings_checker).to have_received(:report?).once
       expect(stuck_virtual_hearings_checker).to_not have_received(:report)
+
+      expect(appeals_with_more_than_one_open_hearing_task_checker).to have_received(:call).once
+      expect(appeals_with_more_than_one_open_hearing_task_checker).to have_received(:report?).once
+      expect(appeals_with_more_than_one_open_hearing_task_checker).to_not have_received(:report)
 
       expect(decision_date_checker).to have_received(:call).once
       expect(decision_date_checker).to have_received(:report?).once

--- a/spec/services/appeals_with_more_than_one_open_hearing_task_checker_spec.rb
+++ b/spec/services/appeals_with_more_than_one_open_hearing_task_checker_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe AppealsWithMoreThanOneOpenHearingTaskChecker do
+  let(:appeal1) { create(:appeal, :with_schedule_hearing_tasks) }
+  let(:appeal2) { create(:appeal, :with_schedule_hearing_tasks) }
+  let(:legacy_appeal) { create(:legacy_appeal, :with_schedule_hearing_tasks) }
+
+  it "reports to correct slack channel" do
+    subject.call
+
+    expect(subject.slack_channel).to eq("#appeals-tango")
+  end
+
+  context "there are no appeals with more than one open hearing task" do
+    it "does not generate a report" do
+      subject.call
+      expect(subject.report?).to be_falsey
+    end
+  end
+
+  context "there is at least one appeal with more than one open hearing task" do
+    before do
+      ScheduleHearingTask.create!(appeal: appeal2, parent: appeal2.root_task)
+    end
+
+    it "generates a report with the expected content" do
+      subject.call
+
+      expect(subject.report?).to be_truthy
+
+      report_lines = subject.report.split("\n")
+      expect(report_lines).to include "Found 1 appeal with more than one open hearing task: "
+      expect(report_lines).to include "`Appeal.find(#{appeal2.id})` (2 open HearingTasks)"
+    end
+
+    context "there are two appeals with more than one open hearing task" do
+      before do
+        ScheduleHearingTask.create!(appeal: legacy_appeal, parent: legacy_appeal.root_task)
+      end
+
+      it "generates a report with the expected content" do
+        subject.call
+
+        expect(subject.report?).to be_truthy
+
+        report_lines = subject.report.split("\n")
+        expect(report_lines).to include "Found 2 appeals with more than one open hearing task: "
+        expect(report_lines).to include "`Appeal.find(#{appeal2.id})` (2 open HearingTasks)"
+        expect(report_lines).to include "`LegacyAppeal.find(#{legacy_appeal.id})` (2 open HearingTasks)"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a new data integrity checker job that reports to #appeals-tango when it finds appeals with more than one open HearingTask.
