### PR TITLE
Create job to check and handle email status

### DIFF
--- a/app/jobs/hearings/hearing_email_status_job.rb
+++ b/app/jobs/hearings/hearing_email_status_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+class Hearings::HearingEmailStatusJob < ApplicationJob
+  include Hearings::EnsureCurrentUserIsSet
+
+  queue_with_priority :low_priority
+  application_attr :hearing_schedule
+
+  def perform
+    ensure_current_user_is_set
+
+    HearingRepository.maybe_needs_email_sent_status_checked.each do |sent_hearing_email_event|
+      begin
+        check_and_handle_reported_status(sent_hearing_email_event)
+      rescue StandardError => error # rescue any error and allow job to continue
+        capture_exception(error: error)
+      end
+    end
+  end
+
+  private
+
+  def check_and_handle_reported_status(sent_hearing_email_event)
+    reported_status =
+      ExternalApi::GovDeliveryService.get_sent_status_from_event(email_event: sent_hearing_email_event)
+
+    sent_hearing_email_event.handle_reported_status(reported_status) unless reported_status.nil?
+  end
+end

--- a/app/jobs/hearings/hearing_email_status_job.rb
+++ b/app/jobs/hearings/hearing_email_status_job.rb
@@ -24,6 +24,6 @@ class Hearings::HearingEmailStatusJob < ApplicationJob
     reported_status =
       ExternalApi::GovDeliveryService.get_sent_status_from_event(email_event: sent_hearing_email_event)
 
-    sent_hearing_email_event.handle_reported_status(reported_status) unless reported_status.nil?
+    sent_hearing_email_event.handle_reported_status(reported_status) unless reported_status.blank?
   end
 end

--- a/spec/factories/sent_hearing_email_event.rb
+++ b/spec/factories/sent_hearing_email_event.rb
@@ -20,5 +20,9 @@ FactoryBot.define do
     trait :with_hearing do
       hearing { create(:hearing) }
     end
+
+    trait :with_virtual_hearing do
+      hearing { create(:hearing, :virtual) }
+    end
   end
 end

--- a/spec/jobs/hearings/hearing_email_status_job_spec.rb
+++ b/spec/jobs/hearings/hearing_email_status_job_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe Hearings::HearingEmailStatusJob do
+  describe "#perform" do
+    subject { Hearings::HearingEmailStatusJob.new.perform }
+
+    let!(:appellant_sent_hearing_email_event) do
+      create(:sent_hearing_email_event, recipient_role: "appellant")
+    end
+
+    let!(:representative_sent_hearing_email_event) do
+      create(:sent_hearing_email_event, recipient_role: "representative")
+    end
+
+    context "when GovDelivery throws an error" do
+    end
+
+    context "when reported status from GovDelivery is invalid" do
+    end
+
+    context "when reported status indicates success" do
+      it "makes request to GovDelivery and handles status successfuly" do
+        subject
+
+        expect(appellant_sent_hearing_email_event.send_successful).to eq(true)
+        expect(appellant_sent_hearing_email_event.send_successful_checked_at).not_to be_nil
+        expect(representative_sent_hearing_email_event.send_successful).to eq(true)
+        expect(representative_sent_hearing_email_event.send_successful_checked_at).not_to be_nil
+      end
+    end
+
+    context "when reported status indicates failure" do
+      it "makes request to GovDelivery and handles status successfuly" do
+        subject
+
+        expect(appellant_sent_hearing_email_event.send_successful).to eq(false)
+        expect(appellant_sent_hearing_email_event.send_successful_checked_at).not_to be_nil
+        expect(representative_sent_hearing_email_event.send_successful).to eq(false)
+        expect(representative_sent_hearing_email_event.send_successful_checked_at).not_to be_nil
+     end
+    end
+  end
+end

--- a/spec/jobs/hearings/hearing_email_status_job_spec.rb
+++ b/spec/jobs/hearings/hearing_email_status_job_spec.rb
@@ -115,7 +115,7 @@ describe Hearings::HearingEmailStatusJob do
           .not_to be_nil
         expect(representative_sent_hearing_email_event.sent_hearing_admin_email_event)
           .not_to be_nil
-     end
+      end
     end
   end
 end

--- a/spec/jobs/hearings/hearing_email_status_job_spec.rb
+++ b/spec/jobs/hearings/hearing_email_status_job_spec.rb
@@ -79,7 +79,7 @@ describe Hearings::HearingEmailStatusJob do
         create(:sent_hearing_email_event)
       end
 
-      it "does not set sent_successful", focus: true do
+      it "does not set sent_successful" do
         subject
 
         expect(non_virtual_sent_hearing_email_event.reload.send_successful)


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/CASEFLOW-2217

### Description
- write new job `Hearings::HearingEmailStatusJob` that iterates through all sent_heairing_email_event objects that need their status checked to make api call to GovDelivery and handle the reported status. 

### Testing Plan
1. pull changes from `rubaiyat/CASEFLOW-2215-repository-method-to-return-sent-events` but do not merge the changes.
2. inspect the tests written in `spec/jobs/hearings/hearing_email_status_job_spec.rb` and run it locally
3. inpect `app/jobs/hearings/hearing_email_status_job.rb` 

