### PR TITLE
add compact to eliminate nil values

### DIFF
--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -118,7 +118,7 @@ class HearingRepository
           Raven.capture_exception(error)
           next
         end
-      end.flatten
+      end.flatten.compact
     end
     # :nocov:
 


### PR DESCRIPTION
Connects #16717

### Description
Compact the results of the map to eliminate nil values.