### PR TITLE
Add filed by va.gov to HLRs

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -106,7 +106,8 @@ class IntakesController < ApplicationController
         useAmaActivationDate: FeatureToggle.enabled?(:use_ama_activation_date, user: current_user),
         rampIntake: FeatureToggle.enabled?(:ramp_intake, user: current_user),
         dateOfBirthField: FeatureToggle.enabled?(:date_of_birth_field, user: current_user),
-        covidTimelinessExemption: FeatureToggle.enabled?(:covid_timeliness_exemption, user: current_user)
+        covidTimelinessExemption: FeatureToggle.enabled?(:covid_timeliness_exemption, user: current_user),
+        filedByVaGovHlr: FeatureToggle.enabled?(:filed_by_va_gov_hlr, user: current_user)
       }
     }
   rescue StandardError => error

--- a/app/models/higher_level_review_intake.rb
+++ b/app/models/higher_level_review_intake.rb
@@ -14,6 +14,6 @@ class HigherLevelReviewIntake < ClaimReviewIntake
   private
 
   def review_param_keys
-    %w[receipt_date informal_conference same_office benefit_type legacy_opt_in_approved]
+    %w[receipt_date informal_conference same_office benefit_type legacy_opt_in_approved filed_by_va_gov]
   end
 end

--- a/client/app/intake/constants.js
+++ b/client/app/intake/constants.js
@@ -201,6 +201,7 @@ export const REVIEW_DATA_FIELDS = {
     same_office: { key: 'sameOffice', required: true },
     benefit_type: { key: 'benefitType', required: true },
     receipt_date: { key: 'receiptDate', required: true },
+    filed_by_va_gov: { key: 'filedByVaGov', required: false },
     claimant: { key: 'claimant' },
     claimant_type: { key: 'claimantType', required: true },
     payee_code: { key: 'payeeCode' },

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -114,7 +114,8 @@ const formFieldMapping = (props) => {
       value={props.sameOffice === null || props.sameOffice === undefined ? null : props.sameOffice.toString()}
       inputRef={props.register}
     />,
-    'filed-by-va-gov': <RadioField
+    'filed-by-va-gov': (props.formName === FORM_TYPES.APPEAL.formName || props.featureToggles.filedByVaGovHlr) &&
+    <RadioField
       name="filed-by-va-gov"
       label={<span><b>Was this form submitted through VA.gov? </b>
         (Indicated by a stamp at the top right corner of the form)</span>}

--- a/client/app/intake/pages/higherLevelReview/review.jsx
+++ b/client/app/intake/pages/higherLevelReview/review.jsx
@@ -8,14 +8,15 @@ const higherLevelReviewFormHeader = (veteranName) => (
   <h1>Review { veteranName }'s { FORM_TYPES.HIGHER_LEVEL_REVIEW.name }</h1>
 );
 
-const reviewHigherLevelReviewSchema = yup.object().shape({
-  'benefit-type-options': yup.string().required(GENERIC_FORM_ERRORS.blank),
+const reviewHigherLevelReviewSchema = (yup.object().shape({
   ...receiptDateInputValidation(true),
+  'filed-by-va-gov': yup.string(),
+  'benefit-type-options': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'informal-conference': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'same-office': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'different-claimant-option': yup.string().required(GENERIC_FORM_ERRORS.blank),
   'legacy-opt-in': yup.string().required(GENERIC_FORM_ERRORS.blank),
   ...selectClaimantValidations()
-});
+}));
 
 export { reviewHigherLevelReviewSchema, higherLevelReviewFormHeader };

--- a/client/app/intake/reducers/featureToggles.js
+++ b/client/app/intake/reducers/featureToggles.js
@@ -11,6 +11,9 @@ const updateFromServerFeatures = (state, featureToggles) => {
     covidTimelinessExemption: {
       $set: Boolean(featureToggles.covidTimelinessExemption)
     },
+    filedByVaGovHlr: {
+      $set: Boolean(featureToggles.filedByVaGovHlr)
+    },
   });
 };
 
@@ -19,6 +22,7 @@ export const mapDataToFeatureToggle = (data = { featureToggles: {} }) =>
     {
       useAmaActivationDate: false,
       correctClaimReviews: false,
+      filedByVaGovHlr: false
     },
     data.featureToggles
   );

--- a/client/app/intake/reducers/higherLevelReview.js
+++ b/client/app/intake/reducers/higherLevelReview.js
@@ -42,6 +42,8 @@ export const mapDataToInitialHigherLevelReview = (data = { serverIntake: {} }) =
     correctIssueModalVisible: false,
     receiptDate: null,
     receiptDateError: null,
+    filedByVaGov: null,
+    filedByVaGovError: null,
     benefitType: null,
     benefitTypeError: null,
     informalConference: null,
