### PR TITLE
Fix Edit EP flake by soft-coding issue decision date

### DIFF
--- a/spec/feature/intake/edit_ep_claim_labels_spec.rb
+++ b/spec/feature/intake/edit_ep_claim_labels_spec.rb
@@ -130,7 +130,7 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
         click_on("Add issue")
         find(".cf-select", text: "Select or enter").click
         find(".cf-select__option", text: "Unknown Issue Category").click
-        fill_in "decision-date", with: "08192020"
+        fill_in "decision-date", with: 6.months.ago.strftime("%m%d%Y")
         fill_in "Issue description", with: "this is a description"
         click_on("Add this issue")
 


### PR DESCRIPTION
### Description
This PR fixes a now-failing test in the Edit EP feature spec, which was assuming that a hard-coded decision date is within a 1 year + grace period.