### PR TITLE
ETL case_review records: update association to appeals

### DIFF
--- a/app/models/etl/attorney_case_review.rb
+++ b/app/models/etl/attorney_case_review.rb
@@ -18,8 +18,8 @@ class ETL::AttorneyCaseReview < ETL::Record
       judge = user_cache(original.reviewing_judge_id)
       appeal = original.appeal
 
-      target.appeal_id = appeal.id
-      target.appeal_type = appeal.class.name
+      target.appeal_id = original.appeal_id
+      target.appeal_type = original.appeal_type
       target.attorney_css_id = attorney.css_id
       target.attorney_full_name = attorney.full_name
       target.attorney_id = attorney.id

--- a/app/models/etl/attorney_case_review.rb
+++ b/app/models/etl/attorney_case_review.rb
@@ -16,7 +16,6 @@ class ETL::AttorneyCaseReview < ETL::Record
       # memoize to save SQL calls
       attorney = user_cache(original.attorney_id)
       judge = user_cache(original.reviewing_judge_id)
-      appeal = original.appeal
 
       target.appeal_id = original.appeal_id
       target.appeal_type = original.appeal_type
@@ -37,7 +36,7 @@ class ETL::AttorneyCaseReview < ETL::Record
       target.reviewing_judge_sattyid = judge.vacols_user&.sattyid
       target.task_id = original.task_id
       target.untimely_evidence = original.untimely_evidence
-      target.vacols_id = original.vacols_id if appeal.is_a?(LegacyAppeal)
+      target.vacols_id = original.vacols_id if original.appeal_type == "LegacyAppeal"
       target.work_product = original.work_product
 
       target

--- a/app/models/etl/judge_case_review.rb
+++ b/app/models/etl/judge_case_review.rb
@@ -50,11 +50,11 @@ class ETL::JudgeCaseReview < ETL::Record
       target.original_task_id = original.task_id
       begin
         appeal = original.appeal
+        target.appeal_id = original.appeal_id
+        target.appeal_type = original.appeal_type
+
         target.actual_task_id = original.task_id if appeal.is_a?(Appeal)
         target.vacols_id = original.vacols_id if appeal.is_a?(LegacyAppeal)
-
-        target.appeal_id = appeal.id
-        target.appeal_type = appeal.class.name
       rescue ActiveRecord::RecordNotFound
         check_equal(original.id, "task_id", original.task_id, nil)
         target.appeal_id = "0"

--- a/app/models/etl/judge_case_review.rb
+++ b/app/models/etl/judge_case_review.rb
@@ -49,12 +49,11 @@ class ETL::JudgeCaseReview < ETL::Record
 
       target.original_task_id = original.task_id
       begin
-        appeal = original.appeal
         target.appeal_id = original.appeal_id
         target.appeal_type = original.appeal_type
 
-        target.actual_task_id = original.task_id if appeal.is_a?(Appeal)
-        target.vacols_id = original.vacols_id if appeal.is_a?(LegacyAppeal)
+        target.actual_task_id = original.task_id if original.appeal_type == "Appeal"
+        target.vacols_id = original.vacols_id if original.appeal_type == "LegacyAppeal"
       rescue ActiveRecord::RecordNotFound
         check_equal(original.id, "task_id", original.task_id, nil)
         target.appeal_id = "0"

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -64,6 +64,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       jdr_task.update(status: :completed)
       # Note that the judge can continue and complete checkout because frontend was loaded before jdr_task was complete
 
+      expect(page).to have_content("Select an action")
       click_dropdown(text: Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.label)
       # Special Issues page
       expect(page).to have_content("Select special issues")

--- a/spec/services/etl/judge_case_review_syncer_spec.rb
+++ b/spec/services/etl/judge_case_review_syncer_spec.rb
@@ -36,7 +36,7 @@ describe ETL::JudgeCaseReviewSyncer, :etl, :all_dbs do
       let(:appeal) { create(:legacy_appeal) }
       let(:task_id) { "#{appeal.vacols_id}-2019-12-17" }
 
-      it "denormalizes Appeal, Attorney and Reviewing Judge" do
+      it "denormalizes Appeal, Attorney and Judge" do
         expect(ETL::JudgeCaseReview.count).to eq(0)
 
         subject
@@ -56,7 +56,7 @@ describe ETL::JudgeCaseReviewSyncer, :etl, :all_dbs do
       let(:appeal) { create(:appeal) }
       let(:task_id) { create(:ama_judge_decision_review_task, appeal: appeal).id }
 
-      it "denormalizes Appeal, Attorney and Reviewing Judge" do
+      it "denormalizes Appeal, Attorney and Judge" do
         expect(ETL::JudgeCaseReview.count).to eq(0)
 
         subject


### PR DESCRIPTION
Follow-on to PR #16661

### Description
Update ETL syncers to use new `appeal_type` and `appeal_id`, so that the associated appeal does not need to be queries, thus making the query faster.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
See RSpec.