### PR TITLE
Don't create tmp/sql_tracker-*.json files in dev

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -8,6 +8,9 @@ Rails.application.configure do
   end
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Disable SqlTracker from creating tmp/sql_tracker-*.json files -- https://github.com/steventen/sql_tracker/pull/10
+  SqlTracker::Config.enabled = false
+
   # workaround https://groups.google.com/forum/#!topic/rubyonrails-security/IsQKvDqZdKw
   config.secret_key_base = SecureRandom.hex(64)
 


### PR DESCRIPTION
The SqlTracker gem creates log files under `tmp` by default.

### Description
Disable creating these files in our dev environment.
They are currently only used in our test environment.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Start a local Rails console. Notice no `tmp/sql_tracker-*.json` file is created.