### PR TITLE
make-docs action: use github_action_pre_commit_hook in Makefile

### DIFF
--- a/.github/workflows/make-docs.yml
+++ b/.github/workflows/make-docs.yml
@@ -136,9 +136,7 @@ jobs:
         run: |
           cd main-gh-pages_checkout
 
-          echo "::group::Remove files that change with every run"
-          rm -vf schema/make_docs/*-erd.pdf
-          echo "::endgroup::"
+          make github_action_pre_commit_hook
 
           git add .
           if git diff-index --quiet HEAD; then


### PR DESCRIPTION

### Description
Call `make github_action_pre_commit_hook` so we can do various things (delete unnecessary files and move files) before files are committed.

https://github.com/department-of-veterans-affairs/caseflow/blob/main-gh-pages/Makefile#L53

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan