### PR TITLE
Remove check for TZ offset for EvidenceSubmissionWindowTask in substitution spec due to DST issues

### DIFF
--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -193,7 +193,6 @@ RSpec.shared_examples("fill substitution form") do
           evidence_submission_window_end_time - 1.day,
           evidence_submission_window_end_time + 1.day
         )
-        expect(window_task.timer_ends_at.utc_offset).to eql(Time.zone.now.utc_offset)
       end
 
       if docket_type.eql?("hearing")


### PR DESCRIPTION
### Description
This removes a problematic assertion that fails due to change in offset from UTC due to daylight savings time :sad:

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Remove TZ offset assertion
