### PR TITLE
Fix RequestIssue Status during Substitution on Death-Dismissed Appeals

### DIFF
--- a/app/models/appellant_substitution.rb
+++ b/app/models/appellant_substitution.rb
@@ -80,6 +80,11 @@ class AppellantSubstitution < CaseflowRecord
       # This block of code may be a source of bugs as new columns are added to request_issues.
       # It may be better to copy specific attributes, than duplicate everything.
       request_issue.dup.tap do |request_issue_copy|
+        # Death-dismissed issues should be reopened
+        if request_issue.death_dismissed?
+          request_issue_copy.closed_status = nil
+          request_issue_copy.closed_at = nil
+        end
         request_issue_copy.decision_review = target_appeal
         request_issue_copy.save!
       end

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -598,6 +598,10 @@ class RequestIssue < CaseflowRecord
     !contention_connected_to_rating?
   end
 
+  def death_dismissed?
+    decision_issues.any? { |di| di.disposition === "dismissed_death" }
+  end
+
   def remanded?
     # if this request issue is a correction for a decision issue from a remand supplemental claim,
     # consider it a remanded request issue regardless of the decision issue disposition

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -599,7 +599,7 @@ class RequestIssue < CaseflowRecord
   end
 
   def death_dismissed?
-    decision_issues.any? { |di| di.disposition === "dismissed_death" }
+    decision_issues.any? { |di| ["dismissed_death"].include?(di.disposition) }
   end
 
   def remanded?

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -599,7 +599,7 @@ class RequestIssue < CaseflowRecord
   end
 
   def death_dismissed?
-    decision_issues.any? { |di| ["dismissed_death"].include?(di.disposition) }
+    decision_issues.where(disposition: "dismissed_death").any?
   end
 
   def remanded?

