### PR TITLE
SanitizeJsonExporter uses Lorem ipsum for sentences

### DIFF
--- a/lib/helpers/sanitation_transforms.rb
+++ b/lib/helpers/sanitation_transforms.rb
@@ -120,8 +120,9 @@ module SanitizationTransforms
   def obfuscate_sentence(field_name, field_value, obj_class: nil)
     case field_name
     when "instructions", "description", "decision_text", "notes", "comment", /_text$/, /_notes$/, /_description$/
-      # puts "obfuscate_sentence: #{field_name} = #{field_value}"
-      field_value.split.map { |word| word[0..1] }.join(" ")
+      # Preserve the approximate length
+      word_count = field_value.split.count
+      Faker::Lorem.sentence(random_words_to_add: word_count)
     when "military_service"
       branch = %w[ARMY AF NAVY M CG].sample
       discharge = ["Honorable", "Under Honorable Conditions"].sample

--- a/spec/lib/helpers/sanitized_json_exporter_spec.rb
+++ b/spec/lib/helpers/sanitized_json_exporter_spec.rb
@@ -136,12 +136,10 @@ describe "SanitizedJsonExporter/Importer" do
     subject { SjConfiguration.new.obfuscate_sentence(field_name, sentence) }
     context "given sentence" do
       let(:sentence) { "No PII, just potentially sensitive!" }
-      it "returns sentence without any of the original longer words" do
-        obf_words = subject.split
-        sentence.split.select { |word| word.length > 2 }.each do |word|
-          expect(subject).not_to include word
-          obf_words.each { |obf_word| expect(obf_word.chars).not_to match_array word.chars }
-        end
+
+      it "calls Lorem::Faker.sentence" do
+        expect(Faker::Lorem).to receive(:sentence).and_return("something new!")
+        expect(subject).to eq("something new!")
       end
     end
     context "given empty sentence" do


### PR DESCRIPTION
### Description
The [Sanitized JSON importer and exporter](https://github.com/department-of-veterans-affairs/caseflow/wiki/Exporting-and-Importing-Appeals) are super-helpful for grabbing an appeal from prod, scrubbing it of any PII/PHI, and importing it into dev/demo environments.

Previously, the `obfuscate_sentence` method used for obfuscating things like task instructions or descriptions would return the first two letters of each word. When going through an appeal for export, I realized that my subconscious mind was able to make pretty good guesses about what some of the sentences said. Th br is an am th!

Since we're already using Faker::Lorem in some other cases, this PR switches to using that instead.

### Acceptance Criteria
- [ ] Exported task instructions (etc.) are no longer based on truncations of real data