### PR TITLE
AppealsWithNoTasksOrAllTasksOnHoldQuery: ignore appeals without a decision document

### DIFF
--- a/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
+++ b/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
@@ -31,9 +31,13 @@ class AppealsWithNoTasksOrAllTasksOnHoldQuery
   end
 
   def dispatched_appeals_on_hold
-    Appeal.where(id: tasks_for(Appeal.name)
+    suspect_appeals = Appeal.where(id: tasks_for(Appeal.name)
       .where(type: RootTask.name, status: on_hold))
       .where(id: completed_dispatch_tasks(Appeal.name))
+
+    # Ignore appeals without a decision document as they are not fully dispatched.
+    # So return only appeals with a decision document since they are successfully dispatched.
+    suspect_appeals.select(&:decision_document)
   end
 
   def completed_dispatch_tasks(klass_name)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1068,6 +1068,7 @@ describe Appeal, :all_dbs do
       let(:appeal) do
         appeal = create(:appeal, :with_post_intake_tasks)
         create(:bva_dispatch_task, :completed, appeal: appeal)
+        create(:decision_document, citation_number: "A18123456", appeal: appeal)
         appeal
       end
 

--- a/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
+++ b/spec/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query_spec.rb
@@ -40,6 +40,12 @@ describe AppealsWithNoTasksOrAllTasksOnHoldQuery, :postgres do
   let!(:dispatched_appeal_on_hold) do
     appeal = create(:appeal, :with_post_intake_tasks)
     create(:bva_dispatch_task, :completed, appeal: appeal)
+    create(:decision_document, citation_number: "A18123456", appeal: appeal)
+    appeal
+  end
+  let!(:incompletely_dispatched_appeal_on_hold) do
+    appeal = create(:appeal, :with_post_intake_tasks)
+    create(:bva_dispatch_task, :completed, appeal: appeal)
     appeal
   end
 
@@ -106,6 +112,12 @@ describe AppealsWithNoTasksOrAllTasksOnHoldQuery, :postgres do
       let(:appeal) { dispatched_appeal_on_hold }
 
       it { is_expected.to eq(true) }
+    end
+
+    context "incompletely_dispatched_appeal_on_hold" do
+      let(:appeal) { incompletely_dispatched_appeal_on_hold }
+
+      it { is_expected.to eq(false) }
     end
   end
 end

--- a/spec/services/stuck_appeals_checker_spec.rb
+++ b/spec/services/stuck_appeals_checker_spec.rb
@@ -18,6 +18,7 @@ describe StuckAppealsChecker, :postgres do
   let!(:dispatched_appeal_on_hold) do
     appeal = create(:appeal, :with_post_intake_tasks)
     create(:bva_dispatch_task, :completed, appeal: appeal)
+    create(:decision_document, citation_number: "A18123456", appeal: appeal)
     appeal
   end
   let!(:appeal_with_fully_on_hold_subtree) do


### PR DESCRIPTION
Followup to [Slack thread](https://dsva.slack.com/archives/CN3FQR4A1/p1625608136052100?thread_ts=1625567517.049300&cid=CN3FQR4A1)

### Description
In `StuckAppealsChecker`'s `AppealsWithNoTasksOrAllTasksOnHoldQuery`, we check for dispatched appeals with an on-hold RootTask. We have refined/clarified the definition of a "dispatched appeal" to those that have a decision document (rather than simply a completed BvaDispatchTask). This PR makes it so the checker doesn't alert on appeals without a decision document since they are not yet successfully dispatched.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
See RSpec