### PR TITLE
Establish Back-end logic to identify a Contested Claim

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -161,7 +161,15 @@ class Appeal < DecisionReview
   end
 
   def contested_claim?
-    binding.pry
+    category_substrings = ["Contested Claims", "Apportionment"]
+
+    matching_issue_categories = Constants::ISSUE_CATEGORIES.values.flatten.select do |category|
+      category.match? Regexp.union(category_substrings)
+    end
+
+    active_request_issues.any? do |request_issue|
+      matching_issue_categories.include?(request_issue.nonrating_issue_category)
+    end
   end
 
   # Returns the most directly responsible party for an appeal when it is at the Board,

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -160,6 +160,10 @@ class Appeal < DecisionReview
     post_decision_motion&.vacate_type
   end
 
+  def contested_claim?
+    binding.pry
+  end
+
   # Returns the most directly responsible party for an appeal when it is at the Board,
   # mirroring Legacy Appeals' location code in VACOLS
   def assigned_to_location

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1150,7 +1150,7 @@ describe Appeal, :all_dbs do
     end
   end
 
-  fdescribe "#contested_claim?" do
+  describe "#contested_claim?" do
     subject { appeal.contested_claim? }
 
     let(:request_issues) do
@@ -1158,10 +1158,18 @@ describe Appeal, :all_dbs do
         create(:request_issue, benefit_type: "compensation", nonrating_issue_category: issue_category)
       ]
     end
-    let(:appeal) { create(:appeal), request_issues: request_issues }
+    let(:appeal) { create(:appeal, request_issues: request_issues) }
 
-    context "when issue category falls under contested claim" do
-      let(:issue_category) { "Contested Claims - Apportionment" }
+    context "when issue category falls under contested claim and category contains string 'Contested Claim'" do
+      let(:issue_category) { "Contested Claims - Insurance" }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when issue category falls under contested claim and category contains string 'Apportionment'" do
+      let(:issue_category) { "Apportionment" }
 
       it "returns true" do
         expect(subject).to be_truthy

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1160,23 +1160,25 @@ describe Appeal, :all_dbs do
     end
     let(:appeal) { create(:appeal, request_issues: request_issues) }
 
-    context "when issue category falls under contested claim and category contains string 'Contested Claim'" do
-      let(:issue_category) { "Contested Claims - Insurance" }
+    context "when issue category falls under contested claims" do
+      context "contains string 'Contested Claim'" do
+        let(:issue_category) { "Contested Claims - Insurance" }
 
-      it "returns true" do
-        expect(subject).to be_truthy
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context "contains string 'Apportionment'" do
+        let(:issue_category) { "Apportionment" }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
       end
     end
 
-    context "when issue category falls under contested claim and category contains string 'Apportionment'" do
-      let(:issue_category) { "Apportionment" }
-
-      it "returns true" do
-        expect(subject).to be_truthy
-      end
-    end
-
-    context "when issue category doesn't fall under contested claim" do
+    context "when issue category doesn't fall under contested claims" do
       let(:issue_category) { "Military Retired Pay" }
 
       it "returns false" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1150,6 +1150,33 @@ describe Appeal, :all_dbs do
     end
   end
 
+  fdescribe "#contested_claim?" do
+    subject { appeal.contested_claim? }
+
+    let(:request_issues) do
+      [
+        create(:request_issue, benefit_type: "compensation", nonrating_issue_category: issue_category)
+      ]
+    end
+    let(:appeal) { create(:appeal), request_issues: request_issues }
+
+    context "when issue category falls under contested claim" do
+      let(:issue_category) { "Contested Claims - Apportionment" }
+
+      it "returns true" do
+        expect(subject).to be_truthy
+      end
+    end
+
+    context "when issue category doesn't fall under contested claim" do
+      let(:issue_category) { "Military Retired Pay" }
+
+      it "returns false" do
+        expect(subject).to be_falsey
+      end
+    end
+  end
+
   describe "#vacate_type" do
     subject { appeal.vacate_type }
 


### PR DESCRIPTION
Resolves CASEFLOW-2235

### Description
Add backend logic to identify a contested claim (related [Epic](https://vajira.max.gov/browse/CASEFLOW-1626))

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Unit tests for appeal model pass
