### PR TITLE
Send Additional Emails in Production

### DIFF
--- a/app/jobs/hearings/send_email.rb
+++ b/app/jobs/hearings/send_email.rb
@@ -19,13 +19,6 @@ class Hearings::SendEmail
     # already been sent too.
     return if send_reminder
 
-    # Unless this is a reminder, still require a virtual hearing for all emails
-    # checking 'hearing.virtual?' doesnt work because some emails are 'cancellation's
-    # which means the virtual hearing has been cancelled and hearing.virtual? == false
-    # This is likely unnessecary, because we only pass virtual_hearings from all places
-    # other than send_reminder_emails_job
-    return if !hearing.virtual_hearing
-
     if !hearing.appellant_recipient.email_sent
       appellant_recipient.update!(email_sent: send_email(appellant_recipient_info))
     end

--- a/app/services/hearings/reminder_service.rb
+++ b/app/services/hearings/reminder_service.rb
@@ -21,16 +21,11 @@ class Hearings::ReminderService
     return if days_until_hearing <= 0
 
     type_of_reminder = which_type_of_reminder_to_send
+
     # Only log 60 day reminder type email but do not send
     return if type_of_reminder == SIXTY_DAY_REMINDER
 
-    # This stops reminder emails from going out for any video/central hearings until
-    # we to enable that. Because it still calls 'which_type_of_reminder_to_send'
-    # we will log the email to be sent.
-    #
-    # Because hearing.virtual? will return false for any 'cancelled' virtual
-    # hearings, this prevents reminder emails for cancelled virtual hearings.
-    return type_of_reminder if hearing.virtual?
+    return type_of_reminder
   end
 
   private

--- a/app/services/hearings/reminder_service.rb
+++ b/app/services/hearings/reminder_service.rb
@@ -25,7 +25,7 @@ class Hearings::ReminderService
     # Only log 60 day reminder type email but do not send
     return if type_of_reminder == SIXTY_DAY_REMINDER
 
-    return type_of_reminder
+    type_of_reminder
   end
 
   private

--- a/app/services/hearings/reminder_service.rb
+++ b/app/services/hearings/reminder_service.rb
@@ -20,7 +20,7 @@ class Hearings::ReminderService
   def reminder_type
     return if days_until_hearing <= 0
 
-    type_of_reminder
+    which_type_of_reminder_to_send
   end
 
   private

--- a/app/services/hearings/reminder_service.rb
+++ b/app/services/hearings/reminder_service.rb
@@ -20,11 +20,6 @@ class Hearings::ReminderService
   def reminder_type
     return if days_until_hearing <= 0
 
-    type_of_reminder = which_type_of_reminder_to_send
-
-    # Only log 60 day reminder type email but do not send
-    return if type_of_reminder == SIXTY_DAY_REMINDER
-
     type_of_reminder
   end
 

--- a/spec/jobs/hearings/send_reminder_emails_job_spec.rb
+++ b/spec/jobs/hearings/send_reminder_emails_job_spec.rb
@@ -255,99 +255,6 @@ describe Hearings::SendReminderEmailsJob do
       end
     end
 
