### PR TITLE
Refactored HearingTimeService#local_time

### DIFF
--- a/app/services/hearing_time_service.rb
+++ b/app/services/hearing_time_service.rb
@@ -81,6 +81,14 @@ class HearingTimeService
     # if the hearing's regional_office_timezone is nil, assume this is a
     # central office hearing (eastern time)
     regional_office_timezone = @hearing.regional_office_timezone || CENTRAL_OFFICE_TIMEZONE
+    scheduled_for = @hearing.scheduled_for
+
+    # There is a bug in Vacols where timestamps are saved in local time with UTC timezone
+    # for example, Fri, 28 Jul 2017 14:28:01 UTC +00:00 is actually an EST time with UTC timezone
+    # This code is to account for this bug.
+    if scheduled_for.utc?
+      return scheduled_for.strftime("%a, %d %b %Y %H:%M:%S").in_time_zone(regional_office_timezone)
+    end
 
     # convert the hearing time returned by LegacyHearing.scheduled_for
     # to the regional office timezone

--- a/spec/support/timezone.rb
+++ b/spec/support/timezone.rb
@@ -1,0 +1,6 @@
+# Configuration option to change Timezone at a per test basis via metadata attributes
+RSpec.configure do |config|
+  config.around :example, :tz do |example|
+    Time.use_zone(example.metadata[:tz]) { example.run }
+  end
+end

--- a/spec/support/timezone.rb
+++ b/spec/support/timezone.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Configuration option to change Timezone at a per test basis via metadata attributes
 RSpec.configure do |config|
   config.around :example, :tz do |example|


### PR DESCRIPTION
Resolves [CASEFLOW-2586](https://vajira.max.gov/browse/CASEFLOW-2586)

### Description
There is a bug in Vacols where the times are stored in UTC instead of EST. In Caseflow for all Central Hearings coming from Vacols we do not convert the date to any time zone instead we just store whatever Vacols is sending which in this case is the date in UTC. Finally when sending the reminder emails we assume that the times are not in UTC so we proceed to convert the date time to the Appellant or the RO time zone.

### Acceptance Criteria
- [ ] Code compiles correctly
