### PR TITLE
Do not raise Module::DelegationError for Hearings with associated soft-deleted HearingDays

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -60,8 +60,6 @@ class Hearing < CaseflowRecord
            :decision_issues, :available_hearing_locations, :closest_regional_office, :advanced_on_docket?,
            to: :appeal
   delegate :external_id, to: :appeal, prefix: true
-  delegate :hearing_day_full?, :request_type, to: :hearing_day
-  delegate :regional_office, to: :hearing_day, prefix: true
   delegate :timezone, :name, to: :regional_office, prefix: true
 
   after_create :update_fields_from_hearing_day
@@ -85,6 +83,23 @@ class Hearing < CaseflowRecord
     T: "Travel",
     C: "Central"
   }.freeze
+
+  # ActiveRecord can interpret the associated hearing_day as null because acts_as_paranoid
+  # allows us to soft-delete hearing_days by setting the deleted_at value.
+  # As a result, instead of delegating these functions to hearing_day we redefine them using\
+  # the safe navigator operator.
+
+  def request_type
+    hearing_day&.request_type
+  end
+
+  def hearing_day_full?
+    hearing_day&.hearing_day_full?
+  end
+
+  def hearing_day_regional_office
+    hearing_day&.regional_office
+  end
 
   def check_available_slots
     fail HearingDayFull if hearing_day_full?

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -62,6 +62,13 @@ class Hearing < CaseflowRecord
   delegate :external_id, to: :appeal, prefix: true
   delegate :timezone, :name, to: :regional_office, prefix: true
 
+  # ActiveRecord can interpret the associated hearing_day as null because acts_as_paranoid
+  # allows us to soft-delete hearing_days by setting the deleted_at value.
+  # As a result, we need to set allow_nil to true for these attributes/functions.
+
+  delegate :hearing_day_full?, :request_type, to: :hearing_day, allow_nil: true
+  delegate :regional_office, to: :hearing_day, prefix: true, allow_nil: true
+
   after_create :update_fields_from_hearing_day
   before_create :check_available_slots, unless: :override_full_hearing_day_validation
   before_create :assign_created_by_user
@@ -83,23 +90,6 @@ class Hearing < CaseflowRecord
     T: "Travel",
     C: "Central"
   }.freeze
-
-  # ActiveRecord can interpret the associated hearing_day as null because acts_as_paranoid
-  # allows us to soft-delete hearing_days by setting the deleted_at value.
-  # As a result, instead of delegating these functions to hearing_day we redefine them using\
-  # the safe navigator operator.
-
-  def request_type
-    hearing_day&.request_type
-  end
-
-  def hearing_day_full?
-    hearing_day&.hearing_day_full?
-  end
-
-  def hearing_day_regional_office
-    hearing_day&.regional_office
-  end
 
   def check_available_slots
     fail HearingDayFull if hearing_day_full?

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -268,4 +268,19 @@ describe Hearing, :postgres do
       end
     end
   end
+
+  context "when the associated hearing_day has been soft-deleted" do
+    let!(:hearing) { create(:hearing) }
+
+    before do
+      hearing.hearing_day.update!(deleted_at: Time.zone.today - 30.days)
+      hearing.reload
+    end
+
+    it "returns nil for functions that expect an associated hearing_day" do
+      expect(hearing.request_type).to eq(nil)
+      expect(hearing.hearing_day_full?).to eq(nil)
+      expect(hearing.hearing_day_regional_office).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
Resolves [`Module::DelegationError`s that we have been seeing](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/20085/).

The `Module::DelegationError`s are caused by a `HearingDay` associated with a `Hearing` [being soft-deleted](https://github.com/department-of-veterans-affairs/caseflow/blob/de3a9144c94b36b3663b3941fc2948e918b0bdaf/app/models/hearing_day.rb#L29). This error appears to present itself on the Case Search page when somebody searches for a case that has a hearing in this state, and prevents Case Search from returning any results for that case (among other scenarios when this error will present itself).

[This Metabase query](https://query.prod.appeals.va.gov/question/301-hearings-associated-with-soft-deleted-hearing-days) identifies 14 `Hearings` associated with soft-deleted `HearingDays`.

[Related Slack conversation](https://dsva.slack.com/archives/C3EAF3Q15/p1632506398062300).

## Open questions
* @nweinmeister This PR prevents these errors from being thrown, but is the resulting behaviour correct? Should we return nil instead of some other value in these cases?