### PR TITLE
ForeignKeyPolymorphicAssociationJob: fix Slack message

### DIFF
--- a/app/jobs/foreign_key_polymorphic_association_job.rb
+++ b/app/jobs/foreign_key_polymorphic_association_job.rb
@@ -54,12 +54,10 @@ class ForeignKeyPolymorphicAssociationJob < CaseflowJob
   def send_alert(heading, klass, config, record_ids)
     message = <<~MSG
       #{heading} for #{klass.name}:
-        (id, #{config[:type_column]}, #{config[:id_column]})
-        #{record_ids.map(&:to_s).join('\n')}
+      (id, #{config[:type_column]}, #{config[:id_column]})
+      #{record_ids.map(&:to_s).join("\n")}
     MSG
-    slack_service.send_notification(message)
-    # Also send a message to #appeals-data-workgroup
-    slack_service.send_notification(message, klass, "#appeals-data-workgroup")
+    slack_service.send_notification(message, "#{klass.name} orphaned records", "#appeals-data-workgroup")
   end
 
   # Maps the includes_method to a hash containing all the possible types. Each hash entry is:

--- a/app/jobs/foreign_key_polymorphic_association_job.rb
+++ b/app/jobs/foreign_key_polymorphic_association_job.rb
@@ -41,11 +41,12 @@ class ForeignKeyPolymorphicAssociationJob < CaseflowJob
   def find_bad_records(klass, config)
     select_fields = [:id, config[:type_column] || Arel::Nodes::SqlLiteral.new("NULL"), config[:id_column]]
     orphaned_ids = orphan_records(klass, config).pluck(*select_fields)
-    send_alert("Found orphaned records", klass, config, orphaned_ids) if orphaned_ids.any?
+    send_alert("Found #{orphaned_ids.size} orphaned records", klass, config, orphaned_ids) if orphaned_ids.any?
 
     if config[:type_column]
       unusual_record_ids = unusual_records(klass, config).pluck(*select_fields)
-      send_alert("Found unusual records", klass, config, unusual_record_ids) if unusual_record_ids.any?
+      heading = "Found #{unusual_record_ids.size} unusual records"
+      send_alert(heading, klass, config, unusual_record_ids) if unusual_record_ids.any?
     end
   end
 

--- a/app/jobs/foreign_key_polymorphic_association_job.rb
+++ b/app/jobs/foreign_key_polymorphic_association_job.rb
@@ -57,7 +57,8 @@ class ForeignKeyPolymorphicAssociationJob < CaseflowJob
       (id, #{config[:type_column]}, #{config[:id_column]})
       #{record_ids.map(&:to_s).join("\n")}
     MSG
-    slack_service.send_notification(message, "#{klass.name} orphaned records via #{config[:id_column]}", "#appeals-data-workgroup")
+    slack_service.send_notification(message, "#{klass.name} orphaned records via #{config[:id_column]}",
+                                    "#appeals-data-workgroup")
   end
 
   # Maps the includes_method to a hash containing all the possible types. Each hash entry is:

--- a/app/jobs/foreign_key_polymorphic_association_job.rb
+++ b/app/jobs/foreign_key_polymorphic_association_job.rb
@@ -57,7 +57,7 @@ class ForeignKeyPolymorphicAssociationJob < CaseflowJob
       (id, #{config[:type_column]}, #{config[:id_column]})
       #{record_ids.map(&:to_s).join("\n")}
     MSG
-    slack_service.send_notification(message, "#{klass.name} orphaned records", "#appeals-data-workgroup")
+    slack_service.send_notification(message, "#{klass.name} orphaned records via #{config[:id_column]}", "#appeals-data-workgroup")
   end
 
   # Maps the includes_method to a hash containing all the possible types. Each hash entry is:

--- a/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
+++ b/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
@@ -107,7 +107,8 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         # 1 SELECT for orphan_records + 1 SELECT for unusual_records
         expect(query_subscriber.select_queries(/"special_issue_lists"/).size).to eq 2
 
-        message = /Found [[:digit:]]+ orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
+        heading = "Found [[:digit:]]+ orphaned records for SpecialIssueList"
+        message = /#{heading}:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
         expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end
@@ -159,7 +160,8 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         expect(Person.count).to eq 2
         subject
 
-        message = /Found [[:digit:]]+ orphaned records for Claimant:.*\[#{claimant.id}, nil, "#{claimant.participant_id}"\]/m
+        heading = "Found [[:digit:]]+ orphaned records for Claimant"
+        message = /#{heading}:.*\[#{claimant.id}, nil, "#{claimant.participant_id}"\]/m
         expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end

--- a/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
+++ b/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
@@ -50,7 +50,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
       subject
 
       message = /Found unusual records for SpecialIssueList:.*\[#{sil.id}, "Appeal", nil\]/m
-      expect(slack_service).to have_received(:send_notification).with(message).once
+      expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
   end
 
@@ -67,7 +67,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
       subject
 
       message = /Found unusual records for HearingEmailRecipient:.*\[#{her.id}, nil, #{hearing.id}\]/m
-      expect(slack_service).to have_received(:send_notification).with(message).once
+      expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
   end
 
@@ -82,7 +82,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
       subject
 
       message = /Found orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
-      expect(slack_service).to have_received(:send_notification).with(message).once
+      expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
 
     context "check for N+1 query problem" do
@@ -108,7 +108,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         expect(query_subscriber.select_queries(/"special_issue_lists"/).size).to eq 2
 
         message = /Found orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
-        expect(slack_service).to have_received(:send_notification).with(message).once
+        expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end
 
@@ -132,7 +132,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         subject
 
         message = /Found orphaned record/
-        expect(slack_service).to have_received(:send_notification).with(message).twice
+        expect(slack_service).to have_received(:send_notification).with(message, any_args).twice
       end
     end
   end
@@ -160,7 +160,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         subject
 
         message = /Found orphaned records for Claimant:.*\[#{claimant.id}, nil, "#{claimant.participant_id}"\]/m
-        expect(slack_service).to have_received(:send_notification).with(message).once
+        expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end
   end

--- a/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
+++ b/spec/jobs/foreign_key_polymorphic_association_job_spec.rb
@@ -49,7 +49,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
 
       subject
 
-      message = /Found unusual records for SpecialIssueList:.*\[#{sil.id}, "Appeal", nil\]/m
+      message = /Found [[:digit:]]+ unusual records for SpecialIssueList:.*\[#{sil.id}, "Appeal", nil\]/m
       expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
   end
@@ -66,7 +66,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
 
       subject
 
-      message = /Found unusual records for HearingEmailRecipient:.*\[#{her.id}, nil, #{hearing.id}\]/m
+      message = /Found [[:digit:]]+ unusual records for HearingEmailRecipient:.*\[#{her.id}, nil, #{hearing.id}\]/m
       expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
   end
@@ -81,7 +81,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
 
       subject
 
-      message = /Found orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
+      message = /Found [[:digit:]]+ orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
       expect(slack_service).to have_received(:send_notification).with(message, any_args).once
     end
 
@@ -107,7 +107,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         # 1 SELECT for orphan_records + 1 SELECT for unusual_records
         expect(query_subscriber.select_queries(/"special_issue_lists"/).size).to eq 2
 
-        message = /Found orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
+        message = /Found [[:digit:]]+ orphaned records for SpecialIssueList:.*\[#{sil.id}, "Appeal", #{sil.appeal_id}\]/m
         expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end
@@ -131,7 +131,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
 
         subject
 
-        message = /Found orphaned record/
+        message = /Found [[:digit:]]+ orphaned record/
         expect(slack_service).to have_received(:send_notification).with(message, any_args).twice
       end
     end
@@ -159,7 +159,7 @@ describe ForeignKeyPolymorphicAssociationJob, :postgres do
         expect(Person.count).to eq 2
         subject
 
-        message = /Found orphaned records for Claimant:.*\[#{claimant.id}, nil, "#{claimant.participant_id}"\]/m
+        message = /Found [[:digit:]]+ orphaned records for Claimant:.*\[#{claimant.id}, nil, "#{claimant.participant_id}"\]/m
         expect(slack_service).to have_received(:send_notification).with(message, any_args).once
       end
     end


### PR DESCRIPTION
Resolves: `\n` are not being displayed correctly -- see [example alert](https://dsva.slack.com/archives/CN3FQR4A1/p1629228347012800)

### Description
Fix Slack message for recently created ForeignKeyPolymorphicAssociationJob.
And only send Slack message to `#appeals-data-workgroup` for now to avoid spamming `#appeals-job-alerts`.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing
Tested in prod: [Slack result](https://dsva.slack.com/archives/CQTDX9BF0/p1629230272032300)