### PR TITLE
request_decision_issues join table: add delete_at partial index

### DIFF
--- a/db/migrate/20210907215707_add_delete_at_index_on_request_decision_issues.rb
+++ b/db/migrate/20210907215707_add_delete_at_index_on_request_decision_issues.rb
@@ -1,0 +1,8 @@
+class AddDeleteAtIndexOnRequestDecisionIssues < Caseflow::Migration
+  def change
+    # Use a partial index since we don't need to query by a non-null deleted_at value.
+    # https://www.johnnunemaker.com/rails-postgres-partial-indexing/
+    # A partial index should be cheaper: https://dba.stackexchange.com/a/102513
+    add_index(:request_decision_issues, :deleted_at, where: "deleted_at IS NULL", algorithm: :concurrently)
+  end
+end

--- a/db/migrate/20210907215707_add_delete_at_index_on_request_decision_issues.rb
+++ b/db/migrate/20210907215707_add_delete_at_index_on_request_decision_issues.rb
@@ -3,6 +3,6 @@ class AddDeleteAtIndexOnRequestDecisionIssues < Caseflow::Migration
     # Use a partial index since we don't need to query by a non-null deleted_at value.
     # https://www.johnnunemaker.com/rails-postgres-partial-indexing/
     # A partial index should be cheaper: https://dba.stackexchange.com/a/102513
-    add_index(:request_decision_issues, :deleted_at, where: "deleted_at IS NULL", algorithm: :concurrently)
+    add_safe_index(:request_decision_issues, :deleted_at, where: "deleted_at IS NULL", algorithm: :concurrently)
   end
 end

--- a/db/migrate/20210909151937_add_index_decision_issue_to_request_issue.rb
+++ b/db/migrate/20210909151937_add_index_decision_issue_to_request_issue.rb
@@ -1,0 +1,9 @@
+class AddIndexDecisionIssueToRequestIssue < Caseflow::Migration
+  def change
+    # Enable efficient queries when calling di.request_issues
+    add_safe_index(:request_decision_issues, [:decision_issue_id, :request_issue_id],
+                   unique: true, algorithm: :concurrently,
+                   :name => 'index_on_decision_issue_id_and_request_issue_id'
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_215707) do
+ActiveRecord::Schema.define(version: 2021_09_09_151937) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1218,6 +1218,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_215707) do
     t.datetime "deleted_at"
     t.integer "request_issue_id", comment: "The ID of the request issue."
     t.datetime "updated_at", null: false, comment: "Automatically populated when the record is updated."
+    t.index ["decision_issue_id", "request_issue_id"], name: "index_on_decision_issue_id_and_request_issue_id", unique: true
     t.index ["deleted_at"], name: "index_request_decision_issues_on_deleted_at", where: "(deleted_at IS NULL)"
     t.index ["request_issue_id", "decision_issue_id"], name: "index_on_request_issue_id_and_decision_issue_id", unique: true
     t.index ["updated_at"], name: "index_request_decision_issues_on_updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_07_174359) do
+ActiveRecord::Schema.define(version: 2021_09_07_215707) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1218,6 +1218,7 @@ ActiveRecord::Schema.define(version: 2021_09_07_174359) do
     t.datetime "deleted_at"
     t.integer "request_issue_id", comment: "The ID of the request issue."
     t.datetime "updated_at", null: false, comment: "Automatically populated when the record is updated."
+    t.index ["deleted_at"], name: "index_request_decision_issues_on_deleted_at", where: "(deleted_at IS NULL)"
     t.index ["request_issue_id", "decision_issue_id"], name: "index_on_request_issue_id_and_decision_issue_id", unique: true
     t.index ["updated_at"], name: "index_request_decision_issues_on_updated_at"
   end


### PR DESCRIPTION
Resolves these long-running queries: https://onenr.io/01OwvV6N3wv
```sql
SELECT "request_issues".* FROM "request_issues" 
INNER JOIN "request_decision_issues" ON "request_issues"."id" = "request_decision_issues"."request_issue_id"
WHERE "request_decision_issues"."deleted_at" IS ? AND "request_decision_issues"."decision_issue_id" = $?
```

