### PR TITLE
Added SentHearingEmailEvent#handle_reported_status

### DIFF
--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -34,6 +34,22 @@ class SentHearingEmailEvent < CaseflowRecord
     }
   ), _prefix: :is
 
+  # error to capture any instances where we try to update `sent_status`
+  # with an invalid value.
+  class InvalidReportedStatus < StandardError; end
+
+  # error to capture any instances we attempt to send email to a coordinator
+  # regarding email status but `sent_status_email_external_message_id` exists.
+  class SentStatusEmailAlreadySent < StandardError; end
+
+  EMAIL_REPORTED_SENT_STATUSES = %w[
+    new sending sent failed inconclusive blacklisted canceled
+  ].freeze
+
+  FAILED_EMAIL_REPORTED_SENT_STATUSES = %w[
+    failed inconclusive canceled blacklisted
+  ].freeze
+
   def sent_to_role
     case recipient_role
     when "judge"
@@ -53,9 +69,73 @@ class SentHearingEmailEvent < CaseflowRecord
     end
   end
 
+  def handle_reported_status(reported_status)
+    # Exit if the email has been marked as 'sent'
+    return if send_successful
+
+    # Exit if the hearing is not virtual
+    return if !hearing.virtual?
+
+    # Update the date/time of the last attempt to verify the status
+    update!(send_successful_checked_at: Time.zone.now)
+
+    if !reported_status_valid?(reported_status)
+      invalid_reported_status_failure(reported_status)
+    elsif reported_status_sent?(reported_status)
+      update!(send_successful: true)
+    elsif reported_status_failed?(reported_status)
+      update!(send_successful: false)
+
+      handle_failed_email_status
+    else
+      update!(send_successful: nil)
+    end
+  end
+
   private
 
   def assign_sent_at_time
     self.sent_at ||= Time.now.utc
+  end
+
+  def reported_status_valid?(reported_status)
+    EMAIL_REPORTED_SENT_STATUSES.include?(reported_status)
+  end
+
+  def reported_status_sent?(reported_status)
+    reported_status == "sent"
+  end
+
+  def reported_status_failed?(reported_status)
+    FAILED_EMAIL_REPORTED_SENT_STATUSES.include?(reported_status)
+  end
+
+  def invalid_reported_status_failure(reported_status)
+    Raven.capture_exception(
+      InvalidReportedStatus.new(
+        "Cannot update sent_status with invalid status: (#{reported_status})"
+      )
+    )
+  end
+
+  def email_already_sent_failure
+    Raven.capture_exception(
+      SentStatusEmailAlreadySent.new(
+        "Cannot sent an email to because we already have attempeted to send this email: " \
+          "(#{external_message_id})."
+      )
+    )
+  end
+
+  def handle_failed_email_status
+    if sent_hearing_admin_email_events.present?
+      email_already_sent_failure
+    else
+      sent_hearing_admin_email_event = sent_hearing_admin_email_events.create
+
+      Hearings::SendSentStatusEmail.new(
+        sent_hearing_admin_email_event: sent_hearing_admin_email_event
+      ).call
+    end
   end
 end

--- a/app/models/hearings/sent_hearing_email_event.rb
+++ b/app/models/hearings/sent_hearing_email_event.rb
@@ -11,7 +11,7 @@ class SentHearingEmailEvent < CaseflowRecord
   belongs_to :sent_by, class_name: "User"
   belongs_to :email_recipient, class_name: "HearingEmailRecipient"
 
-  has_one :sent_hearing_admin_email_events
+  has_one :sent_hearing_admin_email_event
 
   before_create :assign_sent_at_time
 
@@ -128,10 +128,10 @@ class SentHearingEmailEvent < CaseflowRecord
   end
 
   def handle_failed_email_status
-    if sent_hearing_admin_email_events.present?
+    if sent_hearing_admin_email_event.present?
       email_already_sent_failure
     else
