### PR TITLE
Database Changes - Add SentHearingAdminEmailEvent

### DIFF
--- a/app/models/hearings/sent_hearing_admin_email_event.rb
+++ b/app/models/hearings/sent_hearing_admin_email_event.rb
@@ -1,0 +1,3 @@
+class SentHearingAdminEmailEvent < CaseflowRecord
+  belongs_to :sent_hearing_email_event
+end

--- a/app/models/hearings/sent_hearing_admin_email_event.rb
+++ b/app/models/hearings/sent_hearing_admin_email_event.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SentHearingAdminEmailEvent < CaseflowRecord
   belongs_to :sent_hearing_email_event
 end

--- a/app/models/hearings/sent_hearing_admin_email_event.rb
+++ b/app/models/hearings/sent_hearing_admin_email_event.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 class SentHearingAdminEmailEvent < CaseflowRecord
   belongs_to :sent_hearing_email_event
 end

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -11,6 +11,8 @@ class SentHearingEmailEvent < CaseflowRecord
   belongs_to :sent_by, class_name: "User"
   belongs_to :email_recipient, class_name: "HearingEmailRecipient"
 
+  has_many :sent_hearing_admin_email_events
+
   before_create :assign_sent_at_time
 
   # Allows all keys specified in `MailRecipient::RECIPIENT_TITLES`

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -11,7 +11,7 @@ class SentHearingEmailEvent < CaseflowRecord
   belongs_to :sent_by, class_name: "User"
   belongs_to :email_recipient, class_name: "HearingEmailRecipient"
 
-  has_many :sent_hearing_admin_email_events
+  has_one :sent_hearing_admin_email_events
 
   before_create :assign_sent_at_time
 

--- a/db/migrate/20210826144628_create_sent_hearing_admin_email_events.rb
+++ b/db/migrate/20210826144628_create_sent_hearing_admin_email_events.rb
@@ -1,0 +1,10 @@
+class CreateSentHearingAdminEmailEvents < Caseflow::Migration
+  def change
+    create_table :sent_hearing_admin_email_events do |t|
+      t.references :sent_hearing_email_event, foreign_key: true, index: { name: "index_admin_email_events_on_hearing_email_event_id" }, comment: "Associated sent hearing email event."
+      t.string     :external_message_id, comment: "The ID returned by the GovDelivery API when we send an email."
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210826144628_create_sent_hearing_admin_email_events.rb
+++ b/db/migrate/20210826144628_create_sent_hearing_admin_email_events.rb
@@ -1,7 +1,7 @@
 class CreateSentHearingAdminEmailEvents < Caseflow::Migration
   def change
     create_table :sent_hearing_admin_email_events do |t|
-      t.references :sent_hearing_email_event, foreign_key: true, index: { name: "index_admin_email_events_on_hearing_email_event_id" }, comment: "Associated sent hearing email event."
+      t.references :sent_hearing_email_event, foreign_key: true, index: false, comment: "Associated sent hearing email event."
       t.string     :external_message_id, comment: "The ID returned by the GovDelivery API when we send an email."
 
       t.timestamps

--- a/db/migrate/20210826145249_add_updated_status_columns_to_sent_hearing_email_events.rb
+++ b/db/migrate/20210826145249_add_updated_status_columns_to_sent_hearing_email_events.rb
@@ -1,4 +1,4 @@
-class AddUpdatedStatusColumnsToSentHearingEmailEvents < ActiveRecord::Migration[5.2]
+class AddUpdatedStatusColumnsToSentHearingEmailEvents < Caseflow::Migration
   def change
     add_column :sent_hearing_email_events, :send_successful, :boolean, comment: "This column keeps track of whether the email was sent or not"
     add_column :sent_hearing_email_events, :send_successful_checked_at, :datetime, comment: "The date the status was last checked/updated in the GovDelivery API"

--- a/db/migrate/20210826145249_add_updated_status_columns_to_sent_hearing_email_events.rb
+++ b/db/migrate/20210826145249_add_updated_status_columns_to_sent_hearing_email_events.rb
@@ -1,0 +1,6 @@
+class AddUpdatedStatusColumnsToSentHearingEmailEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sent_hearing_email_events, :send_successful, :boolean, comment: "This column keeps track of whether the email was sent or not"
+    add_column :sent_hearing_email_events, :send_successful_checked_at, :datetime, comment: "The date the status was last checked/updated in the GovDelivery API"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_25_194335) do
+ActiveRecord::Schema.define(version: 2021_08_26_145249) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1314,6 +1314,14 @@ ActiveRecord::Schema.define(version: 2021_08_25_194335) do
     t.index ["user_id"], name: "index_schedule_periods_on_user_id"
   end
 
+  create_table "sent_hearing_admin_email_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.string "external_message_id", comment: "The ID returned by the GovDelivery API when we send an email."
+    t.bigint "sent_hearing_email_event_id", comment: "Associated sent hearing email event."
+    t.datetime "updated_at", null: false
+    t.index ["sent_hearing_email_event_id"], name: "index_admin_email_events_on_hearing_email_event_id"
+  end
+
   create_table "sent_hearing_email_events", comment: "Events related to hearings notification emails", force: :cascade do |t|
     t.string "email_address", comment: "Address the email was sent to"
     t.bigint "email_recipient_id", comment: "Associated HearingEmailRecipient"