-    shared_examples "reminder emails logged but not sent" do
-      context "hearing date is 60 days out" do
-        let(:hearing_date) { Time.zone.now + 60.days }
-        let(:type) { "60 day" }
-
-        it "logs, but doesnt send reminder emails", :aggregate_failures do
-          expect(HearingMailer).not_to receive(:reminder)
-          expect(Rails.logger).to receive(:info).twice.with(/Send #{type} reminder emails: /)
-
-          subject
-          expect(hearing.appellant_recipient&.reminder_sent_at).to be_nil
-        end
-
-        it "logs, but doesnt create sent email events", :aggregate_failures do
-          expect(Rails.logger).to receive(:info).twice.with(/Send #{type} reminder emails: /)
-          subject
-
-          expect(SentHearingEmailEvent.count).to eq(0)
-          expect(SentHearingEmailEvent.is_reminder.count).to eq(0)
-        end
-      end
-
-      context "hearing date is 7 days out" do
-        let(:hearing_date) { Time.zone.now + 6.days }
-        let(:type) { "7 day" }
-
-        it "logs, but doesnt send reminder emails", :aggregate_failures do
-          expect(HearingMailer).not_to receive(:reminder)
-          expect(Rails.logger).to receive(:info).twice.with(/Send #{type} reminder emails: /)
-
-          subject
-          expect(hearing.appellant_recipient&.reminder_sent_at).to be_nil
-          expect(hearing.representative_recipient&.reminder_sent_at).to be_nil
-        end
-
-        it "logs, but doesnt create sent email events", :aggregate_failures do
-          expect(Rails.logger).to receive(:info).twice.with(/Send #{type} reminder emails: /)
-          subject
-
-          expect(SentHearingEmailEvent.count).to eq(0)
-          expect(SentHearingEmailEvent.is_reminder.count).to eq(0)
-        end
-
-        context "representative email was already sent" do
-          let(:representative_reminder_sent_at) { hearing_date - 3.days }
-          let!(:representative_reminder) do
-            create(
-              :sent_hearing_email_event,
-              :reminder,
-              recipient_role: HearingEmailRecipient::RECIPIENT_ROLES[:representative],
-              sent_at: representative_reminder_sent_at,
-              email_recipient: hearing.representative_recipient
-            )
-          end
-
-          it "logs, but doesnt send reminder email for the appellant", :aggregate_failures do
-            expect(HearingMailer).not_to receive(:reminder)
-            expect(Rails.logger).to receive(:info).once.with(/Send #{type} reminder emails: /)
-
-            subject
-            expect(hearing.appellant_recipient&.reminder_sent_at).to be_nil
-            expect(hearing.representative_recipient&.reminder_sent_at).to(
-              be_within(1.second).of(representative_reminder_sent_at)
-            )
-          end
-        end
-
-        context "appellant email was already sent" do
-          let(:appellant_reminder_sent_at) { hearing_date - 4.days }
-          let!(:appellant_reminder) do
-            create(
-              :sent_hearing_email_event,
-              :reminder,
-              recipient_role: HearingEmailRecipient::RECIPIENT_ROLES[:veteran],
-              sent_at: appellant_reminder_sent_at,
-              email_recipient: hearing.appellant_recipient
-            )
-          end
-
-          it "logs, but doesnt send reminder email for the representative", :aggregate_failures do
-            expect(HearingMailer).not_to receive(:reminder)
-            expect(Rails.logger).to receive(:info).once.with(/Send #{type} reminder emails: /)
-
-            subject
-            expect(hearing.appellant_recipient&.reminder_sent_at).to(
-              be_within(1.second).of(appellant_reminder_sent_at)
-            )
-            expect(hearing.representative_recipient&.reminder_sent_at).to be_nil
-          end
-        end
-      end
-    end
-
     context "when there is a virtual hearing" do
       let(:hearing_date) { Time.zone.now }
       let(:ama_disposition) { nil }
@@ -427,12 +334,7 @@ describe Hearings::SendReminderEmailsJob do
         )
       end
 
-      # When we start sending the emails for video/central hearings:
-      # - Use this instead: include_examples "send reminder emails"
-      # - Delete the "reminder emails logged but not sent" shared_examples
-      # - Delete the "logs but doesn't send for type" shared_examples
-      # See reminder_service_spec as well
-      include_examples "reminder emails logged but not sent"
+      include_examples "send reminder emails"
     end
 
     context "when there is a central hearing" do
@@ -473,12 +375,7 @@ describe Hearings::SendReminderEmailsJob do
         )
       end
 
-      # When we start sending the emails for video/central hearings:
-      # - Use this instead: include_examples "send reminder emails"
-      # - Delete the "reminder emails logged but not sent" shared_examples
-      # - Delete the "logs but doesn't send for type" shared_examples
-      # See reminder_service_spec as well
-      include_examples "reminder emails logged but not sent"
+      include_examples "send reminder emails"
     end
   end
 end

--- a/spec/jobs/hearings/send_reminder_emails_job_spec.rb
+++ b/spec/jobs/hearings/send_reminder_emails_job_spec.rb
@@ -5,7 +5,7 @@ describe Hearings::SendReminderEmailsJob do
     subject { Hearings::SendReminderEmailsJob.new.perform }
 
     shared_examples "send reminder emails" do
-      context "hearing date is 60 days out", skip: "will be unskipped when we enable feature" do
+      context "hearing date is 60 days out" do
         let(:hearing_date) { Time.zone.now + 59.days } # at most 60 days out
 
         it "sends reminder emails only to appellant", :aggregate_failures do

--- a/spec/services/hearings/reminder_service_spec.rb
+++ b/spec/services/hearings/reminder_service_spec.rb
@@ -188,10 +188,7 @@ describe Hearings::ReminderService do
     end
   end
 
-  # Right now these tests will fail because we don't send emails for non-virtual
-  # hearings. Once we are sending emails, uncomment this and it should pass.
-  # See: send_reminder_emails_job_spec as well.
-  context "with a central hearing", skip: "will be unskipped when we enable feature" do
+  context "with a central hearing" do
     let(:hearing_day) { create(:hearing_day, scheduled_for: hearing_date) }
     let(:hearing) do
       create(:hearing, hearing_day: hearing_day, created_at: created_at) # scheduled_time is always 8:30 AM ET

--- a/spec/services/hearings/reminder_service_spec.rb
+++ b/spec/services/hearings/reminder_service_spec.rb
@@ -2,7 +2,7 @@
 
 describe Hearings::ReminderService do
   shared_examples "determines which reminders should send" do
-    context "hearing is 60 days out", skip: "will be unskipped when we enable feature" do
+    context "hearing is 60 days out" do
       let(:hearing_date) { Time.zone.now + 59.days } # Nov 5, 2020 12:00 UTC + 59.days => 60 days or less
       let(:created_at) { hearing_date - 61.days }
 


### PR DESCRIPTION
Resolves [CASEFLOW-2175](https://vajira.max.gov/browse/CASEFLOW-2175)

### Description
This PR will make caseflow start sending a variety of emails:
- Video and Central hearings will get reminders, confirmations, etc emails sent.
- 60 day reminders will start being sent for all types (Virtual, Video, Central)

This is the PR version of the comments that appear on that JIRA ticket.

### Acceptance Criteria
- [ ] When a Video or Central hearing has an appellant or representative email entered, the 7 & 2/3-day reminder emails are sent to those recipients
- [ ] When any type of hearing has an appellant or representative email entered, the 60-day reminder emails are sent to those recipients