### PR TITLE
check_task_tree: check for unexpected parent and child tasks

### DIFF
--- a/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
+++ b/app/queries/appeals_with_no_tasks_or_all_tasks_on_hold_query.rb
@@ -30,7 +30,7 @@ class AppealsWithNoTasksOrAllTasksOnHoldQuery
     Constants.TASK_STATUSES.completed
   end
 
-  # Dispatched appeals (with a decision document) should have any open tasks.
+  # Dispatched appeals (with a decision document) should not have open RootTask.
   # Cause: Appeal may be undispatched -- https://github.com/department-of-veterans-affairs/caseflow/issues/14884
   def dispatched_appeals_on_hold
     suspect_appeals = Appeal.where(id: tasks_for(Appeal.name)

--- a/lib/helpers/check_task_tree.rb
+++ b/lib/helpers/check_task_tree.rb
@@ -341,10 +341,7 @@ class CheckTaskTree
                              JudgeQualityReviewTask AttorneyQualityReviewTask
                              JudgeDispatchReturnTask AttorneyDispatchReturnTask
                              VeteranRecordRequest].freeze
-  SINGULAR_OPEN_ORG_TASKS ||= %w[
-                                QualityReviewTask
-                                BvaDispatchTask
-                              ].freeze
+  SINGULAR_OPEN_ORG_TASKS ||= %w[QualityReviewTask BvaDispatchTask].freeze
   def extra_open_tasks
     @appeal.tasks.select(:type).open.of_type(SINGULAR_OPEN_TASKS).group(:type).having("count(*) > 1").count
   end

--- a/lib/helpers/check_task_tree.rb
+++ b/lib/helpers/check_task_tree.rb
@@ -96,8 +96,8 @@ class CheckTaskTree
       @errors << "Open RootTask should have an active task assigned to the Board"
     end
 
-    unless unexpected_child_task.blank?
-      @errors << "Unexpected child task: #{unexpected_child_task.pluck(:type, :id)}"
+    unless unexpected_child_tasks.blank?
+      @errors << "Unexpected child task: #{unexpected_child_tasks.pluck(:type, :id)}"
     end
     unless tasks_with_unexpected_parent_task.blank?
       @errors << "Unexpected parent task for: #{tasks_with_unexpected_parent_task.pluck(:type, :id)}"
@@ -228,7 +228,7 @@ class CheckTaskTree
     }
   end
 
-  def unexpected_child_task
+  def unexpected_child_tasks
     expected_child_task_hash.map do |parent_task_query, child_task_query|
       parent_task_query.where(appeal: @appeal).map do |parent|
         parent.children - child_task_query.where(appeal: @appeal) - TimedHoldTask.where(appeal: @appeal)

--- a/lib/helpers/check_task_tree.rb
+++ b/lib/helpers/check_task_tree.rb
@@ -200,6 +200,7 @@ class CheckTaskTree
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-DR/freq-parentchild.html
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-ES/freq-parentchild.html
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-H/freq-parentchild.html
+  # rubocop:disable Metrics/AbcSize
   def expected_child_task_hash
     @expected_child_task_hash ||= {
       # org-task that expect an associated user-task
@@ -227,6 +228,7 @@ class CheckTaskTree
       BvaDispatchTask.assigned_to_any_user => JudgeDispatchReturnTask.assigned_to_any_user
     }
   end
+  # rubocop:enable Metrics/AbcSize
 
   def unexpected_child_tasks
     expected_child_task_hash.map do |parent_task_query, child_task_query|
@@ -240,6 +242,7 @@ class CheckTaskTree
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-DR/freq-childparent.html
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-ES/freq-childparent.html
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-H/freq-childparent.html
+  # rubocop:disable Metrics/AbcSize
   def expected_parent_task_hash
     @expected_parent_task_hash ||= {
       # task types expected under RootTask
@@ -295,6 +298,7 @@ class CheckTaskTree
       StatusInquiryMailTask.assigned_to_any_user => StatusInquiryMailTask.assigned_to_any_org
     }
   end
+  # rubocop:enable Metrics/AbcSize
 
   def tasks_with_unexpected_parent_task
     expected_parent_task_hash.map do |child_task_query, parent_task_query|

--- a/lib/helpers/check_task_tree.rb
+++ b/lib/helpers/check_task_tree.rb
@@ -198,7 +198,7 @@ class CheckTaskTree
   end
 
   # Task types that are ignored when checking that an appeal is not stuck
-  IGNORED_ACTIVE_TASKS = %w[TrackVeteranTask].freeze
+  IGNORED_ACTIVE_TASKS ||= %w[TrackVeteranTask].freeze
   # Detects one of the problems from AppealsWithNoTasksOrAllTasksOnHoldQuery
   # Should also emcompass OpenHearingTasksWithoutActiveDescendantsChecker
   def active_tasks_with_open_root_task
@@ -334,14 +334,14 @@ class CheckTaskTree
   # but the validations can be subverted, so let's check them here just in case.
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/tasks-overview.html
   # Example: https://github.com/department-of-veterans-affairs/dsva-vacols/issues/217#issuecomment-906779760
