### PR TITLE
Fixed hearing time slots not diplaying on ScheduleVeteranForm

### DIFF
--- a/client/app/components/DataDropdowns/HearingDate.jsx
+++ b/client/app/components/DataDropdowns/HearingDate.jsx
@@ -137,6 +137,8 @@ export const HearingDateDropdown = (props) => {
     // determine if any selection was made
     if (typeof (value) === 'string') {
       comparison = (opt) => opt?.value.hearingDate === formatDateStr(value, 'YYYY-MM-DD', 'YYYY-MM-DD');
+    } else if (value.hearingDate) {
+      comparison = (opt) => opt?.value.hearingDate === value.hearingDate;
     } else {
       comparison = (opt) => opt?.value === value;
     }


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-1752

### Acceptance Criteria
- [ ] Code compiles correctly.
- [ ] The correct time inputs for the selected Hearing Date are always displayed.

### Testing Plan

#### Steps to Reproduce:

1. For this to work you need whatever current day it is (05/17 as I write this) to have both
    - A virtual hearing day
    - A hearing day in the St. Petersburg RO
    - Create those two hearing days if they don't exist.

2. Get a veteran to schedule by following these steps. If you take a shortcut reproducing probably won't work because 
    - Choosing an RO here changes what happens on the schedule screen.
    - Go to the scheduled hearings page: http://localhost:3000/hearings/schedule
    - Click the "Schedule Veterans" button.
    - Select the "St. Petersburg, FL" RO from the dropdown.
    - Click the "AMA Veterans Waiting" tab
    - Click the name of the first veteran.
    - Choose "Schedule Veteran" from the dropdown

3. Look at the Schedule Veteran Form, which looks correct
    - You should be looking at the scheduling form for a veteran.
    - The "Hearing Type" should default to "Video"
    - The "Regional Office" should default to "St. Petersburg, FL"
    - The "Hearing Date" should default to todays date. <- If this doesn't happen, you need to create a hearing day.
    - You should see a "Hearing Time" selection dropdown.

4. Change the "Hearing Type" dropdown to "Virtual"
    - You should still see a "Hearing Time" selection dropdown.
    - The "Hearing Date" dropdown should still be filled in.

5. Change the "Regional Office" dropdown to "Virtual Hearings"
    - You should now see Timeslots and a "Choose a custom time" link.
    - The "Hearing Date" dropdown should still be filled in.

6. Change the "Regional Office" dropdown back to "St. Petersburg, FL".
    - The "Hearing Date" dropdown should still be filled in.
    - There is no way to select a time. No "Hearing Time" dropdown/radio or timeslots.

7. On the fix branch you should always see the correct time inputs for the selected Hearing Date.
