### PR TITLE
Fix VA.gov Fake To Resolve Test Flake

### DIFF
--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -10,11 +10,24 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
         data
       end
 
+      # distances = [
+      #   "vba_317": 1, # RO17, St. Petersburg
+      #   "vba_xxx": 20, # Which RO depends on the ids passed in, they can be different
+      #   "vba_xxx": 21,
+      #   "vba_xxx": 22,
+      #   ...
+      # ]
       distances = query[:ids].split(",").map.with_index do |id, index|
-        {
+        if id == "vba_317" # St. Petersburg
+          {
+            id: id,
+            distance: 1
+          }
+        else {
           id: id,
-          distance: index
+          distance: index + 20 # Because we want St. Petersburg to be the closest
         }
+        end
       end
 
       fake_facilities = fake_facilities_data

--- a/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
+++ b/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
@@ -58,8 +58,8 @@ describe Hearings::GeomatchAndCacheAppealJob do
 
           cached = CachedAppeal.first
 
-          expect(cached.closest_regional_office_city).to eq("Manchester")
-          expect(cached.closest_regional_office_key).to eq("RO73")
+          expect(cached.closest_regional_office_city).to eq("St. Petersburg")
+          expect(cached.closest_regional_office_key).to eq("RO17")
           expect(cached.former_travel).to eq(false)
           expect(cached.hearing_request_type).to eq("Travel")
         end


### PR DESCRIPTION
### Description
We're seeing a lot of [this flake](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/49113/workflows/51966520-c793-4a0c-a6bb-0af9e8a84e45/jobs/195322/tests#failed-test-1) from `spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb`

```ruby
Failure/Error: expect(cached.closest_regional_office_city).to eq("Manchester")

  expected: "Manchester"
       got: "Houston"

  (compared using ==)
./spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb:61:in `block (5 levels) in <top (required)>'
```

The problem seems to be that `lib/fakes/va_dot_gov_service.rb` doesn't actually know the distances so can give a random order. 
- I fixed this by forcing St. Petersburg to always have a distance of "1" from the address while all other ROs have a distance of more than "20".
- This makes the test data better, since the "distance" in prod actually refers to how far from an address the RO is. The address we're using is closest to St. Petersburg.

There's some outdated discussion [here](https://dsva.slack.com/archives/C3EAF3Q15/p1636134608155600).