### PR TITLE
Pass empty string if names not present

### DIFF
--- a/client/app/queue/editAppellantInformation/utils.js
+++ b/client/app/queue/editAppellantInformation/utils.js
@@ -7,8 +7,8 @@ export const mapAppellantDataToApi = (appellant) => {
       unrecognized_party_detail: {
         party_type: (appellant.relationship === "other" || appellant.relationship === "attorney") ? appellant.partyType : "individual",
         name: appellant.partyType === "organization" ? appellant.name : appellant.firstName,
-        middle_name: appellant.middleName,
-        last_name: appellant.lastName,
+        middle_name: appellant.middleName || "",
+        last_name: appellant.lastName || "",
         suffix: appellant.suffix,
         address_line_1: appellant.addressLine1,
         address_line_2: appellant.addressLine2,

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -74,6 +74,9 @@ feature "Unrecognized appellants", :postgres do
       expect(page).to have_current_path("/queue/appeals/#{appeal_with_unrecognized_appellant.uuid}")
       ua = appeal_with_unrecognized_appellant.claimant.unrecognized_appellant
       expect(ua.name).to eq("Organization 1")
+      expect(ua.middle_name).to eq("")
+      expect(ua.last_name).to eq("")
+      
       expect(ua.party_type).to eq("organization")
       expect(ua.versions.count).to eq(2)
       expect(ua.first_version.first_name).to eq("Jane")

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -76,7 +76,7 @@ feature "Unrecognized appellants", :postgres do
       expect(ua.name).to eq("Organization 1")
       expect(ua.middle_name).to eq("")
       expect(ua.last_name).to eq("")
-      
+
       expect(ua.party_type).to eq("organization")
       expect(ua.versions.count).to eq(2)
       expect(ua.first_version.first_name).to eq("Jane")


### PR DESCRIPTION
Resolves #1789

### Description
When updating from an individual to an organization, the middle and last name gets saved on the update even though it's an organization. Doesn't show up on the front end but we should probably address it since it's a little sloppy data-wise

This PR will make it so that when you're updating to an organization, the middle and last name will be explicitly set to empty strings instead of not being present, thus updating the record with an empty middle and last name instead of leaving it as the same middle or last name

