### PR TITLE
Caseflow-2154 Filter/Hide Tasks on Create Tasks page

### DIFF
--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -102,8 +102,11 @@ class InitialTasksFactory
           handle_different_poa
         end
       end
+    when "ScheduleHearingTask"
+      ScheduleHearingTask.create!(appeal: @appeal, parent: distribution_task)
     else
-      source_task.copy_with_ancestors_to_stream(@appeal, extra_excluded_attributes: ["status"])
+      excluded_attrs = %w[status closed_at placed_on_hold_at]
+      source_task.copy_with_ancestors_to_stream(@appeal, extra_excluded_attributes: excluded_attrs)
     end
   end
 

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -96,12 +96,7 @@ class InitialTasksFactory
     when "EvidenceSubmissionWindowTask"
       evidence_submission_window_task(source_task, creation_params)
     when "InformalHearingPresentationTask"
-      create_ihp_task.tap do |vso_tasks|
-        warn_poa_not_a_representative if vso_tasks.blank?
-        if @appeal.power_of_attorney.poa_participant_id != @appeal.appellant_substitution.poa_participant_id
-          handle_different_poa
-        end
-      end
+      handle_substitution_ihp_task_and_poa
     when "ScheduleHearingTask"
       ScheduleHearingTask.create!(appeal: @appeal, parent: distribution_task)
     else
@@ -119,6 +114,15 @@ class InitialTasksFactory
     EvidenceSubmissionWindowTask.create!(appeal: @appeal,
                                          parent: distribution_task,
                                          end_date: evidence_submission_hold_end_date)
+  end
+
+  def handle_substitution_ihp_task_and_poa
+    create_ihp_task.tap do |vso_tasks|
+      warn_poa_not_a_representative if vso_tasks.blank?
+      if @appeal.power_of_attorney.poa_participant_id != @appeal.appellant_substitution.poa_participant_id
+        handle_different_poa
+      end
+    end
   end
 
   def warn_poa_not_a_representative

--- a/client/app/queue/substituteAppellant/tasks/utils.js
+++ b/client/app/queue/substituteAppellant/tasks/utils.js
@@ -15,6 +15,48 @@ export const automatedTasks = [
   'HearingTask'
 ];
 