-      sent_hearing_admin_email_event = sent_hearing_admin_email_events.create
+      sent_hearing_admin_email_event = create_sent_hearing_admin_email_event
 
       Hearings::SendSentStatusEmail.new(
         sent_hearing_admin_email_event: sent_hearing_admin_email_event

--- a/spec/factories/sent_hearing_email_event.rb
+++ b/spec/factories/sent_hearing_email_event.rb
@@ -16,5 +16,9 @@ FactoryBot.define do
       email_type { "reminder" }
       sent_by { User.system_user }
     end
+
+    trait :with_hearing do
+      hearing { create(:hearing) }
+    end
   end
 end

--- a/spec/models/hearings/sent_hearing_email_event_spec.rb
+++ b/spec/models/hearings/sent_hearing_email_event_spec.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 describe SentHearingEmailEvent do
+  # TODO: This will have to be removed once we have a HearingEmailStatusMailer class
+  class Hearings::SendSentStatusEmail
+    def initialize(**args); end
+    def call(**args); end
+  end
+
   context "#create" do
     let(:user) { create(:user) }
     let(:hearing) { create(:hearing) }
@@ -33,6 +39,126 @@ describe SentHearingEmailEvent do
 
       it "fails validation" do
         expect { subject }.to raise_error(ArgumentError)
+      end
+    end
+  end
+
+  context "#handle_reported_status" do
+    let(:sent_hearing_email_event) do
+      create(
+        :sent_hearing_email_event,
+        send_successful_checked_at: DateTime.now,
+        hearing: create(
+          :hearing,
+          virtual_hearing: create(:virtual_hearing)
+        )
+      )
+    end
+
+    it "takes one argument." do
+      expect { sent_hearing_email_event.handle_reported_status }.to raise_error(ArgumentError)
+    end
+
+    it "does nothing if the send_successful is true." do
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+      sent_hearing_email_event.update(send_successful: true)
+
+      sent_hearing_email_event.handle_reported_status("sent")
+
+      expect(sent_hearing_email_event.send_successful_checked_at).to eq(status_checked_at_was)
+      expect(sent_hearing_email_event.send_successful).to be(true)
+    end
+
+    it "does nothing if the hearing is not virtual." do
+      sent_hearing_email_event = create(
+        :sent_hearing_email_event,
+        :with_hearing,
+        send_successful_checked_at: DateTime.now
+      )
+
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+      sent_hearing_email_event.handle_reported_status("failed")
+
+      expect(sent_hearing_email_event.send_successful_checked_at).to eq(status_checked_at_was)
+      expect(sent_hearing_email_event.send_successful).to be(nil)
+    end
+
+    it "updates send_successful_checked_at if the status given is 'new'." do
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+      sent_hearing_email_event.handle_reported_status("new")
+
+      expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+      expect(sent_hearing_email_event.send_successful).to be(nil)
+      expect(sent_hearing_email_event.sent_hearing_admin_email_events.count).to be(0)
+    end
+
+    it "updates send_successful_checked_at if the status given is 'sending'." do
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+      sent_hearing_email_event.handle_reported_status("sending")
+
+      expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+      expect(sent_hearing_email_event.send_successful).to be(nil)
+      expect(sent_hearing_email_event.sent_hearing_admin_email_events.count).to be(0)
+    end
+
+    it "updates send_successful_checked_at and sets send_successful to true when the status is 'sent'." do
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+      sent_hearing_email_event.handle_reported_status("sent")
+
+      expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+      expect(sent_hearing_email_event.send_successful).to be(true)
+    end
+
+    it "raises InvalidReportedStatus when an invalid status is given." do
+      status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+      allow(Raven).to receive(:capture_exception)
+
+      sent_hearing_email_event.handle_reported_status("bananas")
+
+      expect(Raven).to have_received(:capture_exception).with(SentHearingEmailEvent::InvalidReportedStatus)
+      expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+    end
+
+    context "failed status" do
+      SentHearingEmailEvent::FAILED_EMAIL_REPORTED_SENT_STATUSES.each do |failed_status|
+        it "raises SentStatusEmailAlreadySent when #{failed_status} is given a admin_email_event record exists." do
+          status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+          sent_hearing_email_event.sent_hearing_admin_email_events.create
+
+          allow(Raven).to receive(:capture_exception)
+
+          sent_hearing_email_event.handle_reported_status(failed_status)
+
+          expect(Raven).to have_received(:capture_exception).with(SentHearingEmailEvent::SentStatusEmailAlreadySent)
+          expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+          expect(sent_hearing_email_event.send_successful).to be(false)
+        end
+
+        it "invokes Hearings::SendSentStatusEmail when #{failed_status} is given." do
+          status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+          expect(Hearings::SendSentStatusEmail).to receive(:new).once
+
+          sent_hearing_email_event.handle_reported_status(failed_status)
+
+          expect(sent_hearing_email_event.delivery_failures.count).to eq(1)
+          expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+          expect(sent_hearing_email_event.send_successful).to be(false)
+        end
+
+        it "creates a sent_hearing_admin_email_event record when #{failed_status} is given." do
+          status_checked_at_was = sent_hearing_email_event.send_successful_checked_at
+
+          sent_hearing_email_event.handle_reported_status(failed_status)
+
+          expect(sent_hearing_email_event.delivery_failures.count).to eq(1)
+          expect(sent_hearing_email_event.send_successful_checked_at).to be > status_checked_at_was
+          expect(sent_hearing_email_event.send_successful).to be(false)
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves [CASEFLOW-2214](https://vajira.max.gov/browse/CASEFLOW-2214)

### Description
Added methods to the `SentHearingEmailEvent` class so that when we get a reported status for a particular email we either send a failure to deliver status or record the attempt to do so. This relates to [CASEFLOW-2165](https://vajira.max.gov/browse/CASEFLOW-2165)

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Running `bundle exec rspec spec/models/hearings/sent_hearing_email_event_spec.rb` should succeed.

### Testing Plan
1. To test this branch we need to bring the changes from other PRs:
```
git checkout omar/CASEFLOW-2214-handle-status-1 # this PRs branch
git rebase charley/CASEFLOW-2213-mailer-and-job-for-delivery-failure-emails # The branch with Hearings::SendSentStatusEmail
git rebase omar/CASEFLOW-2212-sent-hearing-email-events-db-1 # The PR with the database changes we need
make migrate # To include the DB changes in your db
```
2. Run `make migrate` 
3. Run `bundle exec rspec spec/models/hearings/sent_hearing_email_event_spec.rb`.