### PR TITLE
Do not raise NoMethodErrors when serializing Hearings with soft-deleted HearingDays

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -115,7 +115,7 @@ class Hearing < CaseflowRecord
   end
 
   def readable_request_type
-    HEARING_TYPES[request_type.to_sym]
+    HEARING_TYPES[request_type&.to_sym]
   end
 
   alias original_request_type request_type
@@ -158,6 +158,7 @@ class Hearing < CaseflowRecord
   end
 
   def scheduled_for
+    return nil unless hearing_day
     # returns the date and time a hearing is scheduled for in the regional office's
     # time zone
     #

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -159,6 +159,7 @@ class Hearing < CaseflowRecord
 
   def scheduled_for
     return nil unless hearing_day
+
     # returns the date and time a hearing is scheduled for in the regional office's
     # time zone
     #

--- a/spec/serializers/appeal_hearing_serializer_spec.rb
+++ b/spec/serializers/appeal_hearing_serializer_spec.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 describe AppealHearingSerializer, :all_dbs do
-  context "when a user views hearing information" do
-    let(:hearing) { create(:hearing) }
-    subject { described_class.new(hearing, params: { user: user }) }
+  let(:hearing) { create(:hearing) }
+  let(:user) { create(:user) }
 
+  subject { described_class.new(hearing, params: { user: user }) }
+
+  context "when a user views hearing information" do
     context "when user has a VSO role" do
       let(:user) { create(:user, :vso_role) }
       it "does not display judge name" do
@@ -13,10 +15,21 @@ describe AppealHearingSerializer, :all_dbs do
     end
 
     context "when user does not have a VSO role" do
-      let(:user) { create(:user) }
       it "does display judge name" do
         expect(subject.serializable_hash[:data][:attributes][:held_by]).to eq(hearing.judge.full_name)
       end
+    end
+  end
+
+  context "when the associated hearing_day has been soft-deleted" do
+    before do
+      hearing.hearing_day.update!(deleted_at: Time.zone.today - 90.days)
+      hearing.reload
+    end
+
+    it "returns nil for values that we would retrieve from hearing_day" do
+      expect(subject.serializable_hash[:data][:attributes][:date]).to be_nil
+      expect(subject.serializable_hash[:data][:attributes][:type]).to be_nil
     end
   end
 end


### PR DESCRIPTION
Resolves [`NoMethodErrors` that we have been seeing](https://sentry.prod.appeals.va.gov/department-of-veterans-affairs/caseflow/issues/20298/).

The `NoMethodErrors` are caused by a `HearingDay` associated with a `Hearing` being soft-deleted. This is a follow up to [a previous PR](https://github.com/department-of-veterans-affairs/caseflow/pull/16782) with this PR being focused on preventing this issue from cropping up when we serialize the hearing for the front-end.

### Case Search

Before | After
--- | ---
![case-search-before](https://user-images.githubusercontent.com/32683958/135123998-1297d83c-86d6-4c5e-8c5c-1e7b7223aed3.gif) | ![case-search-after](https://user-images.githubusercontent.com/32683958/135124006-08a7af27-a3f7-4168-91a9-f52c7206fe82.gif)
### Case Details

Before | After
--- | ---
![case-details-before](https://user-images.githubusercontent.com/32683958/135124034-bc4d4231-0193-428a-a23f-11b3d24f27aa.gif) | ![case-details-after](https://user-images.githubusercontent.com/32683958/135124045-82eb4615-bb0a-4d79-861c-b527ee1c1f65.gif)