-  SINGULAR_OPEN_TASKS = %w[RootTask DistributionTask
+  SINGULAR_OPEN_TASKS ||= %w[RootTask DistributionTask
                            HearingTask ScheduleHearingTask AssignHearingDispositionTask ChangeHearingDispositionTask
                            JudgeAssignTask JudgeDecisionReviewTask
                            AttorneyTask AttorneyRewriteTask
                            JudgeQualityReviewTask AttorneyQualityReviewTask
                            JudgeDispatchReturnTask AttorneyDispatchReturnTask
                            VeteranRecordRequest].freeze
-  SINGULAR_OPEN_ORG_TASKS = %w[
+  SINGULAR_OPEN_ORG_TASKS ||= %w[
     QualityReviewTask
     BvaDispatchTask
   ].freeze

--- a/lib/helpers/check_task_tree.rb
+++ b/lib/helpers/check_task_tree.rb
@@ -335,16 +335,16 @@ class CheckTaskTree
   # https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/tasks-overview.html
   # Example: https://github.com/department-of-veterans-affairs/dsva-vacols/issues/217#issuecomment-906779760
   SINGULAR_OPEN_TASKS ||= %w[RootTask DistributionTask
-                           HearingTask ScheduleHearingTask AssignHearingDispositionTask ChangeHearingDispositionTask
-                           JudgeAssignTask JudgeDecisionReviewTask
-                           AttorneyTask AttorneyRewriteTask
-                           JudgeQualityReviewTask AttorneyQualityReviewTask
-                           JudgeDispatchReturnTask AttorneyDispatchReturnTask
-                           VeteranRecordRequest].freeze
+                             HearingTask ScheduleHearingTask AssignHearingDispositionTask ChangeHearingDispositionTask
+                             JudgeAssignTask JudgeDecisionReviewTask
+                             AttorneyTask AttorneyRewriteTask
+                             JudgeQualityReviewTask AttorneyQualityReviewTask
+                             JudgeDispatchReturnTask AttorneyDispatchReturnTask
+                             VeteranRecordRequest].freeze
   SINGULAR_OPEN_ORG_TASKS ||= %w[
-    QualityReviewTask
-    BvaDispatchTask
-  ].freeze
+                                QualityReviewTask
+                                BvaDispatchTask
+                              ].freeze
   def extra_open_tasks
     @appeal.tasks.select(:type).open.of_type(SINGULAR_OPEN_TASKS).group(:type).having("count(*) > 1").count
   end

--- a/spec/lib/helpers/check_task_tree_spec.rb
+++ b/spec/lib/helpers/check_task_tree_spec.rb
@@ -185,6 +185,23 @@ describe "CheckTaskTree" do
         include_examples "has error message", "Open RootTask should have an active task assigned to the Board"
       end
     end
+    describe "#unexpected_child_task" do
+      subject { CheckTaskTree.new(appeal).unexpected_child_task }
+      let(:appeal) { create(:appeal, :at_bva_dispatch) }
+      let(:judge) { appeal.tasks.assigned_to_any_user.find_by_type(:JudgeDecisionReviewTask).assigned_to }
+      let(:dispatch_org_task) { appeal.tasks.assigned_to_any_org.find_by_type(:BvaDispatchTask) }
+      # let(:dispatch_user_task) { appeal.tasks.assigned_to_any_user.find_by_type(:BvaDispatchTask) }
+      it_behaves_like "when tasks are correct"
+      context "when tasks are invalid" do
+        before do
+          # dispatch_user_task.parent.assigned!
+          # dispatch_user_task.update(parent: appeal.root_task)
+          JudgeDispatchReturnTask.create!(appeal: appeal, parent: dispatch_org_task, assigned_to: judge)
+        end
+        it { is_expected.not_to be_blank }
+        include_examples "has error message", /Unexpected child task: .*JudgeDispatchReturnTask/
+      end
+    end
   end
 
   context "check_task_counts" do

--- a/spec/lib/helpers/check_task_tree_spec.rb
+++ b/spec/lib/helpers/check_task_tree_spec.rb
@@ -220,13 +220,18 @@ describe "CheckTaskTree" do
   context "check_task_counts" do
     describe "#extra_open_hearing_tasks" do
       subject { CheckTaskTree.new(appeal).extra_open_hearing_tasks }
-      let(:appeal) { create(:appeal, :with_schedule_hearing_tasks) }
+      let(:appeal) { create(:appeal, :ready_for_distribution, :with_schedule_hearing_tasks) }
+      let(:hearing_task) { appeal.tasks.find_by_type(:HearingTask) }
+      before do
+        hearing_task.update(parent: distribution_task)
+        distribution_task.on_hold!
+      end
       it_behaves_like "when tasks are correct"
 
       context "when tasks are invalid" do
-        before { HearingTask.create!(appeal: appeal, parent: appeal.root_task) }
+        before { HearingTask.create!(appeal: appeal, parent: distribution_task) }
         it { is_expected.not_to be_blank }
-        include_examples "has error message", /There should be no more than 1 open HearingTask/
+        include_examples "has error message", "There should be no more than 1 open HearingTask"
       end
     end
     describe "#extra_open_tasks" do


### PR DESCRIPTION
Helps prevent setting incorrect parent or child tasks. 

### Description
For the `check_task_tree` utility, check task parent and child for expected task based on parent-child stats:
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-DR/freq-parentchild.html
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-ES/freq-parentchild.html
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-H/freq-parentchild.html

and child-parent stats:
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-DR/freq-childparent.html
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-ES/freq-childparent.html
  - https://department-of-veterans-affairs.github.io/caseflow/task_trees/trees/docket-H/freq-childparent.html

Bonus: Replace call to `@appeal.try(:stuck?)` with faster queries.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Check task parent and child for expected task

### Testing Plan
See new RSpec
