### PR TITLE
Fix bug in finding request issues without decision dates

### DIFF
--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -104,7 +104,9 @@ class AddIssuesPage extends React.Component {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  requestIssuesWithoutDecisionDates(requestIssues) {
+  requestIssuesWithoutDecisionDates(intakeData) {
+    const requestIssues = formatRequestIssues(intakeData.requestIssues, intakeData.contestableIssues);
+
     return !requestIssues.every((issue) => issue.ratingIssueReferenceId ||
       issue.isUnidentified || issue.decisionDate);
   }
@@ -204,13 +206,12 @@ class AddIssuesPage extends React.Component {
     const intakeData = intakeForms[formType];
     const { useAmaActivationDate } = featureToggles;
     const hasClearedEp = intakeData && (intakeData.hasClearedRatingEp || intakeData.hasClearedNonratingEp);
-    const requestIssues = formatRequestIssues(intakeData.requestIssues, intakeData.contestableIssues);
 
     if (this.willRedirect(intakeData, hasClearedEp)) {
       return this.redirect(intakeData, hasClearedEp);
     }
 
-    if (this.requestIssuesWithoutDecisionDates(requestIssues)) {
+    if (intakeData && this.requestIssuesWithoutDecisionDates(intakeData)) {
       return <Redirect to={PAGE_PATHS.REQUEST_ISSUE_MISSING_DECISION_DATE} />;
     }
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -19,7 +19,7 @@ import DateSelector from '../../components/DateSelector';
 import ErrorAlert from '../components/ErrorAlert';
 import { REQUEST_STATE, PAGE_PATHS, VBMS_BENEFIT_TYPES, FORM_TYPES } from '../constants';
 import EP_CLAIM_TYPES from '../../../constants/EP_CLAIM_TYPES';
-import { formatAddedIssues, getAddIssuesFields, formatIssuesBySection } from '../util/issues';
+import { formatAddedIssues, formatRequestIssues, getAddIssuesFields, formatIssuesBySection } from '../util/issues';
 import Table from '../../components/Table';
 import IssueList from '../components/IssueList';
 
@@ -104,9 +104,9 @@ class AddIssuesPage extends React.Component {
   }
 
   // eslint-disable-next-line class-methods-use-this
-  requestIssuesWithoutDecisionDates(intakeData) {
-    return !intakeData.requestIssues.every((issue) => issue.rating_issue_reference_id ||
-      issue.is_unidentified || issue.approx_decision_date);
+  requestIssuesWithoutDecisionDates(requestIssues) {
+    return !requestIssues.every((issue) => issue.ratingIssueReferenceId ||
+      issue.isUnidentified || issue.decisionDate);
   }
 
   willRedirect(intakeData, hasClearedEp) {
@@ -204,12 +204,13 @@ class AddIssuesPage extends React.Component {
     const intakeData = intakeForms[formType];
     const { useAmaActivationDate } = featureToggles;
     const hasClearedEp = intakeData && (intakeData.hasClearedRatingEp || intakeData.hasClearedNonratingEp);
+    const requestIssues = formatRequestIssues(intakeData.requestIssues, intakeData.contestableIssues);
 
     if (this.willRedirect(intakeData, hasClearedEp)) {
       return this.redirect(intakeData, hasClearedEp);
     }
 
-    if (this.requestIssuesWithoutDecisionDates(intakeData)) {
+    if (this.requestIssuesWithoutDecisionDates(requestIssues)) {
       return <Redirect to={PAGE_PATHS.REQUEST_ISSUE_MISSING_DECISION_DATE} />;
     }
 

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -105,8 +105,8 @@ class AddIssuesPage extends React.Component {
 
   // eslint-disable-next-line class-methods-use-this
   requestIssuesWithoutDecisionDates(intakeData) {
-    return intakeData.requestIssues?.some((issue) => !issue.ratingIssueReferenceId &&
-     !issue.isUnidentified && !issue.approx_decision_date);
+    return !intakeData.requestIssues.every((issue) => issue.rating_issue_reference_id ||
+      issue.is_unidentified || issue.approx_decision_date);
   }
 
   willRedirect(intakeData, hasClearedEp) {

--- a/client/app/intake/reducers/appeal.js
+++ b/client/app/intake/reducers/appeal.js
@@ -1,6 +1,5 @@
 import { ACTIONS, FORM_TYPES, REQUEST_STATE } from '../constants';
 import { applyCommonReducers, commonStateFromServerIntake } from './common';
-import { formatRequestIssues, formatContestableIssues } from '../util/issues';
 import {
   convertStringToBoolean,
   getReceiptDateError,

--- a/client/app/intake/reducers/supplementalClaim.js
+++ b/client/app/intake/reducers/supplementalClaim.js
@@ -1,6 +1,5 @@
 import { ACTIONS, FORM_TYPES, REQUEST_STATE } from '../constants';
 import { applyCommonReducers, commonStateFromServerIntake } from './common';
-import { formatRequestIssues, formatContestableIssues } from '../util/issues';
 import {
   convertStringToBoolean,
   getReceiptDateError,

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -140,7 +140,7 @@ export const formatRequestIssues = (requestIssues, contestableIssues) => {
       isRating: !issue.category,
       ratingIssueReferenceId: issue.rating_issue_reference_id,
       ratingDecisionReferenceId: issue.rating_decision_reference_id,
-      ratingIssueProfileDate: new Date(issue.rating_issue_profile_date).toISOString(),
+      ratingIssueProfileDate: issue.rating_issue_profile_date && new Date(issue.rating_issue_profile_date).toISOString(),
       approxDecisionDate: issue.approx_decision_date,
       titleOfActiveReview: issue.title_of_active_review,
       rampClaimId: issue.ramp_claim_id,


### PR DESCRIPTION
### Description
This PR fixes a bug in `requestIssuesWithoutDecisionDates` which was causing ordinary unidentified issues to reroute from edit issues page to the missing decision date page.

The crux of the bugfix is that property names on the issues are actually snake_case 😭

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Complete intake for any HLR (or SC) with one identified issue and one unidentified issue.
2. If your environment's feature toggles don't automatically establish the HLR, do `HigherLevelReview.last.establish!` in Rails console.
3. Visit `/higher_level_reviews/UUID/edit` and confirm that it does not reroute to the missing decision date page.