@@ -106,6 +108,18 @@ export const higherLevelReviewReducer = (state = mapDataToInitialHigherLevelRevi
     return update(state, {
       informalConference: {
         $set: action.payload.informalConference
+      }
+    });
+  case ACTIONS.SET_FILED_BY_VA_GOV:
+    return update(state, {
+      filedByVaGov: {
+        $set: action.payload.filedByVaGov
+      }
+    });
+  case ACTIONS.SET_FILED_BY_VA_GOV_ERROR:
+    return update(state, {
+      filedByVaGovError: {
+        $set: action.payload.filedByVaGovError
       }
     });
   case ACTIONS.SET_SAME_OFFICE:

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -52,7 +52,6 @@ feature "Higher-Level Review", :all_dbs do
   before { FeatureToggle.enable!(:filed_by_va_gov_hlr) }
   after { FeatureToggle.disable!(:filed_by_va_gov_hlr) }
   it "Creates an end product and contentions for it" do
-    
     # Testing one relationship, tests 2 relationships in HRL and nil in Appeal
     allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
       first_name: "BOB",

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -49,8 +49,10 @@ feature "Higher-Level Review", :all_dbs do
   let!(:untimely_ratings) { generate_untimely_rating(veteran, untimely_promulgation_date, untimely_profile_date) }
   let!(:future_rating) { generate_future_rating(veteran, future_rating_promulgation_date, future_rating_profile_date) }
   let!(:before_ama_rating) { generate_pre_ama_rating(veteran) }
-
-  it "Creates an end product and contentions for it" do
+  before { FeatureToggle.enable!(:filed_by_va_gov_hlr) }
+  after { FeatureToggle.disable!(:filed_by_va_gov_hlr) }
+  fit "Creates an end product and contentions for it" do
+    
     # Testing one relationship, tests 2 relationships in HRL and nil in Appeal
     allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(
       first_name: "BOB",
@@ -87,6 +89,9 @@ feature "Higher-Level Review", :all_dbs do
       "What is the Benefit Type?\nPlease select an option."
     )
     expect(page).to have_content(
+      "Was this form submitted through VA.gov?"
+    )
+    expect(page).to have_content(
       "Was an informal conference requested?\nPlease select an option."
     )
     expect(page).to have_content(
@@ -98,6 +103,10 @@ feature "Higher-Level Review", :all_dbs do
     expect(page).to have_content(
       "Did the Veteran check the \"OPT-IN from SOC/SSOC\" box on the form?\nPlease select an option."
     )
+
+    within_fieldset("Was this form submitted through VA.gov?") do
+      find("label", text: "Yes", match: :prefer_exact).click
+    end
 
     within_fieldset("What is the Benefit Type?") do
       find("label", text: "Insurance", match: :prefer_exact).click
@@ -182,6 +191,7 @@ feature "Higher-Level Review", :all_dbs do
     higher_level_review = HigherLevelReview.find_by(veteran_file_number: veteran_file_number)
     expect(higher_level_review).to_not be_nil
     expect(higher_level_review.receipt_date).to eq(receipt_date)
+    expect(higher_level_review.filed_by_va_gov).to eq(true)
     expect(higher_level_review.benefit_type).to eq(benefit_type)
     expect(higher_level_review.informal_conference).to eq(true)
     expect(higher_level_review.same_office).to eq(false)

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -51,7 +51,7 @@ feature "Higher-Level Review", :all_dbs do
   let!(:before_ama_rating) { generate_pre_ama_rating(veteran) }
   before { FeatureToggle.enable!(:filed_by_va_gov_hlr) }
   after { FeatureToggle.disable!(:filed_by_va_gov_hlr) }
-  fit "Creates an end product and contentions for it" do
+  it "Creates an end product and contentions for it" do
     
     # Testing one relationship, tests 2 relationships in HRL and nil in Appeal
     allow_any_instance_of(Fakes::BGSService).to receive(:find_all_relationships).and_return(


### PR DESCRIPTION
Resolves #1935

### Description
Enable the filed-by-va-gov for higher level reviews
Behind the feature toggle filed_by_va_gov_hlr
Also updates the order of the questions, I left this not behind a toggle since it's not really much of a change

### Acceptance Criteria
Intake flow in original order with added VA.gov question
Intake flow in updated order to match form with added VA.gov question

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="999" alt="Screen Shot 2021-08-27 at 4 52 05 PM" src="https://user-images.githubusercontent.com/23530352/131187298-fe19e4ee-cd6f-4635-8585-dd73421e770b.png">
<img width="999" alt="Screen Shot 2021-08-27 at 4 52 14 PM" src="https://user-images.githubusercontent.com/23530352/131187308-f54d01d7-5af9-42ce-8021-b9591f1d2b30.png">


