### PR TITLE
handle an empty response from govdelivery

### DIFF
--- a/app/services/external_api/gov_delivery_service.rb
+++ b/app/services/external_api/gov_delivery_service.rb
@@ -27,7 +27,7 @@ class ExternalApi::GovDeliveryService
 
     def get_sent_status(external_message_id:)
       # assumes the email has only one recipient
-      get_recipients(external_message_id: external_message_id).first[STATUS_FIELD_NAME]
+      get_recipients(external_message_id: external_message_id).first&.dig(STATUS_FIELD_NAME)
     end
 
     def get_recipients(external_message_id:)

--- a/spec/services/external_api/gov_delivery_service_spec.rb
+++ b/spec/services/external_api/gov_delivery_service_spec.rb
@@ -51,6 +51,9 @@ describe ExternalApi::GovDeliveryService do
   let(:success_response) do
     HTTPI::Response.new(200, {}, response_body)
   end
+  let(:empty_response) do
+    HTTPI::Response.new(200, {}, [].to_json)
+  end
 
   context "get_recipients" do
     describe "#get_recipients_from_event" do
@@ -135,6 +138,14 @@ describe ExternalApi::GovDeliveryService do
         allow(HTTPI).to receive(:get).and_return(success_response)
 
         expect(subject).to eq event_status_sent
+      end
+
+      context "with an empty response" do
+        it "returns nil" do
+          allow(HTTPI).to receive(:get).and_return(empty_response)
+
+          expect(subject).to be_nil
+        end
       end
     end
   end


### PR DESCRIPTION
Connects #16685

### Description
Handles responses with empty recipients lists from the govdelivery API.