### PR TITLE
Removes pdfjs from yarn.lock

### DIFF
--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -13353,11 +13353,6 @@ pdfjs-dist@2.5.207:
   resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz#b5e8c19627be64269cd3fb6df3eaaf45ddffe7b6"
   integrity sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw==
 
-"pdfjs@npm:pdfjs-dist@2.5.207":
-  version "2.5.207"
-  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.5.207.tgz#b5e8c19627be64269cd3fb6df3eaaf45ddffe7b6"
-  integrity sha512-xGDUhnCYPfHy+unMXCLCJtlpZaaZ17Ew3WIL0tnSgKFUZXHAPD49GO9xScyszSsQMoutNDgRb+rfBXIaX/lJbw==
-
 performance-now@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"


### PR DESCRIPTION
### Description
This wasn't previously committed, but we're all carrying this diff locally.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] People agree this should be committed

### Testing Plan
Not user-facing; only yarn.lock cleanup. Just make sure test suite passes.