### PR TITLE
ETL: unscope queries

### DIFF
--- a/app/models/concerns/has_decision_review_updated_since.rb
+++ b/app/models/concerns/has_decision_review_updated_since.rb
@@ -5,7 +5,8 @@ module HasDecisionReviewUpdatedSince
 
   included do
     scope :updated_since_for_appeals, lambda { |since|
-      select(:decision_review_id)
+      # unscope this query so that soft-deleted records are considered when updated in ETL records
+      unscoped.select(:decision_review_id)
         .where("#{table_name}.updated_at >= ?", since)
         .where("#{table_name}.decision_review_type='Appeal'")
     }

--- a/app/models/concerns/has_decision_review_updated_since.rb
+++ b/app/models/concerns/has_decision_review_updated_since.rb
@@ -5,7 +5,7 @@ module HasDecisionReviewUpdatedSince
 
   included do
     scope :updated_since_for_appeals, lambda { |since|
-      # unscope this query so that soft-deleted records are considered when updated in ETL records
+      # unscope this query so that soft-deleted records are considered
       unscoped.select(:decision_review_id)
         .where("#{table_name}.updated_at >= ?", since)
         .where("#{table_name}.decision_review_type='Appeal'")

--- a/app/services/etl/syncer.rb
+++ b/app/services/etl/syncer.rb
@@ -158,6 +158,6 @@ class ETL::Syncer
   end
 
   def instances_after_id_offset
-    origin_class.where("id >= ?", @id_offset)
+    origin_class.unscoped.where("id >= ?", @id_offset)
   end
 end

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -83,5 +83,31 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
         expect(ETL::Appeal.count).to eq(15)
       end
     end
+
+    context "decision issue is deleted" do
+      let(:appeal) { Appeal.last }
+      let!(:decision_issue) { create(:decision_issue, decision_review: appeal) }
+      subject { described_class.new(since: 2.days.ago, etl_build: etl_build).call }
+
+      it "updates attributes" do
+        described_class.new(etl_build: etl_build).call
+        etl_build_table = ETL::BuildTable.where(table_name: "appeals").last
+        expect(etl_build_table.rows_inserted).to eq(14)
+        expect(ETL::Appeal.count).to eq(Appeal.count)
+        expect(ETL::Appeal.find_by(appeal_id: appeal.id).updated_at).to be_within(1.minute).of(Time.now)
+
+        Timecop.travel(5.days.from_now)
+        decision_issue.soft_delete
+        expect(decision_issue.deleted_at).not_to eq nil
+
+        subject
+        etl_build_table = ETL::BuildTable.where(table_name: "appeals").last
+        expect(etl_build_table.rows_inserted).to eq(0)
+        # The data in appeal record didn't change but it was considered for update
+        # because an associated record (i.e., decision_issue) was updated (i.e., soft-deleted).
+        expect(etl_build_table.rows_updated).to eq(1)
+        expect(ETL::Appeal.count).to eq(Appeal.count)
+      end
+    end
   end
 end

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -94,7 +94,7 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
         etl_build_table = ETL::BuildTable.where(table_name: "appeals").last
         expect(etl_build_table.rows_inserted).to eq(14)
         expect(ETL::Appeal.count).to eq(Appeal.count)
-        expect(ETL::Appeal.find_by(appeal_id: appeal.id).updated_at).to be_within(1.minute).of(Time.now)
+        expect(ETL::Appeal.find_by(appeal_id: appeal.id).updated_at).to be_within(1.minute).of(Time.zone.now)
 
         Timecop.travel(5.days.from_now)
         decision_issue.soft_delete

--- a/spec/services/etl/decision_issue_syncer_spec.rb
+++ b/spec/services/etl/decision_issue_syncer_spec.rb
@@ -19,5 +19,27 @@ describe ETL::DecisionIssueSyncer, :etl, :all_dbs do
         expect(ETL::DecisionIssue.first.issue_created_at.to_s).to eq(decision_issue.created_at.to_s)
       end
     end
+
+    context "deleted decision issue" do
+      # second call
+      subject { described_class.new(since: 2.days.ago.round, etl_build: etl_build).call }
+
+      before do
+        # initial call
+        described_class.new(etl_build: etl_build).call
+      end
+      it "syncs attributes" do
+        expect(ETL::DecisionIssue.count).to eq(1)
+
+        decision_issue.soft_delete
+        expect(decision_issue.deleted_at).not to eq nil
+        subject
+
+        expect(ETL::DecisionIssue.count).to eq(1)
+
+        # stringify datetimes to ignore milliseconds
+        expect(ETL::DecisionIssue.first.issue_deleted_at.to_s).to eq(decision_issue.deleted_at.to_s)
+      end
+    end
   end
 end

--- a/spec/services/etl/decision_issue_syncer_spec.rb
+++ b/spec/services/etl/decision_issue_syncer_spec.rb
@@ -32,7 +32,7 @@ describe ETL::DecisionIssueSyncer, :etl, :all_dbs do
         expect(ETL::DecisionIssue.count).to eq(1)
 
         decision_issue.soft_delete
-        expect(decision_issue.deleted_at).not to eq nil
+        expect(decision_issue.deleted_at).not_to eq nil
         subject
 
         expect(ETL::DecisionIssue.count).to eq(1)


### PR DESCRIPTION
Resolves deleted decision_issue records not being reflected in ETL
See https://github.com/department-of-veterans-affairs/caseflow/pull/16617#issuecomment-915483742

### Description
When querying for updated records to update the ODS database, consider soft-deleted decision_issue records by using `unscoped` to subvert the `default_scope` on `DecisionIssue`: https://github.com/department-of-veterans-affairs/caseflow/blob/40f890c9d334f8682f42cc276db821c8323bad68/app/models/decision_issue.rb#L55

Bonus: also consider associated soft-deleted records, when updating ETL::Appeal records.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] ETL records are updated for soft-deleted records

