### PR TITLE
Fix setting of email_sent flags for recipients

### DIFF
--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -85,7 +85,7 @@ class BaseHearingUpdateForm
     [
       virtual_hearing_updates[:appellant_email_sent],
       virtual_hearing_updates[:representative_email_sent],
-      virtual_hearing_updates[:judge_email_sent_flag]
+      virtual_hearing_updates[:judge_email_sent]
     ].any?(false)
   end
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -267,7 +267,7 @@ class BaseHearingUpdateForm
         email_sent: virtual_hearing_updates&.key?(:judge_email_sent) ? false : true
       }.compact
 
-      hearing.representative_recipient.update!(**update_params) if update_params.any?
+      hearing.judge_recipient.update!(**update_params) if update_params.any?
     end
   end
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -226,7 +226,7 @@ class BaseHearingUpdateForm
     update_params = {
       email_address: appellant_email.presence,
       timezone: virtual_hearing_updates[:appellant_tz].presence,
-      email_sent: virtual_hearing_updates[:appellant_email_sent]
+      email_sent: virtual_hearing_updates[:appellant_email_sent] || true
     }.compact
 
     hearing.appellant_recipient.update!(**update_params) if update_params.any?
@@ -243,7 +243,7 @@ class BaseHearingUpdateForm
     if hearing.representative_recipient.present?
       update_params = {
         timezone: virtual_hearing_updates[:representative_tz].presence,
-        email_sent: virtual_hearing_updates[:representative_email_sent]
+        email_sent: virtual_hearing_updates[:representative_email_sent] || true
       }.compact
 
       hearing.representative_recipient.update!(**update_params) if update_params.any?
@@ -258,8 +258,12 @@ class BaseHearingUpdateForm
       )
     end
 
-    if virtual_hearing_updates.key?(:judge_email_sent)
-      hearing.judge_recipient.update!(email_sent: virtual_hearing_updates[:judge_email_sent])
+    if hearing.judge_recipient.present?
+      update_params = {
+        email_sent: virtual_hearing_updates[:judge_email_sent] || true
+      }.compact
+
+      hearing.representative_recipient.update!(**update_params) if update_params.any?
     end
   end
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -82,7 +82,11 @@ class BaseHearingUpdateForm
   end
 
   def show_virtual_hearing_progress_alerts?
-    [appellant_email_sent_flag, representative_email_sent_flag, judge_email_sent_flag].any?(false)
+    [
+      virtual_hearing_updates[:appellant_email_sent],
+      virtual_hearing_updates[:representative_email_sent],
+      virtual_hearing_updates[:judge_email_sent_flag]
+    ].any?(false)
   end
 
   def should_create_or_update_virtual_hearing?
@@ -226,7 +230,7 @@ class BaseHearingUpdateForm
     update_params = {
       email_address: appellant_email.presence,
       timezone: virtual_hearing_updates[:appellant_tz].presence,
-      email_sent: virtual_hearing_updates[:appellant_email_sent] || true
+      email_sent: virtual_hearing_updates&.key?(:appellant_email_sent) ? false : true
     }.compact
 
     hearing.appellant_recipient.update!(**update_params) if update_params.any?
@@ -243,7 +247,7 @@ class BaseHearingUpdateForm
     if hearing.representative_recipient.present?
       update_params = {
         timezone: virtual_hearing_updates[:representative_tz].presence,
-        email_sent: virtual_hearing_updates[:representative_email_sent] || true
+        email_sent: virtual_hearing_updates&.key?(:representative_email_sent) ? false : true
       }.compact
 
       hearing.representative_recipient.update!(**update_params) if update_params.any?
@@ -260,7 +264,7 @@ class BaseHearingUpdateForm
 
     if hearing.judge_recipient.present?
       update_params = {
-        email_sent: virtual_hearing_updates[:judge_email_sent] || true
+        email_sent: virtual_hearing_updates&.key?(:judge_email_sent) ? false : true
       }.compact
 
       hearing.representative_recipient.update!(**update_params) if update_params.any?

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe HearingsController, type: :controller do
   let(:oakland_ro_pacific) { "RO43" }
   let(:baltimore_ro_eastern) { "RO13" }
   let(:timezone) { "America/New_York" }
+  let(:disposition) { nil }
 
   describe "PATCH update" do
     it "should be successful", :aggregate_failures do
@@ -61,7 +62,46 @@ RSpec.describe HearingsController, type: :controller do
       end
     end
 
