### PR TITLE
Fix NoMethodError in Hearings::SendEmail job

### DIFF
--- a/app/jobs/hearings/send_email.rb
+++ b/app/jobs/hearings/send_email.rb
@@ -53,20 +53,22 @@ class Hearings::SendEmail
   def send_reminder
     return false if !email_type_is_reminder?
 
-    if reminder_info[:recipient] == HearingEmailRecipient::RECIPIENT_TITLES[:appellant] &&
-       send_email(appellant_recipient_info)
+    return true if try_sending_appellant_reminder?
 
-      return true
-    end
-
-    if reminder_info[:recipient] == HearingEmailRecipient::RECIPIENT_TITLES[:representative] &&
-       hearing.representative_recipient&.email_address.present? &&
-       send_email(representative_recipient_info)
-
-      return true
-    end
+    return true if try_sending_representative_reminder?
 
     false
+  end
+
+  def try_sending_appellant_reminder?
+    reminder_info[:recipient] == HearingEmailRecipient::RECIPIENT_TITLES[:appellant] &&
+      send_email(appellant_recipient_info)
+  end
+
+  def try_sending_representative_reminder?
+    reminder_info[:recipient] == HearingEmailRecipient::RECIPIENT_TITLES[:representative] &&
+      hearing.representative_recipient&.email_address.present? &&
+      send_email(representative_recipient_info)
   end
 
   def email_for_recipient(recipient_info)

--- a/app/jobs/hearings/send_email.rb
+++ b/app/jobs/hearings/send_email.rb
@@ -34,7 +34,7 @@ class Hearings::SendEmail
       judge_recipient.update!(email_sent: send_email(judge_recipient_info))
     end
 
-    if hearing.representative_recipient.email_address.present? && !hearing.representative_recipient.email_sent
+    if hearing.representative_recipient&.email_address.present? && !hearing.representative_recipient.email_sent
       representative_recipient.update!(email_sent: send_email(representative_recipient_info))
     end
   end
@@ -60,7 +60,7 @@ class Hearings::SendEmail
     end
 
     if reminder_info[:recipient] == HearingEmailRecipient::RECIPIENT_TITLES[:representative] &&
-       hearing.representative_recipient.email_address.present? &&
+       hearing.representative_recipient&.email_address.present? &&
        send_email(representative_recipient_info)
 
       return true

--- a/app/jobs/hearings/send_reminder_emails_job.rb
+++ b/app/jobs/hearings/send_reminder_emails_job.rb
@@ -62,7 +62,7 @@ class Hearings::SendReminderEmailsJob < ApplicationJob
   end
 
   def appellant_reminder_type(hearing)
-    return if hearing.appellant_recipient.email_address.blank?
+    return if hearing.appellant_recipient&.email_address.blank?
 
     reminder_type = Hearings::ReminderService
       .new(
@@ -77,7 +77,7 @@ class Hearings::SendReminderEmailsJob < ApplicationJob
   end
 
   def representative_reminder_type(hearing)
-    return if hearing.representative_recipient.email_address.blank?
+    return if hearing.representative_recipient&.email_address.blank?
 
     reminder_type = Hearings::ReminderService
       .new(

--- a/spec/jobs/hearings/send_email_spec.rb
+++ b/spec/jobs/hearings/send_email_spec.rb
@@ -59,6 +59,22 @@ describe Hearings::SendEmail do
       allow(send_email_job).to receive(:representative_recipient_info).and_return(representative_recipient_info)
     end
 
+    context "there is no representative recipient" do
+      let!(:virtual_hearing) do
+        create(
+          :virtual_hearing,
+          hearing: hearing,
+          representative_email: nil,
+          judge_email_sent: judge_email_sent,
+          appellant_email_sent: appellant_email_sent
+        )
+      end
+
+      it "does not error" do
+        expect { subject }.to_not raise_error
+      end
+    end
+
     context "appellant_recipient name is populated correctly" do
       context "veteran is appellant" do
         it "uses the full name of the veteran" do


### PR DESCRIPTION
### Description
Fixes [an error raised in the send email job](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/19451/) when no representative recipient exists for a hearing. Also reduces the cyclomatic complexity of the `send_reminder` method.