### PR TITLE
Explain page: add vis-timeline.css import to app.scss

### DIFF
--- a/client/app/styles/app.scss
+++ b/client/app/styles/app.scss
@@ -23,3 +23,5 @@
 @import 'react/_react_styles_root.scss';
 
 @import '~react-draft-wysiwyg/dist/react-draft-wysiwyg.css';
+
+@import '~vis-timeline/dist/vis-timeline-graph2d.min.css';


### PR DESCRIPTION
Tries to resolve `Refused to apply style from mime type ('text/html')` in prod -- [Slack thread](https://dsva.slack.com/archives/CQNPUG8EQ/p1626729286040000).

### Description
Make `vis-timeline.css` available for the `explain` page.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Deploy and check?
