### PR TITLE
HearingRenderer: show associated cancelled HearingTasks

### DIFF
--- a/app/models/concerns/has_hearing_task.rb
+++ b/app/models/concerns/has_hearing_task.rb
@@ -7,6 +7,14 @@ module HasHearingTask
     has_one :hearing_task_association,
             -> { includes(:hearing_task).where(tasks: { status: Task.open_statuses }) },
             as: :hearing
+    has_one :any_hearing_task_association,
+            -> { includes(:hearing_task) },
+            class_name: :HearingTaskAssociation,
+            as: :hearing
+  end
+
+  def any_hearing_task
+    any_hearing_task_association&.hearing_task
   end
 
   def hearing_task

--- a/lib/helpers/hearing_renderer.rb
+++ b/lib/helpers/hearing_renderer.rb
@@ -291,7 +291,7 @@ class HearingRenderer
         end
       }
     end
-    children << structure(hearing&.hearing_task_association&.hearing_task)
+    children << structure(hearing&.any_hearing_task)
   end
 
   def legacy_hearing_children(hearing)

--- a/spec/lib/helpers/hearing_renderer_spec.rb
+++ b/spec/lib/helpers/hearing_renderer_spec.rb
@@ -181,10 +181,10 @@ describe "HearingRenderer" do
         h_task = ahd_task.parent
 
         output = renderer.hearing_task_children(h_task)
-        expect(output).to include /AssignHearingDispositionTask #{ahd_task.id} .cancelled/
+        expect(output).to include(/AssignHearingDispositionTask #{ahd_task.id} .cancelled/)
 
         output_hash = renderer.structure(h_task)
-        expect(output_hash.keys.first.to_s).to match /HearingTask #{h_task.id} .cancelled/
+        expect(output_hash.keys.first.to_s).to match(/HearingTask #{h_task.id} .cancelled/)
       end
     end
   end

--- a/spec/lib/helpers/hearing_renderer_spec.rb
+++ b/spec/lib/helpers/hearing_renderer_spec.rb
@@ -172,5 +172,20 @@ describe "HearingRenderer" do
       expect(output.second).to include "ScheduleHearingTask #{sh_task.id}"
       expect(output.second).to include "assigned"
     end
+
+    context "when associated HearingTask is cancelled" do
+      let!(:hearing) { create(:hearing, :with_tasks, appeal: appeal, hearing_day: hearing_day) }
+      it "shows cancelled HearingTask" do
+        ahd_task = appeal.tasks.find_by(type: AssignHearingDispositionTask.name)
+        ahd_task.cancelled!
+        h_task = ahd_task.parent
+
+        output = renderer.hearing_task_children(h_task)
+        expect(output).to include /AssignHearingDispositionTask #{ahd_task.id} .cancelled/
+
+        output_hash = renderer.structure(h_task)
+        expect(output_hash.keys.first.to_s).to match /HearingTask #{h_task.id} .cancelled/
+      end
+    end
   end
 end


### PR DESCRIPTION
Resolves HearingRenderer not showing associated closed `HearingTask`s

### Description
For `HearingRenderer`, shows associated closed `HearingTask`s.
The hearing renderer output is shown when running `puts appeal.render_hearing` and on the [Explain page](https://github.com/department-of-veterans-affairs/caseflow/wiki/Explain-page-for-Appeals).

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] For `HearingRenderer`, show associated closed `HearingTask`s.

### Testing Plan
Add a `binding.pry` in new RSpec test and run `puts appeal.render_hearing` to see new rendering:
```ruby
Appeal 1 (UUID: f52ba2fc-eaa0-4300-a565-6d844139001a)
├── Hearing 1 (UUID: c32938e2-c093-4ef5-8a74-7e81ec128c7d)
│   ├── Scheduled for: 11-17-2021 10:30AM EST | 8:30AM MST (RO time)
│   ├── Virtual, no disposition, no coordinator
│   ├── HearingDay 1 (RO42 - Cheyenne WY, Virtual, VLJ Abshire)
│   └── HearingTask 4 (cancelled, ca: 11-16-2021 4:49PM EST)
│       └── AssignHearingDispositionTask 5 (cancelled, ca: 11-16-2021 4:49PM EST)
├── Unscheduled Hearing (SCH Task ID: 3, RO queue: Unknown)
├── Appeal History
│   └── Current type: Central
└── breadcrumbs:
    └── Veteran 1 (PID: 500000000)
```