+export const mailTasks = [
+  'AddressChangeMailTask',
+  'AodMotionMailTask',
+  'AppealWithdrawalMailTask',
+  'CavcCorrespondenceMailTask',
+  'ClearAndUnmistakeableErrorMailTask',
+  'CongressionalInterestMailTask',
+  'ControlledCorrespondenceMailTask',
+  'DeathCertificateMailTask',
+  'DocketSwitchMailTask',
+  'EvidenceOrArgumentMailTask',
+  'ExtensionRequestMailTask',
+  'FoiaRequestMailTask',
+  'HearingRelatedMailTask',
+  'OtherMotionMailTask',
+  'PowerOfAttorneyRelatedMailTask',
+  'PrivacyActRequestMailTask',
+  'PrivacyComplaintMailTask',
+  'ReconsiderationMotionMailTask',
+  'ReturnedUndeliverableCorrespondenceMailTask',
+  'StatusInquiryMailTask',
+  'VacateMotionMailTask',
+];
+
+export const hearingAdminActions = [
+  'HearingAdminActionContestedClaimantTask',
+  'HearingAdminActionFoiaPrivacyRequestTask',
+  'HearingAdminActionForeignVeteranCaseTask',
+  'HearingAdminActionIncarceratedVeteranTask',
+  'HearingAdminActionMissingFormsTask',
+  'HearingAdminActionOtherTask',
+  'HearingAdminActionVerifyAddressTask',
+  'HearingAdminActionVerifyPoaTask',
+];
+
+export const nonAutomatedTasksToHide = [
+  'AssignHearingDispositionTask',
+  'ChangeHearingDispositionTask',
+];
+
+export const tasksToHide = [...automatedTasks, ...nonAutomatedTasksToHide, ...mailTasks, ...hearingAdminActions];
+
 // Generic function to determine if a task (`current`) is a descendent of another task (`target`)
 // allItems is object keyed to a specified id
 export const isDescendant = (
@@ -75,20 +117,14 @@ export const taskTypesSelected = ({ tasks, selectedTaskIds }) => {
 export const shouldDisableBasedOnTaskType = (taskType, selectedTaskTypes) => {
   const disablingTaskMap = {
     ScheduleHearingTask: [
-      'AssignHearingDispositionTask',
-      'ChangeHearingDispositionTask',
       'EvidenceSubmissionWindowTask',
       'TranscriptionTask',
     ],
     EvidenceSubmissionWindowTask: [
       'ScheduleHearingTask',
-      'AssignHearingDispositionTask',
-      'ChangeHearingDispositionTask',
     ],
     TranscriptionTask: [
       'ScheduleHearingTask',
-      'AssignHearingDispositionTask',
-      'ChangeHearingDispositionTask',
     ],
   };
 
@@ -134,7 +170,8 @@ export const shouldShowBasedOnOtherTasks = (taskInfo, allTasks) => {
 
 // The following governs which tasks should not actually appear in list of available tasks
 export const shouldHide = (taskInfo, claimantPoa, allTasks) => {
-  if (automatedTasks.includes(taskInfo.type)) {
+  // Some tasks should always be hidden, regardless of additional context
+  if (tasksToHide.includes(taskInfo.type)) {
     return true;
   }
 

--- a/client/test/app/queue/substituteAppellant/tasks/utils.test.js
+++ b/client/test/app/queue/substituteAppellant/tasks/utils.test.js
@@ -2,6 +2,7 @@ import { uniq } from 'lodash';
 
 import {
   automatedTasks,
+  nonAutomatedTasksToHide,
   calculateEvidenceSubmissionEndDate,
   filterTasks,
   prepTaskDataForUi,
@@ -10,7 +11,7 @@ import {
   shouldHideBasedOnPoa,
   shouldHide,
   shouldShowBasedOnOtherTasks, shouldDisableBasedOnTaskType, disabledTasksBasedOnSelections,
-} from 'app/queue/substituteAppellant/tasks/utils';
+  hearingAdminActions, mailTasks } from 'app/queue/substituteAppellant/tasks/utils';
 
 import { sampleTasksForEvidenceSubmissionDocket } from 'test/data/queue/substituteAppellant/tasks';
 import { isSameDay } from 'date-fns';
@@ -81,8 +82,6 @@ describe('utility functions for task manipulation', () => {
       const selectedTaskTypes = ['ExampleTask', 'ScheduleHearingTask'];
 
       const shouldDisables = [
-        'AssignHearingDispositionTask',
-        'ChangeHearingDispositionTask',
         'EvidenceSubmissionWindowTask',
         'TranscriptionTask'
       ];
@@ -106,9 +105,7 @@ describe('utility functions for task manipulation', () => {
     const tasks = [
       { taskId: 1, type: 'EvidenceSubmissionWindowTask' },
       { taskId: 2, type: 'ScheduleHearingTask' },
-      { taskId: 3, type: 'AssignHearingDispositionTask' },
-      { taskId: 4, type: 'ChangeHearingDispositionTask' },
-      { taskId: 5, type: 'TranscriptionTask' }
+      { taskId: 3, type: 'TranscriptionTask' }
     ];
 
     describe('when EvidenceSubmissionWindowTask is selected', () => {
@@ -119,8 +116,6 @@ describe('utility functions for task manipulation', () => {
           expect.arrayContaining([
             expect.objectContaining({ type: 'EvidenceSubmissionWindowTask', disabled: false }),
             expect.objectContaining({ type: 'ScheduleHearingTask', disabled: true }),
-            expect.objectContaining({ type: 'AssignHearingDispositionTask', disabled: true }),
-            expect.objectContaining({ type: 'ChangeHearingDispositionTask', disabled: true }),
             expect.objectContaining({ type: 'TranscriptionTask', disabled: false })
           ])
         );
@@ -174,6 +169,30 @@ describe('utility functions for task manipulation', () => {
 
     describe('tasks in automatedTasks array', () => {
       it.each(automatedTasks)('should hide %s', (type) => {
+        const task = { id: 1, type, assignedTo: { isOrganization: false } };
+
+        expect(shouldHide(task, null, [])).toBe(true);
+      });
+    });
+
+    describe('tasks in nonAutomatedTasksToHide array', () => {
+      it.each(nonAutomatedTasksToHide)('should hide %s', (type) => {
+        const task = { id: 1, type, assignedTo: { isOrganization: false } };
+
+        expect(shouldHide(task, null, [])).toBe(true);
+      });
+    });
+
+    describe('tasks in mailTasks array', () => {
+      it.each(mailTasks)('should hide %s', (type) => {
+        const task = { id: 1, type, assignedTo: { isOrganization: false } };
+
+        expect(shouldHide(task, null, [])).toBe(true);
+      });
+    });
+
+    describe('tasks in hearingAdminActions array', () => {
+      it.each(hearingAdminActions)('should hide %s', (type) => {
         const task = { id: 1, type, assignedTo: { isOrganization: false } };
 
         expect(shouldHide(task, null, [])).toBe(true);

--- a/spec/models/appellant_substitution_spec.rb
+++ b/spec/models/appellant_substitution_spec.rb
@@ -127,7 +127,7 @@ describe AppellantSubstitution do
       shared_examples "new appeal does not have post-distribution tasks" do
         let(:expected_task_types) do
           %w[RootTask DistributionTask TrackVeteranTask InformalHearingPresentationTask
-             EvidenceSubmissionWindowTask ScheduleHearingTask]
+             EvidenceSubmissionWindowTask HearingTask ScheduleHearingTask]
         end
         it "doesn't create tasks typically created after DistributionTask is completed" do
           target_appeal = subject.target_appeal


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-2154

### Description
Mail tasks and hearing admin action tasks are not shown on the task selection page for granted substitutions, and not created on the substitute appeal. This includes the Select Hearing or Change Hearing Disposition task.

ScheduleHearingTasks are created fresh, and other copied tasks do not have "closed_at" copied over.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Jest test

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
--- | ---
![Screen Shot 2021-08-20 at 6 29 47 PM](https://user-images.githubusercontent.com/6589610/130307553-40d4d8bc-ab20-4a7f-a8fb-e6feee5b8a80.png) | ![Screen Shot 2021-08-20 at 6 27 16 PM](https://user-images.githubusercontent.com/6589610/130306378-ab9b1161-6278-4dbe-b39e-3c05fa659501.png)