@@ -1322,6 +1330,8 @@ ActiveRecord::Schema.define(version: 2021_08_25_194335) do
     t.bigint "hearing_id", null: false, comment: "Associated hearing"
     t.string "hearing_type", null: false, comment: "'Hearing' or 'LegacyHearing'"
     t.string "recipient_role", comment: "The role of the recipient: veteran, representative, judge"
+    t.boolean "send_successful", comment: "This column keeps track of whether the email was sent or not"
+    t.datetime "send_successful_checked_at", comment: "The date the status was last checked/updated in the GovDelivery API"
     t.datetime "sent_at", null: false, comment: "The date and time the email was sent"
     t.bigint "sent_by_id", null: false, comment: "User who initiated sending the email"
     t.index ["hearing_type", "hearing_id"], name: "index_sent_hearing_email_events_on_hearing_type_and_hearing_id"
@@ -1749,6 +1759,7 @@ ActiveRecord::Schema.define(version: 2021_08_25_194335) do
   add_foreign_key "request_issues", "request_issues", column: "ineligible_due_to_id"
   add_foreign_key "request_issues_updates", "users"
   add_foreign_key "schedule_periods", "users"
+  add_foreign_key "sent_hearing_admin_email_events", "sent_hearing_email_events"
   add_foreign_key "sent_hearing_email_events", "hearing_email_recipients", column: "email_recipient_id"
   add_foreign_key "sent_hearing_email_events", "users", column: "sent_by_id"
   add_foreign_key "task_timers", "tasks"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1319,7 +1319,6 @@ ActiveRecord::Schema.define(version: 2021_08_26_145249) do
     t.string "external_message_id", comment: "The ID returned by the GovDelivery API when we send an email."
     t.bigint "sent_hearing_email_event_id", comment: "Associated sent hearing email event."
     t.datetime "updated_at", null: false
-    t.index ["sent_hearing_email_event_id"], name: "index_admin_email_events_on_hearing_email_event_id"
   end
 
   create_table "sent_hearing_email_events", comment: "Events related to hearings notification emails", force: :cascade do |t|

--- a/docs/schema/caseflow.csv
+++ b/docs/schema/caseflow.csv
@@ -1001,6 +1001,12 @@ schedule_periods,start_date,date ∗,x,,,,,
 schedule_periods,type,string ∗,x,,,,,
 schedule_periods,updated_at,datetime ∗,x,,,,x,
 schedule_periods,user_id,integer (8) ∗ FK,x,,x,,x,
+sent_hearing_admin_email_events,,,,,,,,
+sent_hearing_admin_email_events,created_at,datetime ∗,x,,,,,
+sent_hearing_admin_email_events,external_message_id,string,,,,,,The ID returned by the GovDelivery API when we send an email.
+sent_hearing_admin_email_events,id,integer (8) PK,x,x,,,,
+sent_hearing_admin_email_events,sent_hearing_email_event_id,integer (8) FK,,,x,,x,Associated sent hearing email event.
+sent_hearing_admin_email_events,updated_at,datetime ∗,x,,,,,
 sent_hearing_email_events,,,,,,,,Events related to hearings notification emails
 sent_hearing_email_events,email_address,string,,,,,,Address the email was sent to
 sent_hearing_email_events,email_recipient_id,integer (8) FK,,,x,,,Associated HearingEmailRecipient
@@ -1010,6 +1016,8 @@ sent_hearing_email_events,hearing_id,integer (8) ∗ FK,x,,x,,x,Associated hea
 sent_hearing_email_events,hearing_type,string ∗,x,,,,x,'Hearing' or 'LegacyHearing'
 sent_hearing_email_events,id,integer (8) PK,x,x,,,,
 sent_hearing_email_events,recipient_role,string,,,,,,"The role of the recipient: veteran, representative, judge"
+sent_hearing_email_events,send_successful,boolean,,,,,,This column keeps track of whether the email was sent or not
+sent_hearing_email_events,send_successful_checked_at,datetime,,,,,,The date the status was last checked/updated in the GovDelivery API
 sent_hearing_email_events,sent_at,datetime ∗,x,,,,,The date and time the email was sent
 sent_hearing_email_events,sent_by_id,integer (8) ∗ FK,x,,x,,x,User who initiated sending the email
 special_issue_lists,,,,,,,,Associates special issues to an AMA or legacy appeal for Caseflow Queue. Caseflow Dispatch uses special issues stored in legacy_appeals. They are intentionally disconnected.


### PR DESCRIPTION
Resolves [CASEFLOW-2212](https://vajira.max.gov/browse/CASEFLOW-2212)

### Description
These changes are based on these [tech spec](https://hackmd.io/fYAyoejJQGaSdj_Ph2xdKA?view#proposed-solution)

Added these columns to the sent_hearing_email_events table; all can be nil:

- `send_successful` (a boolean value that is nil if the status hasn't been checked or is "new" or "sending"; true if the status is "sent"; and false if the status is "failed", "inconclusive", "canceled", or "blacklisted")
- `send_successful_checked_at` (The date the status was last checked/updated)
- Created a new table `SentHearingAdminEmailEvent` to keep track of the 'administrative' email sent to our users.

### Acceptance Criteria
- [ ] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Run `make docs` (after running `make migrate`) to update DB schema docs
* [x] Post this PR in #appeals-schema with a summary