### PR TITLE
Changed Docket request type label in HearingDayInfoButton

### DIFF
--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -16,7 +16,6 @@ import {
 } from './styles';
 
 import {
-  docketReadableRequestType,
   vljFullnameOrEmptyString,
   formatSlotRatio,
   hearingDayHasJudge,
@@ -24,9 +23,11 @@ import {
   hearingRoomOrEmptyString
 } from '../../utils';
 
+import { DOCKET_READABLE_REQUEST_TYPE } from '../../constants';
+
 export const HearingDayInfoButton = ({ id, hearingDay, selected, onSelectedHearingDayChange }) => {
   // Format the pieces of information from hearingDay
-  const formattedHearingType = docketReadableRequestType(hearingDay);
+  const formattedHearingType = DOCKET_READABLE_REQUEST_TYPE[hearingDay.requestType];
   const judgeOrRoom = hearingDayHasJudge(hearingDay) ?
     vljFullnameOrEmptyString(hearingDay) :
     hearingRoomOrEmptyString(hearingDay);

--- a/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
+++ b/client/app/hearings/components/assignHearings/HearingDayInfoButton.jsx
@@ -16,7 +16,7 @@ import {
 } from './styles';
 
 import {
-  formatHearingType,
+  docketReadableRequestType,
   vljFullnameOrEmptyString,
   formatSlotRatio,
   hearingDayHasJudge,
@@ -26,7 +26,7 @@ import {
 
 export const HearingDayInfoButton = ({ id, hearingDay, selected, onSelectedHearingDayChange }) => {
   // Format the pieces of information from hearingDay
-  const formattedHearingType = formatHearingType(hearingDay.readableRequestType);
+  const formattedHearingType = docketReadableRequestType(hearingDay);
   const judgeOrRoom = hearingDayHasJudge(hearingDay) ?
     vljFullnameOrEmptyString(hearingDay) :
     hearingRoomOrEmptyString(hearingDay);

--- a/client/app/hearings/constants.js
+++ b/client/app/hearings/constants.js
@@ -121,6 +121,14 @@ export const CENTRAL_OFFICE_HEARING_LABEL = 'Central';
 export const TRAVEL_BOARD_HEARING_LABEL = 'Travel';
 export const VIRTUAL_HEARING_LABEL = 'Virtual';
 
+// Given a Docket request type return readable request type for that Docket.
+export const DOCKET_READABLE_REQUEST_TYPE = {
+  'R': VIRTUAL_HEARING_LABEL,
+  'V': VIDEO_HEARING_LABEL,
+  'T': TRAVEL_BOARD_HEARING_LABEL,
+  'C': CENTRAL_OFFICE_HEARING_LABEL
+}
+
 export const LIST_SCHEDULE_VIEWS = {
   DEFAULT_VIEW: 'DEFAULT_VIEW',
   SHOW_ALL: 'SHOW_ALL'

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -9,7 +9,12 @@ import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMA
 // To see how values were determined: https://github.com/department-of-veterans-affairs/caseflow/pull/14556#discussion_r447102582
 import TIMEZONES from '../../constants/TIMEZONES';
 import { COMMON_TIMEZONES, REGIONAL_OFFICE_ZONE_ALIASES } from '../constants/AppConstants';
-import { VIDEO_HEARING_LABEL } from './constants';
+import {
+  VIDEO_HEARING_LABEL,
+  CENTRAL_OFFICE_HEARING_LABEL,
+  TRAVEL_BOARD_HEARING_LABEL,
+  VIRTUAL_HEARING_LABEL
+} from './constants';
 import ApiUtil from '../util/ApiUtil';
 import { RESET_VIRTUAL_HEARING } from './contexts/HearingsFormContext';
 import HEARING_REQUEST_TYPES from '../../constants/HEARING_REQUEST_TYPES';
@@ -721,6 +726,20 @@ export const formatHearingType = (hearingType) => {
   return hearingType;
 };
 
+export const docketReadableRequestType = (docket) => {
+  switch (docket.requestType) {
+  case 'R':
+    return VIRTUAL_HEARING_LABEL;
+  case 'V':
+    return VIDEO_HEARING_LABEL;
+  case 'T':
+    return TRAVEL_BOARD_HEARING_LABEL;
+  case 'C':
+    return CENTRAL_OFFICE_HEARING_LABEL;
+
+  default: return '';
+  }
+};
 // Given a hearing day, return the judges last, first or ''
 export const vljFullnameOrEmptyString = (hearingDay) => {
   const first = hearingDay?.judgeFirstName;

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -9,12 +9,7 @@ import REGIONAL_OFFICE_INFORMATION from '../../constants/REGIONAL_OFFICE_INFORMA
 // To see how values were determined: https://github.com/department-of-veterans-affairs/caseflow/pull/14556#discussion_r447102582
 import TIMEZONES from '../../constants/TIMEZONES';
 import { COMMON_TIMEZONES, REGIONAL_OFFICE_ZONE_ALIASES } from '../constants/AppConstants';
-import {
-  VIDEO_HEARING_LABEL,
-  CENTRAL_OFFICE_HEARING_LABEL,
-  TRAVEL_BOARD_HEARING_LABEL,
-  VIRTUAL_HEARING_LABEL
-} from './constants';
+import { VIDEO_HEARING_LABEL } from './constants';
 import ApiUtil from '../util/ApiUtil';
 import { RESET_VIRTUAL_HEARING } from './contexts/HearingsFormContext';
 import HEARING_REQUEST_TYPES from '../../constants/HEARING_REQUEST_TYPES';

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -726,20 +726,6 @@ export const formatHearingType = (hearingType) => {
   return hearingType;
 };
 
-export const docketReadableRequestType = (docket) => {
-  switch (docket.requestType) {
-  case 'R':
-    return VIRTUAL_HEARING_LABEL;
-  case 'V':
-    return VIDEO_HEARING_LABEL;
-  case 'T':
-    return TRAVEL_BOARD_HEARING_LABEL;
-  case 'C':
-    return CENTRAL_OFFICE_HEARING_LABEL;
-
-  default: return '';
-  }
-};
 // Given a hearing day, return the judges last, first or ''
 export const vljFullnameOrEmptyString = (hearingDay) => {
   const first = hearingDay?.judgeFirstName;

--- a/client/test/app/hearings/components/HearingDayInfoButton.test.js
+++ b/client/test/app/hearings/components/HearingDayInfoButton.test.js
@@ -16,7 +16,7 @@ describe('HearingDayInfoButton', () => {
         judgeFirstName: 'Jonas',
         judgeLastName: 'Jerengal',
         room: '14',
-        requestType: 'R',
+        requestType: 'V',
         readableRequestType: 'video',
         hearings: {
           hearing_1: {},
@@ -65,5 +65,13 @@ describe('HearingDayInfoButton', () => {
     expect(setSelectedValue).toHaveBeenCalledTimes(0);
     await userEvent.click(button);
     expect(setSelectedValue).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the Docket readable request type when Docket is type Virtual', () => {
+    props.requestType = 'R';
+
+    const { container } = render(<HearingDayInfoButton {...props} />);
+
+    expect(container).toMatchSnapshot();
   });
 });

--- a/client/test/app/hearings/components/HearingDayInfoButton.test.js
+++ b/client/test/app/hearings/components/HearingDayInfoButton.test.js
@@ -16,6 +16,7 @@ describe('HearingDayInfoButton', () => {
         judgeFirstName: 'Jonas',
         judgeLastName: 'Jerengal',
         room: '14',
+        requestType: 'R',
         readableRequestType: 'video',
         hearings: {
           hearing_1: {},

--- a/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
@@ -29,7 +29,149 @@ exports[`HearingDayInfoButton renders correctly 1`] = `
               data-tip="true"
               tabindex="-1"
             >
-              Virtual · VLJ Jerengal, Jonas
+              Video · VLJ Jerengal, Jonas
+            </span>
+            <span
+              data-css-ftxb8z=""
+            >
+              <div
+                class="__react_component_tooltip t00000000-0000-0000-0000-000000000000 place-bottom type-dark"
+                data-id="tooltip"
+                id="hearing-day-undefined"
+                role="tooltip"
+              >
+                <style>
+                  
+  	.t00000000-0000-0000-0000-000000000000 {
+	    color: #fff;
+	    background: #222;
+	    border: 1px solid transparent;
+  	}
+
+  	.t00000000-0000-0000-0000-000000000000.place-top {
+        margin-top: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::before {
+        border-top: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-top::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        bottom: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-top-color: #222;
+        border-top-style: solid;
+        border-top-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-bottom {
+        margin-top: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::before {
+        border-bottom: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-bottom::after {
+        border-left: 8px solid transparent;
+        border-right: 8px solid transparent;
+        top: -6px;
+        left: 50%;
+        margin-left: -8px;
+        border-bottom-color: #222;
+        border-bottom-style: solid;
+        border-bottom-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-left {
+        margin-left: -10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::before {
+        border-left: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-left::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        right: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-left-color: #222;
+        border-left-style: solid;
+        border-left-width: 6px;
+    }
+
+    .t00000000-0000-0000-0000-000000000000.place-right {
+        margin-left: 10px;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::before {
+        border-right: 8px solid transparent;
+    }
+    .t00000000-0000-0000-0000-000000000000.place-right::after {
+        border-top: 5px solid transparent;
+        border-bottom: 5px solid transparent;
+        left: -6px;
+        top: 50%;
+        margin-top: -4px;
+        border-right-color: #222;
+        border-right-style: solid;
+        border-right-width: 6px;
+    }
+  
+                </style>
+                VLJ Jerengal, Jonas
+              </div>
+            </span>
+          </div>
+        </div>
+        <div
+          data-css-1fnaqki=""
+        >
+          <div
+            data-css-lrak98=""
+          >
+            2 of 8
+          </div>
+          <div
+            data-css-heqg99=""
+          >
+            scheduled
+          </div>
+        </div>
+      </div>
+    </button>
+  </span>
+</div>
+`;
+
+exports[`HearingDayInfoButton renders the Docket readable request type when Docket is type Virtual 1`] = `
+<div>
+  <span>
+    <button
+      class="unselected-hearing-day-info-button cf-btn-link usa-button"
+      data-css-1fa3cif=""
+      type="button"
+    >
+      <div>
+        <div
+          data-css-16v9b8i=""
+        >
+          <div
+            data-css-1o3wy7o=""
+          >
+            Mon Apr 12
+          </div>
+          <div
+            data-css-5bhwlq=""
+          >
+            <span
+              aria-describedby="hearing-day-undefined"
+              currentitem="false"
+              data-event="focus mouseenter"
+              data-event-off="mouseleave keydown"
+              data-for="hearing-day-undefined"
+              data-tip="true"
+              tabindex="-1"
+            >
+              Video · VLJ Jerengal, Jonas
             </span>
             <span
               data-css-ftxb8z=""

--- a/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
+++ b/client/test/app/hearings/components/__snapshots__/HearingDayInfoButton.test.js.snap
@@ -29,7 +29,7 @@ exports[`HearingDayInfoButton renders correctly 1`] = `
               data-tip="true"
               tabindex="-1"
             >
-              Video · VLJ Jerengal, Jonas
+              Virtual · VLJ Jerengal, Jonas
             </span>
             <span
               data-css-ftxb8z=""


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1940

### Description
Regional office dockets that display the label "Virtual" in the Available Hearing Day list also display the label "Virtual" on the Schedule Veteran page in the Hearing Date dropdown, so that Coordinators can use time slots to more efficiently and effectively schedule hearings.

### Acceptance Criteria
- [ ] http://localhost:3000/hearings/schedule/assign On this page on the left hand column where it lists all future Dockets with open slots with should see the Docket request type regardless of what type of hearings the Docket has.

### Testing Plan

1. Make sure that you have Dockets of type "Video" and "Virtual" for the RO selected.
2. Go to http://localhost:3000/hearings/schedule/assign
3. On left column where it lists all future Dockets with open slots with should see the Docket request type regardless of what type of hearings the Docket has.

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.