### PR TITLE
Allow access to the attorneys endpoint

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -3,7 +3,7 @@
 class IntakesController < ApplicationController
   include ValidationConcern
 
-  before_action :verify_access, except: %i[attorneys]
+  before_action :verify_access, except: [:attorneys]
   before_action :react_routed, :set_application, :check_intake_out_of_service
 
   attr_accessor :error_id

--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -3,7 +3,8 @@
 class IntakesController < ApplicationController
   include ValidationConcern
 
-  before_action :verify_access, :react_routed, :set_application, :check_intake_out_of_service
+  before_action :verify_access, except: %i[attorneys]
+  before_action :react_routed, :set_application, :check_intake_out_of_service
 
   attr_accessor :error_id
 

--- a/spec/controllers/intakes_controller_spec.rb
+++ b/spec/controllers/intakes_controller_spec.rb
@@ -216,5 +216,13 @@ RSpec.describe IntakesController, :postgres do
         }
       ]
     end
+    it "works when the user is not an intake user" do
+      User.unauthenticate!
+      User.authenticate!(roles: ["NOT Mail Intake"])
+
+      get :attorneys, params: { query: "JON SMITH" }
+
+      expect(response.status).to eq(200)
+    end
   end
 end


### PR DESCRIPTION
Resolves #1920

### Description
Do not check for intake user role before allowing access to the attorneys endpoint
The base application_controller will still limit access to only caseflow users but no specific role will be required

### Testing Plan
1. Go to the edit appellant information page, select attorney, and search for an attorney
2. You should see the results of the search



