### PR TITLE
Update Intake Confirmation Page for Pre-Docket Appeals

### DIFF
--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -18,6 +18,12 @@ import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIssuesUrl, completedReview }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
+  let vhaHasIssues = false;
+  requestIssues.forEach(function(ri) {
+    if (ri.benefitType == "vha") {
+      vhaHasIssues = true;
+    }
+  });
 
   const leadMessageArr = [
     `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`
@@ -39,9 +45,15 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
     leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
   }
 
-  leadMessageArr.push(
-    <strong>Edit the notice letter to reflect the status of requested issues.</strong>
-  );
+  if (vhaHasIssues) {
+    leadMessageArr.push(
+      <strong>Edit the notice letter to reflect the status of requested issues.</strong>
+    );
+  } else {
+    leadMessageArr.push(
+      <strong>Appeal created and sent to VHA for pre-docket review.</strong>
+    );
+  }
 
   return leadMessageArr;
 };


### PR DESCRIPTION
Resolves #{github issue number}

### Description
Change the Intake confirmation page messaging depending on request issue types for pre-docket appeals.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Using intake, create a new appeal, with a request issue of "Veterans Health Administration" and "Caregiver"
1a. See Sally's gif -> ![IntakeWithTaskTree](https://user-images.githubusercontent.com/2308626/130828605-626e1aa1-3b1c-44e9-b9ee-b523572bc4ef.gif)
2. Verify confirmation page includes pre-docket text.


### User Facing Changes
<img width="800" alt="image" src="https://user-images.githubusercontent.com/2308626/130828332-9e161c85-3f6c-42c8-8d93-c9be2985fe88.png">
