### PR TITLE
1456: allow representatives of substitutes to search for their appeals

### DIFF
--- a/app/workflows/case_search_results_base.rb
+++ b/app/workflows/case_search_results_base.rb
@@ -42,12 +42,14 @@ class CaseSearchResultsBase
     []
   end
 
-  # Users may also view appeals with substitute appellants whom they represent.
-  # That relationship is part of search in implementing classes, so we use this to add
-  # these appeals back into results because the user is not on the veteran's poa.
-  def appeals_user_can_access
+  # Users may also view appeals with appellants whom they represent.
+  # We use this to add these appeals back into results when the user is not on the veteran's poa.
+  def additional_appeals_user_can_access
     appeals.filter do |appeal|
-      appeal.veteran_is_not_claimant
+      appeal.veteran_is_not_claimant &&
+        user.organizations.any? do |uo|
+          appeal.representatives.include?(uo)
+        end
     end
   end
 
@@ -108,7 +110,7 @@ class CaseSearchResultsBase
 
     errors.add(:workflow, prohibited_error) if veterans_user_can_access.empty? &&
       veterans.any? &&
-      appeals_user_can_access.empty?
+      additional_appeals_user_can_access.empty?
     @status = :forbidden
   end
 

--- a/app/workflows/case_search_results_base.rb
+++ b/app/workflows/case_search_results_base.rb
@@ -108,7 +108,8 @@ class CaseSearchResultsBase
   def vso_employee_has_access
     return unless current_user_is_vso_employee?
 
-    errors.add(:workflow, prohibited_error) if veterans_user_can_access.empty? &&
+    errors.add(:workflow, prohibited_error) if
+      veterans_user_can_access.empty? &&
       veterans.any? &&
       additional_appeals_user_can_access.empty?
     @status = :forbidden

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -8,7 +8,6 @@ feature "Search", :all_dbs do
   let(:invalid_docket_number) { "invaliddocket-number" }
   let(:veteran_with_no_appeals) { create(:veteran) }
   let!(:appeal) { create(:legacy_appeal, :with_veteran, vacols_case: create(:case)) }
-  let!(:substitute_appeal) { create(:appellant_substitution) }
 
   before do
     User.authenticate!(user: attorney_user)
@@ -485,7 +484,8 @@ feature "Search", :all_dbs do
     context "when BGS can_access? is false" do
       before do
         Fakes::BGSService.new.bust_can_access_cache(user, appeal.veteran_file_number)
-        Fakes::BGSService.inaccessible_appeal_vbms_ids = [appeal.veteran_file_number]
+        Fakes::BGSService.inaccessible_appeal_vbms_ids =
+          [appeal.veteran_file_number, substitute_appeal.veteran_file_number]
         User.authenticate!(user: user)
       end
 
@@ -499,6 +499,12 @@ feature "Search", :all_dbs do
 
       context "when user is VSO employee" do
         let(:user) { create(:user, :vso_role, css_id: "BVA_VSO") }
+        let!(:appeal_sub) {
+          create(:appellant_substitution, substitute_participant_id: 999, poa_participant_id: 99)
+        }
+        let(:substitute_appeal) { appeal_sub.target_appeal }
+        let!(:other_appeal_sub) { create(:appellant_substitution) }
+        let(:other_substitute_appeal) { other_appeal_sub.target_appeal }
 
         it "displays a helpful error message on same page" do
           perform_search
@@ -507,8 +513,15 @@ feature "Search", :all_dbs do
 
         context "when user represents substitute appellant" do
           it "does not short-circuit to the helpful error message" do
-            perform_search(substitute_appeal)
+            perform_search(other_substitute_appeal.docket_number)
             expect(page).not_to have_content("You do not have access to this claims file number")
+          end
+        end
+
+        context "when user is a vso, appeal is a substitute, but user's org does not represent appellant" do
+          it "emits the helpful error message" do
+            perform_search(substitute_appeal.docket_number)
+            expect(page).to have_content("You do not have access to this claims file number")
           end
         end
       end

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -8,6 +8,7 @@ feature "Search", :all_dbs do
   let(:invalid_docket_number) { "invaliddocket-number" }
   let(:veteran_with_no_appeals) { create(:veteran) }
   let!(:appeal) { create(:legacy_appeal, :with_veteran, vacols_case: create(:case)) }
+  let!(:substitute_appeal) { create(:appellant_substitution) }
 
   before do
     User.authenticate!(user: attorney_user)
@@ -490,9 +491,9 @@ feature "Search", :all_dbs do
 
       let(:user) { create(:user) }
 
