### PR TITLE
CASEFLOW-1928 | Adds judge_id index to hearings table

### DIFF
--- a/db/migrate/20211117184910_index_hearings_on_judge_id.rb
+++ b/db/migrate/20211117184910_index_hearings_on_judge_id.rb
@@ -1,0 +1,5 @@
+class IndexHearingsOnJudgeId < Caseflow::Migration
+  def change
+    add_safe_index :hearings, [:judge_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_05_125151) do
+ActiveRecord::Schema.define(version: 2021_11_17_184910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -838,6 +838,8 @@ ActiveRecord::Schema.define(version: 2021_11_05_125151) do
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.string "witness", comment: "Witness/Observer present during hearing"
     t.index ["created_by_id"], name: "index_hearings_on_created_by_id"
+    t.index ["disposition"], name: "index_hearings_on_disposition"
+    t.index ["judge_id"], name: "index_hearings_on_judge_id"
     t.index ["updated_at"], name: "index_hearings_on_updated_at"
     t.index ["updated_by_id"], name: "index_hearings_on_updated_by_id"
     t.index ["uuid"], name: "index_hearings_on_uuid"


### PR DESCRIPTION
### Description
Related to [CASEFLOW-1928](https://vajira.max.gov/browse/CASEFLOW-1928)

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing
- [ ] Verify index is created
- [ ] Verify rollback works

### Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)
