### PR TITLE
WIP: investigate feature test bug

### DIFF
--- a/spec/fixes/investigate_duplicate_judge_tasks_spec.rb
+++ b/spec/fixes/investigate_duplicate_judge_tasks_spec.rb
@@ -2,15 +2,15 @@
 
 feature "duplicate JudgeAssignTask investigation" do
   before do
-    User.authenticate!(user: judge_user)
+    User.authenticate!(css_id: "PETERSBVAM")
   end
 
   # Ticket: https://github.com/department-of-veterans-affairs/dsva-vacols/issues/212#
   # Desired Target state: JudgeAssignTask should not change status from cancelled to completed
   describe "Judge reassigns JudgeAssignTask in first tab and completes the same task in second tab" do
-    let(:judge_user) { create(:user, station_id: User::BOARD_STATION_ID, full_name: "Anna Juarez") }
-    let!(:judge_staff) { create(:staff, :judge_role, user: judge_user) }
-    let(:judge_team) { JudgeTeam.create_for_judge(judge_user) }
+    let(:judge_user) { User.find_by_css_id("PETERSBVAM") }
+    let(:judge_role) { create(:staff, :judge_role, user: judge_user) }
+
     let(:judge_user_second) do
       create(:user, station_id: User::BOARD_STATION_ID, css_id: "BVAAABSHIRE",
                     full_name: "Aaron Judge_HearingsAndCases Abshire")
@@ -21,7 +21,16 @@ feature "duplicate JudgeAssignTask investigation" do
     let!(:attorney_staff) { create(:staff, :attorney_role, user: attorney_user) }
     let(:attorney_user_second) { create(:user, station_id: User::BOARD_STATION_ID, full_name: "John Lee") }
     let!(:attorney_staff_second) { create(:staff, :attorney_role, user: attorney_user_second) }
-
+    let(:attorney_user_third) { User.find_by_css_id("BVAEERDMAN") }
+    let(:attorney_user_fourth) { create(:user, station_id: User::BOARD_STATION_ID, full_name: "Jia James") }
+    let!(:attorney_staff_fourth) { create(:staff, :attorney_role, user: attorney_user_fourth) }
+    let(:judge_team) do
+      JudgeTeam.create_for_judge(judge_user).tap do |team|
+        team.add_user(attorney_user)
+        team.add_user(attorney_user_second)
+        team.add_user(attorney_user_third)
+      end
+    end
     let(:root_task) { create(:root_task) }
     let(:judge_assign_task) { create(:ama_judge_assign_task, parent: root_task, assigned_to: judge_user) }
     let(:appeal) { judge_assign_task.appeal }
@@ -44,6 +53,7 @@ feature "duplicate JudgeAssignTask investigation" do
       first_judge_assign_task_id = appeal.tasks.select { |task| task.type == "JudgeAssignTask" }[0].id
       click_dropdown(prompt: "Select an action", text: "Re-assign to a judge")
       click_dropdown(prompt: "Select a user", text: judge_user_second.full_name)
+
       fill_in "taskInstructions", with: "reassign this task! teamwork makes the dreamwork!"
       click_on "Submit"
       expect(page).to have_content(appeal.veteran.first_name, wait: 30)
@@ -57,6 +67,7 @@ feature "duplicate JudgeAssignTask investigation" do
       within_window second_window do
         click_dropdown(prompt: "Select an action", text: "Assign to attorney")
         click_dropdown(prompt: "Select a user", text: "Other")
+        # Below breaks because attorneys don't load
         click_dropdown(prompt: "Select a user", text: attorney_user.full_name)
         fill_in "taskInstructions", with: "assign to attorney"
         click_on "Submit"


### PR DESCRIPTION
I am pushing this WIP PR so @yoomlam can see my work before I rubber duck the bug with him.

TLDR: The task validation limits the number of `JudgeAssignTask`/`JudgeDecisionReview`/`AttorneyTasks` tasks but does not prevent a `JudgeAssignTask` from going from `cancelled` to `completed`. (Also, there seems to be a problem with the dropdown to select attorneys that do not belong to the assigned judge's `JudgeAssignTask`.)

Here is the current flow when I locally run through this rspec feature tests scenario

Switch the user that has the `JudgeAssignTask` assigned to them, BVAABSHIRE.  Below is the treee.


```
─────────┐
Appeal 16 (E 210816-16 Original)  │ ID   │ STATUS      │ ASGN_BY   │ ASGN_TO     │ UPDATED_AT              │
└── RootTask                      │ 2533 │ on_hold     │           │ Bva         │ 2021-08-17 16:05:13 UTC │
    └── JudgeAssignTask           │ 2534 │ in_progress │ CSS_ID580 │ BVAAABSHIRE │ 2021-08-17 17:58:29 UTC │
                                  └────────────────────────────────────────────────────────────────────────┘
```


1. In the first tab, reassign the JudgeAssignTask to someone else
2. In the second tab, assign the AttorneyTask to an attorney
3. Both actions completed successfully. 😕 🕵️‍♀️ 
4. below is the tree status after these actions
```
Appeal 16 (E 210816-16 Original)  │ ID   │ STATUS      │ ASGN_BY     │ ASGN_TO      │ UPDATED_AT              │
└── RootTask                      │ 2533 │ on_hold     │             │ Bva          │ 2021-08-17 16:05:13 UTC │
    ├── JudgeAssignTask           │ 2534 │ completed   │ CSS_ID580   │ BVAAABSHIRE  │ 2021-08-17 17:59:17 UTC │
    ├── JudgeAssignTask           │ 6771 │ in_progress │ BVAAABSHIRE │ BVACOTBJUDGE │ 2021-08-17 17:59:12 UTC │
    └── JudgeDecisionReviewTask   │ 6772 │ on_hold     │ BVAAABSHIRE │ BVAAABSHIRE  │ 2021-08-17 17:59:17 UTC │
        └── AttorneyTask          │ 6773 │ assigned    │ BVAAABSHIRE │ BVARDUBUQUE  │ 2021-08-17 17:59:17 UTC │
                                  └───────────────────────────────────────────────────────────────────────────┘
```

5. If, while logged in as BVACOTBJUDGE, I view the case details page, I don’t see the option to assign the case to an attorney.
6. If, while logged in as BVARDUBUQUE, I attempt to cancel the task and return it to BVAABSHIRE, I see the “Looks like this appeal already has an open JudgeAssignTask and this action cannot be completed” error message
7. It seems as if the limitation on the number of open tasks works, but doesn’t prevent the user from acting on the case in two different browser tabs.

The feature test currently fails because it doesn't load any attorneys to assign the `AttorneyTask` to.


