### PR TITLE
Handle inactive organizations for Case Detail page

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -36,14 +36,15 @@ class WorkQueue::TaskSerializer
 
   attribute :assigned_to do |object|
     assignee = object.assigned_to
+    is_organization = object.assigned_to_type == "Organization"
 
     {
       css_id: assignee.try(:css_id),
       full_name: assignee.try(:full_name),
-      is_organization: assignee.is_a?(Organization),
-      name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
-      type: assignee.class.name,
-      id: assignee.id
+      is_organization: is_organization,
+      name: is_organization ? assignee.try(:name) : assignee.try(:css_id),
+      type: assignee.try(:class)&.name,
+      id: assignee.try(:id)
     }
   end
 
@@ -68,7 +69,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assignee_name do |object|
-    object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+    (object.assigned_to_type == "Organization") ? object.assigned_to.try(:name) : object.assigned_to.try(:css_id)
   end
 
   attribute :placed_on_hold_at, &:calculated_placed_on_hold_at

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,7 @@ class Task < CaseflowRecord
   has_many :task_timers, dependent: :destroy
   has_one :cached_appeal, ->(task) { where(appeal_type: task.appeal_type) }, foreign_key: :appeal_id
 
-  validates :assigned_to, :appeal, :type, :status, presence: true
+  validates :assigned_to, :appeal, :type, :status, presence: true, on: :create
   validate :status_is_valid_on_create, on: :create
   validate :assignee_status_is_valid_on_create, on: :create
   validate :parent_can_have_children

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -25,7 +25,8 @@ class Task < CaseflowRecord
   has_many :task_timers, dependent: :destroy
   has_one :cached_appeal, ->(task) { where(appeal_type: task.appeal_type) }, foreign_key: :appeal_id
 
-  validates :assigned_to, :appeal, :type, :status, presence: true, on: :create
+  validates :appeal, :type, :status, presence: true
+  validates :assigned_to, presence: true, on: :create
   validate :status_is_valid_on_create, on: :create
   validate :assignee_status_is_valid_on_create, on: :create
   validate :parent_can_have_children

--- a/spec/models/serializers/work_queue/task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/task_serializer_spec.rb
@@ -44,4 +44,32 @@ describe WorkQueue::TaskSerializer, :postgres do
       end
     end
   end
+
+  describe "the attribute assigned_to" do
+    subject { described_class.new(task).serializable_hash[:data][:attributes] }
+
+    context "an task assigned to an Organization" do
+      let(:org) { Bva.singleton }
+      let(:task) { TrackVeteranTask.create!(appeal: parent.appeal, assigned_to: org, parent: parent) }
+      it "return a non-nil assigned_to values" do
+        expect(subject[:assigned_to][:is_organization]).to eq true
+        expect(subject[:assigned_to][:name]).to eq org.name
+        expect(subject[:assigned_to][:type]).to eq org.class.name
+        expect(subject[:assigned_to][:id]).to eq org.id
+      end
+
+      context "an task assigned to an inactive Organization" do
+        before do
+          org.inactive!
+          task.reload
+        end
+        it "returns nil assigned_to values" do
+          expect(subject[:assigned_to][:is_organization]).to eq true
+          expect(subject[:assigned_to][:name]).to eq nil
+          expect(subject[:assigned_to][:type]).to eq nil
+          expect(subject[:assigned_to][:id]).to eq nil
+        end
+      end
+    end
+  end
 end

--- a/spec/models/serializers/work_queue/task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/task_serializer_spec.rb
@@ -61,13 +61,14 @@ describe WorkQueue::TaskSerializer, :postgres do
       context "an task assigned to an inactive Organization" do
         before do
           org.inactive!
-          task.reload
+          task.reload # needed so that task.assigned_to returns nil
         end
         it "returns nil assigned_to values" do
           expect(subject[:assigned_to][:is_organization]).to eq true
           expect(subject[:assigned_to][:name]).to eq nil
           expect(subject[:assigned_to][:type]).to eq nil
           expect(subject[:assigned_to][:id]).to eq nil
+          expect(subject[:assignee_name].to eq nil
         end
       end
     end

--- a/spec/models/serializers/work_queue/task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/task_serializer_spec.rb
@@ -68,7 +68,7 @@ describe WorkQueue::TaskSerializer, :postgres do
           expect(subject[:assigned_to][:name]).to eq nil
           expect(subject[:assigned_to][:type]).to eq nil
           expect(subject[:assigned_to][:id]).to eq nil
-          expect(subject[:assignee_name].to eq nil
+          expect(subject[:assignee_name]).to eq nil
         end
       end
     end


### PR DESCRIPTION
Resolves [Bat Team ticket](https://dsva.slack.com/archives/CJL810329/p1627064170261500)

The MOPH organization (id=12) was made `inactive`, causing `task.assigned_to` to return `nil`, which caused 
```
NoMethodError (undefined method `css_id' for nil:NilClass)
app/models/serializers/work_queue/task_serializer.rb:71:in `block in <class:TaskSerializer>'
app/serializers/ama_and_legacy_task_serializer.rb:19:in `call'
app/controllers/tasks_controller.rb:273:in `json_tasks'
app/controllers/tasks_controller.rb:139:in `for_appeal'
```
and prevented the Case Details page to load. 

### Description
Handle `nil` `task.assigned_to` values gracefully.

Follow-on work: Search for `assignee.is_a?(Organization)` and similar code and handle inactive organizations appropriately. 
Alternatively: Consider removing `default_scope` (which is [considered bad practice](https://www.ombulabs.com/blog/ruby/rails/best-practices/why-using-default-scope-is-a-bad-idea.html)): 
https://github.com/department-of-veterans-affairs/caseflow/blob/40f3f77ecf7229dce71c7aa89256d199f37eddf0/app/models/organization.rb#L21

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Go to the Case Details page for an appeal.
Find a task that is assigned to an organization.
Make that `organization.inactive!`.
Reload the page.

Prior to this PR, the page shows an error for inactive org assignees.