### PR TITLE
`make_docs` GitHub Action: create or update PR to update DB documentation

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,6 +2,9 @@ name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
+  push: # TEMP
+    branches:
+      - yoom/make-docs_create-update-docs-pr
   pull_request:
     types: [ closed ]
 
@@ -9,8 +12,11 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    if: github.event.pull_request.merged == true
+    # TEMP if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
+    # Map a step output to a job output
+    outputs:
+      changes_docs: ${{ steps.compare_docs.outputs.changes_docs }}
     services:
       postgres:
         image: postgres:11
@@ -120,10 +126,7 @@ jobs:
           cd main-gh-pages_checkout/schema/bin
           sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
       - name: Commit 'make docs' files to main-gh-pages
-        env:
-          WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
-          WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
-          WIKI_COMMIT_USER_NAME: 'yoomlam'
+        id: compare_docs
         run: |
           cd main-gh-pages_checkout
 
@@ -133,13 +136,36 @@ jobs:
 
           git add .
           if git diff-index --quiet HEAD; then
+            echo "::set-output name=changes_docs::false"
             echo "::group::No changes to make_docs"
             ls -alR schema/make_docs
             echo "::endgroup::"
           else
-            echo "::group::Pushing changes to main-gh-pages"
-            git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
-            git config --local user.name "$WIKI_COMMIT_USER_NAME"
-            git commit -m "$WIKI_COMMIT_MESSAGE" && git push
-            echo "::endgroup::"
+            echo "::set-output name=changes_docs::true"
           fi
+  update_docs_pr:
+    name: Create or add to PR to update DB documentation
+    needs: make_docs
+    # Be aware: https://github.com/actions/runner/issues/491
+    # TEMP if: needs.make_docs.outputs.changes_docs == 'true'
+    steps:
+      - run: |
+          echo "From `make_docs` job, changes_docs=${{needs.make_docs.outputs.changes_docs}}"
+          echo "${{ toJSON(needs) }}"
+      - name: Create/Update PR for main-gh-pages base branch
+        id: compare_docs
+        env:
+          WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
+          WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
+          WIKI_COMMIT_USER_NAME: 'yoomlam'
+        run: |
+          ls -al
+          cd main-gh-pages_checkout
+
+          git add .
+          git status
+          echo "::group::Pushing changes to main-gh-pages"
+          # git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
+          # git config --local user.name "$WIKI_COMMIT_USER_NAME"
+          # git commit -m "$WIKI_COMMIT_MESSAGE" && git push
+          echo "::endgroup::"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,9 +2,6 @@ name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
-  push: # TEMP
-    branches:
-      - yoom/make-docs_create-update-docs-pr
   pull_request:
     types: [ closed ]
 
@@ -12,7 +9,7 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    # TEMP if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     # Map a step output to a job output
     outputs:
