### PR TITLE
Add nonformatted option to full name

### DIFF
--- a/app/models/full_name.rb
+++ b/app/models/full_name.rb
@@ -25,6 +25,8 @@ class FullName
     case format
     when :readable_full
       [first_name, middle_initial, last_name].select(&:present?).join(" ").titleize
+    when :readable_full_nonformatted
+      [first_name, middle_initial, last_name].select(&:present?).join(" ")
     when :readable_mi_formatted
       [first_name, middle_initial + ".", last_name].select(&:present?).join(" ").titleize
     when :readable_fi_last_formatted

--- a/app/models/unrecognized_party_detail.rb
+++ b/app/models/unrecognized_party_detail.rb
@@ -20,7 +20,7 @@ class UnrecognizedPartyDetail < CaseflowRecord
   def name
     return self[:name] if organization?
 
-    FullName.new(first_name, middle_name, last_name).formatted(:readable_full)
+    FullName.new(first_name, middle_name, last_name).formatted(:readable_full_nonformatted)
   end
 
   # return a hash in the same format that BgsAddressService uses

--- a/spec/models/full_name_spec.rb
+++ b/spec/models/full_name_spec.rb
@@ -26,6 +26,19 @@ describe FullName do
       end
     end
 
+    context "readable_full_nonformatted" do
+      let(:first) { "charles" }
+      let(:format) { :readable_full_nonformatted }
+
+      it { is_expected.to eq("charles E Cheese") }
+
+      context "parts of the name are missing" do
+        let(:middle) { nil }
+        let(:last) { nil }
+        it { is_expected.to eq("charles") }
+      end
+    end
+
     context "readable_short" do
       let(:format) { :readable_short }
 


### PR DESCRIPTION
Resolves #2122

### Description
Add option to do a full nonformatted name for unrecognized appellant in response to a feedback request during UAT

### Acceptance Criteria
- Unrecognized appellant information will now not be formatted when displayed on the case details page

