### PR TITLE
Fix proptype errors in CaseDetails component

### DIFF
--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -293,7 +293,7 @@ HeaderRow.propTypes = {
 
 Row.propTypes = {
   footer: PropTypes.bool,
-  rowId: PropTypes.number,
+  rowId: PropTypes.string,
   rowClassNames: PropTypes.func,
   rowObject: PropTypes.object.isRequired
 };

--- a/client/app/components/Tooltip.jsx
+++ b/client/app/components/Tooltip.jsx
@@ -56,7 +56,7 @@ const Tooltip = (props) => {
 };
 
 Tooltip.propTypes = {
-  text: PropTypes.string,
+  text: PropTypes.any,
   id: PropTypes.string,
   position: PropTypes.string,
   offset: PropTypes.object,

--- a/client/app/components/badges/Badge.jsx
+++ b/client/app/components/badges/Badge.jsx
@@ -39,7 +39,7 @@ Badge.propTypes = {
   name: PropTypes.string.isRequired,
   displayName: PropTypes.string.isRequired,
   tooltipText: PropTypes.object,
-  id: PropTypes.number
+  id: PropTypes.string
 };
 
 export default Badge;

--- a/client/app/components/badges/FnodBadge/FnodBadge.jsx
+++ b/client/app/components/badges/FnodBadge/FnodBadge.jsx
@@ -22,7 +22,7 @@ const FnodBadge = (props) => {
 FnodBadge.propTypes = {
   veteranAppellantDeceased: PropTypes.bool,
   uniqueId: PropTypes.string,
-  tooltipText: PropTypes.string
+  tooltipText: PropTypes.object
 };
 
 export default FnodBadge;

--- a/client/app/queue/components/Address.jsx
+++ b/client/app/queue/components/Address.jsx
@@ -37,13 +37,5 @@ export default class Address extends React.PureComponent {
 }
 
 Address.propTypes = {
-  address: PropTypes.shape({
-    address_line_1: PropTypes.string,
-    address_line_2: PropTypes.string,
-    address_line_3: PropTypes.string,
-    city: PropTypes.string,
-    state: PropTypes.string,
-    zip: PropTypes.number,
-    country: PropTypes.string,
-  })
+  address: PropTypes.objectOf(PropTypes.string)
 };


### PR DESCRIPTION
Resolves a number of proptype errors found in the Case Details component.

### Description
There were a few proptype errors when loading the case details component. This PR fixes those proptypes so that no errors appear in the console. 

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Proptype errors are no longer present when loading the CaseDetails Component.

### Testing Plan
1. Search for case number "54545454" - or any case with a badge.
2. Open console and check for any proptype errors. There should be none.
