### PR TITLE
Changed Hearings Scheduled column to display only scheduled hearings

### DIFF
--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -158,7 +158,7 @@ class ListSchedule extends React.Component {
   }
 
   formatHearingsScheduled = (filledSlots) => {
-    return `${filledSlots}`;
+    return filledSlots;
   }
 
   getHearingScheduleRows = () => {

--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -157,8 +157,8 @@ class ListSchedule extends React.Component {
     this.setState({ dateRangeKey: `${this.props.startDate}->${this.props.endDate}` });
   }
 
-  formatHearingsScheduled = (filledSlots, totalSlots) => {
-    return `${filledSlots} of ${totalSlots}`;
+  formatHearingsScheduled = (filledSlots) => {
+    return `${filledSlots}`;
   }
 
   getHearingScheduleRows = () => {
@@ -173,7 +173,7 @@ class ListSchedule extends React.Component {
         room: hearingDay.room,
         vlj: formatVljName(hearingDay.judgeLastName, hearingDay.judgeFirstName),
         ...this.props.user.userCanViewAndDownloadHearingScheduledColumn &&
-          { hearingsScheduled: this.formatHearingsScheduled(hearingDay.filledSlots, hearingDay.totalSlots) }
+          { hearingsScheduled: this.formatHearingsScheduled(hearingDay.filledSlots) }
       }));
   };
 

--- a/spec/feature/hearings/list_schedule/build_hearsched_spec.rb
+++ b/spec/feature/hearings/list_schedule/build_hearsched_spec.rb
@@ -54,9 +54,9 @@ RSpec.feature "List Schedule for Build HearSched", :all_dbs do
       expect(page).to have_content(COPY::HEARING_SCHEDULE_VIEW_PAGE_HEADER)
       expect(page).to have_content("Hearings Scheduled")
       table_row = page.find("tr", id: "table-row-0")
-      expect(table_row).to have_content("2 of #{hearing_day_one.total_slots}")
+      expect(table_row).to have_content("2")
       table_row = page.find("tr", id: "table-row-1")
-      expect(table_row).to have_content("2 of #{hearing_day_two.total_slots}")
+      expect(table_row).to have_content("2")
     end
   end
 end


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1966

### Description
Our default time slots for Video dockets (12) and Central dockets (10) don't reflect current state, which is more like 8 but can also vary across time zones/ROs. Removing the "of <total slots>" – i.e., showing only the number of hearings scheduled – will result in a single numeric value in the downloaded CSV and make it easier for folks who download that CSV to use it for capacity planning and reporting.

### Acceptance Criteria
- [x] The Hearings Scheduled column shows only the number of hearing scheduled without " of <total slots>" on The hearing schedule / landing page
- [x] The CSV can be downloaded from that page

### Testing Plan
1. Go to http://localhost:3000/hearings/schedule
2. The Hearings Scheduled column should only the number of hearing scheduled without " of <total slots>" on The hearing schedule / landing page
3. Should be able to download the  CSV from this page