### PR TITLE
Snooze CVE-2021-41098; extend jquery snooze

### DIFF
--- a/.security.yml
+++ b/.security.yml
@@ -1,4 +1,5 @@
 CVES:
 # placeholder to make non-nil array
   CVE-no-such-number: 2020-01-01
-  CVE-2020-11023: 2021-09-30
+  CVE-2020-11023: 2021-10-31
+  CVE-2021-41098: 2021-10-31


### PR DESCRIPTION
### Description
Snoozes an alert for CVE-2021-41098, which impacts only JRuby nokogiri users.
Extends alerts for existing jQuery issue since it will come due in a couple days.
The pressure is on for Halloween, though.

### Acceptance Criteria
- [ ] Code compiles correctly