### PR TITLE
Send reminders for Travel Board Hearings

### DIFF
--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -3,6 +3,8 @@
 ##
 # HearingMailer will:
 # - Generate emails from the templates in app/views/hearing_mailer
+#   - All types will use layouts/hearing_mailer.html.erb to determine the order of the sections
+#     - Example section: :test_your_connection, :rescheduling_or_canceling_your_hearing
 #   - The method name like "cancellation" determines which template is used.
 #   - The 'cancellation' method uses app/views/hearing_mailer/cancellation.html.erb
 #   - cancellation.html.erb prepends the recipient type and uses another template.

--- a/app/repositories/hearing_repository.rb
+++ b/app/repositories/hearing_repository.rb
@@ -180,7 +180,8 @@ class HearingRepository
       [
         HearingDay::REQUEST_TYPES[:virtual],
         HearingDay::REQUEST_TYPES[:video],
-        HearingDay::REQUEST_TYPES[:central]
+        HearingDay::REQUEST_TYPES[:central],
+        HearingDay::REQUEST_TYPES[:travel]
       ]
     end
 

--- a/lib/tasks/emails.rake
+++ b/lib/tasks/emails.rake
@@ -8,7 +8,9 @@ namespace :emails do
 
     return if body.blank?
 
-    output_file = Rails.root.join("tmp", file_name)
+    email_output_dir = "tmp/hearing_emails/"
+    FileUtils.mkpath(email_output_dir)
+    output_file = Rails.root.join(email_output_dir, file_name)
     File.write(output_file, subject, mode: "w")
     File.write(output_file, body, mode: "a")
   end
@@ -77,6 +79,8 @@ namespace :emails do
       end
     end
 
+    # Example arg passing syntax, note the double-quotes
+    # bundle exec rake "emails:hearings:reminder[travel]"
     desc "creates reminder emails for hearings mailer"
     task :reminder, [:request_type, :reminder_type] => :environment do |_task, args|
       include FactoryBot::Syntax::Methods
@@ -97,7 +101,7 @@ namespace :emails do
           regional_office: "RO15",
           hearing_day: hearing_day
         )
-      elsif args.request_type.to_sym == :central
+      elsif args.request_type.to_sym == :central || args.request_type.to_sym == :travel
         hearing_day = build(
           :hearing_day,
           created_by: User.last,
@@ -171,7 +175,7 @@ namespace :emails do
       end
     end
 
-    desc "creates reminder emails for hearings mailer"
+    desc "creates notification/status emails for hearings mailer"
     # :environment is required for FactoryBot build/create to work
     task status_emails: :environment do
       %w["appellant representative"].each do |recipient_role|

--- a/spec/services/hearings/reminder_service_spec.rb
+++ b/spec/services/hearings/reminder_service_spec.rb
@@ -214,4 +214,32 @@ describe Hearings::ReminderService do
       include_examples "determines which reminders should send"
     end
   end
+
+  # This test is identical to "with a central hearing" except for the :travel trait on :hearing_day
+  context "with a travel hearing" do
+    let(:hearing_day) { create(:hearing_day, :travel, scheduled_for: hearing_date) }
+    let(:hearing) do
+      create(:hearing, hearing_day: hearing_day, created_at: created_at) # scheduled_time is always 8:30 AM ET
+    end
+
+    before do
+      Timecop.freeze(Time.utc(2020, 11, 5, 12, 0, 0)) # Nov 5, 2020 12:00 ET (Thursday)
+      hearing
+      hearing.reload
+    end
+
+    after { Timecop.return }
+
+    context ".reminder_type" do
+      subject do
+        described_class.new(
+          hearing: hearing,
+          last_sent_reminder: last_sent_reminder,
+          hearing_created_at: created_at
+        ).reminder_type
+      end
+
+      include_examples "determines which reminders should send"
+    end
+  end
 end


### PR DESCRIPTION
Resolves [CASEFLOW-1828](https://vajira.max.gov/browse/CASEFLOW-1828)

### Description
We've added the ability to capture email addresses for both the appellant and the representative for all types of hearings. Caseflow currently sends email reminders to those addresses for video, central, and virtual hearings. This PR will start sending reminder emails for travel hearings as well.

### Acceptance Criteria
- [ ] This AC has already been met by the work in #16616. ~~When scheduling a hearing, appellant/Veteran and representative emails and timezones can be optionally entered for the hearing~~
- [ ] For scheduled hearings on a Travel docket with a saved email recipient, send
    - [ ] 60-day reminder
    - [ ] 7-day reminder
    - [ ] 2/3-day reminder

### Testing Plan
- 11/08 The failing test in `geomatch_and_cache_appeal_job_spec.rb` is under [discussion here](https://dsva.slack.com/archives/C3EAF3Q15/p1636134608155600). Not caused by this work.
- Run this rake command to generate all the emails for a travel docket
     - `bundle exec rake "emails:hearings:reminder[travel]"`
     - Output goes to `caseflow/tmp/hearing_emails`
     -  They should look identical to the ones that are generated for a video day
- It's worth noting that there is some request_type based logic in `app/views/hearing_mailer/_appellant_reminder.html.erb`.
    - My understanding is that we're not changing email text with this ticket.
    - This was the only request_type based logic I could find after `hearing_mailer::reminder` 
- I added an rpsec test that confirms all the logic around when email reminder goes out will work the same for travel hearings. 
