### PR TITLE
Limit CaseIssue.issdesc to 100 ASCII characters

### DIFF
--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -7,7 +7,7 @@ class VACOLS::CaseIssue < VACOLS::Record
 
   class IssueError < StandardError; end
 
-  attribute :issdesc, :ascii_string
+  attribute :issdesc, :ascii_string, limit: 100
 
   validates :isskey, :issseq, :issprog, :isscode, :issaduser, :issadtime, presence: true, on: :create
 


### PR DESCRIPTION
### Description
This PR limits `CaseIssue.issdesc` to 100 ASCII characters. Not having the limit was causing an issue where non-ASCII characters were being converted by ActiveRecord and lengthening the ASCII representation beyond 100, resulting in a VACOLS exception.

See this [Slack thread](https://dsva.slack.com/archives/C2ZAMLK88/p1633452331223700) for investigation.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan

Creating a new issue in local FACOLS with a string that lengthens dramatically upon ASCIIfication:

```ruby
params = {
  note: "\u88c5" * 100,
  issue: "01",
  program: "02",
  level_1: "02",
  level_2: nil,
  level_3: nil,
  vacols_user_id: User.last.vacols_user_id,
  vacols_id: LegacyAppeal.last.vacols_id
}
issue = Issue.create_in_vacols!(issue_attrs: params)
issue.issdesc
=> "Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zhuang Zh"
issue.issdesc.length
=> 100
```