### PR TITLE
fix Update POA & Refresh POA render logic 

### DIFF
--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -161,7 +161,7 @@ export const CaseDetailsView = (props) => {
     appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
 
   const editPOAInformation =
-  !appeal.hasPOA && props.hasVLJSupportRole && props.featureToggles.edit_unrecognized_appellant_poa;
+  !appeal.hasPOA && props.hasVLJSupportRole && props.featureToggles.edit_unrecognized_appellant_poa && appeal.appellantType === 'OtherClaimant';
 
   const supportCavcRemand =
   currentUserIsOnCavcLitSupport && !appeal.isLegacyAppeal;

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -161,7 +161,8 @@ export const CaseDetailsView = (props) => {
     appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
 
   const editPOAInformation =
-  !appeal.hasPOA && props.hasVLJSupportRole && props.featureToggles.edit_unrecognized_appellant_poa && appeal.appellantType === 'OtherClaimant';
+    props.hasVLJSupportRole && appeal.appellantType === 'OtherClaimant' &&
+    !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =
   currentUserIsOnCavcLitSupport && !appeal.isLegacyAppeal;

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -128,12 +128,11 @@ export const PowerOfAttorneyDetailUnconnected = ({ powerOfAttorney, appealId, po
     COPY.CASE_DETAILS_NO_POA;
 
   const renderPoaLogic = () => {
-    const unrecognizedAppellant = 'OtherClaimant';
     const unrecognizedPoa = 'Unrecognized representative';
-    const recognizedAppellant = appellantType !== unrecognizedAppellant;
+    const isRecognizedAppellant = !['OtherClaimant', 'AttorneyClaimant'].includes(appellantType);
     const recognizedPoa = poa.representative_type !== unrecognizedPoa;
 
-    if (recognizedAppellant && recognizedPoa) {
+    if (isRecognizedAppellant && recognizedPoa) {
       return <PoaRefresh powerOfAttorney={poa} appealId={appealId} {...detailListStyling} />;
     } else if (poa.representative_type === unrecognizedPoa) {
       return <em>{ COPY.CASE_DETAILS_UNRECOGNIZED_POA }</em>;


### PR DESCRIPTION
In Case Details -> Update POA section, this PR does the following: 
- Hides Refresh POA button for listed attorney appellants and all unrecognized appellants 
- Hide Update POA link for for listed attorney appellants 

Screenshot shows buttons in question:
![Screen Shot 2021-09-30 at 12 56 36 PM](https://user-images.githubusercontent.com/14364118/135506693-65926c00-7429-4fd3-b4ba-cf67067bc775.png)
 
