### PR TITLE
Refine Sentry Alert to Show Error is Not Actionable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,8 @@ class ApplicationController < ApplicationBaseController
     fail e unless e.class.method_defined?(:serialize_response)
 
     # The `actionable` attribute will be shown as part of the Slack message from Sentry
-    Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable) })
+    Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable),
+                                        application: e.try(:application) })
     render(e.serialize_response)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,13 +12,9 @@ class ApplicationController < ApplicationBaseController
   before_action :deny_vso_access, except: [:unauthorized, :feedback]
   before_action :set_no_cache_headers
 
-  NONACTIONABLE_ERRORS = [Caseflow::Error::MultipleOpenTasksOfSameTypeError].freeze
-
   rescue_from StandardError do |e|
     fail e unless e.class.method_defined?(:serialize_response)
-
-    actionable = !NONACTIONABLE_ERRORS.include?(error.class)
-    Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: actionable })
+    Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable) })
     render(e.serialize_response)
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ApplicationBaseController
 
   rescue_from StandardError do |e|
     fail e unless e.class.method_defined?(:serialize_response)
+    # The `actionable` attribute will be shown as part of the Slack message from Sentry
     Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable) })
     render(e.serialize_response)
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ApplicationBaseController
 
   rescue_from StandardError do |e|
     fail e unless e.class.method_defined?(:serialize_response)
-  
+
     # The `actionable` attribute will be shown as part of the Slack message from Sentry
     Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable) })
     render(e.serialize_response)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,6 +14,7 @@ class ApplicationController < ApplicationBaseController
 
   rescue_from StandardError do |e|
     fail e unless e.class.method_defined?(:serialize_response)
+  
     # The `actionable` attribute will be shown as part of the Slack message from Sentry
     Raven.capture_exception(e, extra: { error_uuid: error_uuid, actionable: e.try(:actionable) })
     render(e.serialize_response)

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -17,7 +17,7 @@ module Caseflow::Error
 
   class SerializableError < StandardError
     include Caseflow::Error::ErrorSerializer
-    attr_accessor :code, :message, :title
+    attr_accessor :code, :message, :title, :actionable
   end
 
   class TransientError < SerializableError
@@ -106,6 +106,7 @@ module Caseflow::Error
 
   class MultipleOpenTasksOfSameTypeError < SerializableError
     def initialize(args)
+      @actionable = false
       @task_type = args[:task_type]
       @code = args[:code] || 400
       @title = "Error assigning tasks"

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -17,7 +17,7 @@ module Caseflow::Error
 
   class SerializableError < StandardError
     include Caseflow::Error::ErrorSerializer
-    attr_accessor :code, :message, :title, :actionable
+    attr_accessor :code, :message, :title, :actionable, :application
   end
 
   class TransientError < SerializableError
@@ -108,6 +108,7 @@ module Caseflow::Error
   class MultipleOpenTasksOfSameTypeError < SerializableError
     def initialize(args)
       @actionable = false
+      @application = "queue"
       @task_type = args[:task_type]
       @code = args[:code] || 400
       @title = "Error assigning tasks"

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -104,6 +104,7 @@ module Caseflow::Error
     end
   end
 
+  # :reek:TooManyInstanceVariables
   class MultipleOpenTasksOfSameTypeError < SerializableError
     def initialize(args)
       @actionable = false

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,4 +60,48 @@ describe ApplicationController, type: :controller do
       end
     end
   end
+
+  describe "error handling v2" do
+    context "when a MultipleOpenTasksOfSameTypeError error is raised" do
+      subject { fail Caseflow::Error::MultipleOpenTasksOfSameTypeError, task_type: "JudgeDecisionReviewTask" }
+
+      it "reports to sentry that the error is not actionable" do
+        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
+          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        end
+      end
+    end
+  end
+
+  describe "error handling" do
+    let!(:attorney) { create(:user) }
+    let!(:judge) { create(:user) }
+    let!(:attorney_staff) { create(:staff, :attorney_role, sdomainid: attorney.css_id) }
+    let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
+    let!(:assign_task) { create(:ama_judge_assign_task, assigned_to: judge, parent: create(:root_task)) }
+    let!(:assignee) { attorney }
+    let!(:params) do
+      { external_id: assign_task.appeal.external_id, parent_id: assign_task.id,
+        assigned_to_id: assignee.id }
+    end
+    # TODO: figure out how to post to the judge_assign_tasks_controller create action
+    # subject { post "/judge_assign_tasks", to: "judge_assign_tasks#create", as: :create }
+    subject { post "/judge_assign_tasks", :controller=>"judge_assign_tasks", as: :create, params: { tasks: params } }
+    # subject { post :create, params: { tasks: params } }
+
+    before do
+      User.authenticate!(user: judge)
+      judge_decision_review_task = double(JudgeDecisionReviewTask)
+      allow(judge_decision_review_task).to(
+        receive(:create!).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
+      )
+    end
+
+    context "when an appeal has more than one open active task of the same type" do
+      it "reports the error as non-actionable to Sentry" do
+        subject
+        expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+      end
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -60,49 +60,4 @@ describe ApplicationController, type: :controller do
       end
     end
   end
