### PR TITLE
Add the "on hold" action to the Assess Documentation task

### DIFF
--- a/app/models/organizations/vha_program_office.rb
+++ b/app/models/organizations/vha_program_office.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
+# nocov pending additional model behavior
+# :nocov:
 class VhaProgramOffice < Organization
   def can_receive_task?(_task)
     false
   end
 end
+# :nocov:

--- a/app/models/organizations/vha_program_office.rb
+++ b/app/models/organizations/vha_program_office.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
 
-# nocov pending additional model behavior
-# :nocov:
 class VhaProgramOffice < Organization
   def can_receive_task?(_task)
     false
   end
 end
-# :nocov:

--- a/app/models/tasks/pre_docket/assess_documentation_task.rb
+++ b/app/models/tasks/pre_docket/assess_documentation_task.rb
@@ -6,4 +6,13 @@
 # will also need to move up the chain as well i.e. Regional -> Program etc.
 
 class AssessDocumentationTask < Task
+  TASK_ACTIONS = [
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
+  ].freeze
+
+  def available_actions(user)
+    return [] unless assigned_to.user_has_access?(user)
+
+    TASK_ACTIONS
+  end
 end

--- a/spec/factories/task.rb
+++ b/spec/factories/task.rb
@@ -493,6 +493,11 @@ FactoryBot.define do
         assigned_by { nil }
       end
 
+      factory :assess_documentation_task, class: AssessDocumentationTask do
+        parent { create(:vha_document_search_task, appeal: appeal) }
+        assigned_by { nil }
+      end
+
       factory :vha_document_search_task, class: VhaDocumentSearchTask do
         parent { create(:pre_docket_task, appeal: appeal) }
         assigned_to { VhaCamo.singleton }

--- a/spec/models/organizations/vha_program_office_spec.rb
+++ b/spec/models/organizations/vha_program_office_spec.rb
@@ -8,4 +8,13 @@ describe VhaProgramOffice, :postgres do
       expect(program_office.name).to eq("Program Office")
     end
   end
+
+  describe ".can_receive_task?" do
+    let(:appeal) { create(:appeal) }
+    let(:doc_task) { create(:vha_document_search_task, appeal: appeal) }
+
+    it "returns false because program offices should not have vha document search tasks assigned to them" do
+      expect(program_office.can_receive_task?(doc_task)).to eq(false)
+    end
+  end
 end

--- a/spec/models/organizations/vha_program_office_spec.rb
+++ b/spec/models/organizations/vha_program_office_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+describe VhaProgramOffice, :postgres do
+  let(:program_office) { VhaProgramOffice.create!(name: "Program Office", url: "Program Office") }
+
+  describe ".create!" do
+    it "creates a Vha Program Office" do
+      expect(program_office.name).to eq("Program Office")
+    end
+  end
+end

--- a/spec/models/tasks/assess_documentation_task_spec.rb
+++ b/spec/models/tasks/assess_documentation_task_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+describe AssessDocumentationTask, :postgres do
+  let(:program_office) { VhaProgramOffice.create!(name: "Program Office", url: "Program Office") }
+  let(:task) { create(:assess_documentation_task, assigned_to: program_office) }
+  let(:user) { create(:user) }
+
+  before { program_office.add_user(user) }
+
+  describe "#available_actions" do
+    subject { task.available_actions(user) }
+    it { is_expected.to eq [Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h] }
+  end
+end


### PR DESCRIPTION
Resolves [CASEFLOW-1949](https://vajira.max.gov/browse/CASEFLOW-1949)

### Description
Adds the on hold task action to the AssessDocumentationTask, allowing either VhaProgramOffice or VhaRegionalOffice users to place their task on hold.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Log in as a BvaIntake user, and complete a 10182 (Appeal) Intake with at least one VHA issue 
2. Log in as a CAMO user and assign the appeal to the Program Office
3. Log in as a Program Office user and attempt to put the appeal on hold.
4. Check the appeal's task tree to confirm the tasks are in the correct state
5. Take the appeal off of hold
6. Re-check the task tree

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 ![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/18618189/131201127-f142c946-0fd2-40f5-8d4d-a18e4df84acf.gif)
