### PR TITLE
Fix Flake: Dont Use Index for Dropdown Selection

### DIFF
--- a/spec/feature/hearings/edit_hearing_day_spec.rb
+++ b/spec/feature/hearings/edit_hearing_day_spec.rb
@@ -71,7 +71,7 @@ RSpec.feature "Edit a Hearing Day", :all_dbs do
     end
 
     it "can make changes to the Coordinator on the docket" do
-      click_dropdown(name: "coordinator", index: 1)
+      click_dropdown(name: "coordinator", text: "#{coordinator.snamef} #{coordinator.snamel}")
       find("button", text: "Save Changes").click
 
       expect(page).to have_content("You have successfully updated this hearing day.")


### PR DESCRIPTION
### Description
We've had a quite flaky set of tests (88% success over 41 runs in master branch). This PR fixes those tests (🤞 ) so they will no longer flake.

### Problem examples
- [Slack thread](https://dsva.slack.com/archives/C2ZAMLK88/p1635781769069500?thread_ts=1635775888.064000&cid=C2ZAMLK88)
- [Flake list](https://app.circleci.com/insights/github/department-of-veterans-affairs/caseflow/workflows/build/tests?branch=master&reporting-window=last-30-days) (with these near the top)
- [CircleCI example](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/48939/workflows/787562fe-17fd-480d-a264-95746eea2941/jobs/194458/tests#failed-test-0)