### PR TITLE
Snooze jquery warning for a week

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -1,3 +1,4 @@
 CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
+  CVE-2020-11023: 2021-07-26


### PR DESCRIPTION
Snooze the jquery-rails gem security warning while we work on updating it safely
See this PR for updating the gem: https://github.com/department-of-veterans-affairs/caseflow/pull/16514
Updating jquery-rails updates loofah to a version that revealed a bug in brakeman. See: https://github.com/flavorjones/loofah/issues/211
Updating brakeman is going to be a more complicated step so snoozing to unblock prs for now