--- a/db/seeds/substitutions.rb
+++ b/db/seeds/substitutions.rb
@@ -30,7 +30,7 @@ module Seeds
 
       create(
         :appeal,
-        :dispatched, :with_decision_issue,
+        :with_decision_issue, :dispatched,
         disposition: "dismissed_death",
         number_of_claimants: 1,
         veteran: veteran,

--- a/db/seeds/substitutions.rb
+++ b/db/seeds/substitutions.rb
@@ -30,7 +30,7 @@ module Seeds
 
       create(
         :appeal,
-        :with_decision_issue, :dispatched,
+        :with_decision_issue, :dispatched, # trait order matters to ensure correct `closed_status` on RI
         disposition: "dismissed_death",
         number_of_claimants: 1,
         veteran: veteran,

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -461,12 +461,14 @@ FactoryBot.define do
 
     trait :with_decision_issue do
       after(:create) do |appeal, evaluator|
-        create(:decision_issue,
+        create(
+          :decision_issue,
           :rating,
           decision_review: appeal,
           disposition: evaluator.disposition,
           description: "Issue description",
-          decision_text: "Decision text")
+          decision_text: "Decision text"
+        )
       end
     end
 

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -460,15 +460,13 @@ FactoryBot.define do
     end
 
     trait :with_decision_issue do
-      description = "Service connection for pain disorder is granted with an evaluation of 70\% effective May 1 2011"
-      notes = "Pain disorder with 100\% evaluation per examination"
       after(:create) do |appeal, evaluator|
-        decision_issue = create(:decision_issue,
-                                :rating,
-                                decision_review: appeal,
-                                disposition: evaluator.disposition,
-                                description: "Issue description",
-                                decision_text: "Decision text")
+        create(:decision_issue,
+          :rating,
+          decision_review: appeal,
+          disposition: evaluator.disposition,
+          description: "Issue description",
+          decision_text: "Decision text")
       end
     end
 

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -463,20 +463,12 @@ FactoryBot.define do
       description = "Service connection for pain disorder is granted with an evaluation of 70\% effective May 1 2011"
       notes = "Pain disorder with 100\% evaluation per examination"
       after(:create) do |appeal, evaluator|
-        request_issue = create(:request_issue,
-                               :rating,
-                               :with_rating_decision_issue,
-                               decision_review: appeal,
-                               veteran_participant_id: appeal.veteran.participant_id,
-                               contested_issue_description: description,
-                               notes: notes)
         decision_issue = create(:decision_issue,
                                 :rating,
                                 decision_review: appeal,
                                 disposition: evaluator.disposition,
                                 description: "Issue description",
                                 decision_text: "Decision text")
-        request_issue.decision_issues << decision_issue
       end
     end
 

--- a/spec/models/appellant_substitution_spec.rb
+++ b/spec/models/appellant_substitution_spec.rb
@@ -289,22 +289,31 @@ describe AppellantSubstitution do
       end
 
       context "source appeal has request issues" do
-        let(:source_appeal) { create(:appeal, :active, :with_request_issues).reload }
-        it "copies request issues but not decision issues to new appeal" do
-          expect(source_appeal.request_issues.count).to be > 0
+        context "on death-dismissed appeal" do
+          let(:source_appeal) do
+            create(:appeal, :with_decision_issue, :dispatched, disposition: "dismissed_death").reload
+          end
 
-          appellant_substitution = subject
-          target_appeal = appellant_substitution.target_appeal
-          expect(target_appeal.request_issues.count).to eq source_appeal.request_issues.count
-          expect(target_appeal.request_issues.pluck(:benefit_type))
-            .to eq source_appeal.request_issues.pluck(:benefit_type)
-          expect(target_appeal.request_issues.pluck(:contested_issue_description))
-            .to eq source_appeal.request_issues.pluck(:contested_issue_description)
-          expect(target_appeal.request_issues.pluck(:notes)).to eq source_appeal.request_issues.pluck(:notes)
-          expect(target_appeal.request_issues.pluck(:decision_date))
-            .to eq source_appeal.request_issues.pluck(:decision_date)
-
-          expect(target_appeal.decision_issues.count).to eq 0
+          it "copies request issues but not decision issues to new appeal" do
+            expect(source_appeal.request_issues.count).to be > 0
+  
+            appellant_substitution = subject
+            target_appeal = appellant_substitution.target_appeal
+            expect(target_appeal.request_issues.count).to eq source_appeal.request_issues.count
+            expect(target_appeal.request_issues.pluck(:benefit_type))
+              .to eq source_appeal.request_issues.pluck(:benefit_type)
+            expect(target_appeal.request_issues.pluck(:contested_issue_description))
+              .to eq source_appeal.request_issues.pluck(:contested_issue_description)
+            expect(target_appeal.request_issues.pluck(:notes)).to eq source_appeal.request_issues.pluck(:notes)
+            expect(target_appeal.request_issues.pluck(:decision_date))
+              .to eq source_appeal.request_issues.pluck(:decision_date)
+  
+            # new request issues should not maintain decided status
+            expect(target_appeal.request_issues.any? { |ri| ri.closed_status || ri.closed_at }).to eql(false)
+  
+            # There should not be any decision issues copied
+            expect(target_appeal.decision_issues.count).to eq 0
+          end
         end
       end
     end

--- a/spec/models/appellant_substitution_spec.rb
+++ b/spec/models/appellant_substitution_spec.rb
@@ -296,7 +296,7 @@ describe AppellantSubstitution do
 
           it "copies request issues but not decision issues to new appeal" do
             expect(source_appeal.request_issues.count).to be > 0
-  
+
             appellant_substitution = subject
             target_appeal = appellant_substitution.target_appeal
             expect(target_appeal.request_issues.count).to eq source_appeal.request_issues.count
@@ -307,10 +307,10 @@ describe AppellantSubstitution do
             expect(target_appeal.request_issues.pluck(:notes)).to eq source_appeal.request_issues.pluck(:notes)
             expect(target_appeal.request_issues.pluck(:decision_date))
               .to eq source_appeal.request_issues.pluck(:decision_date)
-  
+
             # new request issues should not maintain decided status
             expect(target_appeal.request_issues.any? { |ri| ri.closed_status || ri.closed_at }).to eql(false)
-  
+
             # There should not be any decision issues copied
             expect(target_appeal.decision_issues.count).to eq 0
           end

--- a/spec/models/concerns/belongs_to_polymorphic_appeal_concern_spec.rb
+++ b/spec/models/concerns/belongs_to_polymorphic_appeal_concern_spec.rb
@@ -26,7 +26,7 @@ describe BelongsToPolymorphicAppealConcern do
     context "when `has_many ama_decision_issues through: :ama_appeal` is defined" do
       subject { decision_doc.ama_decision_issues }
       it "returns the correct decision_issues" do
-        expect(subject.count).to eq 2
+        expect(subject.count).to eq 1
         expect(subject).to eq decision_doc.appeal.decision_issues
       end
 
@@ -53,7 +53,7 @@ describe BelongsToPolymorphicAppealConcern do
 
             # 2. Querying using SQL produces incomprehensible numerical column names
             sql_result = ActiveRecord::Base.connection.exec_query(query.to_sql)
-            expect(sql_result.to_hash.size).to eq 10
+            expect(sql_result.to_hash.size).to eq 5
 
             # 3. Querying using pluck_to_hash works but must specify all columns
             fields = DecisionDocument.column_names.map { |n| DecisionDocument.table_name + "." + n } +

--- a/spec/models/concerns/belongs_to_polymorphic_appeal_concern_spec.rb
+++ b/spec/models/concerns/belongs_to_polymorphic_appeal_concern_spec.rb
@@ -59,7 +59,7 @@ describe BelongsToPolymorphicAppealConcern do
             fields = DecisionDocument.column_names.map { |n| DecisionDocument.table_name + "." + n } +
                      DecisionIssue.column_names.map { |n| DecisionIssue.table_name + "." + n }
             hash_result = query.pluck_to_hash(*fields.uniq) # sensible column names as long as they're unique
-            expect(hash_result.size).to eq 10
+            expect(hash_result.size).to eq 5
             expect(hash_result.sample.size).to eq fields.size # ensure result has all requested fields
           end
 

--- a/spec/policies/appeal_decision_issues_policy_spec.rb
+++ b/spec/policies/appeal_decision_issues_policy_spec.rb
@@ -80,7 +80,7 @@ describe AppealDecisionIssuesPolicy, :postgres do
           let(:result) { subject }
 
           it "can be seen" do
-            expect(result[1].id).to eq(appeal.decision_issues[1].id)
+            expect(result[0].id).to eq(appeal.decision_issues[0].id)
           end
 
           it "its issue description is visible" do

--- a/spec/policies/appeal_decision_issues_policy_spec.rb
+++ b/spec/policies/appeal_decision_issues_policy_spec.rb
@@ -24,7 +24,6 @@ describe AppealDecisionIssuesPolicy, :postgres do
 
           it "can be seen" do
             expect(result[0].id).to eq(appeal.decision_issues[0].id)
-            expect(result[1].id).to eq(appeal.decision_issues[1].id)
           end
 
           it "its issue description is not visible" do

--- a/spec/services/etl/decision_document_syncer_spec.rb
+++ b/spec/services/etl/decision_document_syncer_spec.rb
@@ -46,7 +46,7 @@ describe ETL::DecisionDocumentSyncer, :etl, :all_dbs do
       it "enables SQL joins" do
         subject
         expect(ETL::DecisionDocument.count).to eq(1)
-        expect(ETL::DecisionIssue.count).to eq(2)
+        expect(ETL::DecisionIssue.count).to eq(1)
 
         # Paul Saindon's DecisionDocument query
         query = <<~SQL


### PR DESCRIPTION
Connects [CASEFLOW-2299](https://vajira.max.gov/browse/CASEFLOW-2299)

### Description
This adjusts the logic in `AppellantSubstitution` to ensure that request issues that were closed on the source appeal due to death dismissal are reopened when copied to the target appeal. This fixes a bug that prevented attorney checkout from completing with these issues.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Decided request issues (with `dismissed_death` DecisionIssue) from source appeal have `nil` for `closed_status` and `closed_at` on target appeal

### Testing Plan
You can see the basics in the updated model test for `AppellantSubstitution`

For manual testing, and to ensure that the attorney checkout flow continues to work, perform these steps:
1. Use one of the death-dismissed cases for veteran ID `54545454` (for proper setup, you may need to `make reset` or follow the code in `Seeds::Substitutions` to create the appeal with correct request issue / decision issue relationships)
2. Perform a substitution and note the uuid of the new appeal stream
3. Create new judge/attorney tasks (in order to bypass difficult-to-replicate distribution process)
```ruby
uuid = "" # copy from URL of new/substitution appeal stream
target_appeal = Appeal.find_by(uuid: uuid)

judge_user = User.find_by_css_id("BVAAABSHIRE")
attorney_user = User.find_by_css_id("BVAEERDMAN")

# Create judge task
parent_task = FactoryBot.create(
  :ama_judge_decision_review_task,
  assigned_to: judge_user,
  parent: target_appeal.root_task
)

# Create attorney task
FactoryBot.create(
  :ama_attorney_task,
  :in_progress,
  assigned_to: attorney_user,
  assigned_by: judge_user,
  parent: parent_task
)

```
4. Log in as the attorney (BVAEERDMAN), and go to Case Details for the new/target/substitution appeal
5. Choose task action to draft decision and add a decision for the existing request issue
