### PR TITLE
Add Additional Groups to POA Feature Release 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -389,6 +389,11 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     ::CompletedTasksTab.new(assignee: self, show_regional_office_column: show_regional_office_in_queue?)
   end
 
+  def can_edit_unrecognized_poa?
+    allowed_orgs = [LitigationSupport, ClerkOfTheBoard, BoardProductOwners].map(&:singleton)
+    colocated_in_vacols? || allowed_orgs.any? { |org| org.user_has_access?(self) }
+  end
+
   def can_act_on_behalf_of_judges?
     member_of_organization?(SpecialCaseMovementTeam.singleton)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -390,7 +390,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def can_edit_unrecognized_poa?
-    allowed_orgs = [LitigationSupport, ClerkOfTheBoard, BoardProductOwners].map(&:singleton)
+    allowed_orgs = [LitigationSupport, ClerkOfTheBoard, BoardProductOwners, BvaIntake].map(&:singleton)
     colocated_in_vacols? || allowed_orgs.any? { |org| org.user_has_access?(self) }
   end
 

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -14,7 +14,7 @@
     flash: flash,
     buildDate: build_date,
     hasCaseDetailsRole: current_user.roles.include?('Case Details'),
-    hasVLJSupportRole: current_user.colocated_in_vacols?,
+    userCanEditUnrecognizedPOA: current_user.can_edit_unrecognized_poa?,
     userCanAssignHearingSchedule: current_user.can_assign_hearing_schedule?,
     userCanViewHearingSchedule: current_user.can_view_hearing_schedule?,
     userCanViewOvertimeStatus: current_user.can_view_overtime_status?,

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -161,7 +161,7 @@ export const CaseDetailsView = (props) => {
     appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
 
   const editPOAInformation =
-  !appeal.hasPOA && props.hasVLJSupportRole && props.featureToggles.edit_unrecognized_appellant_poa;
+  !appeal.hasPOA && props.userCanEditUnrecognizedPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =
   currentUserIsOnCavcLitSupport && !appeal.isLegacyAppeal;
@@ -323,7 +323,7 @@ CaseDetailsView.propTypes = {
   userCanAccessReader: PropTypes.bool,
   veteranCaseListIsVisible: PropTypes.bool,
   userCanScheduleVirtualHearings: PropTypes.bool,
-  hasVLJSupportRole: PropTypes.bool,
+  userCanEditUnrecognizedPOA: PropTypes.bool,
   scheduledHearingId: PropTypes.string,
   pollHearing: PropTypes.bool,
   stopPollingHearing: PropTypes.func,

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -178,7 +178,7 @@ class QueueApp extends React.PureComponent {
       userCanAccessReader={
         !this.props.hasCaseDetailsRole && !this.props.userCanViewHearingSchedule
       }
-      hasVLJSupportRole={this.props.hasVLJSupportRole}
+      userCanEditUnrecognizedPOA={this.props.userCanEditUnrecognizedPOA}
     />
   );
 
@@ -1160,11 +1160,11 @@ QueueApp.propTypes = {
   userIsVsoEmployee: PropTypes.bool,
   setFeedbackUrl: PropTypes.func,
   hasCaseDetailsRole: PropTypes.bool,
-  hasVLJSupportRole: PropTypes.bool,
   caseSearchHomePage: PropTypes.bool,
   applicationUrls: PropTypes.array,
   flash: PropTypes.array,
   reviewActionType: PropTypes.string,
+  userCanEditUnrecognizedPOA: PropTypes.bool,
   userCanViewHearingSchedule: PropTypes.bool,
   userCanViewOvertimeStatus: PropTypes.bool,
   userCanViewEditNodDate: PropTypes.bool,

--- a/lib/helpers/intake_renderer.rb
+++ b/lib/helpers/intake_renderer.rb
@@ -220,7 +220,7 @@ class IntakeRenderer
       if request_issue.contention_disposition
         contention += " (disp: #{request_issue.contention_disposition.disposition})"
       end
-      children << contention
+      result << contention
     end
 
     result

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -769,6 +769,13 @@ describe User, :all_dbs do
       end
     end
 
+    context "when current user is a member of BvaIntake org" do
+      it "returns true" do
+        BvaIntake.singleton.add_user(user)
+        expect(subject).to eq(true)
+      end
+    end
+
     context "when current user is colocated in VACOLS" do
       it "returns true" do
         allow(user).to receive(:vacols_roles).and_return(["colocated"])

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -744,6 +744,45 @@ describe User, :all_dbs do
     end
   end
 
+  describe "can_edit_unrecognized_poa?" do
+    let(:user) { create(:user) }
+    subject { user.can_edit_unrecognized_poa? }
+
+    context "when current user is a member of LitigationSupport org" do
+      it "returns true" do
+        LitigationSupport.singleton.add_user(user)
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when current user is a member of ClerkOfTheBoard org" do
+      it "returns true" do
+        ClerkOfTheBoard.singleton.add_user(user)
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when current user is a member of BoardProductOwners org" do
+      it "returns true" do
+        BoardProductOwners.singleton.add_user(user)
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when current user is colocated in VACOLS" do
+      it "returns true" do
+        allow(user).to receive(:vacols_roles).and_return(["colocated"])
+        expect(subject).to eq(true)
+      end
+    end
+
+    context "when current user isn't a member of allowed organization" do
+      it "returns false" do
+        expect(subject).to eq(false)
+      end
+    end
+  end
+
   describe ".can_withdraw_issues?" do
     let(:user) { create(:user) }
 


### PR DESCRIPTION
Resolves [caseflow-2360](https://vajira.max.gov/browse/CASEFLOW-2360)

### Description
- Adds can_edit_unrecognized_poa?-- returns true if the user is colocated in VACOLS or is a member of the following organizations: 
   -  BoardProductOwner
   - ClerkOfTheBoard
   - LitigationSupport
   - BvaIntake