### PR TITLE
Remaing changes for the update POA work

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -14,6 +14,7 @@
     flash: flash,
     buildDate: build_date,
     hasCaseDetailsRole: current_user.roles.include?('Case Details'),
+    hasVLJSupportRole: current_user.colocated_in_vacols?,
     userCanAssignHearingSchedule: current_user.can_assign_hearing_schedule?,
     userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
     userCanViewOvertimeStatus: current_user.can_view_overtime_status?,

--- a/client/app/intake/addClaimant/ClaimantForm.jsx
+++ b/client/app/intake/addClaimant/ClaimantForm.jsx
@@ -191,7 +191,7 @@ export const ClaimantForm = ({
                 optional
                 strongLabel
               />
-              { dateOfBirthFieldToggle &&
+              { dateOfBirthFieldToggle && !props.POA &&
                 <DateSelector
                   optional
                   inputRef={register({

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -5,7 +5,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
-import _, { isEmpty } from 'lodash';
+import _ from 'lodash';
 
 import { APPELLANT_TYPES, CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
@@ -161,7 +161,7 @@ export const CaseDetailsView = (props) => {
     appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
 
   const editPOAInformation =
-    !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
+    !appeal.hasPOA && props.hasVLJSupportRole && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =
     currentUserIsOnCavcLitSupport && props.featureToggles.cavc_remand && !appeal.isLegacyAppeal;
@@ -323,6 +323,7 @@ CaseDetailsView.propTypes = {
   userCanAccessReader: PropTypes.bool,
   veteranCaseListIsVisible: PropTypes.bool,
   userCanScheduleVirtualHearings: PropTypes.bool,
+  hasVLJSupportRole: PropTypes.bool,
   scheduledHearingId: PropTypes.string,
   pollHearing: PropTypes.bool,
   stopPollingHearing: PropTypes.func,

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -5,7 +5,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
 import PropTypes from 'prop-types';
 import React, { useEffect, useMemo } from 'react';
-import _ from 'lodash';
+import _, { isEmpty } from 'lodash';
 
 import { APPELLANT_TYPES, CATEGORIES, TASK_ACTIONS } from './constants';
 import { COLORS } from '../constants/AppConstants';
@@ -161,7 +161,7 @@ export const CaseDetailsView = (props) => {
     appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
 
   const editPOAInformation =
-    props.featureToggles.edit_unrecognized_appellant_poa;
+    !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =
     currentUserIsOnCavcLitSupport && props.featureToggles.cavc_remand && !appeal.isLegacyAppeal;

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -176,6 +176,7 @@ class QueueApp extends React.PureComponent {
       userCanAccessReader={
         !this.props.hasCaseDetailsRole && !this.props.userCanViewHearingSchedule
       }
+      hasVLJSupportRole={this.props.hasVLJSupportRole}
     />
   );
 
@@ -1110,6 +1111,7 @@ QueueApp.propTypes = {
   userIsVsoEmployee: PropTypes.bool,
   setFeedbackUrl: PropTypes.func,
   hasCaseDetailsRole: PropTypes.bool,
+  hasVLJSupportRole: PropTypes.bool,
   caseSearchHomePage: PropTypes.bool,
   applicationUrls: PropTypes.array,
   flash: PropTypes.array,

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -136,7 +136,7 @@ feature "Unrecognized appellants", :postgres do
     end
   end
 
-  fcontext "with attorney unrecognized appellant poa" do
+  context "with attorney unrecognized appellant poa" do
     before { FeatureToggle.enable!(:edit_unrecognized_appellant_poa) }
     after { FeatureToggle.disable!(:edit_unrecognized_appellant_poa) }
 

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -140,7 +140,7 @@ feature "Unrecognized appellants", :postgres do
     before { FeatureToggle.enable!(:edit_unrecognized_appellant_poa) }
     after { FeatureToggle.disable!(:edit_unrecognized_appellant_poa) }
 
-    it "should NOT show the edit information button if there's a POA already" do
+    it "should not show the edit information button if there's a POA already" do
       visit "/queue/appeals/#{appeal_with_recognized_appellant.uuid}"
       expect(page).not_to have_content("Edit Information")
     end

--- a/spec/feature/queue/unrecognized_appellant_spec.rb
+++ b/spec/feature/queue/unrecognized_appellant_spec.rb
@@ -136,15 +136,16 @@ feature "Unrecognized appellants", :postgres do
     end
   end
 
-  context "with attorney unrecognized appellant poa" do
+  fcontext "with attorney unrecognized appellant poa" do
     before { FeatureToggle.enable!(:edit_unrecognized_appellant_poa) }
     after { FeatureToggle.disable!(:edit_unrecognized_appellant_poa) }
 
-    it "should show the edit information button if there's a POA already" do
+    it "should NOT show the edit information button if there's a POA already" do
       visit "/queue/appeals/#{appeal_with_recognized_appellant.uuid}"
-      expect(page).to have_content("Edit Information")
+      expect(page).not_to have_content("Edit Information")
     end
     it "should show the update POA button if there's no POA" do
+      allow(user).to receive(:vacols_roles).and_return(["colocated"])
       visit "/queue/appeals/#{appeal_with_no_poa.uuid}"
       expect(page).to have_content("Update POA")
 


### PR DESCRIPTION
Resolves #1085

### Description
The update POA functionality should be limited to only VLJ support team members and if there's not already a POA (for now). See this thread for discussion on how to determine if user is in VLJ support: https://dsva.slack.com/archives/CJL810329/p1628875432220100

### Acceptance Criteria
- User cannot see the Update POA button if the user is not in the VLJ Support team role

BEFORE
<img width="1056" alt="Screen Shot 2021-08-16 at 2 11 17 PM" src="https://user-images.githubusercontent.com/23530352/129610069-0b42b57e-e522-4d7e-82cf-87831b1fe0b0.png">

AFTER
<img width="1055" alt="Screen Shot 2021-08-16 at 2 10 05 PM" src="https://user-images.githubusercontent.com/23530352/129609932-62f6dafd-1be5-4145-9f92-7cd83d464e26.png">

<img width="1364" alt="Screen Shot 2021-08-16 at 2 49 56 PM" src="https://user-images.githubusercontent.com/23530352/129614674-bb49f8e9-bd73-49cb-98b4-52147a235a3e.png">
