### PR TITLE
Skip Danger CI step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,10 +293,11 @@ jobs:
 
       - install_node_dependencies
 
-      - run:
-          name: Danger
-          command: |
-            ~/project/ci-bin/capture-log "bundle exec danger"
+      # 2021-08-13: Temporarily stop running Danger until we can resolve email verification issue.
+      # - run:
+      #     name: Danger
+      #     command: |
+      #       ~/project/ci-bin/capture-log "bundle exec danger"
 
       - run:
           name: Lint


### PR DESCRIPTION
Resolves `At least one email address must be verified to do that` error we are seeing that is preventing CI from completing successfully by skipping the Danger step ([related Slack thread](https://dsva.slack.com/archives/C2ZAMLK88/p1628874236055800)).

[Example failure](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/45856/workflows/e521bc58-2578-42ca-9bfa-f60abe12262b/jobs/181035):
```
#!/bin/bash -eo pipefail
~/project/ci-bin/capture-log "bundle exec danger"

bundler: failed to load command: danger (/home/circleci/project/vendor/bundle/ruby/2.7.0/bin/danger)
/home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/response/raise_error.rb:16:in `on_complete': POST https://api.github.com/repos/department-of-veterans-affairs/caseflow/issues/16626/comments: 403 - At least one email address must be verified to do that. // See: https://docs.github.com/articles/adding-an-email-address-to-your-github-account (Octokit::UnverifiedEmail)
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/response.rb:9:in `block in call'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/response.rb:61:in `on_complete'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/response.rb:8:in `call'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/middleware/follow_redirects.rb:73:in `perform_with_redirection'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/middleware/follow_redirects.rb:61:in `call'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/request/retry.rb:128:in `call'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/faraday-0.15.4/lib/faraday/connection.rb:175:in `post'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/sawyer-0.8.2/lib/sawyer/agent.rb:94:in `call'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/connection.rb:156:in `request'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/connection.rb:28:in `post'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/octokit-4.18.0/lib/octokit/client/issues.rb:284:in `add_comment'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/lib/danger/request_sources/github/github.rb:196:in `update_pull_request!'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/lib/danger/danger_core/dangerfile.rb:256:in `post_results'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/lib/danger/danger_core/dangerfile.rb:284:in `run'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/lib/danger/danger_core/executor.rb:29:in `run'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/lib/danger/commands/runner.rb:73:in `run'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/claide-1.0.3/lib/claide/command.rb:334:in `run'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/gems/danger-6.3.2/bin/danger:5:in `<top (required)>'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/bin/danger:23:in `load'
	from /home/circleci/project/vendor/bundle/ruby/2.7.0/bin/danger:23:in `<top (required)>'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli/exec.rb:63:in `load'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli/exec.rb:63:in `kernel_load'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli/exec.rb:28:in `run'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli.rb:481:in `exec'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in `invoke_command'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/vendor/thor/lib/thor.rb:392:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli.rb:31:in `dispatch'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/vendor/thor/lib/thor/base.rb:485:in `start'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/cli.rb:25:in `start'
	from /usr/local/bundle/gems/bundler-2.2.25/exe/bundle:49:in `block in <top (required)>'
	from /usr/local/bundle/gems/bundler-2.2.25/lib/bundler/friendly_errors.rb:128:in `with_friendly_errors'
	from /usr/local/bundle/gems/bundler-2.2.25/exe/bundle:37:in `<top (required)>'
	from /usr/local/bundle/bin/bundle:23:in `load'
	from /usr/local/bundle/bin/bundle:23:in `<main>'

Exited with code exit status 1
CircleCI received exit code 1
```