### PR TITLE
Send IDT authentication errors to Sentry

### DIFF
--- a/app/controllers/idt/authentications_controller.rb
+++ b/app/controllers/idt/authentications_controller.rb
@@ -10,8 +10,8 @@ class Idt::AuthenticationsController < ApplicationController
 
     Idt::Token.activate_proposed_token(key, current_user.css_id)
     render json: { message: "Success!" }
-  rescue_from Caseflow::Error::InvalidOneTimeKey do |e|
-    Raven.capture_exception(e)
+  rescue Caseflow::Error::InvalidOneTimeKey => error
+    Raven.capture_exception(error)
     render json: { message: "Invalid key." }, status: :bad_request
   end
 end

--- a/app/controllers/idt/authentications_controller.rb
+++ b/app/controllers/idt/authentications_controller.rb
@@ -10,7 +10,8 @@ class Idt::AuthenticationsController < ApplicationController
 
     Idt::Token.activate_proposed_token(key, current_user.css_id)
     render json: { message: "Success!" }
-  rescue Caseflow::Error::InvalidOneTimeKey
+  rescue_from Caseflow::Error::InvalidOneTimeKey do |e|
+    Raven.capture_exception(e)
     render json: { message: "Invalid key." }, status: :bad_request
   end
 end


### PR DESCRIPTION
To aid when we troubleshoot authentication issues with IDT (like [this example from today](https://dsva.slack.com/archives/CHX8FMP28/p1637069989334000)).