-      def perform_search
+      def perform_search(docket_number = appeal.docket_number)
         visit "/search"
-        fill_in "searchBarEmptyList", with: appeal.docket_number
+        fill_in "searchBarEmptyList", with: docket_number
         click_on "Search"
       end
 
@@ -502,6 +503,13 @@ feature "Search", :all_dbs do
         it "displays a helpful error message on same page" do
           perform_search
           expect(page).to have_content("You do not have access to this claims file number")
+        end
+
+        context "when user represents substitute appellant" do
+          it "does not short-circuit to the helpful error message" do
+            perform_search(substitute_appeal)
+            expect(page).not_to have_content("You do not have access to this claims file number")
+          end
         end
       end
 

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -499,9 +499,9 @@ feature "Search", :all_dbs do
 
       context "when user is VSO employee" do
         let(:user) { create(:user, :vso_role, css_id: "BVA_VSO") }
-        let!(:appeal_sub) {
+        let!(:appeal_sub) do
           create(:appellant_substitution, substitute_participant_id: 999, poa_participant_id: 99)
-        }
+        end
         let(:substitute_appeal) { appeal_sub.target_appeal }
         let!(:other_appeal_sub) { create(:appellant_substitution) }
         let(:other_substitute_appeal) { other_appeal_sub.target_appeal }


### PR DESCRIPTION
Resolves [Allow POA for non-Veteran claimants to find appeals through Search functionality](https://vajira.max.gov/browse/CASEFLOW-1456)

### Description
Instead of changing how search works in any way, I found it simpler to use a method listing appeals that have a non-veteran appellant for whom the user is a representative for the purpose of checking whether to have an access error.  This is confusing so let me put it in more words:
* Before: if a user represented no veterans, the access error would show.
* After: if a user represented no veterans but is a representative for the appellant on a non-veteran appeal, they will not get the error message, but if they are not, the previous error condition still holds. 

### Acceptance Criteria
- [X] Code compiles correctly
- [X] New unit test demonstrates new expectations
- [x] Existing unit tests pass
- [x] Manual test evoked by another engineer and found convincing

### Testing Plan
Buckle in and assure your seat-back is locked in an upright position.

`RequestStore[:current_user] = User.system_user`
 
In caseflow, become MICHAEL_VSO.  Find the user in the rails console and note the id and organization ids:
```ruby
user = User.find_by(css_id: "MICHAEL_VSO")
user.organizations.pluck(:participant_id)
=> ["2452415"]
user.id
=> 31
```

make factoryBot convenient with `f = FactoryBot`
Then create a substitute.  `sub = f.create(:appellant_substitution)`
```
=> #<AppellantSubstitution:0x00007ff3f70aa350
 id: 1,
 claimant_type: "DependentClaimant",
 created_at: Thu, 05 Aug 2021 21:20:38 UTC +00:00,
 created_by_id: 2000016654,
 poa_participant_id: "2",
 selected_task_ids: [],
 source_appeal_id: 1618,
 substitute_participant_id: "2",
 substitution_date: Thu, 05 Aug 2021,
 target_appeal_id: 1619,
 task_params: "{}",
 updated_at: Thu, 05 Aug 2021 21:20:38 UTC +00:00>
``` 
grab the target docket number - you'll need it twice:
`sub.target_appeal.docket_number`
=> "210804-1618"

I'm sorry for this step but, prepare the bgs faker to reproduce the access problem with substitute appellants by returning false for all access requests in `bgs_service.rb`:
```ruby
  def can_access?(vbms_id)
    return false
  end
```
Probably a better solution would be to permit a configuration file to set the values used in this file, but this gets us by for now.

Search for that docket number as Michael_VSO at http://localhost:3000/search and notice the expected error.  We don't have access.

Now note that that substitute has a participant id of 2 and check out the backing data
```sql
select * from bgs_power_of_attorneys where claimant_participant_id = '2';
-[ RECORD 1 ]------------------+---------------------------
id                             | 1478
authzn_change_clmant_addrs_ind |
authzn_poa_access_ind          |
claimant_participant_id        | 2
created_at                     | 2021-08-05 21:20:38.910723
file_number                    | 00001234
last_synced_at                 | 2021-08-05 21:20:38.910673
legacy_poa_cd                  | 100
poa_participant_id             | 600153863
representative_name            | Clarence Darrow
representative_type            | Attorney
updated_at                     | 2021-08-05 21:20:38.910723
```

To view the new discriminator working correctly, we need to become Clarance Darrow, id 1478.  I did User.find(1478) to grab the css id and log in as Lauren Roth (weird, right?).  

Search for the same docket number, and note the beautiful successful results.




