### PR TITLE
Show BoardGrantEffectuation Tasks in the Business Line Queue

### DIFF
--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -58,7 +58,11 @@ class DecisionReviewsController < ApplicationController
   def in_progress_tasks
     apply_task_serializer(
       business_line.tasks.open.includes([:assigned_to, :appeal]).order(assigned_at: :desc).select do |task|
-        task.appeal.request_issues.active.any? || (task.active? && task.is_a?(BoardGrantEffectuationTask))
+        if FeatureToggle.enabled?(:board_grant_effectuation_task, user: :current_user)
+          task.appeal.request_issues.active.any? || (task.active? && task.is_a?(BoardGrantEffectuationTask))
+        else
+          task.appeal.request_issues.active.any?
+        end
       end
     )
   end

--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -31,6 +31,7 @@ class DecisionReviewsController < ApplicationController
   def update
     if task
       if task.complete_with_payload!(decision_issue_params, decision_date)
+        binding.pry
         business_line.tasks.reload
         render json: { in_progress_tasks: in_progress_tasks, completed_tasks: completed_tasks }, status: :ok
       else

--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -55,6 +55,7 @@ class DecisionReviewsController < ApplicationController
     @task ||= Task.includes([:appeal, :assigned_to]).find(task_id)
   end
 
+  # :reek:FeatureEnvy
   def in_progress_tasks
     apply_task_serializer(
       business_line.tasks.open.includes([:assigned_to, :appeal]).order(assigned_at: :desc).select do |task|

--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -60,7 +60,7 @@ class DecisionReviewsController < ApplicationController
     apply_task_serializer(
       business_line.tasks.open.includes([:assigned_to, :appeal]).order(assigned_at: :desc).select do |task|
         if FeatureToggle.enabled?(:board_grant_effectuation_task, user: :current_user)
-          task.appeal.request_issues.active.any? || (task.active? && task.is_a?(BoardGrantEffectuationTask))
+          task.appeal.request_issues.active.any? || task.is_a?(BoardGrantEffectuationTask)
         else
           task.appeal.request_issues.active.any?
         end

--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -31,7 +31,6 @@ class DecisionReviewsController < ApplicationController
   def update
     if task
       if task.complete_with_payload!(decision_issue_params, decision_date)
-        binding.pry
         business_line.tasks.reload
         render json: { in_progress_tasks: in_progress_tasks, completed_tasks: completed_tasks }, status: :ok
       else
@@ -59,7 +58,7 @@ class DecisionReviewsController < ApplicationController
   def in_progress_tasks
     apply_task_serializer(
       business_line.tasks.open.includes([:assigned_to, :appeal]).order(assigned_at: :desc).select do |task|
-        task.appeal.request_issues.active.any?
+        task.appeal.request_issues.active.any? || (task.active? && task.is_a?(BoardGrantEffectuationTask))
       end
     )
   end

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -16,7 +16,7 @@ feature "NonComp Reviews Queue", :postgres do
     let!(:request_issue_a) { create(:request_issue, :rating, decision_review: hlr_a) }
     let!(:request_issue_b) { create(:request_issue, :rating, decision_review: hlr_b) }
     let!(:request_issue_c) { create(:request_issue, :rating, :removed, decision_review: hlr_c) }
-    let!(:request_issue_d) { create(:request_issue, :rating, decision_review: appeal) }
+    let!(:request_issue_d) { create(:request_issue, :rating, decision_review: appeal, closed_at: 1.day.ago) }
 
     let(:today) { Time.zone.now }
     let(:last_week) { Time.zone.now - 7.days }

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -68,39 +68,41 @@ feature "NonComp Reviews Queue", :postgres do
 
     before { FeatureToggle.enable!(:board_grant_effectuation_task) }
     after { FeatureToggle.disable!(:board_grant_effectuation_task) }
+    
+    scenario "displays tasks page" do
+      visit "decision_reviews/nco"
+      expect(page).to have_content("Non-Comp Org")
+      expect(page).to have_content("In progress tasks")
+      expect(page).to have_content("Completed tasks")
 
-      scenario "displays tasks page" do
-        visit "decision_reviews/nco"
-        expect(page).to have_content("Non-Comp Org")
-        expect(page).to have_content("In progress tasks")
-        expect(page).to have_content("Completed tasks")
+      # default is the in progress page
+      expect(page).to have_content("Days Waiting")
+      expect(page).to have_content("Higher-Level Review", count: 2)
+      binding.pry
+      spec/feature/non_comp/reviews_spec.rb
+      expect(page).to have_content("Board Grant")
+      expect(page).to have_content(veteran_a.name)
+      expect(page).to have_content(veteran_b.name)
+      expect(page).to have_content(veteran_c.name)
+      expect(page).to have_content(veteran_a.participant_id)
+      expect(page).to have_content(veteran_b.participant_id)
+      expect(page).to have_content(veteran_c.participant_id)
 
-        # default is the in progress page
-        expect(page).to have_content("Days Waiting")
-        expect(page).to have_content("Higher-Level Review", count: 2)
-        expect(page).to have_content("Board Grant")
-        expect(page).to have_content(veteran_a.name)
-        expect(page).to have_content(veteran_b.name)
-        expect(page).to have_content(veteran_c.name)
-        expect(page).to have_content(veteran_a.participant_id)
-        expect(page).to have_content(veteran_b.participant_id)
-        expect(page).to have_content(veteran_c.participant_id)
+      # ordered by assigned_at descending
 
-        # ordered by assigned_at descending
+      expect(page).to have_content(
+        /#{veteran_b.name}.+\s#{veteran_c.name}.+\s#{veteran_a.name}/
+      )
 
-        expect(page).to have_content(
-          /#{veteran_b.name}.+\s#{veteran_c.name}.+\s#{veteran_a.name}/
-        )
+      click_on "Completed tasks"
+      expect(page).to have_content("Higher-Level Review", count: 1)
+      expect(page).to have_content("Date Completed")
 
-        click_on "Completed tasks"
-        expect(page).to have_content("Higher-Level Review", count: 1)
-        expect(page).to have_content("Date Completed")
-
-        # ordered by closed_at descending
-        expect(page).to have_content(
-          /#{veteran_b.name} 5\d+ 1 [\d\/]+ Higher-Level Review/
-        )
-      end
+      # ordered by closed_at descending
+      expect(page).to have_content(
+        /#{veteran_b.name} 5\d+ 1 [\d\/]+ Higher-Level Review/
+      )
+    end
 
     context "with user enabled for intake" do
       scenario "displays tasks page" do

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -68,7 +68,7 @@ feature "NonComp Reviews Queue", :postgres do
 
     before { FeatureToggle.enable!(:board_grant_effectuation_task) }
     after { FeatureToggle.disable!(:board_grant_effectuation_task) }
-    
+
     scenario "displays tasks page" do
       visit "decision_reviews/nco"
       expect(page).to have_content("Non-Comp Org")
@@ -78,8 +78,6 @@ feature "NonComp Reviews Queue", :postgres do
       # default is the in progress page
       expect(page).to have_content("Days Waiting")
       expect(page).to have_content("Higher-Level Review", count: 2)
-      binding.pry
-      spec/feature/non_comp/reviews_spec.rb
       expect(page).to have_content("Board Grant")
       expect(page).to have_content(veteran_a.name)
       expect(page).to have_content(veteran_b.name)

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -66,38 +66,41 @@ feature "NonComp Reviews Queue", :postgres do
       non_comp_org.add_user(user)
     end
 
-    scenario "displays tasks page" do
-      visit "decision_reviews/nco"
-      expect(page).to have_content("Non-Comp Org")
-      expect(page).to have_content("In progress tasks")
-      expect(page).to have_content("Completed tasks")
+    before { FeatureToggle.enable!(:board_grant_effectuation_task) }
+    after { FeatureToggle.disable!(:board_grant_effectuation_task) }
 
-      # default is the in progress page
-      expect(page).to have_content("Days Waiting")
-      expect(page).to have_content("Higher-Level Review", count: 2)
-      expect(page).to have_content("Board Grant")
-      expect(page).to have_content(veteran_a.name)
-      expect(page).to have_content(veteran_b.name)
-      expect(page).to have_content(veteran_c.name)
-      expect(page).to have_content(veteran_a.participant_id)
-      expect(page).to have_content(veteran_b.participant_id)
-      expect(page).to have_content(veteran_c.participant_id)
+      scenario "displays tasks page" do
+        visit "decision_reviews/nco"
+        expect(page).to have_content("Non-Comp Org")
+        expect(page).to have_content("In progress tasks")
+        expect(page).to have_content("Completed tasks")
 
-      # ordered by assigned_at descending
+        # default is the in progress page
+        expect(page).to have_content("Days Waiting")
+        expect(page).to have_content("Higher-Level Review", count: 2)
+        expect(page).to have_content("Board Grant")
+        expect(page).to have_content(veteran_a.name)
+        expect(page).to have_content(veteran_b.name)
+        expect(page).to have_content(veteran_c.name)
+        expect(page).to have_content(veteran_a.participant_id)
+        expect(page).to have_content(veteran_b.participant_id)
+        expect(page).to have_content(veteran_c.participant_id)
 
-      expect(page).to have_content(
-        /#{veteran_b.name}.+\s#{veteran_c.name}.+\s#{veteran_a.name}/
-      )
+        # ordered by assigned_at descending
 
-      click_on "Completed tasks"
-      expect(page).to have_content("Higher-Level Review", count: 1)
-      expect(page).to have_content("Date Completed")
+        expect(page).to have_content(
+          /#{veteran_b.name}.+\s#{veteran_c.name}.+\s#{veteran_a.name}/
+        )
 
-      # ordered by closed_at descending
-      expect(page).to have_content(
-        /#{veteran_b.name} 5\d+ 1 [\d\/]+ Higher-Level Review/
-      )
-    end
+        click_on "Completed tasks"
+        expect(page).to have_content("Higher-Level Review", count: 1)
+        expect(page).to have_content("Date Completed")
+
+        # ordered by closed_at descending
+        expect(page).to have_content(
+          /#{veteran_b.name} 5\d+ 1 [\d\/]+ Higher-Level Review/
+        )
+      end
 
     context "with user enabled for intake" do
       scenario "displays tasks page" do


### PR DESCRIPTION
Resolves [CASEFLOW-2191](https://vajira.max.gov/browse/CASEFLOW-2191)

### Description
- `BoardGrantEffectuationTask` shows in appropriate Business Line Queue upon dispatching of appeal and processing of BVA decision
- `BoardGrantEffectuationTask` show up in the "In Progress" Queue, when the task is not completed. 
- `BoardGrantEffectuationTask` show up in the "Completed" Queue, when the task is completed.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)


