### PR TITLE
AttorneyCaseReview Foreign Keys

### DIFF
--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -7,7 +7,7 @@ class AttorneyCaseReview < CaseflowRecord
 
   belongs_to :reviewing_judge, class_name: "User"
   belongs_to :attorney, class_name: "User"
-  belongs_to :task
+  belongs_to :task, class_name: "AttorneyTask"
 
   validates :attorney, :document_type, :task_id, :reviewing_judge, :document_id, :work_product, presence: true
   validates :untimely_evidence, inclusion: { in: [true, false] }

--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -7,7 +7,7 @@ class AttorneyCaseReview < CaseflowRecord
 
   belongs_to :reviewing_judge, class_name: "User"
   belongs_to :attorney, class_name: "User"
-  belongs_to :task, class_name: "AttorneyTask"
+  belongs_to :task
 
   validates :attorney, :document_type, :task_id, :reviewing_judge, :document_id, :work_product, presence: true
   validates :untimely_evidence, inclusion: { in: [true, false] }

--- a/config/initializers/immigrant.rb
+++ b/config/initializers/immigrant.rb
@@ -10,10 +10,6 @@ Immigrant.ignore_keys = [
   # Add FK to dispatch_tasks table (not the tasks table)
   { from_table: "claim_establishments", column: "task_id" },
 
-  # Add FK to users table
-  { from_table: "attorney_case_reviews", column: "attorney_id" },
-  { from_table: "attorney_case_reviews", column: "reviewing_judge_id" },
-
   # Investigate these next and add foreign key if possible.
   { from_table: "advance_on_docket_motions", column: "person_id" },
   { from_table: "ramp_issues", column: "source_issue_id" },

--- a/config/initializers/immigrant.rb
+++ b/config/initializers/immigrant.rb
@@ -36,6 +36,7 @@ Immigrant.ignore_keys = [
 
   # Refers to the tasks table for AMA appeals, but something like `4107503-2021-05-31` for legacy appeals
   # Search for `review_class.complete(params)` in our code to see where task_id is set.
+  # Possible solution: Create new column for VACOLS task ID, transfer VACOLS non integer strings to new column, update the code to assign VACOLS strings to new column, delete the VACOLS string from task_id column, and then add the FK
   { from_table: "judge_case_reviews", column: "task_id" },
   { from_table: "attorney_case_reviews", column: "task_id" },
 

--- a/db/migrate/20210726142344_add_attorney_case_review_f_ks.rb
+++ b/db/migrate/20210726142344_add_attorney_case_review_f_ks.rb
@@ -2,6 +2,5 @@ class AddAttorneyCaseReviewFKs < Caseflow::Migration
   def change
     add_foreign_key "attorney_case_reviews", "users", column: "attorney_id", validate: false
     add_foreign_key "attorney_case_reviews", "users", column: "reviewing_judge_id", validate: false
-    add_foreign_key "attorney_case_reviews", "tasks", validate: false
   end
 end

--- a/db/migrate/20210726142344_add_attorney_case_review_f_ks.rb
+++ b/db/migrate/20210726142344_add_attorney_case_review_f_ks.rb
@@ -1,0 +1,7 @@
+class AddAttorneyCaseReviewFKs < Caseflow::Migration
+  def change
+    add_foreign_key "attorney_case_reviews", "users", column: "attorney_id", validate: false
+    add_foreign_key "attorney_case_reviews", "users", column: "reviewing_judge_id", validate: false
+    add_foreign_key "attorney_case_reviews", "tasks", validate: false
+  end
+end

--- a/db/migrate/20210726142412_validate_attorney_case_review_f_ks.rb
+++ b/db/migrate/20210726142412_validate_attorney_case_review_f_ks.rb
@@ -1,0 +1,7 @@
+class ValidateAttorneyCaseReviewFKs < Caseflow::Migration
+  def change
+    validate_foreign_key "attorney_case_reviews", column: "attorney_id"
+    validate_foreign_key "attorney_case_reviews", column: "reviewing_judge_id"
+    validate_foreign_key "attorney_case_reviews", "tasks"
+  end
+end

--- a/db/migrate/20210726142412_validate_attorney_case_review_f_ks.rb
+++ b/db/migrate/20210726142412_validate_attorney_case_review_f_ks.rb
@@ -2,6 +2,5 @@ class ValidateAttorneyCaseReviewFKs < Caseflow::Migration
   def change
     validate_foreign_key "attorney_case_reviews", column: "attorney_id"
     validate_foreign_key "attorney_case_reviews", column: "reviewing_judge_id"
-    validate_foreign_key "attorney_case_reviews", "tasks"
   end
 end


### PR DESCRIPTION
### Description

This is phase 11 of a multi-phase plan to add missing foreign keys.

Phase 10 PR #16513 
Phase 9 PR #16366
Phase 8 PR #16327
Phase 7c PR #16313
Phase 7b PR #16304
Phase 7 PR #16277
Phase 5c PR #16263
Phase 5b PR #16281
Phase 4 PR #16137
Phase 3 PR #16120
Phase 2 PR #16114
Phase 1 PR #16034 has more details

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
```ruby=
AttorneyCaseReview.unscoped.includes(:attorney).where.not(attorney_id: nil).select{|r| r.attorney == nil}.count
=> 0 #Prod
=> 0 #Preprod
=> 0 #UAT

AttorneyCaseReview.unscoped.includes(:reviewing_judge).where.not(reviewing_judge_id: nil).select{|r| r.reviewing_judge == nil}.count
=> 0 #Prod
=> 0 #Preprod
=> 0 #UAT
```

### Database Changes
*Only for Schema Changes*


* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb`
* [ ] Run `make docs` (after running `make migrate`) to update DB schema docs

