### PR TITLE
Add TaskPolicy for Filtering Task Data

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,17 +34,21 @@ class WorkQueue::TaskSerializer
     }
   end
 
-  attribute :assigned_to do |object|
-    assignee = object.assigned_to
+  attribute :assigned_to do |object, params|
+    assignee = TaskPolicy.new(user: params[:user], resource: object).assigned_to
 
-    {
-      css_id: assignee.try(:css_id),
-      full_name: assignee.try(:full_name),
-      is_organization: assignee.is_a?(Organization),
-      name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
-      type: assignee.class.name,
-      id: assignee.id
-    }
+    if assignee.nil? 
+      nil
+    else
+      {
+        css_id: assignee.try(:css_id),
+        full_name: assignee.try(:full_name),
+        is_organization: assignee.is_a?(Organization),
+        name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
+        type: assignee.class.name,
+        id: assignee.id
+      }
+    end
   end
 
   attribute :cancelled_by do |object|

--- a/app/policies/task_policy.rb
+++ b/app/policies/task_policy.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class TaskPolicy
+  def initialize(user:, resource:)
+    @user = user
+    @resource = resource
+  end
+
+  def assigned_to
+    if restrict_vso?
+      nil
+    else
+      @resource.assigned_to
+    end
+  end
+
+  private
+
+  attr_reader :user, :resource
+
+  def restrict_vso?
+    FeatureToggle.enabled?(:restrict_poa_visibility, user: @user) && @user.vso_employee?
+  end
+end


### PR DESCRIPTION
Connects [CASEFLOW-1596](https://vajira.max.gov/browse/CASEFLOW-1596)

### Description
This adds a `TaskPolicy` class and alters existing task serializers to utilize it. Currently it contains logic to remove `assigned_to` for VSO users.

### Acceptance Criteria
- [ ] Code compiles correctly

