### PR TITLE
Fix Geomatch Distance Flake

### DIFF
--- a/app/models/regional_office.rb
+++ b/app/models/regional_office.rb
@@ -196,6 +196,7 @@ class RegionalOffice
         .select(&:facility_id?)
         .map(&:facility_id)
         .uniq
+        .sort
     end
 
     # Get all RO facility IDs for a given state (excludes satellite offices).

--- a/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
+++ b/spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb
@@ -58,8 +58,8 @@ describe Hearings::GeomatchAndCacheAppealJob do
 
           cached = CachedAppeal.first
 
-          expect(cached.closest_regional_office_city).to eq("Manchester")
-          expect(cached.closest_regional_office_key).to eq("RO73")
+          expect(cached.closest_regional_office_city).to eq("Boston")
+          expect(cached.closest_regional_office_key).to eq("RO01")
           expect(cached.former_travel).to eq(false)
           expect(cached.hearing_request_type).to eq("Travel")
         end


### PR DESCRIPTION
### Description
We're seeing a lot of [this flake](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/49113/workflows/51966520-c793-4a0c-a6bb-0af9e8a84e45/jobs/195322/tests#failed-test-1), [another example](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/49184/workflows/96fcdf26-4716-452a-a377-2b7426da2e35/jobs/195716/tests#failed-test-0), from `spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb`

```ruby
Failure/Error: expect(cached.closest_regional_office_city).to eq("Manchester")

  expected: "Manchester"
       got: "Houston"

  (compared using ==)
./spec/jobs/hearings/geomatch_and_cache_appeal_job_spec.rb:61:in `block (5 levels) in <top (required)>'
```

The problem seems to be that `lib/fakes/va_dot_gov_service.rb` doesn't actually know the distances so can give a random order. The fix was to give `RegionalOffice.ro_facility_ids` a defined order via `.sort`.

There's some outdated discussion [here](https://dsva.slack.com/archives/C3EAF3Q15/p1636134608155600).


