### PR TITLE
Fix Taskable assigned_attorney method to ignore Docket Switch attorneys

### DIFF
--- a/app/models/concerns/taskable.rb
+++ b/app/models/concerns/taskable.rb
@@ -7,7 +7,7 @@ module Taskable
     tasks.not_cancelled
       .order(created_at: :desc)
       .includes(:assigned_to)
-      .detect { |t| t.is_a?(AttorneyTask) }
+      .detect { |t| t.is_a?(AttorneyTask) && !t.is_a?(DocketSwitchAbstractAttorneyTask) }
       .try(:assigned_to)
   end
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -967,7 +967,8 @@ describe Appeal, :all_dbs do
       end
       let!(:task2) do
         task.completed!
-        create(:ama_attorney_task, parent: judge_decision_review_task, assigned_to: attorney2, appeal: appeal)
+        create(:ama_attorney_task, parent: judge_decision_review_task, assigned_to: attorney2,
+                                   appeal: appeal, created_at: 1.hour.ago)
       end
 
       subject { appeal.assigned_attorney }
@@ -985,8 +986,8 @@ describe Appeal, :all_dbs do
         let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
         let(:root_task) { create(:root_task, appeal: appeal) }
         let!(:ds_task) do
-          create(:docket_switch_denied_task, parent: root_task, assigned_to: attorney,
-                 assigned_by: judge, appeal: appeal, created_at: 1.minute.ago)
+          create(:docket_switch_denied_task, parent: root_task, appeal: appeal, assigned_to: attorney,
+                                             assigned_by: judge, created_at: 1.minute.ago)
         end
 
         it "ignores the attorney assigned to the DocketSwitch attorney task" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -980,6 +980,19 @@ describe Appeal, :all_dbs do
         task2.cancelled!
         expect(subject).to eq attorney
       end
+
+      context "when there is a more recent DocketSwitch attorney task" do
+        let(:judge) { create(:user, :with_vacols_judge_record, full_name: "Judge the First", css_id: "JUDGE_1") }
+        let(:root_task) { create(:root_task, appeal: appeal) }
+        let!(:ds_task) do
+          create(:docket_switch_denied_task, parent: root_task, assigned_to: attorney,
+                 assigned_by: judge, appeal: appeal, created_at: 1.minute.ago)
+        end
+
+        it "ignores the attorney assigned to the DocketSwitch attorney task" do
+          expect(subject).to eq attorney2
+        end
+      end
     end
 
     context ".assigned_judge" do


### PR DESCRIPTION
### Description
This PR fixes a bug in the implementation of `Taskable#assigned_attorney` so that it never reports an attorney solely assigned to a Docket Switch task.

The `assigned_attorney` denotes the attorney tasked with drafting an appeal's decision, and is saved on the associated JudgeCaseReview record to give that attorney "credit" for their work. Therefore it is important to ensure that the correct attorney is being returned.

[Slack thread](https://dsva.slack.com/archives/C54QCEHAL/p1631806550182100) where the investigation into the bug happened.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Added a new test for `Appeal#assigned_attorney`
2. New test fails on old application logic