-    context "when updating an existing hearing to a virtual hearing" do
+    shared_context "based on hearing disposition" do
+      before do
+        # Stub out the job starting, so we can check to make sure the email
+        # sent flags are set properly.
+        allow(VirtualHearings::CreateConferenceJob).to receive(:perform_now)
+        allow(VirtualHearings::DeleteConferencesJob).to receive(:perform_now)
+        hearing.update!(disposition: disposition)
+      end
+
+      shared_examples "does not set email flags" do
+        it "returns the expected status and updates the virtual hearing", :aggregate_failures do
+          expect(subject.status).to eq(200)
+
+          virtual_hearing.reload
+          expect(virtual_hearing.appellant_email_sent).to eq(true)
+          expect(virtual_hearing.representative_email_sent).to eq(true)
+          expect(virtual_hearing.judge_email_sent).to eq(true)
+        end
+      end
+
+      context "when hearing disposition is postponed" do
+        let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.to_h[:postponed] }
+
+        include_examples "does not set email flags"
+      end
+
+      context "when hearing disposition is cancelled" do
+        let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.to_h[:cancelled] }
+
+        include_examples "does not set email flags"
+      end
+
+      context "when hearing disposition is scheduled_in_error" do
+        let(:disposition) { Constants.HEARING_DISPOSITION_TYPES.to_h[:scheduled_in_error] }
+
+        include_examples "does not set email flags"
+      end
+    end
+
+    context "when updating an existing hearing to a virtual hearing", focus: true do
       let(:judge) { create(:user, station_id: User::BOARD_STATION_ID, email: "new_judge_email@caseflow.gov") }
       let(:hearing) { create(:hearing, regional_office: cheyenne_ro_mountain, judge: judge) }
       let(:virtual_hearing_params) { {} }
@@ -125,6 +165,8 @@ RSpec.describe HearingsController, type: :controller do
             expect(virtual_hearing.judge_email_sent).to eq(true)
             expect(virtual_hearing.representative_email).to eq("new_representative_email@caseflow.gov")
           end
+
+          include_context "based on hearing disposition"
         end
       end
 
@@ -196,7 +238,8 @@ RSpec.describe HearingsController, type: :controller do
               hearing: hearing,
               appellant_email: "existing_veteran_email@caseflow.gov",
               appellant_email_sent: true,
-              judge_email: nil,
+              judge_email: "judge@email.com",
+              judge_email_sent: true,
               representative_email: "existing_rep_email@casfelow.gov",
               representative_email_sent: true
             )
@@ -208,6 +251,8 @@ RSpec.describe HearingsController, type: :controller do
             expect(virtual_hearing.appellant_email).to eq("new_veteran_email@caseflow.gov")
             expect(virtual_hearing.representative_email).to eq("new_representative_email@caseflow.gov")
           end
+
+          include_context "based on hearing disposition"
         end
       end
 
@@ -229,11 +274,23 @@ RSpec.describe HearingsController, type: :controller do
           }
         end
 
+        before do
+          # Stub out the job starting, so we can check to make sure the email
+          # sent flags are set properly.
+          allow(VirtualHearings::DeleteConferencesJob).to receive(:perform_now)
+        end
+
         it "returns the expected status and updates the virtual hearing", :aggregate_failures do
           expect(subject.status).to eq(200)
           virtual_hearing.reload
           expect(virtual_hearing.cancelled?).to eq(true)
+          # Ensure email_sent flags are not set for judge recipient
+          expect(virtual_hearing.appellant_email_sent).to eq(false)
+          expect(virtual_hearing.representative_email_sent).to eq(false)
+          expect(virtual_hearing.judge_email_sent).to eq(true)
         end
+
+        include_context "based on hearing disposition"
       end
 
       context "with valid appellant_tz" do
@@ -314,6 +371,8 @@ RSpec.describe HearingsController, type: :controller do
         expect(virtual_hearing.appellant_email_sent).to eq(true)
         expect(virtual_hearing.representative_email_sent).to eq(true)
       end
+
+      include_context "based on hearing disposition"
     end
 
     context "when updating the AOD" do

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe HearingsController, type: :controller do
       end
     end
 
-    context "when updating an existing hearing to a virtual hearing", focus: true do
+    context "when updating an existing hearing to a virtual hearing" do
       let(:judge) { create(:user, station_id: User::BOARD_STATION_ID, email: "new_judge_email@caseflow.gov") }
       let(:hearing) { create(:hearing, regional_office: cheyenne_ro_mountain, judge: judge) }
       let(:virtual_hearing_params) { {} }


### PR DESCRIPTION
Follows https://github.com/department-of-veterans-affairs/caseflow/pull/16511

This PR resolves an issue where when virtual hearings were being cancelled the `email_sent` flags evaluated to `false` so they were getting picked up by our alerts [here](https://dsva.slack.com/archives/C3EAF3Q15/p1627901908008100). The desired behavior should be that the `email_sent` should be set to `true` when we don't intent to send out emails to recipients. The cases in which we should not send out emails to recipients are the following
- if virtual hearing is being cancelled (i.e converted back to original type), do not set judge email_sent flag to false 
- if hearing it self has disposition of  postponed, cancelled or scheduled_in_error, and if any updates are made to the virtual hearing, do not set the email_sent flags for any recipients. 

### Description
- ensures `email_sent` for recipients are not set to false if we do not mean to send any emails
- write tests
