### PR TITLE
Make Issue description hash Sentry message more actionable

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -275,7 +275,11 @@ class Issue
     # if there are more levels and codes there is the chance that issue description
     # this shouldn't happen, but suspect this is happening and adding the log message.
     if issue_description.is_a?(Hash)
-      Raven.capture_message("legacy appeal #{id} has an issue description that is a hash")
+      msg = "legacy appeal #{id} has an issue description that is a hash. "\
+          "This usually indicates a problem with the underlying data in VACOLS. Reach out to Jed via the dsva-vacols "\
+          "repo to determine if updating VACOLS data resolves the problem. For a prior example, see this ticket: "\
+          "https://github.com/department-of-veterans-affairs/dsva-vacols/issues/211"
+      Raven.capture_message(msg)
       return ""
     end
 


### PR DESCRIPTION
Adds more information to the `legacy appeal ... has an issue description that is a hash` message so that it is more actionable.

This message is starting to get a little long for my liking (though long Sentry messages is a pattern we currently use in [a handful](https://github.com/department-of-veterans-affairs/caseflow/blob/d381d7cce5f224704d14488b68ca0d5352db6ff8/app/models/tasks/evidence_submission_window_task.rb#L68) [of places](https://github.com/department-of-veterans-affairs/caseflow/blob/d381d7cce5f224704d14488b68ca0d5352db6ff8/app/models/tasks/judge_assign_task.rb#L28) [in our codebase](https://github.com/department-of-veterans-affairs/caseflow/blob/d381d7cce5f224704d14488b68ca0d5352db6ff8/app/workflows/initial_tasks_factory.rb#L117)) but I came up empty-handed in searching [the Sentry docs](https://docs.sentry.io/platforms/ruby/) for a way to send a shorter title and longer description to `Raven.capture_message`, so I'm happy to go ahead with this solution but welcome thoughts on how to make this tidier.