### PR TITLE
Fix BGS Participant ID lookup

### DIFF
--- a/client/app/queue/LookupParticipantIdModal.jsx
+++ b/client/app/queue/LookupParticipantIdModal.jsx
@@ -70,13 +70,13 @@ class LookupParticipantIdModal extends React.Component {
     });
 
     try {
-      const { res } = await ApiUtil.get(url);
+      const res = await ApiUtil.get(url);
 
       this.setState({
         representedOrganizations: res.body.represented_organizations,
         alert: 'success'
       });
-    } catch ({ response }) {
+    } catch (response) {
       const error = response?.body?.errors?.[0];
 
       this.setState({


### PR DESCRIPTION
Fixes a bug in our BGS participant ID lookup tool that appears to have been introduced last March in #13640.

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/32683958/128726521-605831a7-88f8-45da-bfeb-3134c9b02f9c.gif) | ![after](https://user-images.githubusercontent.com/32683958/128726530-682d906c-e7c6-4d71-af8c-a68e4785dffd.gif)
