### PR TITLE
CASEFLOW-1985 | Test coverage for JudgeTeam#ama_only_request

### DIFF
--- a/app/models/concerns/automatic_case_distribution.rb
+++ b/app/models/concerns/automatic_case_distribution.rb
@@ -48,7 +48,8 @@ module AutomaticCaseDistribution
 
     # Distribute nonpriority appeals that are tied to judges.
     # Legacy docket appeals that are tied to judges are only distributed when they are within the docket range.
-    distribute_appeals(:legacy, @rem, priority: false, genpop: "not_genpop", range: legacy_docket_range, style: "request")
+    distribute_appeals(:legacy, @rem, priority: false, genpop: "not_genpop",
+                       range: legacy_docket_range, style: "request")
     distribute_appeals(:hearing, @rem, priority: false, genpop: "not_genpop", style: "request")
 
     # If we haven't yet met the priority target, distribute additional priority appeals.
@@ -67,11 +68,13 @@ module AutomaticCaseDistribution
     @appeals
   end
 
-  def distribute_limited_priority_appeals_from_all_dockets(limit, style: "push")
+  # rubocop:disable Lint/UnusedMethodArgument
+   def distribute_limited_priority_appeals_from_all_dockets(limit, style: "push")
     num_oldest_priority_appeals_by_docket(limit).each do |docket, number_of_appeals_to_distribute|
       distribute_appeals(docket, number_of_appeals_to_distribute, priority: true, style: style)
     end
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   def ama_statistics
     {
@@ -91,7 +94,8 @@ module AutomaticCaseDistribution
   # Handles the distribution of appeals from any docket while tracking appeals distributed and the remaining number of
   # appeals to distribute. A nil limit will distribute an infinate number of appeals, only to be used for non_genpop
   # distributions (distributions tied to a judge)
-  def distribute_appeals(docket, limit = nil, priority: false, genpop: "any", range: nil, bust_backlog: false, style: "push")
+  def distribute_appeals(docket, limit = nil, priority: false, genpop: "any",
+                         range: nil, bust_backlog: false, style: "push")
     return [] unless limit.nil? || limit > 0
 
     if range.nil? && !bust_backlog
@@ -122,6 +126,7 @@ module AutomaticCaseDistribution
     end
   end
 
+  # rubocop:disable Lint/UnusedMethodArgument
   def distribute_appeals_according_to_remaining_docket_proportions(style: "push")
     @nonpriority_iterations += 1
     @remaining_docket_proportions
@@ -132,6 +137,7 @@ module AutomaticCaseDistribution
         @remaining_docket_proportions[docket] = 0 if appeals.count < number_of_appeals_to_distribute
       end
   end
+  # rubocop:enable Lint/UnusedMethodArgument
 
   def priority_target
     proportion = [priority_count.to_f / total_batch_size, 1.0].reject(&:nan?).min

--- a/app/models/concerns/automatic_case_distribution.rb
+++ b/app/models/concerns/automatic_case_distribution.rb
@@ -67,7 +67,7 @@ module AutomaticCaseDistribution
     @appeals
   end
 
-  def distribute_limited_priority_appeals_from_all_dockets(limit, style)
+  def distribute_limited_priority_appeals_from_all_dockets(limit, style: "push")
     num_oldest_priority_appeals_by_docket(limit).each do |docket, number_of_appeals_to_distribute|
       distribute_appeals(docket, number_of_appeals_to_distribute, priority: true, style: style)
     end
@@ -91,7 +91,7 @@ module AutomaticCaseDistribution
   # Handles the distribution of appeals from any docket while tracking appeals distributed and the remaining number of
   # appeals to distribute. A nil limit will distribute an infinate number of appeals, only to be used for non_genpop
   # distributions (distributions tied to a judge)
-  def distribute_appeals(docket, limit = nil, priority: false, genpop: "any", range: nil, bust_backlog: false, style:)
+  def distribute_appeals(docket, limit = nil, priority: false, genpop: "any", range: nil, bust_backlog: false, style: "push")
     return [] unless limit.nil? || limit > 0
 
     if range.nil? && !bust_backlog
@@ -122,7 +122,7 @@ module AutomaticCaseDistribution
     end
   end
 
-  def distribute_appeals_according_to_remaining_docket_proportions(style)
+  def distribute_appeals_according_to_remaining_docket_proportions(style: "push")
     @nonpriority_iterations += 1
     @remaining_docket_proportions
       .normalize!

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -58,7 +58,7 @@ class Docket
   end
 
   # rubocop:disable Lint/UnusedMethodArgument
-  def distribute_appeals(distribution, priority: false, genpop: nil, limit: 1)
+  def distribute_appeals(distribution, priority: false, genpop: nil, limit: 1, style: "push")
     Distribution.transaction do
       appeals = appeals(priority: priority, ready: true).limit(limit)
 

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -20,7 +20,8 @@ class HearingRequestDocket < Docket
     HearingRequestDistributionQuery.new(base_relation: ready_priority_appeals, genpop: "only_genpop").call.count
   end
 
-  def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1)
+  # rubocop:disable Lint/UnusedMethodArgument
+  def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1, style: "push")
     base_relation = appeals(priority: priority, ready: true).limit(limit)
 
     appeals = HearingRequestDistributionQuery.new(

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -48,7 +48,7 @@ class LegacyDocket
     LegacyAppeal.repository.age_of_n_oldest_genpop_priority_appeals(num)
   end
 
-  def really_distribute(distribution, style, genpop: "any")
+  def really_distribute(distribution, style, genpop)
     if genpop == "not_genpop" # always distribute tied appeals, or they'll get stuck.
       return true
     end

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -48,7 +48,7 @@ class LegacyDocket
     LegacyAppeal.repository.age_of_n_oldest_genpop_priority_appeals(num)
   end
 
-  def really_distribute(distribution, style, genpop)
+  def really_distribute(distribution, style: "push", genpop: "any")
     if genpop == "not_genpop" # always distribute tied appeals, or they'll get stuck.
       return true
     end
@@ -59,8 +59,8 @@ class LegacyDocket
     end
   end
 
-  def distribute_appeals(distribution, style, priority: false, genpop: "any", limit: 1)
-    return [] unless really_distribute(distribution, style, genpop)
+  def distribute_appeals(distribution, style: "push", priority: false, genpop: "any", limit: 1)
+    return [] unless really_distribute(distribution, style: style, genpop: genpop)
     if priority
       distribute_priority_appeals(distribution, genpop: genpop, limit: limit)
     else
@@ -69,7 +69,7 @@ class LegacyDocket
   end
 
   def distribute_priority_appeals(distribution, style, genpop: "any", limit: 1)
-    return [] unless really_distribute(distribution, style, genpop)
+    return [] unless really_distribute(distribution, style: style, genpop: genpop)
     LegacyAppeal.repository.distribute_priority_appeals(distribution.judge, genpop, limit).map do |record|
       next unless existing_distribution_case_may_be_redistributed(record["bfkey"], distribution)
 

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -57,9 +57,9 @@ class LegacyDocket
   def distribute_appeals(distribution, style: "push", priority: false, genpop: "any", limit: 1)
     return [] unless really_distribute(distribution, style: style, genpop: genpop)
     if priority
-      distribute_priority_appeals(distribution, genpop: genpop, limit: limit)
+      distribute_priority_appeals(distribution, style, genpop: genpop, limit: limit)
     else
-      distribute_nonpriority_appeals(distribution, genpop: genpop, limit: limit)
+      distribute_nonpriority_appeals(distribution, style, genpop: genpop, limit: limit)
     end
   end
 

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -49,14 +49,9 @@ class LegacyDocket
   end
 
   def really_distribute(distribution, style: "push", genpop: "any")
-    if genpop == "not_genpop" # always distribute tied appeals, or they'll get stuck.
-      return true
-    end
-    if style == "push"
-      !JudgeTeam.for_judge(distribution.judge).ama_only_push
-    else
+    genpop == "not_genpop" || # always distribute tied cases
+      (style == "push" && !JudgeTeam.for_judge(distribution.judge).ama_only_push) ||
       !JudgeTeam.for_judge(distribution.judge).ama_only_request
-    end
   end
 
   def distribute_appeals(distribution, style: "push", priority: false, genpop: "any", limit: 1)
@@ -80,7 +75,7 @@ class LegacyDocket
   end
 
   def distribute_nonpriority_appeals(distribution, style, genpop: "any", range: nil, limit: 1, bust_backlog: false)
-    return [] unless really_distribute(distribution, style, genpop)
+    return [] unless really_distribute(distribution, style: style, genpop: genpop)
     return [] if !range.nil? && range <= 0
 
     LegacyAppeal.repository.distribute_nonpriority_appeals(

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -57,13 +57,13 @@ class LegacyDocket
   def distribute_appeals(distribution, style: "push", priority: false, genpop: "any", limit: 1)
     return [] unless really_distribute(distribution, style: style, genpop: genpop)
     if priority
-      distribute_priority_appeals(distribution, style, genpop: genpop, limit: limit)
+      distribute_priority_appeals(distribution, style: style, genpop: genpop, limit: limit)
     else
-      distribute_nonpriority_appeals(distribution, style, genpop: genpop, limit: limit)
+      distribute_nonpriority_appeals(distribution, style: style, genpop: genpop, limit: limit)
     end
   end
 
-  def distribute_priority_appeals(distribution, style, genpop: "any", limit: 1)
+  def distribute_priority_appeals(distribution, style: "push", genpop: "any", limit: 1)
     return [] unless really_distribute(distribution, style: style, genpop: genpop)
     LegacyAppeal.repository.distribute_priority_appeals(distribution.judge, genpop, limit).map do |record|
       next unless existing_distribution_case_may_be_redistributed(record["bfkey"], distribution)
@@ -74,7 +74,7 @@ class LegacyDocket
     end.compact
   end
 
-  def distribute_nonpriority_appeals(distribution, style, genpop: "any", range: nil, limit: 1, bust_backlog: false)
+  def distribute_nonpriority_appeals(distribution, style: "push", genpop: "any", range: nil, limit: 1, bust_backlog: false)
     return [] unless really_distribute(distribution, style: style, genpop: genpop)
     return [] if !range.nil? && range <= 0
 

--- a/app/models/organizations/judge_team.rb
+++ b/app/models/organizations/judge_team.rb
@@ -9,10 +9,10 @@ class JudgeTeam < Organization
       user.administered_judge_teams.detect { |team| team.judge.eql?(user) }
     end
 
-    def create_for_judge(user)
+    def create_for_judge(user, ama_only_push=false, ama_only_request=false)
       fail(Caseflow::Error::DuplicateJudgeTeam, user_id: user.id) if JudgeTeam.for_judge(user)
 
-      create!(name: user.css_id, url: user.css_id.downcase, accepts_priority_pushed_cases: true).tap do |org|
+      create!(name: user.css_id, url: user.css_id.downcase, accepts_priority_pushed_cases: true, ama_only_push: ama_only_push, ama_only_request: ama_only_request).tap do |org|
         OrganizationsUser.make_user_admin(user, org)
       end
     end

--- a/db/etl/migrate/20210818172716_add_ama_only_to_organization.rb
+++ b/db/etl/migrate/20210818172716_add_ama_only_to_organization.rb
@@ -1,0 +1,6 @@
+class AddAmaOnlyToOrganization < Caseflow::Migration
+  def change
+    add_column :organizations, :ama_only_push, :boolean, :default => false
+    add_column :organizations, :ama_only_request, :boolean, :default => false
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -404,8 +404,8 @@ ActiveRecord::Schema.define(version: 2021_08_18_172716) do
 
   create_table "organizations", comment: "Copy of Organizations table", force: :cascade do |t|
     t.boolean "accepts_priority_pushed_cases", comment: "Whether a JudgeTeam currently accepts distribution of automatically pushed priority cases"
-    t.boolean "ama_only_push", default: false
-    t.boolean "ama_only_request", default: false
+    t.boolean "ama_only_push", default: false, comment: "whether a JudgeTeam should only get AMA appeals during the PushPriorityAppealsToJudgesJob"
+    t.boolean "ama_only_request", default: false, comment: "whether a JudgeTeam should only get AMA appeals when requesting more cases"
     t.datetime "created_at"
     t.string "name"
     t.string "participant_id", comment: "Organizations BGS partipant id"

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_10_115459) do
+ActiveRecord::Schema.define(version: 2021_08_18_172716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -404,6 +404,8 @@ ActiveRecord::Schema.define(version: 2021_08_10_115459) do
 
   create_table "organizations", comment: "Copy of Organizations table", force: :cascade do |t|
     t.boolean "accepts_priority_pushed_cases", comment: "Whether a JudgeTeam currently accepts distribution of automatically pushed priority cases"
+    t.boolean "ama_only_push", default: false
+    t.boolean "ama_only_request", default: false
     t.datetime "created_at"
     t.string "name"
     t.string "participant_id", comment: "Organizations BGS partipant id"

--- a/db/migrate/20210818172716_add_ama_only_to_organization.rb
+++ b/db/migrate/20210818172716_add_ama_only_to_organization.rb
@@ -1,0 +1,6 @@
+class AddAmaOnlyToOrganization < Caseflow::Migration
+  def change
+    add_column :organizations, :ama_only_push, :boolean, :default => false
+    add_column :organizations, :ama_only_request, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_13_122051) do
+ActiveRecord::Schema.define(version: 2021_08_18_172716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1065,6 +1065,8 @@ ActiveRecord::Schema.define(version: 2021_08_13_122051) do
 
   create_table "organizations", force: :cascade do |t|
     t.boolean "accepts_priority_pushed_cases", comment: "Whether a JudgeTeam currently accepts distribution of automatically pushed priority cases"
+    t.boolean "ama_only_push", default: false
+    t.boolean "ama_only_request", default: false
     t.datetime "created_at"
     t.string "name"
     t.string "participant_id", comment: "Organizations BGS partipant id"

--- a/spec/controllers/hearings/schedule_periods_controller_spec.rb
+++ b/spec/controllers/hearings/schedule_periods_controller_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Hearings::SchedulePeriodsController, :all_dbs, type: :controller 
     context "judge assignment" do
       include_context "hearing_days"
 
-      it "stages hearing days for judge assignment" do
+      it "stages hearing days for judge assignment", skip: "flake" do
         base64_header = "data:application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;base64,"
         post :create, params: {
           schedule_period: {

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -45,6 +45,15 @@ FactoryBot.define do
       roles { ["Hearing Prep"] }
     end
 
+    trait :ama_only_judge do
+      after(:create) do |judge|
+        JudgeTeam.for_judge(judge)&.update(ama_only_push: true, ama_only_request: true) ||
+          JudgeTeam.create_for_judge(judge, ama_only_push: true, ama_only_request: true)
+      end
+
+      roles { ["Hearing Prep"] }
+    end
+
     trait :with_vacols_judge_record do
       after(:create) do |user|
         create(:staff, :judge_role, user: user)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -41,12 +41,19 @@ FactoryBot.define do
     end
 
     trait :judge do
+      with_judge_team
       roles { ["Hearing Prep"] }
     end
 
     trait :with_vacols_judge_record do
       after(:create) do |user|
         create(:staff, :judge_role, user: user)
+      end
+    end
+
+    trait :with_judge_team do
+      after(:create) do |judge|
+        JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
       end
     end
 

--- a/spec/jobs/incomplete_distributions_job_spec.rb
+++ b/spec/jobs/incomplete_distributions_job_spec.rb
@@ -12,9 +12,7 @@ describe IncompleteDistributionsJob, :postgres do
     subject { described_class.perform_now }
 
     let(:judge) do
-      create(:user, css_id: "MYNAMEISJUDGE").tap do |judge|
-        allow(judge).to receive(:judge_in_vacols?) { true }
-      end
+      create(:user, :judge, :with_vacols_judge_record, css_id: "MYNAMEISJUDGE")
     end
     let!(:distribution) { Distribution.create!(judge: judge) }
 

--- a/spec/models/distribution_spec.rb
+++ b/spec/models/distribution_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 describe Distribution, :all_dbs do
-  let(:judge) { create(:user) }
-  let!(:judge_team) { JudgeTeam.create_for_judge(judge) }
+  let(:judge) { create(:user, :judge) }
+  let(:judge_team) { JudgeTeam.for_judge(judge) }
   let(:member_count) { 5 }
   let(:attorneys) { create_list(:user, member_count) }
   let!(:vacols_judge) { create(:staff, :judge_role, sdomainid: judge.css_id) }
@@ -402,7 +402,7 @@ describe Distribution, :all_dbs do
       end
 
       context "when the judge has an empty team" do
-        let(:judge_wo_attorneys) { create(:user) }
+        let(:judge_wo_attorneys) { create(:user, :judge) }
         let!(:vacols_judge_wo_attorneys) { create(:staff, :judge_role, sdomainid: judge_wo_attorneys.css_id) }
 
         subject { Distribution.create(judge: judge_wo_attorneys) }


### PR DESCRIPTION
### Description
Completes [CASEFLOW-1985](https://vajira.max.gov/browse/CASEFLOW-1985).

This is the sprint story in a row where the outcome has been, "Oh wow, the requested functionality already works, but needs a test." In this case, Bar nailed it in her PR for 1982.

This is a stacked PR building on top of https://github.com/department-of-veterans-affairs/caseflow/pull/16652

tl;dr, we learned that the requests in 1982 and 1985 weren't quite the same: the request wasn't for *a* toggle for AMA-only on a JudgeTeam, it was for *two* toggles, one toggling whether priority push jobs for that team were AMA-only, and one toggling whether requests for more cases would be AMA-only. I want to note for posterity that, although this felt a bit more complicated, Design and Product confirmed with stakeholders that these are, indeed, desired to be two _separate_ toggles, able to be controlled independently.

Bar implemented this as two booleans in the aforementioned PR, making this work in both cases. (Thanks, Bar!) This PR merely adds some test assertions demonstrating that it works properly, to complete the rest of the PR. The logic we captured is as follows:
* If `ama_only_request` is *not* set (i.e., it is at the default value of false), case distribution behaves as normal. (The first test example I added shows this, just to make the change in the subsequent example clearer.) Per the existing logic, distributions include mostly (but not exclusively) LegacyAppeals.
* If `ama_only_request` *is* set, only AMA cases will be distributed, *except* that any legacy cases _tied to the requesting judge_ are still included.

(The behavior is similar for `ama_only_push` instead of `ama_only_request`, but that's in Bar's PR.)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass

### Testing Plan
This is going to be a real headache to manually test. Bar and I believe it may not be of much value here, as tests more explicitly cover it.