### PR TITLE
CASEFLOW-1928 | Create 'disposition' index on hearings

### DIFF
--- a/db/migrate/20211117182908_index_hearings_on_disposition.rb
+++ b/db/migrate/20211117182908_index_hearings_on_disposition.rb
@@ -1,7 +1,7 @@
-class IndexHearingsOnDisposition < ActiveRecord::Migration[5.2]
-  disable_ddl_transaction!
+# frozen_string_literal: true
 
+class IndexHearingsOnDisposition < Caseflow::Migration
   def change
-    add_index :hearings, :disposition, algorithm: :concurrently
+    add_safe_index :hearings, [:disposition]
   end
 end

--- a/db/migrate/20211117182908_index_hearings_on_disposition.rb
+++ b/db/migrate/20211117182908_index_hearings_on_disposition.rb
@@ -1,0 +1,7 @@
+class IndexHearingsOnDisposition < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def change
+    add_index :hearings, :disposition, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_125151) do
+ActiveRecord::Schema.define(version: 2021_11_17_182908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -838,6 +838,7 @@ ActiveRecord::Schema.define(version: 2021_11_05_125151) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "witness", comment: "Witness/Observer present during hearing"
     t.index ["created_by_id"], name: "index_hearings_on_created_by_id"
+    t.index ["disposition"], name: "index_hearings_on_disposition"
     t.index ["updated_at"], name: "index_hearings_on_updated_at"
     t.index ["updated_by_id"], name: "index_hearings_on_updated_by_id"
     t.index ["uuid"], name: "index_hearings_on_uuid"


### PR DESCRIPTION
### Description
Part of [CASEFLOW-1928](https://vajira.max.gov/browse/CASEFLOW-1928).

Our query became unacceptably slow, and this was a key part of why. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing
- [ ] Verify index is created
- [ ] Verify rollback works

### Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)