@@ -138,8 +135,6 @@ jobs:
           rm -vf schema/make_docs/*-erd.pdf
           echo "::endgroup::"
 
-          echo "<!-- TEMPORARY 2 -->" >> schema/html/index.html
-
           git add .
           if git diff-index --quiet HEAD; then
             echo "::set-output name=changes_docs::false"
@@ -174,5 +169,6 @@ jobs:
       - name: PR info
         if: steps.create_pr.outcome == 'success'
         run: |
+          echo "PR ${{ steps.create_pr.outputs.pull-request-operation }}"
           echo "Pull Request Number - ${{ steps.create_pr.outputs.pull-request-number }}"
           echo "Pull Request URL - ${{ steps.create_pr.outputs.pull-request-url }}"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -170,7 +170,7 @@ jobs:
         with:
           title: "GH Action: update DB documentation"
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
-          branch: "gh-actions/make_docs-update_docs"
+          branch: "main-gh-pages"
           path: "main-gh-pages_checkout/"
           author: 'GitHub Action make_docs <yoomlam@navapbc.com>'
           labels: "Type: Documentation"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -125,7 +125,7 @@ jobs:
           CASEFLOW_HOME=`pwd`
           cd main-gh-pages_checkout/schema/bin
           sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
-      - name: Commit 'make docs' files to main-gh-pages
+      - name: Compare 'make docs' output files to main-gh-pages branch
         id: compare_docs
         run: |
           cd main-gh-pages_checkout
@@ -143,27 +143,16 @@ jobs:
           else
             echo "::set-output name=changes_docs::true"
           fi
-  update_docs_pr:
-    name: Create or add to PR to update DB documentation
-    needs: make_docs
-    # Be aware: https://github.com/actions/runner/issues/491
-    # TEMP if: needs.make_docs.outputs.changes_docs == 'true'
-    steps:
-      - run: |
-          echo "From `make_docs` job, changes_docs=${{needs.make_docs.outputs.changes_docs}}"
-          echo "${{ toJSON(needs) }}"
       - name: Create/Update PR for main-gh-pages base branch
-        id: compare_docs
+        if: steps.compare_docs.outputs.changes_docs == 'true'
         env:
           WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
           WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
           WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |
-          ls -al
           cd main-gh-pages_checkout
-
-          git add .
           git status
+
           echo "::group::Pushing changes to main-gh-pages"
           # git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
           # git config --local user.name "$WIKI_COMMIT_USER_NAME"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -145,18 +145,23 @@ jobs:
           else
             echo "::set-output name=changes_docs::true"
           fi
+      - name: Changes to DB documentation
+        if: steps.compare_docs.outputs.changes_docs == 'true'
+        working-directory: main-gh-pages_checkout
+        run: |
+          git status
+          git diff
       - name: Create/Update PR to merge into main-gh-pages
         if: steps.compare_docs.outputs.changes_docs == 'true'
+        uses: gr2m/create-or-update-pull-request-action@v1
         env:
-          WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
-          WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
-          WIKI_COMMIT_USER_NAME: 'yoomlam'
-        run: |
-          cd main-gh-pages_checkout
-          git status
-
-          echo "::group::Pushing changes to main-gh-pages"
-          # git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
-          # git config --local user.name "$WIKI_COMMIT_USER_NAME"
-          # git commit -m "$WIKI_COMMIT_MESSAGE" && git push
-          echo "::endgroup::"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          title: "GH Action: update DB documentation"
+          body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
+          branch: "gh-actions/make_docs-update_docs"
+          path: "main-gh-pages_checkout/"
+          author: 'GitHub Action make_docs <yoomlam@navapbc.com>'
+          labels: "Type: Documentation"
+          assignees: yoomlam
+          commit-message: '`make docs` GH Action: automatically update DB schema documentation files'

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -145,12 +145,23 @@ jobs:
           else
             echo "::set-output name=changes_docs::true"
           fi
-      - name: Changes to DB documentation
+
+      - name: Commit changes to DB documentation
         if: steps.compare_docs.outputs.changes_docs == 'true'
         working-directory: main-gh-pages_checkout
+        env:
+          WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
+          WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
+          WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |
           git status
           git diff
+
+          echo "::group::Pushing changes to main-gh-pages"
+          git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
+          git config --local user.name "$WIKI_COMMIT_USER_NAME"
+          git commit -m "$WIKI_COMMIT_MESSAGE"
+          echo "::endgroup::"
       - name: Create/Update PR to merge into main-gh-pages
         if: steps.compare_docs.outputs.changes_docs == 'true'
         uses: gr2m/create-or-update-pull-request-action@v1

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -11,9 +11,6 @@ jobs:
     # Only run if the PR has been merged (rather than simply closed)
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
-    # Map a step output to a job output
-    outputs:
-      changes_docs: ${{ steps.compare_docs.outputs.changes_docs }}
     services:
       postgres:
         image: postgres:11

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -125,44 +125,40 @@ jobs:
           CASEFLOW_HOME=`pwd`
           cd main-gh-pages_checkout/schema/bin
           sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
-      - name: Compare generated docs against main-gh-pages branch
+      - name: Compare (and locally commit) generated docs against main-gh-pages branch
         id: compare_docs
-        run: |
-          cd main-gh-pages_checkout
-
-          echo "::group::Ignore files that change with every run"
-          rm -vf schema/make_docs/*-erd.pdf
-          echo "::endgroup::"
-
-          echo "<!-- TEMPORARY -->" >> schema/html/index.html
-
-          git add .
-          if git diff-index --quiet HEAD; then
-            echo "::set-output name=changes_docs::false"
-            echo "::group::No changes to make_docs"
-            ls -alR schema/make_docs
-            echo "::endgroup::"
-          else
-            echo "::set-output name=changes_docs::true"
-          fi
-
-      - name: Commit changes to DB documentation
-        if: steps.compare_docs.outputs.changes_docs == 'true'
-        working-directory: main-gh-pages_checkout
         env:
           WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'
           WIKI_COMMIT_USER_EMAIL: 'yoomlam@navapbc.com'
           WIKI_COMMIT_USER_NAME: 'yoomlam'
         run: |
-          git status
-          git diff
+          cd main-gh-pages_checkout
 
-          echo "::group::Pushing changes to main-gh-pages"
-          git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
-          git config --local user.name "$WIKI_COMMIT_USER_NAME"
-          git commit -m "$WIKI_COMMIT_MESSAGE"
+          echo "::group::Remove files that change with every run"
+          rm -vf schema/make_docs/*-erd.pdf
           echo "::endgroup::"
+
+          echo "<!-- TEMPORARY 2 -->" >> schema/html/index.html
+
+          git add .
+          if git diff-index --quiet HEAD; then
+            echo "::set-output name=changes_docs::false"
+
+            echo "::group::No changes to make_docs"
+            ls -alR schema/make_docs
+            echo "::endgroup::"
+          else
+            echo "::set-output name=changes_docs::true"
+
+            echo "::group::Committing changes locally"
+            git config --local user.email "$WIKI_COMMIT_USER_EMAIL"
+            git config --local user.name "$WIKI_COMMIT_USER_NAME"
+            git commit -m "$WIKI_COMMIT_MESSAGE"
+            echo "::endgroup::"
+          fi
+
       - name: Create/Update PR to merge into main-gh-pages
+        id: create_pr
         if: steps.compare_docs.outputs.changes_docs == 'true'
         uses: peter-evans/create-pull-request@v3
         with:
@@ -175,3 +171,8 @@ jobs:
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
           labels: "Type: Documentation"
           assignees: yoomlam
+      - name: PR info
+        if: steps.create_pr.outcome == 'success'
+        run: |
+          echo "Pull Request Number - ${{ steps.create_pr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.create_pr.outputs.pull-request-url }}"

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Copy results of `make docs` to checkout of main-gh-pages
         run: |
           rsync -av --exclude .git --exclude .keep "docs/schema/" "main-gh-pages_checkout/schema/make_docs/"
-      - name: Update Jailer-generated DB schema docs for Caseflow
+      - name: Update Jailer-generated DB schema docs for Caseflow using results of `make docs`
         env:
           POSTGRES_DB: caseflow_certification_test
           POSTGRES_PASSWORD: postgres
@@ -125,7 +125,7 @@ jobs:
           CASEFLOW_HOME=`pwd`
           cd main-gh-pages_checkout/schema/bin
           sh ./gen_jailer_schema_docs.sh "$CASEFLOW_HOME" ../make_docs/caseflow-jailer_polymorphic_associations.csv
-      - name: Compare 'make docs' output files to main-gh-pages branch
+      - name: Compare generated docs against main-gh-pages branch
         id: compare_docs
         run: |
           cd main-gh-pages_checkout
@@ -133,6 +133,8 @@ jobs:
           echo "::group::Ignore files that change with every run"
           rm -vf schema/make_docs/*-erd.pdf
           echo "::endgroup::"
+
+          echo "<!-- TEMPORARY -->" >> schema/html/index.html
 
           git add .
           if git diff-index --quiet HEAD; then
@@ -143,7 +145,7 @@ jobs:
           else
             echo "::set-output name=changes_docs::true"
           fi
-      - name: Create/Update PR for main-gh-pages base branch
+      - name: Create/Update PR to merge into main-gh-pages
         if: steps.compare_docs.outputs.changes_docs == 'true'
         env:
           WIKI_COMMIT_MESSAGE: '`make docs` GH Action: automatically update DB schema documentation files'

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -164,15 +164,14 @@ jobs:
           echo "::endgroup::"
       - name: Create/Update PR to merge into main-gh-pages
         if: steps.compare_docs.outputs.changes_docs == 'true'
-        uses: gr2m/create-or-update-pull-request-action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: peter-evans/create-pull-request@v3
         with:
+          path: "main-gh-pages_checkout/"
+          base: "main-gh-pages"
+          branch: "gh-actions/make_docs-update_docs"
+          delete-branch: true # when closing PR
+          commit-message: '`make docs` GH Action: automatically update DB schema documentation files'
           title: "GH Action: update DB documentation"
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
-          branch: "main-gh-pages"
-          path: "main-gh-pages_checkout/"
-          author: 'GitHub Action make_docs <yoomlam@navapbc.com>'
           labels: "Type: Documentation"
           assignees: yoomlam
-          commit-message: '`make docs` GH Action: automatically update DB schema documentation files'


### PR DESCRIPTION
Since a GitHub Action cannot trigger another GitHub Action, we'll create a PR to update DB documentation instead.

https://github.community/t/triggering-a-new-workflow-from-another-workflow/16250:
> An action in a workflow run can’t trigger a new workflow run

Approach: Use `steps.compare_docs.outputs` to conditionally create/update the PR
https://stackoverflow.com/questions/60453924/running-a-github-actions-step-only-if-previous-step-has-run

### Description
Add a step to the GH Action to create (or update) a PR to update DB documentation only if there are changes to the DB documentation.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
* [Run #69](https://github.com/department-of-veterans-affairs/caseflow/runs/3603678086?check_suite_focus=true) shows the "Create/Update PR ..." step is skipped if no changes are detected.
* [Run #70](https://github.com/department-of-veterans-affairs/caseflow/runs/3603761274?check_suite_focus=true) shows the "Create/Update PR ..." step is attempted if changes are detected.
* [Run #74](https://github.com/department-of-veterans-affairs/caseflow/runs/3603761274?check_suite_focus=true) shows the "Create/Update PR ..." step is creating a PR: https://github.com/department-of-veterans-affairs/caseflow/pull/16752
* Manually re-running `Run #74` correctly makes no update to the PR
* [Run #75](https://github.com/department-of-veterans-affairs/caseflow/runs/3604189990?check_suite_focus=true) adds a step to print PR info

