### PR TITLE
Do not raise InvalidCountryNameError for 'U.S.'

### DIFF
--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -28,7 +28,7 @@ class TimezoneService
     def address_to_timezone(address)
       # Return addresses for addresses in US using zip code before calling
       # iso3166_alpha2_code_from_name() because that method will raise an error given country "US".
-      if address.country == "US"
+      if address.country.in? ["US", "U.S."]
         return TimezoneService.zip5_to_timezone(address.zip)
       end
 

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -28,7 +28,7 @@ class TimezoneService
     def address_to_timezone(address)
       # Return addresses for addresses in US using zip code before calling
       # iso3166_alpha2_code_from_name() because that method will raise an error given country "US".
-      if address.country.in? ["US", "U.S."]
+      if ["US", "U.S."].include?(address.country)
         return TimezoneService.zip5_to_timezone(address.zip)
       end
 

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -67,14 +67,18 @@ describe TimezoneService do
       include_examples "zip code resolves to equivalent timezone", "96898",
                        "Wake Island, HI", "Pacific/Wake"
 
-      context "Country name of US" do
-        let(:country) { "US" }
-        let(:zip) { "68107" }
+      shared_examples "Variations on the country name of 'United States'" do |country, zip_code, expected_timezone_name|
+        context "Country name of '#{country}'" do
+          let(:zip) { zip_code }
 
-        it "Valid zip code with country 'US' resolves to valid timezone" do
-          expect(subject.identifier).to eq("America/Chicago")
+          it "Valid zip code with country '#{country}' resolves to valid timezone" do
+            expect(subject.identifier).to eq(expected_timezone_name)
+          end
         end
       end
+
+      include_examples "Variations on the country name of 'United States'", "US", "68107", "America/Chicago"
+      include_examples "Variations on the country name of 'United States'", "U.S.", "03833", "America/New_York"
 
       context "invalid zip code input" do
         let(:zip) { "934" }


### PR DESCRIPTION
Expands on the pattern established by #16399. See [this Slack thread for an example](https://dsva.slack.com/archives/CLRTL92TW/p1626295442254200) of an address formatted with the country name of 'U.S.'.