### PR TITLE
Fix bug where form being invalid on relationship change

### DIFF
--- a/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
+++ b/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
@@ -72,8 +72,6 @@ const EditAppellantInformation = ({ appealId }) => {
   const editAppellantHeader = 'Edit Appellant Information';
   const editAppellantDescription = COPY.EDIT_CLAIMANT_PAGE_DESCRIPTION;
 
-  console.log(isValid)
-  console.log(errors)
   return <div>
     <FormProvider {...methods}>
       <AppSegment filledBackground>

--- a/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
+++ b/client/app/queue/editAppellantInformation/EditAppellantInformation.jsx
@@ -5,6 +5,7 @@ import { connect, useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router';
 import { sprintf } from 'sprintf-js';
+import { isEmpty } from 'lodash';
 
 import { ClaimantForm as EditClaimantForm } from '../../intake/addClaimant/ClaimantForm';
 import { useClaimantForm } from '../../intake/addClaimant/utils';
@@ -35,7 +36,7 @@ const EditAppellantInformation = ({ appealId }) => {
   const [editFailure, setEditFailure] = useState(false);
 
   const {
-    formState: { isValid },
+    formState: { isValid, errors },
     handleSubmit,
   } = methods;
 
@@ -71,6 +72,8 @@ const EditAppellantInformation = ({ appealId }) => {
   const editAppellantHeader = 'Edit Appellant Information';
   const editAppellantDescription = COPY.EDIT_CLAIMANT_PAGE_DESCRIPTION;
 
+  console.log(isValid)
+  console.log(errors)
   return <div>
     <FormProvider {...methods}>
       <AppSegment filledBackground>
@@ -96,7 +99,7 @@ const EditAppellantInformation = ({ appealId }) => {
         onClick={handleSubmit(handleUpdate)}
         classNames={['cf-right-side']}
         loading={loading}
-        disabled={!isValid}
+        disabled={!isValid && !isEmpty(errors)}
         name="Save"
       >
         Save


### PR DESCRIPTION
Resolves #1788

### Description
Fix bug with form not being valid preventing submission
This a temporary quick fix to address UAT. I'm going to dig into the issue a little more which is: The form is invalid when the user switches from Individual to Other - Individual, however, the validation process does not give any errors so it's unclear what's wrong. So adding this check will allow the form to still be submitted as long as there are no errors in the errors object. 