### PR TITLE
`make_docs` GitHub Action: fixes minor error for missing directory

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -134,7 +134,7 @@ jobs:
           git add .
           if git diff-index --quiet HEAD; then
             echo "::group::No changes to make_docs"
-            ls -alR make_docs
+            ls -alR schema/make_docs
             echo "::endgroup::"
           else
             echo "::group::Pushing changes to main-gh-pages"


### PR DESCRIPTION
Resolves minor error for `make_docs` GitHub Action: https://github.com/department-of-veterans-affairs/caseflow/runs/3599973683?check_suite_focus=true

### Description
Forgot to update one more line to refer to `schema/make_docs`.

### Acceptance Criteria
- [ ] Code compiles correctly
