### PR TITLE
Send DoB field from backend and properly set it in frontend

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -105,6 +105,7 @@ class IntakesController < ApplicationController
       featureToggles: {
         useAmaActivationDate: FeatureToggle.enabled?(:use_ama_activation_date, user: current_user),
         rampIntake: FeatureToggle.enabled?(:ramp_intake, user: current_user),
+        dateOfBirthField: FeatureToggle.enabled?(:date_of_birth_field, user: current_user),
         covidTimelinessExemption: FeatureToggle.enabled?(:covid_timeliness_exemption, user: current_user)
       }
     }

--- a/client/app/intake/addClaimant/AddClaimantPage.jsx
+++ b/client/app/intake/addClaimant/AddClaimantPage.jsx
@@ -117,7 +117,7 @@ export const AddClaimantPage = ({ onAttorneySearch = fetchAttorneys, featureTogg
           onBack={handleBack}
           onSubmit={onSubmit}
           onAttorneySearch={onAttorneySearch}
-          dateOfBirthFieldToggle={featureToggles?.dateOfBirthField}
+          dateOfBirthFieldToggle={featureToggles?.dateOfBirthField || false}
         />
         {confirmModal && (
           <AddClaimantConfirmationModal


### PR DESCRIPTION
Related to #16613 and [appeals-deployment#3421](https://github.com/department-of-veterans-affairs/appeals-deployment/pull/3421)

### Description
Last bit of plumbing to get the feature toggle to actually toggle the DoB field on the frontend.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. As a Board Intake user, start an intake with an unrecognized appellant and choose "child" or "spouse". Verify that DoB field does not show.
2. Enable the `date_of_birth_field` feature toggle, and verify that the DoB field does show.