### PR TITLE
Return nil person for unrecognized appellant appeals

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -25,7 +25,7 @@ class Person < CaseflowRecord
       return person if person
 
       person = new(participant_id: participant_id)
-      return nil unless person.found?
+      return unless person.found?
 
       person.update_cached_attributes!
       person

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -25,7 +25,9 @@ class Person < CaseflowRecord
       return person if person
 
       person = new(participant_id: participant_id)
-      person.update_cached_attributes! if person.found?
+      return nil unless person.found?
+
+      person.update_cached_attributes!
       person
     end
 


### PR DESCRIPTION
Resolves returning empty Person record when calling `claimant.person` for unrecognized appellant:
```
=> #<Person:0x00007f2f48377598
 id: nil,
 participant_id: "",
 date_of_birth: nil,
 created_at: nil,
 updated_at: nil,
 first_name: nil,
 last_name: nil,
 middle_name: nil,
 name_suffix: nil,
 email_address: nil,
 ssn: nil>
```
which could suggest that a person record exists.

### Description
Return nil `claimant.person` for unrecognized appellant appeals.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Return nil `claimant.person` for unrecognized appellant appeals

### Testing
In prod
```ruby
p=Person.new(participant_id: "")
p.found?
=> false
p.update_cached_attributes!
=> ... ActiveRecord::RecordInvalid: Validation failed: Participant can't be blank
```

### Related
PR #16767