### PR TITLE
Allow more variations on US country name and zip codes

### DIFF
--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -18,7 +18,7 @@ class TimezoneService
     end
   end
 
-  ACCEPTABLE_USA_VARIATIONS = ["us", "u.s."]
+  ACCEPTABLE_USA_VARIATIONS = ["us", "u.s."].freeze
 
   class << self
     # Attempts to find a timezone based on an address. For addresses within the United States,

--- a/app/services/timezone_service.rb
+++ b/app/services/timezone_service.rb
@@ -18,6 +18,8 @@ class TimezoneService
     end
   end
 
+  ACCEPTABLE_USA_VARIATIONS = ["us", "u.s."]
+
   class << self
     # Attempts to find a timezone based on an address. For addresses within the United States,
     # this does a lookup of timezone based on zip code. For addresses outisde of the US,
@@ -26,12 +28,6 @@ class TimezoneService
     # Fails if there are multiple timezones for a country outside of the US.
     # Fails if country name or zip code are formatted incorrectly.
     def address_to_timezone(address)
-      # Return addresses for addresses in US using zip code before calling
-      # iso3166_alpha2_code_from_name() because that method will raise an error given country "US".
-      if ["US", "U.S."].include?(address.country)
-        return TimezoneService.zip5_to_timezone(address.zip)
-      end
-
       iso3166_code = TimezoneService.iso3166_alpha2_code_from_name(address.country)
 
       if iso3166_code == "US"
@@ -42,7 +38,9 @@ class TimezoneService
     end
 
     # Maps a US 5-digit zip code to a timezone.
-    def zip5_to_timezone(zip)
+    def zip5_to_timezone(orig_zip)
+      zip = orig_zip&.strip
+
       Address.validate_zip5_code(zip)
 
       timezone_name = Ziptz.new.time_zone_name(zip)
@@ -83,6 +81,8 @@ class TimezoneService
     # with an error if not found.
     def iso3166_alpha2_code_from_name(orig_country_name)
       country_name = orig_country_name&.strip
+
+      return "US" if ACCEPTABLE_USA_VARIATIONS.include?(country_name&.downcase)
 
       iso3166_code = ISO3166::Country.find_country_by_name(country_name)
       iso3166_code = ISO3166::Country.find_country_by_alpha3(country_name) if iso3166_code.blank?

--- a/spec/services/timezone_service_spec.rb
+++ b/spec/services/timezone_service_spec.rb
@@ -58,6 +58,10 @@ describe TimezoneService do
       include_examples "zip code resolves to timezone", "00601", "Puerto Rico", "America/Puerto_Rico"
       include_examples "zip code resolves to timezone", "96799", "American Samoa", "Pacific/Pago_Pago"
 
+      # Zip codes with leading and trailing spaces resolve to the proper time zone.
+      include_examples "zip code resolves to timezone", " 27605", "Raleigh, NC", "America/New_York"
+      include_examples "zip code resolves to timezone", "78744 ", "Austin, TX", "America/Chicago"
+
       # Note: These tests resolve to the incorrect IANA timezone (ex. 00803 should resolve to America/St_Thomas),
       # but the offsets from UTC are the same.
       include_examples "zip code resolves to equivalent timezone", "00803",
@@ -178,6 +182,8 @@ describe TimezoneService do
 
     include_examples "it resolves to a valid ISO 3166 country code", "USA", "US"
     include_examples "it resolves to a valid ISO 3166 country code", "united states", "US"
+    include_examples "it resolves to a valid ISO 3166 country code", "US", "US"
+    include_examples "it resolves to a valid ISO 3166 country code", "u.s. ", "US"
     include_examples "it resolves to a valid ISO 3166 country code", "Australia", "AU"
     include_examples "it resolves to a valid ISO 3166 country code", "Canada", "CA"
     include_examples "it resolves to a valid ISO 3166 country code", "Colombia", "CO"
@@ -209,7 +215,6 @@ describe TimezoneService do
     include_examples "it throws an error if not a valid country name", "F R A N C E"
     include_examples "it throws an error if not a valid country name", "New York"
     include_examples "it throws an error if not a valid country name", "United St."
-    include_examples "it throws an error if not a valid country name", "US"
   end
 
   describe "#iso3166_alpha2_code_to_timezone" do


### PR DESCRIPTION
Resolves [more `TimezoneService` errors](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/?query=timezone_service).

1. Allows for acceptable variations of "USA" country name to be upper- or lower-case (or mixed).
    * Example [Sentry errors for `us`](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18545/).
2. Strips leading and trailing space characters from zip codes before attempting to find time zones.
    * Example [Sentry errors for leading space character](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/18999/).