### PR TITLE
Properly access hearing disposition in tasks_visible_to_vso_employee

### DIFF
--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -48,7 +48,7 @@ class TasksForAppeal
       .includes(*task_includes)
       .select do |task|
       task.assigned_to.is_a?(Representative) || task.assigned_to_vso_user? || user == task.assigned_to ||
-        (task.is_a?(HearingTask) && task.disposition == Constants.HEARING_DISPOSITION_TYPES.held) ||
+        (task.is_a?(HearingTask) && task&.hearing&.disposition == Constants.HEARING_DISPOSITION_TYPES.held) ||
         task.is_a?(DistributionTask)
     end
   end

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -22,6 +22,26 @@ describe TasksForAppeal do
         ihps = tasks.select { |t| t.is_a?(InformalHearingPresentationTask) }
         expect(ihps).not_to be_empty
       end
+
+      context "with HearingTask" do
+        let(:appeal) { create(:appeal, :hearing_docket) }
+
+        context "hearing has not been held" do
+          let!(:hearing) { create(:hearing, :with_tasks, :cancelled, appeal: appeal) }
+
+          it "does not include the HearingTask" do
+            expect(subject.find { |t| t.is_a?(HearingTask) }).to be_nil
+          end
+        end
+
+        context "hearing has been held" do
+          let!(:hearing) { create(:hearing, :with_tasks, :held, appeal: appeal) }
+          
+          it "includes the HearingTask" do
+            expect(subject.find { |t| t.is_a?(HearingTask) }).to_not be_nil
+          end
+        end
+      end
     end
 
     context "for a legacy appeal with a travel board hearing request" do

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -36,7 +36,7 @@ describe TasksForAppeal do
 
         context "hearing has been held" do
           let!(:hearing) { create(:hearing, :with_tasks, :held, appeal: appeal) }
-          
+
           it "includes the HearingTask" do
             expect(subject.find { |t| t.is_a?(HearingTask) }).to_not be_nil
           end


### PR DESCRIPTION
### Description
This fixes a bug in the VSO visilbity handlers (`TasksForAppeal.tasks_visible_to_vso_employee`) that was causing a 5xx error when a VSO viewed an appeal with a `HearingTask`. It was improperly attempting to access  a `disposition` method off of the `HearingTask`, when it should actually be done off of `Hearing`.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Things don't error

### Testing Plan
1. As a VSO user, access an appeal on the `hearing` docket
2. Verify that the case loads without errors

