### PR TITLE
Disable save button when form is not valid

### DIFF
--- a/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
+++ b/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
@@ -33,6 +33,7 @@ const EditAppellantInformation = ({ appealId }) => {
   const [loading, setLoading] = useState(false);
 
   const {
+    formState: { isValid },
     handleSubmit,
   } = methods;
 
@@ -81,6 +82,7 @@ const EditAppellantInformation = ({ appealId }) => {
         onClick={handleSubmit(handleUpdate)}
         classNames={['cf-right-side']}
         loading={loading}
+        disabled={!isValid}
         name="Save"
       >
         Save

--- a/client/test/app/queue/editAppellantInformation/__snapshots__/EditAppellantInformation.test.js.snap
+++ b/client/test/app/queue/editAppellantInformation/__snapshots__/EditAppellantInformation.test.js.snap
@@ -10245,6 +10245,7 @@ exports[`EditAppellantInformation renders default state correctly 1`] = `
               "cf-right-side",
             ]
           }
+          disabled={false}
           linkStyling={false}
           loading={false}
           name="Save"
@@ -10255,6 +10256,7 @@ exports[`EditAppellantInformation renders default state correctly 1`] = `
           <span>
             <button
               className="cf-right-side usa-button"
+              disabled={false}
               id="button-Save"
               onClick={[Function]}
               type="button"

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -42,6 +42,9 @@ feature "Unrecognized appellants", :postgres do
       expect(find("#firstName").value).to eq "Jane"
       expect(find("#lastName").value).to eq "Smith"
 
+      fill_in "First name", with: ""
+      expect(page).to have_button("Save", disabled: true)
+
       fill_in "First name", with: "Updated First Name"
       click_on "Save"
       expect(page).to have_current_path("/queue/appeals/#{appeal_with_unrecognized_appellant.uuid}")


### PR DESCRIPTION
Resolves #1038

### Description
Need to disable the save button on the edit appellant information page when the form is invalid, to follow the pattern set by the add appellant page

### Acceptance Criteria
- Save button is disabled when the form is invalid

### Testing Plan
1. Go to the edit appellant information page
2. Remove a required field
3. Verify that the save button is disabled

