### PR TITLE
Return nil if request_type comes back as :none from VACOLS

### DIFF
--- a/app/models/concerns/hearing_request_type_concern.rb
+++ b/app/models/concerns/hearing_request_type_concern.rb
@@ -105,7 +105,7 @@ module HearingRequestTypeConcern
 
   # rubocop:disable Metrics/CyclomaticComplexity
   def format_hearing_request_type(request_type)
-    return nil if request_type.nil?
+    return nil if request_type.nil? || request_type == :none
 
     case request_type
     when HearingDay::REQUEST_TYPES[:central], :central_office, :central

--- a/spec/models/concerns/hearing_request_type_concern_spec.rb
+++ b/spec/models/concerns/hearing_request_type_concern_spec.rb
@@ -173,6 +173,12 @@ describe HearingRequestTypeConcern do
 
         it { is_expected.to be_nil }
       end
+
+      context "when hearing_request_type is none in VACOLS" do
+        let(:vacols_case) { create(:case, bfhr: "5") }
+
+        it { is_expected.to be_nil }
+      end
     end
 
     context "#readable_previous_hearing_request_type_for_task and #readable_current_hearing_request_type_for_task" do


### PR DESCRIPTION
Resolves an issue that came through Bat Team ([INC19505704](https://dsva.slack.com/archives/CHX8FMP28/p1631542573253900)) where sometimes [`format_hearing_request_type`](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/concerns/hearing_request_type_concern.rb#L107-L122) would incorrectly return `:video` when `hearing_request_type` is `:none` in VACOLS.