### PR TITLE
Avoid DB Seed Flake (on stafkey)

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,8 +15,10 @@ class SeedDB
     Fakes::VeteranStore.new.clear!
   end
 
+  # In development environments this log goes to
+  # caseflow/log/development.log
   def call_and_log_seed_step(step)
-    msg = "Starting seed step #{step}"
+    msg = "Starting seed step #{step} at #{Time.zone.now.strftime('%m/%d/%Y %H:%M:%S')}"
     Rails.logger.debug(msg)
 
     if step.is_a?(Symbol)
@@ -25,7 +27,7 @@ class SeedDB
       step.new.seed!
     end
 
-    msg = "Finished seed step #{step}"
+    msg = "Finished seed step #{step} at #{Time.zone.now.strftime('%m/%d/%Y %H:%M:%S')}"
     Rails.logger.debug(msg)
   end
 

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -207,12 +207,16 @@ module Seeds
     def create_legacy_appeal(hearing_day)
       @bfkey += 1
       @bfcorkey += 1
+      # This avoids a flake where stafkey collides with the random stafkey
+      # that seeds/priority_distributions.rb uses to create cases. This solution
+      # is from seeds/tasks.rb
+      correspondent = VACOLS::Correspondent.find_or_create_by(stafkey: @bfcorkey.to_s)
       vacols_case = create(
         :case,
         bfkey: @bfkey.to_s,
         bfcorkey: @bfcorkey.to_s,
         bfac: %w[1 3].sample, # original or Post remand,
-        correspondent: create(:correspondent, stafkey: @bfcorkey.to_s)
+        correspondent: correspondent
       )
 
       file_number = LegacyAppeal.veteran_file_number_from_bfcorlid(vacols_case.bfcorlid)
@@ -318,12 +322,16 @@ module Seeds
     def create_travel_board_vacols_case
       @bfkey += 1
       @bfcorkey += 1
+      # This avoids a flake where stafkey collides with the random stafkey
+      # that seeds/priority_distributions.rb uses to create cases. This solution
+      # is from seeds/tasks.rb
+      correspondent = VACOLS::Correspondent.find_or_create_by(stafkey: @bfcorkey.to_s)
       create(
         :case,
         :travel_board_hearing,
         bfkey: @bfkey.to_s,
         bfcorkey: @bfcorkey.to_s,
-        correspondent: create(:correspondent, stafkey: @bfcorkey.to_s)
+        correspondent: correspondent
       )
     end
 


### PR DESCRIPTION
### Description
This fixes a flake that would sometimes prevent the database from seeding after running for ~15minutes. It was a key collision in a table that we generate random ids into. Fixed by using the find_or_create pattern rather than assuming we can use any given key.
