### PR TITLE
CAMO Organization Queue via Business Line Queue

### DIFF
--- a/app/models/organizations/vha_camo.rb
+++ b/app/models/organizations/vha_camo.rb
@@ -2,6 +2,6 @@
 
 class VhaCamo < Organization
   def self.singleton
-    VhaCamo.first || VhaCamo.create(name: "VHA CAMO", url: "vha-camo")
+    VhaCamo.first || VhaCamo.create(name: "VHA CAMO", type: "BusinessLine", url: "vha-camo")
   end
 end

--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types';
 import SearchBar from '../../components/SearchBar';
 import TabWindow from '../../components/TabWindow';
 import { TaskTableUnconnected } from '../../queue/components/TaskTable';
-import { claimantColumn, veteranParticipantIdColumn, decisionReviewTypeColumn } from './TaskTableColumns';
+import {
+  claimantColumn,
+  veteranParticipantIdColumn,
+  decisionReviewTypeColumn,
+  caseDetialsColumn,
+  tasksColumn } from './TaskTableColumns';
 import COPY from '../../../COPY';
 
 class NonCompTabsUnconnected extends React.PureComponent {
@@ -16,7 +21,8 @@ class NonCompTabsUnconnected extends React.PureComponent {
         key="inprogress"
         predefinedColumns={{ includeDaysWaiting: true,
           defaultSortIdx: 3 }}
-        tasks={this.props.inProgressTasks} />
+        tasks={this.props.inProgressTasks}
+        businessLine={this.props.businessLine} />
     }, {
       label: 'Completed tasks',
       page: <TaskTableTab
@@ -24,7 +30,8 @@ class NonCompTabsUnconnected extends React.PureComponent {
         description={COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}
         predefinedColumns={{ includeCompletedDate: true,
           defaultSortIdx: 3 }}
-        tasks={this.props.completedTasks} />
+        tasks={this.props.completedTasks}
+        businessLine={this.props.businessLine} />
     }];
 
     return <TabWindow
@@ -40,6 +47,7 @@ NonCompTabsUnconnected.propTypes = {
   currentTab: PropTypes.node,
   dispatch: PropTypes.func,
   inProgressTasks: PropTypes.array,
+  businessLine: PropTypes.string,
 };
 
 class TaskTableTab extends React.PureComponent {
@@ -72,6 +80,13 @@ class TaskTableTab extends React.PureComponent {
   }
 
   render = () => {
+    let columns = [claimantColumn(), veteranParticipantIdColumn(),
+            decisionReviewTypeColumn(this.state.allTasks)];
+
+    if (this.props.businessLine == "VHA CAMO") {
+      columns = [caseDetialsColumn(), tasksColumn(), decisionReviewTypeColumn(this.state.allTasks)];
+    }
+
     return <React.Fragment>
       {this.props.description && <div className="cf-noncomp-queue-completed-task">{this.props.description}</div>}
       <div className="cf-search-ahead-parent cf-push-right cf-noncomp-search">
@@ -89,8 +104,7 @@ class TaskTableTab extends React.PureComponent {
         <TaskTableUnconnected
           {...this.state.predefinedColumns}
           getKeyForRow={(row, object) => object.id}
-          customColumns={[claimantColumn(), veteranParticipantIdColumn(),
-            decisionReviewTypeColumn(this.state.allTasks)]}
+          customColumns={columns}
           includeIssueCount
           tasks={this.state.shownTasks}
         />
@@ -103,6 +117,7 @@ TaskTableTab.propTypes = {
   description: PropTypes.node,
   predefinedColumns: PropTypes.object,
   tasks: PropTypes.array,
+  businessLine: PropTypes.string,
 };
 
 const NonCompTabs = connect(

--- a/client/app/nonComp/components/TaskTableColumns.jsx
+++ b/client/app/nonComp/components/TaskTableColumns.jsx
@@ -33,3 +33,19 @@ export const decisionReviewTypeColumn = (tasks) => {
     order: -1
   };
 };
+
+export const caseDetialsColumn = () => {
+  return {
+    header: 'Case Details',
+    valueFunction: (task) => `${task.claimant.name} (${task.veteranParticipantId})`,
+    getSortValue: (task) => task.claimant.name
+  }
+};
+
+export const tasksColumn = () => {
+  return {
+    header: 'Tasks',
+    valueFunction: (task) => task.type,
+    getSortValue: (task) => task.claimant.name
+  }
+};

--- a/client/app/nonComp/pages/ReviewPage.jsx
+++ b/client/app/nonComp/pages/ReviewPage.jsx
@@ -70,7 +70,7 @@ class NonCompReviewsPage extends React.PureComponent {
           }
         </div>
       </div>
-      <NonCompTabs />
+      <NonCompTabs businessLine={this.props.businessLine} />
     </div>;
   }
 }


### PR DESCRIPTION
Resolves [CASEFLOW-1879](https://vajira.max.gov/browse/CASEFLOW-1879), Create CAMO Organization Queue

### Description
Adds a queue for the CAMO Organization

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
* Follow steps to create the CAMO Org from the [Pre-docketing VHA Appeals: User organizations & permissions investigation](https://hackmd.io/dChKQLSyQXWGoPplHRHURQ#How-to-create-an-organization).
* Follow the steps to create and assign a user from the [Pre-docketing VHA Appeals: User organizations & permissions investigation](https://hackmd.io/dChKQLSyQXWGoPplHRHURQ#How-to-add-user-to-a-new-organization).
* Create a new non-10182 intake.
* In your console `t = Task.last;  t.assigned_to = Organization.find_by(name: 'VHA CAMO'); t.save` to assign it to the VHA CAMO organization.
* Visit http://127.0.0.1:3000/decision_reviews/vha-camo to view queue.

### User Facing Changes

This screenshot will be edited as the design changes.
<img width="625" alt="image" src="https://user-images.githubusercontent.com/2308626/125982777-7559d9cb-d10d-435c-bf0f-7b267732b93f.png">