![image](https://user-images.githubusercontent.com/55255674/132418214-b31b9d95-2f4c-45f2-8193-4880e18eb720.png)

[Slack](https://dsva.slack.com/archives/C4JECDLSE/p1631028867035300)

Note that a slow `Seq Scan` is used:
```
                                            QUERY PLAN
--------------------------------------------------------------------------------------------------
 Nested Loop  (cost=1000.43..33753.02 rows=1 width=853)
   ->  Gather  (cost=1000.00..33744.57 rows=1 width=4)
         Workers Planned: 2
         ->  Parallel Seq Scan on request_decision_issues  (cost=0.00..32744.47 rows=1 width=4)
               Filter: ((deleted_at IS NULL) AND (decision_issue_id = 1794746))
   ->  Index Scan using request_issues_pkey on request_issues  (cost=0.43..8.45 rows=1 width=853)
         Index Cond: (id = request_decision_issues.request_issue_id)
```

### Description

Adds a partial index since we don't need to query by a non-null `deleted_at` value -- https://www.johnnunemaker.com/rails-postgres-partial-indexing/.
A partial index should be cheaper: https://dba.stackexchange.com/a/102513

Bonus: add an index to enable efficient queries when calling `di.request_issues`. `ri.decision_issues` already uses an index.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Above query uses DB index

### Testing Plan 1
Add the following (to increase the table size large enough to warrant using the index) around line 74 of `spec/models/decision_issue_spec.rb`:
```
    context "scale" do
      before do
        100.times do
          create(
            :decision_issue,
            decision_review: decision_review,
            disposition: disposition,
            decision_text: decision_text,
            description: description,
            request_issues: 2.times.map{create(:request_issue)},
            benefit_type: benefit_type,
            rating_profile_date: profile_date,
            rating_promulgation_date: promulgation_date,
            end_product_last_action_date: end_product_last_action_date,
            caseflow_decision_date: caseflow_decision_date,
            diagnostic_code: diagnostic_code
          )
        end
      end
      it "uses index" do
        di=decision_issue
        binding.pry
      end
    end
  end
```
In the pry prompt run and note that a `seq scan` is not used:
```
di.request_issues.explain
EXPLAIN for: SELECT "request_issues".* FROM "request_issues" INNER JOIN "request_decision_issues" ON "request_issues"."id" = "request_decision_issues"."request_issue_id" WHERE "request_decision_issues"."deleted_at" IS NULL AND "request_decision_issues"."decision_issue_id" = $1 [["decision_issue_id", 1]]
                                                   QUERY PLAN
----------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=4.34..22.00 rows=1 width=812)
   ->  Bitmap Heap Scan on request_decision_issues  (cost=4.20..13.67 rows=1 width=4)
         Recheck Cond: (deleted_at IS NULL)
         Filter: (decision_issue_id = 1)
         ->  Bitmap Index Scan on index_request_decision_issues_on_deleted_at  (cost=0.00..4.20 rows=6 width=0)
               Index Cond: (deleted_at IS NULL)
   ->  Index Scan using request_issues_pkey on request_issues  (cost=0.14..8.16 rows=1 width=812)
         Index Cond: (id = request_decision_issues.request_issue_id)
(8 rows)
```

Compare that with the query plan before the migration.

### Testing Plan 2
In local Rails console:
```
di=DecisionIssue.last

di.request_issues.explain
=> EXPLAIN for: SELECT "request_issues".* FROM "request_issues" INNER JOIN "request_decision_issues" ON "request_issues"."id" = "request_decision_issues"."request_issue_id" WHERE "request_decision_issues"."deleted_at" IS NULL AND "request_decision_issues"."decision_issue_id" = $1 [["decision_issue_id", 2001171726]]
                                                             QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.55..16.59 rows=1 width=646)
   ->  Index Scan using index_on_decision_issue_id_and_request_issue_id on request_decision_issues  (cost=0.27..8.29 rows=1 width=4)
         Index Cond: (decision_issue_id = 2001171726)
         Filter: (deleted_at IS NULL)
   ->  Index Scan using request_issues_pkey on request_issues  (cost=0.28..8.30 rows=1 width=646)
         Index Cond: (id = request_decision_issues.request_issue_id)
(6 rows)
```
Note the `index_on_decision_issue_id_and_request_issue_id` index is used.

In prod (before the migration), a `seq scan` is used:
```
di.request_issues.explain
SELECT "request_issues".* FROM "request_issues" 
INNER JOIN "request_decision_issues" 
  ON "request_issues"."id" = "request_decision_issues"."request_issue_id" 
WHERE "request_decision_issues"."deleted_at" IS NULL 
  AND "request_decision_issues"."decision_issue_id" = 1797400
                                            QUERY PLAN
--------------------------------------------------------------------------------------------------
 Nested Loop  (cost=1000.43..33753.02 rows=1 width=853)
   ->  Gather  (cost=1000.00..33744.57 rows=1 width=4)
         Workers Planned: 2
         ->  Parallel Seq Scan on request_decision_issues  (cost=0.00..32744.47 rows=1 width=4)
               Filter: ((deleted_at IS NULL) AND (decision_issue_id = 1797400))
   ->  Index Scan using request_issues_pkey on request_issues  (cost=0.43..8.45 rows=1 width=853)
         Index Cond: (id = request_decision_issues.request_issue_id)
(7 rows)
```

See [Slack](https://dsva.slack.com/archives/CHNHVHZ2T/p1631199823003900?thread_ts=1631053593.003300&cid=CHNHVHZ2T) for details.

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`)
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Post this PR in #appeals-schema with a summary
