### PR TITLE
Un-hardcode the date so issues are not untimely

### DIFF
--- a/spec/feature/intake/edit_ep_claim_labels_spec.rb
+++ b/spec/feature/intake/edit_ep_claim_labels_spec.rb
@@ -130,7 +130,7 @@ feature "Intake Edit EP Claim Labels", :all_dbs do
         click_on("Add issue")
         find(".cf-select", text: "Select or enter").click
         find(".cf-select__option", text: "Unknown Issue Category").click
-        fill_in "decision-date", with: "08192020"
+        fill_in "decision-date", with: (DateTime.now - 1.month).strftime("%m%d%Y") # Best guess 'always timely'
         fill_in "Issue description", with: "this is a description"
         click_on("Add this issue")
 


### PR DESCRIPTION
### Description
All builds (including master) have failing tests right now because of a hardcoded date causing a flake. This fixes that flake by un-hardcoding the date. What was happening is that the hardcoded date of "08192020" is now untimely and was triggering an additional option to appear.

This leaves the code-path where there's an untimely exemption untested (see AddIssueManager.jsx) in the interest of resolving this quickly.

### Testing Plan
- Checkout master
- Run: `make one-test spec/feature/intake/edit_ep_claim_labels_spec.rb:101`
- It fails
- Checkout this branch and rerun that command, it should pass.