### PR TITLE
Block addition of more than one substitute on active appeal

### DIFF
--- a/client/app/queue/substituteAppellant/caseDetails/utils.js
+++ b/client/app/queue/substituteAppellant/caseDetails/utils.js
@@ -21,13 +21,14 @@ export const supportsSubstitutionPreDispatch = ({
   currentUserOnClerkOfTheBoard,
   featureToggles,
   userIsCobAdmin,
+  hasSubstitution,
 }) => {
   return (
     appealSupportsSubstitution(appeal) &&
     currentUserOnClerkOfTheBoard &&
     featureToggles?.listed_granted_substitution_before_dismissal && // eslint-disable-line camelcase
     // For now, only allow a single substitution from a given appeal
-    !appealHasSubstitution(appeal) &&
+    !hasSubstitution &&
     // below is needed to avoid showing multiple substitution buttons on post-dispatch appeals
     !appealHasDeathDismissal(appeal) &&
     // Only admins can perform sub on cases w/o FNOD status

--- a/client/test/app/queue/substituteAppellant/caseDetails/utils.test.js
+++ b/client/test/app/queue/substituteAppellant/caseDetails/utils.test.js
@@ -102,6 +102,7 @@ describe('supportsSubstitutionPreDispatch', () => {
     currentUserOnClerkOfTheBoard: true,
     featureToggles,
     userIsCobAdmin: false,
+    hasSubstitution: false,
   };
 
   describe('with requisite values', () => {
@@ -119,7 +120,7 @@ describe('supportsSubstitutionPreDispatch', () => {
         appeal: { ...appeal, appellantIsNotVeteran: true },
       };
 
-      expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+      expect(supportsSubstitutionPreDispatch(args)).toBe(false);
     });
   });
 
@@ -129,7 +130,7 @@ describe('supportsSubstitutionPreDispatch', () => {
     it.each(ineligibleCaseTypes)('for %s, returns false', (caseType) => {
       const args = { ...defaults, appeal: { ...appeal, caseType } };
 
-      expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+      expect(supportsSubstitutionPreDispatch(args)).toBe(false);
     });
   });
 
@@ -137,7 +138,7 @@ describe('supportsSubstitutionPreDispatch', () => {
     it('returns false', () => {
       const args = { ...defaults, appeal: { ...appeal, isLegacyAppeal: true } };
 
-      expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+      expect(supportsSubstitutionPreDispatch(args)).toBe(false);
     });
   });
 
@@ -145,7 +146,7 @@ describe('supportsSubstitutionPreDispatch', () => {
     it('returns false', () => {
       const args = { ...defaults, hasSubstitution: true };
 
-      expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+      expect(supportsSubstitutionPreDispatch(args)).toBe(false);
     });
   });
 
@@ -153,7 +154,7 @@ describe('supportsSubstitutionPreDispatch', () => {
     it('returns false', () => {
       const args = { ...defaults, currentUserOnClerkOfTheBoard: false };
 
-      expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+      expect(supportsSubstitutionPreDispatch(args)).toBe(false);
     });
   });
 
@@ -164,13 +165,14 @@ describe('supportsSubstitutionPreDispatch', () => {
     const testAppeal = {
       ...appeal,
       decisionIssues: nonDismissedDecisionIssues,
+      veteranAppellantDeceased: false,
     };
 
     describe('with regular COB user', () => {
       it('returns false', () => {
         const args = { ...defaults, appeal: testAppeal };
 
-        expect(supportsSubstitutionPostDispatch(args)).toBe(false);
+        expect(supportsSubstitutionPreDispatch(args)).toBe(false);
       });
     });
 
@@ -178,7 +180,7 @@ describe('supportsSubstitutionPreDispatch', () => {
       it('returns true', () => {
         const args = { ...defaults, appeal: testAppeal, userIsCobAdmin: true };
 
-        expect(supportsSubstitutionPostDispatch(args)).toBe(true);
+        expect(supportsSubstitutionPreDispatch(args)).toBe(true);
       });
     });
   });


### PR DESCRIPTION
Resolves [CASEFLOW-1659](https://vajira.max.gov/browse/CASEFLOW-1659) - Block addition of more than one substitute on active appeal

### Description
As a Clerk of the Board user, I should not have the ability to add additional substitutes on an active appeal, as there could only be one substitution appeal for the Veteran at a time. 

### Sidenote
This story looks like it was previously completed, but somehow ended up in the backlog. After reviewing the code, there were some things that needed to be changed/refactored. See change log.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Blocks COB user from adding additional substitutes on an active appeal.

### Testing Plan
- [x] Switch to user 'BVATCOBB' (or another Clerk of the Board admin).
- [x] Search for case '54545454'.
- [x]  Select a case with an FNOD badge.
- [x]  Click 'Add Substitute' button and go through steps.
- [x]  Navigate away from case.
- [x]  Go back to case where you created a substitution and you should see no option to add another substitute.
