### PR TITLE
Fix Contested claim check logic 

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -166,7 +166,7 @@ class Appeal < DecisionReview
 
     category_substrings = ["Contested Claims", "Apportionment"]
 
-    active_request_issues.any? do |request_issue|
+    request_issues.any? do |request_issue|
       category_substrings.any? { |substring| request_issue.nonrating_issue_category.include?(substring) }
     end
   end

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -167,7 +167,7 @@ class Appeal < DecisionReview
     category_substrings = ["Contested Claims", "Apportionment"]
 
     request_issues.any? do |request_issue|
-      category_substrings.any? { |substring| request_issue.nonrating_issue_category.include?(substring) }
+      category_substrings.any? { |substring| request_issue.nonrating_issue_category&.include?(substring) }
     end
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -166,12 +166,8 @@ class Appeal < DecisionReview
 
     category_substrings = ["Contested Claims", "Apportionment"]
 
-    matching_issue_categories = Constants::ISSUE_CATEGORIES.values.flatten.select do |category|
-      category.match? Regexp.union(category_substrings)
-    end
-
     active_request_issues.any? do |request_issue|
-      matching_issue_categories.include?(request_issue.nonrating_issue_category)
+      category_substrings.any? { |substring| request_issue.nonrating_issue_category.include?(substring) }
     end
   end
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1453,7 +1453,8 @@ RSpec.feature "Case details", :all_dbs do
 
     let(:request_issues) do
       [
-        create(:request_issue, benefit_type: "compensation", nonrating_issue_category: "Contested Claims - Insurance")
+        create(:request_issue, benefit_type: "compensation", nonrating_issue_category: "Contested Claims - Insurance"),
+        create(:request_issue2, benefit_type: "fiduciaru", nonrating_issue_category),
       ]
     end
     let(:appeal) { create(:appeal, request_issues: request_issues) }

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1158,14 +1158,15 @@ describe Appeal, :all_dbs do
 
     let(:request_issues) do
       [
-        create(:request_issue, benefit_type: "compensation", nonrating_issue_category: issue_category)
+        create(:request_issue, benefit_type: benefit_type, nonrating_issue_category: issue_category)
       ]
     end
     let(:appeal) { create(:appeal, request_issues: request_issues) }
 
-    context "when issue category falls under contested claims" do
+    context "when issue category falls under contested claims and request issue is rating" do
       context "contains string 'Contested Claim'" do
-        let(:issue_category) { "Contested Claims - Insurance" }
+        let(:benefit_type) { "compensation" }
+        let(:nonrating_issue_category) { "Contested Claims - Insurance" }
 
         it "returns true" do
           expect(subject).to be_truthy
@@ -1173,7 +1174,8 @@ describe Appeal, :all_dbs do
       end
 
       context "contains string 'Apportionment'" do
-        let(:issue_category) { "Contested Claims - Apportionment" }
+        let(:benefit_type) { "compensation" }
+        let(:nonrating_issue_category) { "Contested Claims - Apportionment" }
 
         it "returns true" do
           expect(subject).to be_truthy
@@ -1181,8 +1183,9 @@ describe Appeal, :all_dbs do
       end
     end
 
-    context "when issue category doesn't fall under contested claims" do
-      let(:issue_category) { "Military Retired Pay" }
+    context "when issue category doesn't fall under contested claims request issue is nonrating issue" do
+      let(:benefit_type) { "fiduciary" }
+      let(:issue_category) { "Appointment of a Fiduciary (38 CFR 13.100)" }
 
       it "returns false" do
         expect(subject).to be_falsey


### PR DESCRIPTION
Resolves [CASEFLOW-2544](https://vajira.max.gov/browse/CASEFLOW-2544)

### Description
Account for nil `nonrating_issue_category` in Contested Claim logic check.

This fix is due to the need to roll back a [PR created to fix the contested claim logic by checking all request issues](https://github.com/department-of-veterans-affairs/caseflow/pull/16907) #16907 

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass
