### PR TITLE
Task serialization: return name of inactive organization

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -35,16 +35,18 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assigned_to do |object|
-    assignee = object.assigned_to
+    Organization.unscoped do
+      assignee = object.assigned_to
 
-    {
-      css_id: assignee.try(:css_id),
-      full_name: assignee.try(:full_name),
-      is_organization: assignee.is_a?(Organization),
-      name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
-      type: assignee.class.name,
-      id: assignee.id
-    }
+      {
+        css_id: assignee.try(:css_id),
+        full_name: assignee.try(:full_name),
+        is_organization: assignee.is_a?(Organization),
+        name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
+        type: assignee.class.name,
+        id: assignee.id
+      }
+    end
   end
 
   attribute :cancelled_by do |object|
@@ -68,7 +70,9 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assignee_name do |object|
-    object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+    Organization.unscoped do
+      object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+    end
   end
 
   attribute :placed_on_hold_at, &:calculated_placed_on_hold_at

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,7 +34,7 @@ class WorkQueue::TaskSerializer
     }
   end
 
-  def initialize(object)
+  def initialize(object, **_kw_args)
     Organization.unscoped do
       # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
       # Also need to call `assigned_to` so that the potentially inactive Organization is queried unscoped.

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -35,7 +35,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assigned_to do |object|
-    assignee = object.try(:unscoped_assigned_to) || object.assigned_to
+    assignee = object.try(:unscoped_assigned_to)
 
     {
       css_id: assignee.try(:css_id),
@@ -69,7 +69,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assignee_name do |object|
-    assignee = object.try(:unscoped_assigned_to) || object.assigned_to
+    assignee = object.try(:unscoped_assigned_to)
     assignee.is_a?(Organization) ? assignee.name : assignee.css_id
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -36,13 +36,15 @@ class WorkQueue::TaskSerializer
 
   attribute :assigned_to do |object|
     Organization.unscoped do
-      assignee = object.assigned_to
+      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
+      assignee = object.reload.assigned_to
 
       {
         css_id: assignee.try(:css_id),
         full_name: assignee.try(:full_name),
         is_organization: assignee.is_a?(Organization),
         name: assignee.is_a?(Organization) ? assignee.name : assignee.css_id,
+        status: assignee.try(:status),
         type: assignee.class.name,
         id: assignee.id
       }
@@ -71,7 +73,8 @@ class WorkQueue::TaskSerializer
 
   attribute :assignee_name do |object|
     Organization.unscoped do
-      object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
+      object.reload.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
     end
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -49,8 +49,11 @@ class WorkQueue::TaskSerializer
   end
 
   def self.unscoped_assignee(object)
+    @unscoped_assignee ||= {}
     # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-    @unscoped_assignee ||= Organization.unscoped do
+    puts "#{object.id} => #{@unscoped_assignee[object.id]&.id}"
+    @unscoped_assignee[object.id] ||= Organization.unscoped do
+      puts "reloading #{object.id}"
       object.reload.assigned_to
     end
   end

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,18 +34,10 @@ class WorkQueue::TaskSerializer
     }
   end
 
-  def initialize(object, **_kw_args)
-    Organization.unscoped do
-      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-      # Also need to call `assigned_to` so that the potentially inactive Organization is queried unscoped.
-      object.reload.assigned_to
-    end
-    super
-  end
-
   attribute :assigned_to do |object|
     Organization.unscoped do
-      assignee = object.assigned_to
+      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
+      assignee = object.reload.assigned_to
 
       {
         css_id: assignee.try(:css_id),
@@ -81,7 +73,8 @@ class WorkQueue::TaskSerializer
 
   attribute :assignee_name do |object|
     Organization.unscoped do
-      object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
+      object.reload.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
     end
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -34,10 +34,18 @@ class WorkQueue::TaskSerializer
     }
   end
 
-  attribute :assigned_to do |object|
+  def initialize(object)
     Organization.unscoped do
       # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-      assignee = object.reload.assigned_to
+      # Also need to call `assigned_to` so that the potentially inactive Organization is queried unscoped.
+      object.reload.assigned_to
+    end
+    super
+  end
+
+  attribute :assigned_to do |object|
+    Organization.unscoped do
+      assignee = object.assigned_to
 
       {
         css_id: assignee.try(:css_id),
@@ -73,8 +81,7 @@ class WorkQueue::TaskSerializer
 
   attribute :assignee_name do |object|
     Organization.unscoped do
-      # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-      object.reload.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
+      object.assigned_to.is_a?(Organization) ? object.assigned_to.name : object.assigned_to.css_id
     end
   end
 

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -35,7 +35,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assigned_to do |object|
-    assignee = unscoped_assignee(object)
+    assignee = object.try(:unscoped_assigned_to) || object.assigned_to
 
     {
       css_id: assignee.try(:css_id),
@@ -46,16 +46,6 @@ class WorkQueue::TaskSerializer
       type: assignee.class.name,
       id: assignee.id
     }
-  end
-
-  def self.unscoped_assignee(object)
-    @unscoped_assignee ||= {}
-    # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-    puts "#{object.id} => #{@unscoped_assignee[object.id]&.id}"
-    @unscoped_assignee[object.id] ||= Organization.unscoped do
-      puts "reloading #{object.id}"
-      object.reload.assigned_to
-    end
   end
 
   attribute :cancelled_by do |object|
@@ -79,7 +69,7 @@ class WorkQueue::TaskSerializer
   end
 
   attribute :assignee_name do |object|
-    assignee = unscoped_assignee(object)
+    assignee = object.try(:unscoped_assigned_to) || object.assigned_to
     assignee.is_a?(Organization) ? assignee.name : assignee.css_id
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -423,6 +423,13 @@ class Task < CaseflowRecord
     end
   end
 
+  def unscoped_assigned_to
+    # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
+    @unscoped_assigned_to ||= Organization.unscoped do
+      reload.assigned_to
+    end
+  end
+
   def assigned_to_same_org?(task_to_check)
     assigned_to.is_a?(Organization) && assigned_to.eql?(task_to_check.assigned_to)
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -424,10 +424,9 @@ class Task < CaseflowRecord
   end
 
   def unscoped_assigned_to
-    # `reload` is needed to prevent use of a cached query on object that uses Organization.default_scope
-    @unscoped_assigned_to ||= Organization.unscoped do
-      reload.assigned_to
-    end
+    return Organization.unscoped.find(assigned_to_id) if assigned_to_type == "Organization"
+
+    assigned_to
   end
 
   def assigned_to_same_org?(task_to_check)

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -972,7 +972,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
         expect(task["attributes"]["available_actions"].size).to eq 2
 
-        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(14)
+        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(22)
       end
     end
 

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -972,7 +972,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
         expect(task["attributes"]["available_actions"].size).to eq 2
 
-        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(22)
+        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(14)
       end
     end
 

--- a/spec/models/serializers/work_queue/task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/task_serializer_spec.rb
@@ -27,6 +27,19 @@ describe WorkQueue::TaskSerializer, :postgres do
     end
   end
 
+  context "inactive organization assignee" do
+    subject { described_class.new(child).serializable_hash[:data][:attributes] }
+    let(:inactive_org) { create(:organization, status: :inactive) }
+    let!(:child) { create(:ama_task, parent: parent, assigned_to: inactive_org).reload }
+    it "serializes assignee information" do
+      expect(child.assigned_to).to eq nil
+      expect(subject[:assigned_to][:id]).to eq inactive_org.id
+      expect(subject[:assigned_to][:name]).to eq inactive_org.name
+      expect(subject[:assignee_name]).to eq inactive_org.name
+      expect(subject[:assigned_to][:status]).to eq "inactive"
+    end
+  end
+
   describe "the attribute timer_ends_at" do
     subject { described_class.new(task).serializable_hash[:data][:attributes] }
 

--- a/spec/models/serializers/work_queue/task_serializer_spec.rb
+++ b/spec/models/serializers/work_queue/task_serializer_spec.rb
@@ -29,7 +29,7 @@ describe WorkQueue::TaskSerializer, :postgres do
 
   context "inactive organization assignee" do
     subject { described_class.new(child).serializable_hash[:data][:attributes] }
-    let(:inactive_org) { create(:organization, status: :inactive) }
+    let(:inactive_org) { create(:private_bar, status: :inactive) }
     let!(:child) { create(:ama_task, parent: parent, assigned_to: inactive_org).reload }
     it "serializes assignee information" do
       expect(child.assigned_to).to eq nil


### PR DESCRIPTION
Resolves [Sentry alert](https://dsva.slack.com/archives/CLRTL92TW/p1632240728192700)

### Description
When `task.assigned_to.inactive = true`, show the assignee info instead of raising an error.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Doesn't error on inactive organization assignee

### Testing Plan
See RSpec

1. Go to Case Details for an appeal
2. Pick a task assigned to an organization
3. Make the organization inactive
4. Reload Case Details. Before the PR, note the error; after the PR, no error and the assignee name is shown.

### Reflection

BLUF: stay clear away from `default_scope` if you ever want to refer to records excluded by the default scope.

* `default_scope` is used for Organization, DecisionIssue, and RequestDecisionIssue
* Appropriately used by DecisionIssue and RequestDecisionIssue for soft deleting records.
* For Organization, tasks can refer to inactive orgs, which results in a nil or erroneous `task.assigned_to`
* `acts_as_paranoid` is also used to soft-delete records. It uses `default_scope`: https://github.com/ActsAsParanoid/acts_as_paranoid/blob/cf7c83f083fc87147ba272b380c2b28469a704a8/lib/acts_as_paranoid.rb#L49

