### PR TITLE
GH Action: refine PR creation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -381,12 +381,14 @@ workflows:
               ignore:
                 - gh-pages
                 - main-gh-pages
+                - gh-actions/make_docs-update_docs
       - demo:
           filters:
             branches:
               ignore:
                 - gh-pages
                 - main-gh-pages
+                - gh-actions/make_docs-update_docs
       - rspec:
           requires:
             - build_workspace
@@ -395,15 +397,18 @@ workflows:
               ignore:
                 - gh-pages
                 - main-gh-pages
+                - gh-actions/make_docs-update_docs
       - js_tests:
           filters:
             branches:
               ignore:
                 - gh-pages
                 - main-gh-pages
+                - gh-actions/make_docs-update_docs
       - lint:
           filters:
             branches:
               ignore:
                 - gh-pages
                 - main-gh-pages
+                - gh-actions/make_docs-update_docs

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -23,6 +23,17 @@ jobs:
         ports: ["5432:5432"]
 
     steps:
+      - name: Debugging info
+        # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: |
+          env
+          echo "-------- $GITHUB_CONTEXT --------------"
+          echo $GITHUB_CONTEXT
+          echo "-------- $GITHUB_EVENT_PATH --------------"
+          cat $GITHUB_EVENT_PATH
+
       - name: Checkout code
         uses: actions/checkout@v2
 
@@ -149,17 +160,6 @@ jobs:
             git commit -m "$WIKI_COMMIT_MESSAGE"
             echo "::endgroup::"
           fi
-
-      - name: Debugging info
-        # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: |
-          env
-          echo "-------- $GITHUB_CONTEXT --------------"
-          cat $GITHUB_CONTEXT
-          echo "-------- $GITHUB_EVENT_PATH --------------"
-          echo $GITHUB_EVENT_PATH
 
       - name: Create/Update PR to merge into main-gh-pages
         id: create_pr

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -29,10 +29,8 @@ jobs:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           env
-          echo "-------- $GITHUB_CONTEXT --------------"
+          echo "-------- GITHUB_CONTEXT --------------"
           echo $GITHUB_CONTEXT
-          echo "-------- $GITHUB_EVENT_PATH --------------"
-          cat $GITHUB_EVENT_PATH
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -175,7 +173,7 @@ jobs:
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
           labels: "Type: Documentation"
           assignees: yoomlam
-          reviewers: ${{ github.event.pull_request.head_commit.username }}
+          reviewers: ${{ github.event.commits[0].committer.username }}
       - name: PR info
         if: steps.create_pr.outcome == 'success'
         run: |

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,6 +2,7 @@ name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
+  push:
   pull_request:
     types: [ closed ]
 
@@ -9,7 +10,7 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -149,6 +150,12 @@ jobs:
             echo "::endgroup::"
           fi
 
+      - name: Debugging info
+        run: |
+          env
+          echo "-------- $GITHUB_EVENT_PATH --------------"
+          cat $GITHUB_EVENT_PATH
+
       - name: Create/Update PR to merge into main-gh-pages
         id: create_pr
         if: steps.compare_docs.outputs.changes_docs == 'true'
@@ -163,7 +170,6 @@ jobs:
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
           labels: "Type: Documentation"
           assignees: yoomlam
-          reviewers: ${{ github.actor }}
       - name: PR info
         if: steps.create_pr.outcome == 'success'
         run: |

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -151,10 +151,15 @@ jobs:
           fi
 
       - name: Debugging info
+        # https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
           env
+          echo "-------- $GITHUB_CONTEXT --------------"
+          cat $GITHUB_CONTEXT
           echo "-------- $GITHUB_EVENT_PATH --------------"
-          cat $GITHUB_EVENT_PATH
+          echo $GITHUB_EVENT_PATH
 
       - name: Create/Update PR to merge into main-gh-pages
         id: create_pr
@@ -165,11 +170,12 @@ jobs:
           base: "main-gh-pages"
           branch: "gh-actions/make_docs-update_docs"
           delete-branch: true # when closing PR
-          commit-message: '${{ github.actor }} - `make docs` GH Action: automatically update DB schema documentation files'
+          commit-message: '`make docs` GH Action: automatically update DB schema documentation files'
           title: "GH Action: update DB documentation"
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
           labels: "Type: Documentation"
           assignees: yoomlam
+          reviewers: ${{ github.event.pull_request.head_commit.username }}
       - name: PR info
         if: steps.create_pr.outcome == 'success'
         run: |

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -2,7 +2,6 @@ name: Make-docs-to-webpage
 
 # Trigger running when a PR is closed
 on:
-  push:
   pull_request:
     types: [ closed ]
 
@@ -10,7 +9,7 @@ jobs:
   make_docs:
     name: Update DB schema files in webpage
     # Only run if the PR has been merged (rather than simply closed)
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -28,9 +28,8 @@ jobs:
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: |
+          # prints GITHUB_CONTEXT env variable
           env
-          echo "-------- GITHUB_CONTEXT --------------"
-          echo $GITHUB_CONTEXT
 
       - name: Checkout code
         uses: actions/checkout@v2
@@ -172,8 +171,8 @@ jobs:
           title: "GH Action: update DB documentation"
           body: "This PR was created by GitHub Action `make_docs` to automatically update DB documentation."
           labels: "Type: Documentation"
-          assignees: yoomlam
-          reviewers: ${{ github.event.commits[0].committer.username }}
+          reviewers: yoomlam
+          assignees: ${{ github.event.commits[0].committer.username }}
       - name: PR info
         if: steps.create_pr.outcome == 'success'
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ tags
 !.dockerignore
 !.fasterer.yml
 !.reek.yml
+!/.circleci/config.yml
 
 # React on Rails
 npm-debug.log*


### PR DESCRIPTION
Resolves the mistake of setting the PR reviewer as `va-bot` for a PR created by a GH Action, e.g., PR #16761.

When the `make-docs` GH Action is triggered, the `github.actor` is `va-bot` because it is the one who merges PRs into the main branch. 

[Run #18](https://github.com/department-of-veterans-affairs/caseflow/actions/runs/1243086591)
![image](https://user-images.githubusercontent.com/55255674/133691525-39feb4e0-251e-4d4b-bbd4-153255ea7e82.png)

Resulting automatically-created PR #16761:
![image](https://user-images.githubusercontent.com/55255674/133691619-843f8ac6-edd4-406b-8f0d-efd91efb408f.png)


The reviewer should be the author of the original PR that triggered the GH Action.

### Description
Set the PR reviewer to be the committer of the first commit on the PR.

Also don't run CircleCI for the `gh-actions/make_docs-update_docs` branch, which is for documentation and created by the GH Action.

### Acceptance Criteria
- [ ] Code compiles correctly
