### PR TITLE
Batch caching of AMA appeal attributes

### DIFF
--- a/app/jobs/update_cached_appeals_attributes_job.rb
+++ b/app/jobs/update_cached_appeals_attributes_job.rb
@@ -33,9 +33,10 @@ class UpdateCachedAppealsAttributesJob < CaseflowJob
       .where(id: open_appeals_from_tasks(Appeal.name))
       .order(updated_at: :desc)
 
-    cached_appeals = cached_appeal_service.cache_ama_appeals(appeals)
-
-    increment_appeal_count(cached_appeals.length, Appeal.name)
+    appeals.in_groups_of(POSTGRES_BATCH_SIZE, false) do |batch_ama_appeals|
+      cached_appeals = cached_appeal_service.cache_ama_appeals(batch_ama_appeals)
+      increment_appeal_count(cached_appeals.length, Appeal.name)
+    end
   end
 
   def open_appeals_from_tasks(appeal_type)


### PR DESCRIPTION
Resolves an `ActiveRecord::QueryCanceled` error [we've been seeing](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/19127/) regularly over the past month.

![image](https://user-images.githubusercontent.com/32683958/131156397-21cbd022-d985-4844-bd7a-417fea87df4e.png)

The `insert` statement is timing out, and I believe it is because we are trying to insert too many records into the database at once. I logged into the prod Rails console and used a [slightly modified version of `open_appeals_from_tasks`](https://github.com/department-of-veterans-affairs/caseflow/blob/5a3f726123ec454c20b88e82d7b440d938fde5a9/app/jobs/update_cached_appeals_attributes_job.rb#L41) to determine that we are attempting to insert more than 100,000 rows at once.
```ruby
rails c> Task.open.where(appeal_type: Appeal.name).pluck(:appeal_id).uniq.count
# 101291
```

This change follows the [existing pattern for batching](https://github.com/department-of-veterans-affairs/caseflow/blob/5a3f726123ec454c20b88e82d7b440d938fde5a9/app/jobs/update_cached_appeals_attributes_job.rb#L64) established in this very same file and reduces the number of rows we attempt to insert at once [to 10,000](https://github.com/department-of-veterans-affairs/caseflow/blob/5a3f726123ec454c20b88e82d7b440d938fde5a9/app/jobs/update_cached_appeals_attributes_job.rb#L4).