### PR TITLE
Bug Fix | Non-Dynamic Dates in substitute_appellant_spec

### DIFF
--- a/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
+++ b/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
@@ -4,7 +4,7 @@ require_relative "./shared_setup.rb"
 
 RSpec.feature "granting substitute appellant for appeals", :all_dbs do
   describe "with a dismissed appeal" do
-    let(:veteran) { create(:veteran, date_of_death: 30.days.ago) }
+    let(:veteran) { create(:veteran, date_of_death: Time.zone.parse("2021-07-04")) }
     let(:appeal) do
       create(:appeal,
              :dispatched, :with_decision_issue,
@@ -23,7 +23,7 @@ RSpec.feature "granting substitute appellant for appeals", :all_dbs do
 
       context "with evidence submission docket" do
         let(:docket_type) { "evidence_submission" }
-        let(:evidence_submission_window_end_time) { Time.zone.parse("2021-10-05 00:00") }
+        let(:evidence_submission_window_end_time) { Time.zone.parse("2021-10-17 00:00") }
 
         it_should_behave_like "fill substitution form"
       end


### PR DESCRIPTION
Fixes a bug introduced in #16529

### Description
This addresses a bug in RSpec tests for appellant substitution whereby the expected end date of an evidence submission window got out of sync with what it should be. This was due to the test being based off of dynamic date values, but the comparison date was static. 

This PR changes things so that all dates will be based off a statically specified date for veteran's death.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] RSpec tests don't fail