### PR TITLE
Prevent creation of QualityReviewTasks for unrecognized appellants

### DIFF
--- a/spec/models/tasks/quality_review_task_spec.rb
+++ b/spec/models/tasks/quality_review_task_spec.rb
@@ -74,4 +74,27 @@ describe QualityReviewTask, :all_dbs do
       expect(qr_task.status).to eq(Constants.TASK_STATUSES.assigned)
     end
   end
+
+  describe ".create_from_root_task" do
+    context "when case belongs to an unrecognized appellant" do
+      let(:claimant) { create(:claimant, :with_unrecognized_appellant_detail, type: "OtherClaimant") }
+      let(:appeal) { create(:appeal, claimants: [claimant]) }
+      let(:root_task) { create(:root_task, appeal: appeal) }
+
+      subject { QualityReviewTask.create_from_root_task(root_task) }
+
+      it "should raise an error" do
+        expect { subject }.to raise_error(NotImplementedError)
+      end
+
+      context "when allow_unrecognized_appellant_dispatch toggle is enabled" do
+        before { FeatureToggle.enable!(:allow_unrecognized_appellant_dispatch) }
+        after { FeatureToggle.disable!(:allow_unrecognized_appellant_dispatch) }
+
+        it "should not raise an error" do
+          subject
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Follows in the pattern of [a similar PR for `BvaDispatchTask`s](https://github.com/department-of-veterans-affairs/caseflow/pull/16355) since we create `QualityReviewTask`s instead of dispatch tasks roughly 20% of the time [following judge's completing decision review](https://github.com/department-of-veterans-affairs/caseflow/blob/32e814777c643f82d49b1c3021b334b90f5bff3b/app/workflows/complete_case_review.rb#L31).

This ticket may not be totally necessary since the unrecognized appellant cases that have run into this situation were all SCM'ed to judges (since [we currently prevent unrecognized appellant cases](https://github.com/department-of-veterans-affairs/caseflow/blob/32e814777c643f82d49b1c3021b334b90f5bff3b/app/models/docket.rb#L87) from being distributed through automatic case distribution) so we may be able to prevent more cases from ending up in this situation by informing folks not to use SCM for these cases.