### PR TITLE
Don't re-initialize ErdRecordAssociations::EXCLUDED_ASSOCIATIONS constant

### DIFF
--- a/lib/tasks/support/erd_record_associations.rb
+++ b/lib/tasks/support/erd_record_associations.rb
@@ -80,7 +80,7 @@ module ErdRecordAssociations
     klass.reflect_on_all_associations.select { |assoc| assoc.macro == :belongs_to }
   end
 
-  EXCLUDED_ASSOCIATIONS = [
+  EXCLUDED_ASSOCIATIONS ||= [
     # These are common Rails fields that clutter the visualization
     :created_by, :updated_by,
 


### PR DESCRIPTION
Resolves `already initialized constant ` warnings when starting up the dev Rails console.

```
/lib/tasks/support/erd_record_associations.rb:83: warning: already initialized constant ErdRecordAssociations::EXCLUDED_ASSOCIATIONS
/lib/tasks/support/erd_record_associations.rb:83: warning: previous definition of EXCLUDED_ASSOCIATIONS was here
```

### Description
Don't re-initialize `EXCLUDED_ASSOCIATIONS` constant.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] warnings do not appear in Rails console

### Testing Plan
Open Rails console. These warnings are gone.