### PR TITLE
Create vha_predocket_workflow FeatureToggle

### DIFF
--- a/app/models/tasks/pre_docket/vha_document_search_task.rb
+++ b/app/models/tasks/pre_docket/vha_document_search_task.rb
@@ -8,9 +8,12 @@ class VhaDocumentSearchTask < Task
   validates :parent, presence: true
 
   def available_actions(user)
-    return [] unless assigned_to.user_has_access?(user)
-
-    TASK_ACTIONS
+    if assigned_to.user_has_access?(user) &&
+       FeatureToggle.enabled?(:vha_predocket_workflow, user: RequestStore.store[:current_user])
+      TASK_ACTIONS
+    else
+      []
+    end
   end
 
   TASK_ACTIONS = [

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -40,6 +40,7 @@
       edit_unrecognized_appellant_poa: FeatureToggle.enabled?(:edit_unrecognized_appellant_poa, user: current_user),
       hearings_substitution_death_dismissal: FeatureToggle.enabled?(:hearings_substitution_death_dismissal, user: current_user),
       restrict_poa_visibility: FeatureToggle.enabled?(:restrict_poa_visibility, user: current_user),
+      vha_predocket_workflow: FeatureToggle.enabled?(:vha_predocket_workflow, user: current_user)
     }
   }) %>
 <% end %>

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
   include IntakeHelpers
 
   before do
+    FeatureToggle.enable!(:vha_predocket_workflow)
     FeatureToggle.enable!(:vha_predocket_appeals)
     bva_intake.add_user(bva_intake_user)
     camo.add_user(camo_user)
@@ -11,7 +12,10 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
     regional_office.add_user(regional_office_user)
   end
 
-  after { FeatureToggle.disable!(:vha_predocket_appeals) }
+  after do
+    FeatureToggle.disable!(:vha_predocket_workflow)
+    FeatureToggle.disable!(:vha_predocket_appeals)
+  end
 
   let(:bva_intake) { BvaIntake.singleton }
   let!(:bva_intake_user) { create(:intake_user) }

--- a/spec/models/tasks/vha_document_search_task_spec.rb
+++ b/spec/models/tasks/vha_document_search_task_spec.rb
@@ -8,12 +8,16 @@ describe VhaDocumentSearchTask, :postgres do
   before { camo.add_user(user) }
 
   describe ".label" do
+    before { FeatureToggle.enable!(:vha_predocket_workflow) }
+    after { FeatureToggle.disable!(:vha_predocket_workflow) }
     it "uses a friendly label" do
       expect(task.class.label).to eq COPY::VHA_ASSESS_DOCUMENTATION_TASK_LABEL
     end
   end
 
   describe "#available_actions" do
+    before { FeatureToggle.enable!(:vha_predocket_workflow) }
+    after { FeatureToggle.disable!(:vha_predocket_workflow) }
     subject { task.available_actions(user) }
 
     it { is_expected.to eq VhaDocumentSearchTask::TASK_ACTIONS }


### PR DESCRIPTION
Resolves [CASEFLOW-2367](https://vajira.max.gov/browse/CASEFLOW-2367)

### Description
We need to hide the VHA Camo users available actions for the initial pre docket release where they are not yet an active participant in the workflow (only BVA Intake users)

### Acceptance Criteria
- [ ] when vha_predocket_workflow FeatureToggle is enabled, CAMO users do not see available actions

### Testing Plan
1. Complete a VHA pre-docket intake as a BVA Intake user
2. Login as a CAMO user and visit the CAMO org queue to select the pre-docket appeal you've created
3. Check in the console that the vha_predocket_workflow FeatureToggle is disabled:
`FeatureToggle.enabled?(:vha_predocket_workflow)
=> false`
4. Visit the appeals case details and confirm you are not able to view available actions
5. Enable the FeatureToggle:
`FeatureToggle.enable!(:vha_predocket_workflow)
=> true`
6. Confirm that you do not see available actions 

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![Screen Shot 2021-10-01 at 4 02 00 PM](https://user-images.githubusercontent.com/18618189/135679978-d9e4efeb-805d-4d61-9c95-33f46e36ff2c.png)|![Screen Shot 2021-10-01 at 4 01 04 PM](https://user-images.githubusercontent.com/18618189/135680006-23ec47d6-f52e-411d-8e75-a96b97b1c618.png)