-
-  describe "error handling v2" do
-    context "when a MultipleOpenTasksOfSameTypeError error is raised" do
-      subject { fail Caseflow::Error::MultipleOpenTasksOfSameTypeError, task_type: "JudgeDecisionReviewTask" }
-
-      it "reports to sentry that the error is not actionable" do
-        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
-          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
-        end
-      end
-    end
-  end
-
-  describe "error handling" do
-    let!(:attorney) { create(:user) }
-    let!(:judge) { create(:user) }
-    let!(:attorney_staff) { create(:staff, :attorney_role, sdomainid: attorney.css_id) }
-    let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
-    let!(:assign_task) { create(:ama_judge_assign_task, assigned_to: judge, parent: create(:root_task)) }
-    let!(:assignee) { attorney }
-    let!(:params) do
-      { external_id: assign_task.appeal.external_id, parent_id: assign_task.id,
-        assigned_to_id: assignee.id }
-    end
-    # TODO: figure out how to post to the judge_assign_tasks_controller create action
-    # subject { post "/judge_assign_tasks", to: "judge_assign_tasks#create", as: :create }
-    subject { post "/judge_assign_tasks", :controller=>"judge_assign_tasks", as: :create, params: { tasks: params } }
-    # subject { post :create, params: { tasks: params } }
-
-    before do
-      User.authenticate!(user: judge)
-      judge_decision_review_task = double(JudgeDecisionReviewTask)
-      allow(judge_decision_review_task).to(
-        receive(:create!).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
-      )
-    end
-
-    context "when an appeal has more than one open active task of the same type" do
-      it "reports the error as non-actionable to Sentry" do
-        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
-          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
-        end
-      end
-    end
-  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -99,8 +99,9 @@ describe ApplicationController, type: :controller do
 
     context "when an appeal has more than one open active task of the same type" do
       it "reports the error as non-actionable to Sentry" do
-        subject
-        expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
+          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        end
       end
     end
   end

--- a/spec/controllers/judge_assign_tasks_controller_spec.rb
+++ b/spec/controllers/judge_assign_tasks_controller_spec.rb
@@ -134,15 +134,14 @@ RSpec.describe JudgeAssignTasksController, :all_dbs do
     before do
       User.authenticate!(user: judge)
       allow_any_instance_of(AttorneyTaskCreator).to(
-        receive(:call).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
+        receive(:call).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError.new(message: "testing"))
       )
     end
 
     context "when an appeal has more than one open active task of the same type" do
       it "reports the error as non-actionable to Sentry" do
-        expect { subject }.to raise_error do |_err|
-          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
-        end
+        expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        subject
       end
     end
   end

--- a/spec/controllers/judge_assign_tasks_controller_spec.rb
+++ b/spec/controllers/judge_assign_tasks_controller_spec.rb
@@ -133,15 +133,14 @@ RSpec.describe JudgeAssignTasksController, :all_dbs do
 
     before do
       User.authenticate!(user: judge)
-      judge_decision_review_task = double(JudgeDecisionReviewTask)
-      allow(judge_decision_review_task).to(
-        receive(:create!).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
+      allow_any_instance_of(AttorneyTaskCreator).to(
+        receive(:call).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
       )
     end
 
     context "when an appeal has more than one open active task of the same type" do
       it "reports the error as non-actionable to Sentry" do
-        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
+        expect { subject }.to raise_error do |_err|
           expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
         end
       end

--- a/spec/controllers/judge_assign_tasks_controller_spec.rb
+++ b/spec/controllers/judge_assign_tasks_controller_spec.rb
@@ -140,7 +140,8 @@ RSpec.describe JudgeAssignTasksController, :all_dbs do
 
     context "when an appeal has more than one open active task of the same type" do
       it "reports the error as non-actionable to Sentry" do
-        expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        expect(Raven).to receive(:capture_exception).with(anything, extra: { application: "queue", error_uuid: anything,
+                                                                             actionable: false })
         subject
       end
     end

--- a/spec/controllers/judge_assign_tasks_controller_spec.rb
+++ b/spec/controllers/judge_assign_tasks_controller_spec.rb
@@ -117,4 +117,34 @@ RSpec.describe JudgeAssignTasksController, :all_dbs do
       end
     end
   end
+
+  describe "error handling" do
+    let!(:attorney) { create(:user) }
+    let!(:judge) { create(:user) }
+    let!(:attorney_staff) { create(:staff, :attorney_role, sdomainid: attorney.css_id) }
+    let!(:judge_staff) { create(:staff, :judge_role, sdomainid: judge.css_id) }
+    let!(:assign_task) { create(:ama_judge_assign_task, assigned_to: judge, parent: create(:root_task)) }
+    let!(:assignee) { attorney }
+    let!(:params) do
+      { external_id: assign_task.appeal.external_id, parent_id: assign_task.id,
+        assigned_to_id: assignee.id }
+    end
+    subject { post :create, params: { tasks: params } }
+
+    before do
+      User.authenticate!(user: judge)
+      judge_decision_review_task = double(JudgeDecisionReviewTask)
+      allow(judge_decision_review_task).to(
+        receive(:create!).and_raise(Caseflow::Error::MultipleOpenTasksOfSameTypeError)
+      )
+    end
+
+    context "when an appeal has more than one open active task of the same type" do
+      it "reports the error as non-actionable to Sentry" do
+        expect { subject }.to raise_error(Caseflow::Error::MultipleOpenTasksOfSameTypeError) do |_err|
+          expect(Raven).to receive(:capture_exception).with(anything, extra: { error_uuid: anything, actionable: false })
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves Jira ticket [2373]( https://vajira.max.gov/browse/CASEFLOW-2373)


### Description
When the `MultipleOpenTasksOfSameTypeError` occurs, the sentry exception will indicate that it is not actionable, and that bat team does not need to do anything in response to this message.


### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The sentry alert will indicate that the error is not actionable
- [ ] The sentry alert will go to  #appeals-queue-alerts instead of #appeals-app-alert

### Testing Plan
1. Confirm automated tests pass