### PR TITLE
WIP | Make DateSelector Always Use Date Inputs

### DIFF
--- a/client/app/certification/SignAndCertify.jsx
+++ b/client/app/certification/SignAndCertify.jsx
@@ -206,6 +206,7 @@ export class SignAndCertify extends React.Component {
           <DateSelector
             name="Date:"
             value={formatDateStr(certificationDate)}
+            type="date"
             readOnly
           />
         </div>

--- a/client/app/certification/SignAndCertify.jsx
+++ b/client/app/certification/SignAndCertify.jsx
@@ -206,7 +206,6 @@ export class SignAndCertify extends React.Component {
           <DateSelector
             name="Date:"
             value={formatDateStr(certificationDate)}
-            type="date"
             readOnly
           />
         </div>

--- a/client/app/components/BasicDateRangeSelector.jsx
+++ b/client/app/components/BasicDateRangeSelector.jsx
@@ -13,7 +13,6 @@ export default class BasicDateRangeSelector extends React.Component {
           label={this.props.startDateLabel}
           value={this.props.startDateValue}
           onChange={this.props.onStartDateChange}
-          type="date"
         />
         &nbsp;{this.props.messageLabel && 'to'}&nbsp;
         <DateSelector
@@ -21,7 +20,6 @@ export default class BasicDateRangeSelector extends React.Component {
           label={this.props.endDateLabel}
           value={this.props.endDateValue}
           onChange={this.props.onEndDateChange}
-          type="date"
         />
       </InlineForm>
     </div>;

--- a/client/app/components/DateSelector.jsx
+++ b/client/app/components/DateSelector.jsx
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import TextField from '../components/TextField';
 
 const DEFAULT_TEXT = 'mm/dd/yyyy';
-// A regex that will match as much of a mm/dd/yyyy date as possible.
-// TODO (mdbenjam): modify this to not accept months like 13 or days like 34
-const DATE_REGEX = /[0,1](?:\d(?:\/(?:[0-3](?:\d(?:\/(?:\d{0,4})?)?)?)?)?)?/;
 
 export const DateSelector = (props) => {
   const {
@@ -15,44 +12,13 @@ export const DateSelector = (props) => {
     onChange,
     readOnly,
     required,
-    type,
     validationError,
     value,
     dateErrorMessage,
     ...passthroughProps
   } = props;
 
-  const dateFill = (newVal = '') => {
-    const propsValue = props.value || '';
-    let updatedVal = newVal;
-
-    if (type === 'date') {
-      // input type=date handles validation, returns yyyy-mm-dd, displays mm/dd/yyyy
-      return onChange?.(newVal);
-    }
-
-    // If the user added characters we append a '/' before putting
-    // it through the regex. If this spot doesn't accept a '/' then
-    // the regex test will strip it. Otherwise, the user doesn't have
-    // to type a '/'. If the user removed characters we check if the
-    // last character is a '/' and remove it for them.
-    if (updatedVal.length > propsValue.length) {
-      updatedVal = `${updatedVal}/`;
-    } else if (propsValue.charAt(propsValue.length - 1) === '/') {
-      updatedVal = updatedVal.substr(0, updatedVal.length - 1);
-    }
-
-    // Test the input against the date regex above. The regex matches
-    // as much of an allowed date as possible. Therefore this will just
-    // removing any non-date characters
-    const match = DATE_REGEX.exec(updatedVal);
-
-    const result = match ? match[0] : '';
-
-    onChange?.(result);
-  };
-
-  const handleChange = (val) => dateFill(val);
+  const handleChange = (val = '') => onChange?.(val);
 
   return (
     <TextField
@@ -60,7 +26,7 @@ export const DateSelector = (props) => {
       label={label}
       name={name}
       readOnly={readOnly}
-      type={type}
+      type="date"
       value={value}
       validationError={validationError}
       onChange={handleChange}
@@ -129,10 +95,6 @@ DateSelector.propTypes = {
    */
   required: PropTypes.bool,
 
-  /**
-   * Specifies the `type` parameter for the underlying `input` element
-   */
-  type: PropTypes.string,
   validationError: PropTypes.string,
 
   /**

--- a/client/app/components/DateSelector.stories.js
+++ b/client/app/components/DateSelector.stories.js
@@ -11,13 +11,9 @@ export default {
   args: {
     name: 'datefield',
     label: 'Enter Date',
-    type: 'date',
   },
   argTypes: {
     onChange: { action: 'onChange' },
-    type: {
-      control: { type: 'select', options: ['date', 'datetime-local', 'text'] },
-    },
   },
 };
 

--- a/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
@@ -65,7 +65,6 @@ export class EstablishClaimForm extends React.Component {
           <DateSelector
             label="Decision Date"
             name="date"
-            type="date"
             readOnly
             value={decisionDate}
           />

--- a/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
+++ b/client/app/containers/EstablishClaimPage/EstablishClaimForm.jsx
@@ -65,6 +65,7 @@ export class EstablishClaimForm extends React.Component {
           <DateSelector
             label="Decision Date"
             name="date"
+            type="date"
             readOnly
             value={decisionDate}
           />

--- a/client/app/containers/TestPage.jsx
+++ b/client/app/containers/TestPage.jsx
@@ -22,6 +22,7 @@ export default class TestPage extends React.Component {
       <DateSelector
         label="Test Date"
         name="testDate"
+        type="date"
         onChange={(value) => {
           this.setState({ testDate: value });
         }}

--- a/client/app/containers/TestPage.jsx
+++ b/client/app/containers/TestPage.jsx
@@ -22,7 +22,6 @@ export default class TestPage extends React.Component {
       <DateSelector
         label="Test Date"
         name="testDate"
-        type="date"
         onChange={(value) => {
           this.setState({ testDate: value });
         }}

--- a/client/app/hearings/components/AddHearingDay.jsx
+++ b/client/app/hearings/components/AddHearingDay.jsx
@@ -245,7 +245,6 @@ export const AddHearingDay = ({
             errorMessage={dateError ? getErrorMessage() : null}
             value={selectedHearingDay}
             onChange={onHearingDateChange}
-            type="date"
           />
           <SearchableDropdown
             name="requestType"

--- a/client/app/hearings/components/details/TranscriptionDetailsInputs.jsx
+++ b/client/app/hearings/components/details/TranscriptionDetailsInputs.jsx
@@ -51,7 +51,6 @@ const TranscriptionDetailsInputs = ({ transcription, update, readOnly }) => (
         name="sentToTranscriberDate"
         label="Sent to Transcriber"
         strongLabel
-        type="date"
         readOnly={readOnly}
         value={transcription?.sentToTranscriberDate}
         onChange={(sentToTranscriberDate) => update({ sentToTranscriberDate })}
@@ -60,7 +59,6 @@ const TranscriptionDetailsInputs = ({ transcription, update, readOnly }) => (
         name="expectedReturnDate"
         label="Expected Return Date"
         strongLabel
-        type="date"
         readOnly={readOnly}
         value={transcription?.expectedReturnDate}
         onChange={(expectedReturnDate) => update({ expectedReturnDate })}
@@ -69,7 +67,6 @@ const TranscriptionDetailsInputs = ({ transcription, update, readOnly }) => (
         name="uploadedToVbmsDate"
         label="Transcript Uploaded to VBMS"
         strongLabel
-        type="date"
         readOnly={readOnly}
         value={transcription?.uploadedToVbmsDate}
         onChange={(uploadedToVbmsDate) => update({ uploadedToVbmsDate })}

--- a/client/app/hearings/components/details/TranscriptionProblemInputs.jsx
+++ b/client/app/hearings/components/details/TranscriptionProblemInputs.jsx
@@ -45,7 +45,6 @@ const TranscriptionProblemInputs = ({ transcription, update, readOnly }) => (
       name="problemNoticeSentDate"
       label="Problem Notice Sent"
       strongLabel
-      type="date"
       readOnly={readOnly || _.isEmpty(transcription?.problemType)}
       value={transcription?.problemNoticeSentDate}
       onChange={(problemNoticeSentDate) => update({ problemNoticeSentDate })}

--- a/client/app/hearings/components/details/TranscriptionRequestInputs.jsx
+++ b/client/app/hearings/components/details/TranscriptionRequestInputs.jsx
@@ -21,7 +21,6 @@ const TranscriptionRequestInputs = ({ hearing, update, readOnly }) => (
       name="copySentDate"
       label="Copy Sent to Appellant/Rep"
       strongLabel
-      type="date"
       readOnly={readOnly}
       value={hearing?.transcriptSentDate}
       onChange={(transcriptSentDate) => update({ transcriptSentDate })}

--- a/client/app/intake/components/NonratingRequestIssueModal.jsx
+++ b/client/app/intake/components/NonratingRequestIssueModal.jsx
@@ -230,7 +230,6 @@ class NonratingRequestIssueModal extends React.Component {
             value={decisionDate}
             errorMessage={this.state.dateError}
             onChange={this.decisionDateOnChange}
-            type="date"
           />
         </div>
 

--- a/client/app/intake/components/UnidentifiedIssuesModal.jsx
+++ b/client/app/intake/components/UnidentifiedIssuesModal.jsx
@@ -122,7 +122,6 @@ class UnidentifiedIssuesModal extends React.Component {
             value={decisionDate}
             errorMessage={this.state.dateError}
             onChange={this.decisionDateOnChange}
-            type="date"
             optional={!this.state.verifiedUnidentifiedIssue}
           />
         </div>

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -460,7 +460,6 @@ class AddIssuesPage extends React.Component {
                 value={intakeData.withdrawalDate}
                 onChange={this.withdrawalDateOnChange}
                 dateErrorMessage={withdrawError()}
-                type="date"
               />
             </InlineForm>
           </div>

--- a/client/app/intake/pages/receiptDateInput.jsx
+++ b/client/app/intake/pages/receiptDateInput.jsx
@@ -19,7 +19,6 @@ const ReceiptDateInput = ({
     value={receiptDate}
     onChange={setReceiptDate}
     errorMessage={errors?.['receipt-date']?.message || receiptDateError}
-    type="date"
     strongLabel
     inputRef={register}
   />

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -216,7 +216,6 @@ class NonCompDispositions extends React.PureComponent {
               value={decisionDate}
               onChange={this.handleDecisionDate}
               readOnly={Boolean(task.closed_at)}
-              type="date"
             />
           </InlineForm>
         </div>

--- a/client/app/queue/AddCavcDatesModal.jsx
+++ b/client/app/queue/AddCavcDatesModal.jsx
@@ -74,7 +74,6 @@ const AddCavcDatesModal = ({ appealId, decisionType, error, highlightInvalid, hi
 
   const judgementField = <DateSelector
     label={COPY.CAVC_JUDGEMENT_DATE}
-    type="date"
     name="judgement-date"
     value={judgementDate}
     onChange={(val) => setJudgementDate(val)}
@@ -84,7 +83,6 @@ const AddCavcDatesModal = ({ appealId, decisionType, error, highlightInvalid, hi
 
   const mandateField = <DateSelector
     label={COPY.CAVC_MANDATE_DATE}
-    type="date"
     name="mandate-date"
     value={mandateDate}
     onChange={(val) => setMandateDate(val)}

--- a/client/app/queue/AddCavcRemandView.jsx
+++ b/client/app/queue/AddCavcRemandView.jsx
@@ -295,7 +295,6 @@ const AddCavcRemandView = (props) => {
 
   const decisionField = <DateSelector
     label={COPY.CAVC_COURT_DECISION_DATE}
-    type="date"
     name="decision-date"
     value={decisionDate}
     onChange={(val) => setDecisionDate(val)}
@@ -322,7 +321,6 @@ const AddCavcRemandView = (props) => {
 
   const judgementField = <DateSelector
     label={COPY.CAVC_JUDGEMENT_DATE}
-    type="date"
     name="judgement-date"
     value={judgementDate}
     onChange={(val) => setJudgementDate(val)}
@@ -332,7 +330,6 @@ const AddCavcRemandView = (props) => {
 
   const mandateField = <DateSelector
     label={COPY.CAVC_MANDATE_DATE}
-    type="date"
     name="mandate-date"
     value={mandateDate}
     onChange={(val) => setMandateDate(val)}

--- a/client/app/queue/cavc/EditCavcRemandForm.jsx
+++ b/client/app/queue/cavc/EditCavcRemandForm.jsx
@@ -287,7 +287,6 @@ export const EditCavcRemandForm = ({
         <DateSelector
           inputRef={register}
           label={COPY.CAVC_COURT_DECISION_DATE}
-          type="date"
           name="decisionDate"
           errorMessage={errors?.decisionDate && COPY.CAVC_DECISION_DATE_ERROR}
           strongLabel
@@ -312,7 +311,6 @@ export const EditCavcRemandForm = ({
             <DateSelector
               inputRef={register}
               label={COPY.CAVC_JUDGEMENT_DATE}
-              type="date"
               name="judgementDate"
               errorMessage={
                 errors?.judgementDate && COPY.CAVC_JUDGEMENT_DATE_ERROR
@@ -323,7 +321,6 @@ export const EditCavcRemandForm = ({
             <DateSelector
               inputRef={register}
               label={COPY.CAVC_MANDATE_DATE}
-              type="date"
               name="mandateDate"
               errorMessage={errors?.mandateDate && COPY.CAVC_MANDATE_DATE_ERROR}
               strongLabel

--- a/client/app/queue/components/EditNodDateModal.jsx
+++ b/client/app/queue/components/EditNodDateModal.jsx
@@ -230,7 +230,6 @@ export const EditNodDateModal = ({
           errorMessage={errors.nodDate?.message}
           label={COPY.EDIT_NOD_DATE_LABEL}
           strongLabel
-          type="date"
         />
         <Controller
           name="reason"

--- a/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.jsx
+++ b/client/app/queue/docketSwitch/denial/DocketSwitchDenialForm.jsx
@@ -45,7 +45,6 @@ export const DocketSwitchDenialForm = ({
 
         <DateSelector
           inputRef={register}
-          type="date"
           name="receiptDate"
           label="What is the Receipt Date of the docket switch request?"
           strongLabel

--- a/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.jsx
+++ b/client/app/queue/docketSwitch/grant/DocketSwitchReviewRequestForm.jsx
@@ -152,7 +152,6 @@ export const DocketSwitchReviewRequestForm = ({
 
         <DateSelector
           inputRef={register}
-          type="date"
           errorMessage={touched.receiptDate && errors.receiptDate?.message}
           name="receiptDate"
           label="What is the Receipt Date of the docket switch request?"

--- a/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsForm.jsx
+++ b/client/app/queue/substituteAppellant/basics/SubstituteAppellantBasicsForm.jsx
@@ -60,7 +60,6 @@ export const SubstituteAppellantBasicsForm = ({
 
         <DateSelector
           inputRef={register}
-          type="date"
           errorMessage={errors.substitutionDate?.message}
           name="substitutionDate"
           label="When was substitution granted for this appellant?"

--- a/client/app/reader/EditComment.jsx
+++ b/client/app/reader/EditComment.jsx
@@ -68,7 +68,6 @@ export default class EditComment extends React.Component {
         name="Relevant Date"
         onChange={this.onChangeDate}
         value={this.props.comment.relevant_date}
-        type="date"
         strongLabel
       />
       <SaveableTextArea

--- a/client/test/app/components/__snapshots__/DateSelector.test.js.snap
+++ b/client/test/app/components/__snapshots__/DateSelector.test.js.snap
@@ -18,7 +18,7 @@ exports[`DateSelector renders correctly 1`] = `
       max="9999-12-31"
       name="date1"
       placeholder="mm/dd/yyyy"
-      type="text"
+      type="date"
       value=""
     />
   </div>

--- a/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/DetailsForm.test.js.snap
@@ -8980,7 +8980,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                 name="sentToTranscriberDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -9039,7 +9038,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                 name="expectedReturnDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -9098,7 +9096,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                 name="uploadedToVbmsDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -11032,7 +11029,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                 onChange={[Function]}
                 readOnly={true}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -11362,7 +11358,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable convert c
                 name="copySentDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -20437,7 +20432,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                 name="sentToTranscriberDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -20496,7 +20490,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                 name="expectedReturnDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -20555,7 +20548,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                 name="uploadedToVbmsDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -22489,7 +22481,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                 onChange={[Function]}
                 readOnly={true}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -22829,7 +22820,6 @@ exports[`DetailsForm Matches snapshot if user does not have the enable virtual h
                 name="copySentDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -33527,7 +33517,6 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                 name="sentToTranscriberDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -33586,7 +33575,6 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                 name="expectedReturnDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -33645,7 +33633,6 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                 name="uploadedToVbmsDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -35579,7 +35566,6 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                 onChange={[Function]}
                 readOnly={true}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -35919,7 +35905,6 @@ exports[`DetailsForm Matches snapshot with default props when passed in 1`] = `
                 name="copySentDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -46618,7 +46603,6 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                 name="sentToTranscriberDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -46677,7 +46661,6 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                 name="expectedReturnDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -46736,7 +46719,6 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                 name="uploadedToVbmsDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -48670,7 +48652,6 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                 onChange={[Function]}
                 readOnly={true}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={
@@ -49010,7 +48991,6 @@ exports[`DetailsForm Matches snapshot with for AMA hearing 1`] = `
                 name="copySentDate"
                 onChange={[Function]}
                 strongLabel={true}
-                type="date"
               >
                 <TextField
                   className={

--- a/client/test/app/queue/__snapshots__/AddCavcDatesModal.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcDatesModal.test.js.snap
@@ -379,7 +379,6 @@ exports[`AddCavcDatesModal renders correctly 1`] = `
                             name="judgement-date"
                             onChange={[Function]}
                             strongLabel={true}
-                            type="date"
                             value={null}
                           >
                             <TextField
@@ -443,7 +442,6 @@ exports[`AddCavcDatesModal renders correctly 1`] = `
                             name="mandate-date"
                             onChange={[Function]}
                             strongLabel={true}
-                            type="date"
                             value={null}
                           >
                             <TextField
@@ -1000,7 +998,6 @@ exports[`AddCavcDatesModal submits succesfully 1`] = `
                             name="judgement-date"
                             onChange={[Function]}
                             strongLabel={true}
-                            type="date"
                             value="03/27/2020"
                           >
                             <TextField
@@ -1064,7 +1061,6 @@ exports[`AddCavcDatesModal submits succesfully 1`] = `
                             name="mandate-date"
                             onChange={[Function]}
                             strongLabel={true}
-                            type="date"
                             value="03/31/2019"
                           >
                             <TextField

--- a/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/AddCavcRemandView.test.js.snap
@@ -3746,7 +3746,6 @@ exports[`AddCavcRemandView renders correctly 1`] = `
                   name="decision-date"
                   onChange={[Function]}
                   strongLabel={true}
-                  type="date"
                   value={null}
                 >
                   <TextField


### PR DESCRIPTION
This was an attempt to clean up the regex in DateSelector and use the built in validation of input["type"]. That was not as easy as expected. Closing this PR for now.