### PR TITLE
Don't show "Add Substitute" button if Veteran is living

### DIFF
--- a/client/app/queue/substituteAppellant/caseDetails/utils.js
+++ b/client/app/queue/substituteAppellant/caseDetails/utils.js
@@ -12,6 +12,7 @@ export const shouldSupportSubstituteAppellant = ({
 
   return (
     !appeal.isLegacyAppeal &&
+    appeal.veteranDateOfDeath &&
       currentUserOnClerkOfTheBoard &&
       !appeal.appellantIsNotVeteran &&
       featureToggles.recognized_granted_substitution_after_dd &&

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1910,6 +1910,7 @@ RSpec.feature "Case details", :all_dbs do
         before do
           ClerkOfTheBoard.singleton.add_user(cob_user)
           User.authenticate!(user: cob_user)
+          appeal.veteran.update!(date_of_death: 1.week.ago)
         end
 
         shared_examples "the button is not shown" do
@@ -1965,7 +1966,17 @@ RSpec.feature "Case details", :all_dbs do
         context "when the disposition is 'Dismissed, Death'" do
           let(:disposition) { "dismissed_death" }
 
-          it_behaves_like "the button is shown"
+          # This is a nonsensical state but happens often in dev/demo:
+          context "when the veteran is living" do
+            before { appeal.veteran.update!(date_of_death: nil) }
+            after { appeal.veteran.update!(date_of_death: 1.week.ago) }
+
+            it_behaves_like "the button is not shown"
+          end
+
+          context "when the veteran is deceased" do
+            it_behaves_like "the button is shown"
+          end
 
           context "but if the claimant is not a veteran" do
             before { appeal.update(veteran_is_not_claimant: true) }


### PR DESCRIPTION
### Description
This is unlikely to come up in prod, but it is a frequent nuisance in dev
(and probably demo). If the Veteran does not have a date of death, the
"Continue" button will not work, which is an infuriating user experience.

We could (should?) fix the issue with the Continue button, but AIUI it's a nonsensical use case.

### Acceptance Criteria
- [ ] Tests pass
- [ ] Someone agrees that what I'm actually introducing is correct behavior

### Testing Plan
You can use:
```ruby
appeal = FactoryBot.create(:appeal,
  :dispatched, :with_decision_issue,
  docket_type: Constants.AMA_DOCKETS.hearing)
```

And then set/unset a Veteran's date of death, which should toggle the display on the page. (You will have to reload to see that, of course.)