### Tested
ETL's DB:
```sql
select count(*)
FROM decision_issues as issues
WHERE issues.issue_deleted_at IS NOT NULL
```
returned 0 -- bad.

Manually updated code in prod and ran the update
```ruby
etl_build = ETL::Build.create
syncer=ETL::DecisionIssueSyncer.new(etl_build: etl_build)
syncer.call
```

Checked results in ETL's DB:
```sql
select count(*)
FROM decision_issues as issues
WHERE issues.issue_deleted_at IS NOT NULL
```
returned 112486 -- good

For Caseflow's DB:
```sql
select count(*)
FROM decision_issues as issues
WHERE issues.deleted_at IS NOT NULL
```
returned 112486 -- consistent


For context, all decision_issues in Caseflow:
```sql
select count(*)
FROM decision_issues as issues
```
=> 1770564

and in ETL:
```sql
select count(*)
FROM decision_issues as issues
```
=> 1770564 -- good, consistent


Then, manually ran DMS job to update ODS: https://console.amazonaws-us-gov.com/dms/v2/home?region=us-gov-west-1#taskDetails/dsva-appeals-ods-redshift-onetime

```sql
select count(*)
FROM ods.decision_issues as issues
WHERE issues.issue_deleted_at IS NOT NULL
```
now returns 112486

```sql
select id, issue_deleted_at, issue_updated_at, issue_created_at, *
FROM ods.decision_issues as issues
   WHERE issues.decision_review_type='Appeal'
      AND issues.disposition IN ('denied','remanded','allowed')
   and issues.decision_review_id=1402
      AND issues.issue_deleted_at IS NULL
ORDER BY id
```
returns 5 instead of all 15 -- great!

Then ran "New Query" at https://github.com/department-of-veterans-affairs/caseflow/pull/16617#issuecomment-915483742 to compare with results of "Original Query".

The "New Query" needs to be modified to not join against multiple AttorneyCaseReview and count distinct issues. New Query v2:
```sql
SELECT
  docs.appeal_id, docs.appeal_type,
  to_char(judge_cr.review_created_at, 'mm/dd/yy') AS "updated",
  atty_cr.overtime, -- probably want to aggregate this

-- debugging: 
--   docs.id AS "doc_id", issues.id "iss_id", atty_cr.id "acr.id", judge_cr.id "jcr.id", 
--   judge.id "judge.id", atty.id "atty.id"
  
  COUNT(DISTINCT (CASE WHEN issues.disposition IN ('denied','remanded','allowed') THEN issues.id ELSE null END)) AS "ard_issues",
  COUNT(DISTINCT (CASE WHEN issues.disposition IN ('denied','remanded','allowed') THEN null ELSE issues.id END)) AS "other_issues"
FROM ods.decision_documents AS docs
LEFT JOIN ods.decision_issues AS issues
  ON docs.appeal_id = issues.decision_review_id
  AND docs.appeal_type = issues.decision_review_type
  AND issues.issue_deleted_at IS NULL
LEFT JOIN ods.attorney_case_reviews AS atty_cr
  ON docs.appeal_id = atty_cr.appeal_id
  AND docs.appeal_type = atty_cr.appeal_type
LEFT JOIN ods.judge_case_reviews AS judge_cr
  ON docs.appeal_id = judge_cr.appeal_id
  AND docs.appeal_type = judge_cr.appeal_type
LEFT JOIN ods.users AS judge
  ON judge.user_id = docs.judge_user_id
LEFT JOIN ods.users AS atty
  ON atty.user_id = docs.attorney_user_id
WHERE
  atty.sattyid = '1826' and docs.appeal_type = 'Appeal'
--   AND docs.appeal_id = 1402
GROUP BY docs.appeal_id, docs.appeal_type,
  judge_cr.review_created_at
,  atty_cr.overtime
ORDER BY judge_cr.review_created_at, docs.appeal_id;
```
returns:
```csv
appeal_id,appeal_type,updated,overtime,ard_issues,other_issues
5478,Appeal,06/11/19,false,1,0
14838,Appeal,10/21/19,false,2,0
5674,Appeal,10/21/19,false,10,0
19490,Appeal,11/19/19,false,2,0
7096,Appeal,11/19/19,false,1,0
7020,Appeal,11/19/19,false,1,0
6569,Appeal,11/21/19,false,2,0
6628,Appeal,12/20/19,false,1,0
8903,Appeal,12/20/19,false,3,0
1402,Appeal,02/04/20,false,5,0
4387,Appeal,02/05/20,false,11,0
12731,Appeal,03/19/20,false,1,0
10816,Appeal,03/23/20,false,0,2
36435,Appeal,04/08/20,false,7,0
50611,Appeal,04/13/20,false,1,0
15555,Appeal,07/17/20,false,4,0
78194,Appeal,08/21/20,false,2,0
12601,Appeal,11/13/20,false,1,0
43141,Appeal,12/02/20,false,4,0
72790,Appeal,02/04/21,false,3,0
83297,Appeal,02/11/21,false,3,0
79341,Appeal,03/23/21,false,7,0
50580,Appeal,04/09/21,false,1,0
```
consistent with Original Query!