### PR TITLE
Swap confirmation message depending on type of issues

### DIFF
--- a/app/serializers/intake/request_issue_serializer.rb
+++ b/app/serializers/intake/request_issue_serializer.rb
@@ -33,4 +33,5 @@ class Intake::RequestIssueSerializer
   attribute :end_product_cleared do |object|
     object.end_product_establishment&.status_cleared?
   end
+  attribute :benefit_type
 end

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -116,9 +116,7 @@ class AddedIssue extends React.PureComponent {
             <em>(Originally: {issue.text})</em>
           </div>
         )}
-        {issue.benefitType &&
-          this.props.formType !== 'higher_level_review' &&
-          <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
+        {issue.benefitType && <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
         {issue.date && <span className="issue-date">Decision date: {formatDateStr(issue.date)}</span>}
         {issue.notes && <span className="issue-notes">Notes:&nbsp;{issue.notes}</span>}
         {issue.untimelyExemptionNotes && (

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -116,7 +116,9 @@ class AddedIssue extends React.PureComponent {
             <em>(Originally: {issue.text})</em>
           </div>
         )}
-        {issue.benefitType && this.props.formType === 'appeal' && <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
+        {issue.benefitType &&
+          this.props.formType === 'appeal' &&
+          <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
         {issue.date && <span className="issue-date">Decision date: {formatDateStr(issue.date)}</span>}
         {issue.notes && <span className="issue-notes">Notes:&nbsp;{issue.notes}</span>}
         {issue.untimelyExemptionNotes && (

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -116,7 +116,7 @@ class AddedIssue extends React.PureComponent {
             <em>(Originally: {issue.text})</em>
           </div>
         )}
-        {issue.benefitType && <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
+        {issue.benefitType && this.props.formType === 'appeal' && <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
         {issue.date && <span className="issue-date">Decision date: {formatDateStr(issue.date)}</span>}
         {issue.notes && <span className="issue-notes">Notes:&nbsp;{issue.notes}</span>}
         {issue.untimelyExemptionNotes && (

--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -117,7 +117,7 @@ class AddedIssue extends React.PureComponent {
           </div>
         )}
         {issue.benefitType &&
-          this.props.formType === 'appeal' &&
+          this.props.formType !== 'higher_level_review' &&
           <span className="issue-date">Benefit type: {BENEFIT_TYPES[issue.benefitType]}</span>}
         {issue.date && <span className="issue-date">Decision date: {formatDateStr(issue.date)}</span>}
         {issue.notes && <span className="issue-notes">Notes:&nbsp;{issue.notes}</span>}

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -15,6 +15,18 @@ import COPY from '../../../COPY';
 import Alert from '../../components/Alert';
 import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 
+const checkIssuesForVha = (requestIssues) => {
+  let hasVhaIssues = false;
+
+  requestIssues.forEach((ri) => {
+    if (ri.benefitType === 'vha') {
+      hasVhaIssues = true;
+    }
+  });
+
+  return hasVhaIssues;
+};
+
 const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIssuesUrl, completedReview }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
@@ -49,25 +61,16 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
   return leadMessageArr;
 };
 
-const checkIssuesForVha = (requestIssues) => {
-  let hasVhaIssues = false;
-  requestIssues.forEach((ri) => {
-    if (ri.benefitType === 'vha') {
-      hasVhaIssues = true;
-    }
-  });
-  return hasVhaIssues;
-}
-
 const getChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
 
   if (formType === 'appeal') {
-    let statusMessage = "Appeal created:"
+    let statusMessage = 'Appeal created:';
 
     if (checkIssuesForVha(requestIssues)) {
-      statusMessage = "Appeal created and sent to VHA for pre-docket review."
+      statusMessage = 'Appeal created and sent to VHA for pre-docket review.';
     }
+
     return [<Fragment>
       <strong>{statusMessage}</strong>
       {eligibleRequestIssues.map((ri, i) => <p key={`appeal-issue-${i}`}>Issue: {ri.contentionText}</p>)}
@@ -165,9 +168,10 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       return <SmallLoader message="Creating task..." spinnerColor={LOGO_COLORS.CERTIFICATION.ACCENT} />;
     }
 
-    let title = "Intake completed"
+    let title = 'Intake completed';
+
     if (checkIssuesForVha(requestIssues)) {
-      title = "Appeal recorded in pre-docket queue"
+      title = 'Appeal recorded in pre-docket queue';
     }
 
     const deceasedVeteranAlert = () => {

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -20,7 +20,7 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
   let vhaHasIssues = false;
   requestIssues.forEach(function(ri) {
-    if (ri.benefitType == "vha") {
+    if (ri.benefitType === "vha") {
       vhaHasIssues = true;
     }
   });

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -68,7 +68,7 @@ const getChecklistItems = (formType, requestIssues, isInformalConferenceRequeste
     let statusMessage = 'Appeal created:';
 
     if (checkIssuesForVha(requestIssues)) {
-      statusMessage = 'Appeal created and sent to VHA for document assessment';
+      statusMessage = 'Appeal created and sent to VHA for document assessment.';
     }
 
     return [<Fragment>

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -68,7 +68,7 @@ const getChecklistItems = (formType, requestIssues, isInformalConferenceRequeste
     let statusMessage = 'Appeal created:';
 
     if (checkIssuesForVha(requestIssues)) {
-      statusMessage = 'Appeal created and sent to VHA for pre-docket review.';
+      statusMessage = 'Appeal created and sent to VHA for document assessment';
     }
 
     return [<Fragment>

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -20,7 +20,7 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
   let vhaHasIssues = false;
 
-  requestIssues.forEach(ri => {
+  requestIssues.forEach((ri) => {
     if (ri.benefitType === 'vha') {
       vhaHasIssues = true;
     }

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -19,8 +19,9 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
   let vhaHasIssues = false;
-  requestIssues.forEach(function(ri) {
-    if (ri.benefitType === "vha") {
+
+  requestIssues.forEach(ri => {
+    if (ri.benefitType === 'vha') {
       vhaHasIssues = true;
     }
   });

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -18,6 +18,12 @@ import UnidentifiedIssueAlert from '../components/UnidentifiedIssueAlert';
 const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIssuesUrl, completedReview }) => {
   const unidentifiedIssues = requestIssues.filter((ri) => ri.isUnidentified);
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
+  let vhaHasIssues = false;
+  requestIssues.forEach(function(ri) {
+    if (ri.benefitType == "vha") {
+      vhaHasIssues = true;
+    }
+  });
 
   const leadMessageArr = [
     `${veteran.name}'s (ID #${veteran.fileNumber}) Request for ${formName} has been submitted.`
@@ -39,9 +45,15 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
     leadMessageArr.push(<UnidentifiedIssueAlert unidentifiedIssues={unidentifiedIssues} />);
   }
 
-  leadMessageArr.push(
-    <strong>Edit the notice letter to reflect the status of requested issues.</strong>
-  );
+  if (vhaHasIssues) {
+    leadMessageArr.push(
+      <strong>Edit the notice letter to reflect the status of requested issues.</strong>
+    );
+  } else {
+    leadMessageArr.push(
+      <strong>Appeal created and sent to VHA for pre-docket review.</strong>
+    );
+  }
 
   return leadMessageArr;
 };

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -320,6 +320,7 @@ feature "Appeal Edit issues", :all_dbs do
     end
 
     let!(:rating_request_issue) { nil }
+    let!(:nonrating_request_issue) { nil }
 
     scenario "adding an issue with a vbms benefit type" do
       visit "appeals/#{appeal.uuid}/edit/"

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -60,4 +60,24 @@ feature "Intake Confirmation Page", :postgres do
       end
     end
   end
+
+  describe "when completing an appeal" do
+    context "appeal has VHA issues" do
+      let(:claim_review_type) { :board_appeal }
+      it "displays the correct copy on confirmation page" do
+        start_claim_review(claim_review_type)
+        visit "/intake"
+        click_intake_continue
+        click_intake_add_issue
+
+        add_intake_vha_issue(date: 2.days.ago)
+        click_intake_finish
+
+        expect(page).to have_content("Intake completed")
+        expect(page).to have_content("If needed, you may correct the issues")
+        expect(page).to_not have_content("Edit the notice letter to reflect the status of requested issues.")
+        expect(page).to have_content("Appeal created and sent to VHA for pre-docket review.")
+      end
+    end
+  end
 end

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -77,7 +77,7 @@ feature "Intake Confirmation Page", :postgres do
         expect(page).to have_content("Appeal recorded in pre-docket queue")
         expect(page).to have_content("If needed, you may correct the issues")
         expect(page).to_not have_content("Edit the notice letter to reflect the status of requested issues.")
-        expect(page).to have_content("Appeal created and sent to VHA for pre-docket review.")
+        expect(page).to have_content("Appeal created and sent to VHA for document assessment.")
       end
     end
   end

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -73,7 +73,8 @@ feature "Intake Confirmation Page", :postgres do
         add_intake_vha_issue(date: 2.days.ago)
         click_intake_finish
 
-        expect(page).to have_content("Intake completed")
+        expect(page).to_not have_content("Intake completed")
+        expect(page).to have_content("Appeal recorded in pre-docket queue")
         expect(page).to have_content("If needed, you may correct the issues")
         expect(page).to_not have_content("Edit the notice letter to reflect the status of requested issues.")
         expect(page).to have_content("Appeal created and sent to VHA for pre-docket review.")

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -399,7 +399,9 @@ feature "Higher Level Review Edit issues", :all_dbs do
         expect(page).to have_content(
           "#{untimely_request_issue.contention_text} #{ineligible.untimely}"
         )
+        # rubocop:disable LineLength
         expect(page).to have_content("#{eligible_request_issue.contention_text}\nBenefit type: Compensation\nDecision date: #{Time.zone.today.mdY}")
+        # rubocop:enable LineLength
         expect(page).to have_content(
           "#{ri_before_ama.contention_text} #{ineligible.before_ama}"
         )

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -399,7 +399,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
         expect(page).to have_content(
           "#{untimely_request_issue.contention_text} #{ineligible.untimely}"
         )
-        expect(page).to have_content("#{eligible_request_issue.contention_text}\nDecision date: #{Time.zone.today.mdY}")
+        expect(page).to have_content("#{eligible_request_issue.contention_text}\nBenefit type: Compensation\nDecision date: #{Time.zone.today.mdY}")
         expect(page).to have_content(
           "#{ri_before_ama.contention_text} #{ineligible.before_ama}"
         )

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -308,7 +308,7 @@ module IntakeHelpers
     fill_in "Issue category", with: category
     find("#issue-category").send_keys :enter
     fill_in "Issue description", with: description
-    find('#decision-date').set(date.strftime("%m/%d/%Y"))
+    find("#decision-date").set(date.strftime("%m/%d/%Y"))
     safe_click "#decision-date"
     expect(page).to have_button(add_button_text, disabled: false)
     safe_click ".add-issue"

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -170,6 +170,12 @@ module IntakeHelpers
         benefit_type: benefit_type,
         no_claimant: no_claimant
       )
+    elsif claim_review_type == :board_appeal
+      start_appeal(
+        veteran,
+        claim_participant_id: claim_participant_id,
+        no_claimant: no_claimant
+      )
     else
       start_higher_level_review(
         veteran,
@@ -277,6 +283,33 @@ module IntakeHelpers
     find("#issue-category").send_keys :enter
     fill_in "Issue description", with: description
     fill_in "Decision date", with: date
+    expect(page).to have_button(add_button_text, disabled: false)
+    safe_click ".add-issue"
+  end
+
+  def add_intake_vha_issue(
+    benefit_type: "Veterans Health Administration",
+    category: "Caregiver",
+    description: "Some description",
+    date: "01/01/2016",
+    legacy_issues: false
+  )
+    add_button_text = legacy_issues ? "Next" : "Add this issue"
+    expect(page.text).to match(/Does issue \d+ match any of these non-rating issue categories?/)
+    expect(page).to have_button(add_button_text, disabled: true)
+
+    # has_css will wait 5 seconds by default, and we want an instant decision.
+    # we can trust the modal is rendered because of the expect() calls above.
+    if page.has_css?("#issue-benefit-type", wait: 0)
+      fill_in "Benefit type", with: benefit_type
+      find("#issue-benefit-type").send_keys :enter
+    end
+
+    fill_in "Issue category", with: category
+    find("#issue-category").send_keys :enter
+    fill_in "Issue description", with: description
+    find('#decision-date').set(date.strftime("%m/%d/%Y"))
+    safe_click "#decision-date"
     expect(page).to have_button(add_button_text, disabled: false)
     safe_click ".add-issue"
   end


### PR DESCRIPTION
Resolves [CASEFLOW-2184](https://vajira.max.gov/browse/CASEFLOW-2184)

### Description
Change the Intake confirmation page messaging depending on request issue types for pre-docket appeals.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Using intake, create a new appeal, with a request issue of "Veterans Health Administration" and "Caregiver"
1a. See Sally's gif -> ![IntakeWithTaskTree](https://user-images.githubusercontent.com/2308626/130828605-626e1aa1-3b1c-44e9-b9ee-b523572bc4ef.gif)
2. Verify confirmation page includes pre-docket text.


### User Facing Changes
<img width="800" alt="image" src="https://user-images.githubusercontent.com/2308626/131536391-a3654149-1344-4abb-b0a2-ac433eff6407.png">
