### PR TITLE
Add test to ensure parent `TranscriptionTask` is correctly closed

### DIFF
--- a/spec/models/tasks/transcription_task_spec.rb
+++ b/spec/models/tasks/transcription_task_spec.rb
@@ -160,6 +160,28 @@ describe TranscriptionTask, :postgres do
 
         expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
       end
+
+      context "completing child TranscriptionTask with parent TranscriptionTask" do
+        let!(:child_task) { create(:transcription_task, parent: transcription_task, assigned_to: transcription_user) }
+        let!(:tr_team_admin) do
+          admin = create(:user)
+          TranscriptionTeam.singleton.add_user(admin)
+          OrganizationsUser.make_user_admin(admin, TranscriptionTeam.singleton)
+          admin
+        end
+        it "completes the child and parent task" do
+          expect(child_task.available_actions_unwrapper(transcription_user).size).to be > 0
+
+          # parent TranscriptionTask has no action, even for the tr_team_admin
+          expect(transcription_task.available_actions_unwrapper(transcription_user).size).to eq 0
+          expect(transcription_task.available_actions_unwrapper(tr_team_admin).size).to eq 0
+
+          child_task.update_from_params(update_params, transcription_user)
+
+          expect(child_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
+          expect(transcription_task.reload.status).to eq(Constants.TASK_STATUSES.completed)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves action item from https://github.com/department-of-veterans-affairs/dsva-vacols/issues/224#issuecomment-931555726
> * Make sure child `TranscriptionTask` is completed when parent `TranscriptionTask` is completed

### Description
Added test to ensure parent `TranscriptionTask` is correctly closed.

Given that the test passes, the cause for the open child `TranscriptionTask` in https://github.com/department-of-veterans-affairs/dsva-vacols/issues/224 is probably an engineer forgetting to close the child task. These should be caught by the `OpenTasksWithClosedAtChecker`.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Completing child `TranscriptionTask` with a parent `TranscriptionTask` completes both the child and parent tasks

### Testing Plan
See RSpec
