### PR TITLE
Fix small oversight from #16648 refactor

### DIFF
--- a/lib/helpers/intake_renderer.rb
+++ b/lib/helpers/intake_renderer.rb
@@ -220,7 +220,7 @@ class IntakeRenderer
       if request_issue.contention_disposition
         contention += " (disp: #{request_issue.contention_disposition.disposition})"
       end
-      children << contention
+      result << contention
     end
 
     result


### PR DESCRIPTION
### Description
Fixes a bug (introduced in #16648) that was preventing IntakeRenderer from working whenever a request issue had a contention reference ID.