### PR TITLE
GH Action `make docs`: push to main-gh-pages instead of wiki

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -1,13 +1,15 @@
-name: Make-docs-to-wiki
+name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
+  # TEMPORARY for testing
+  push:
   pull_request:
     types: [ closed ]
 
 jobs:
   make_docs:
-    name: Update DB schema files in wiki
+    name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
@@ -102,11 +104,16 @@ jobs:
       # The following is adapted from: https://github.com/SwiftDocOrg/github-wiki-publish-action/blob/v1/entrypoint.sh
       # and https://github.com/Andrew-Chen-Wang/github-wiki-action/blob/master/entrypoint.sh
       # and https://github.community/t/how-to-updade-repo-wiki-from-github-actions/121151/7
-      - name: Checkout wiki code
+      - name: Checkout branch main-gh-pages
         uses: actions/checkout@v2
         with:
           ref: main-gh-pages
           path: main-gh-pages_checkout
+      - name: Update Jailer-generated DB schema docs for Caseflow
+        run: |
+          CASEFLOW_HOME=`pwd`
+          cd main-gh-pages_checkout/schema/bin
+          sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
       - name: Commit 'make docs' files to main-gh-pages
         env:
           WIKI_COMMIT_MESSAGE: '`make docs` - Automatically update DB schema documentation files'

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -11,7 +11,7 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    if: github.event.pull_request.merged == true
+    # TEMPORARY if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -109,6 +109,9 @@ jobs:
         with:
           ref: main-gh-pages
           path: main-gh-pages_checkout
+      - name: Copy results of `make docs` to checkout of main-gh-pages
+        run: |
+          rsync -av --exclude .git --exclude .keep "docs/schema/" "main-gh-pages_checkout/schema/make_docs/"
       - name: Update Jailer-generated DB schema docs for Caseflow
         run: |
           CASEFLOW_HOME=`pwd`
@@ -120,8 +123,6 @@ jobs:
           WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
           WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |
-          rsync -av --exclude .git --exclude .keep "docs/schema/" "main-gh-pages_checkout/schema/make_docs/"
-
           cd main-gh-pages_checkout
 
           echo "::group::Ignore files that change with every run"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -116,7 +116,7 @@ jobs:
           sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
       - name: Commit 'make docs' files to main-gh-pages
         env:
-          WIKI_COMMIT_MESSAGE: '`make docs` - Automatically update DB schema documentation files'
+          WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
           WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
           WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -113,6 +113,10 @@ jobs:
         run: |
           rsync -av --exclude .git --exclude .keep "docs/schema/" "main-gh-pages_checkout/schema/make_docs/"
       - name: Update Jailer-generated DB schema docs for Caseflow
+        env:
+          POSTGRES_DB: caseflow_certification_test
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
         run: |
           CASEFLOW_HOME=`pwd`
           cd main-gh-pages_checkout/schema/bin

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -87,7 +87,7 @@ jobs:
           UPDATE_SCHEMA_ERD_IMAGES: true
         run: |
           ln -s Makefile.example Makefile
-          
+
           echo "::group::Caseflow schema"
           make erd-caseflow doc-schema-caseflow
           echo "::endgroup::"
@@ -105,29 +105,29 @@ jobs:
       - name: Checkout wiki code
         uses: actions/checkout@v2
         with:
-          repository: ${{github.repository}}.wiki
-          path: wiki_checkout
-      - name: Push 'make docs' files to wiki
+          ref: main-gh-pages
+          path: main-gh-pages_checkout
+      - name: Commit 'make docs' files to main-gh-pages
         env:
           WIKI_COMMIT_MESSAGE: '`make docs` - Automatically update DB schema documentation files'
           WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
           WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |
-          rsync -av --exclude .git "docs/schema" "wiki_checkout/make_docs"
+          rsync -av --exclude .git --exclude .keep "docs/schema/" "main-gh-pages_checkout/schema/make_docs/"
 
-          cd wiki_checkout
+          cd main-gh-pages_checkout
 
           echo "::group::Ignore files that change with every run"
-          rm -vf make_docs/schema/*-erd.pdf
+          rm -vf make_docs/*-erd.pdf
           echo "::endgroup::"
 
           git add .
           if git diff-index --quiet HEAD; then
-            echo "::group::No changes to schema"
+            echo "::group::No changes to make_docs"
             ls -alR make_docs
             echo "::endgroup::"
           else
-            echo "::group::Pushing changes to wiki"
+            echo "::group::Pushing changes to main-gh-pages"
             git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
             git config --local user.name "$WIKI_COMMIT_USER_NAME"
             git commit -m "$WIKI_COMMIT_MESSAGE" && git push

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,8 +2,6 @@ name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
-  # TEMPORARY for testing
-  push:
   pull_request:
     types: [ closed ]
 
@@ -11,7 +9,7 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    # TEMPORARY if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -130,7 +130,7 @@ jobs:
           cd main-gh-pages_checkout
 
           echo "::group::Ignore files that change with every run"
-          rm -vf make_docs/*-erd.pdf
+          rm -vf schema/make_docs/*-erd.pdf
           echo "::endgroup::"
 
           git add .

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -161,7 +161,7 @@ namespace :doc do
     end
 
     def update_schema_images?
-      ENV.fetch("UPDATE_SCHEMA_ERD_IMAGES", nil)
+      ActiveModel::Type::Boolean.new.cast(ENV.fetch("UPDATE_SCHEMA_ERD_IMAGES", true))
     end
 
     desc "Generate belongs_to ERD"


### PR DESCRIPTION
### Description
Wiki page https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Database-Schema-Documentation has been migrated to GH Pages: http://department-of-veterans-affairs.github.io/caseflow/schema/schema_diagrams.html.

Update GH Action `make docs` to push to `main-gh-pages` instead of the wiki.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
When a DB schema change occurs, check that GH Pages's DB Schema Diagrams page is updated with the new diagrams.

