### PR TITLE
Temporarily add MPI library into Caseflow

### DIFF
--- a/app/services/external_api/mpi_service.rb
+++ b/app/services/external_api/mpi_service.rb
@@ -15,25 +15,30 @@ class ExternalApi::MPIService
   end
 
   # rubocop:disable Metrics/ParameterLists
-  def search_people_info(last_name:, first_name: nil, middle_name: nil, date_of_birth: nil, gender: nil, address: nil)
+  def search_people_info(last_name:, first_name: nil, middle_name: nil,
+                         ssn: nil, date_of_birth: nil, gender: nil, address: nil, telephone: nil)
     DBService.release_db_connections
 
     mpi_info = MetricsService.record("MPI: search people info: \
                                      last_name = #{last_name}, \
                                      first_name = #{first_name}, \
                                      middle_name = #{middle_name}, \
+                                     ssn = #{ssn}, \
                                      date_of_birth = #{date_of_birth}, \
                                      gender = #{gender}, \
-                                     address = #{address}",
+                                     address = #{address}, \
+                                     telephone = #{telephone}",
                                      service: :mpi,
                                      name: "people.search_people_info") do
       client.people.search_people_info(
         last_name: last_name,
         first_name: first_name,
         middle_name: middle_name,
+        ssn: ssn,
         date_of_birth: date_of_birth,
         gender: gender,
-        address: address
+        address: address,
+        telephone: telephone
       )
     end
     {} unless mpi_info

--- a/config/initializers/mpi.rb
+++ b/config/initializers/mpi.rb
@@ -1,0 +1,3 @@
+require 'connect_mpi/mpi'
+
+MPIService = ExternalApi::MPIService

--- a/config/initializers/mpi.rb
+++ b/config/initializers/mpi.rb
@@ -1,3 +1,3 @@
 require 'connect_mpi/mpi'
 
-MPIService = ExternalApi::MPIService
+MPIService = (!ApplicationController.dependencies_faked? ? ExternalApi::MPIService : Fakes::MPIService)

--- a/lib/connect_mpi/mpi.rb
+++ b/lib/connect_mpi/mpi.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+require_relative "mpi/base"
+require_relative "mpi/errors"
+require_relative "mpi/services"

--- a/lib/connect_mpi/mpi/base.rb
+++ b/lib/connect_mpi/mpi/base.rb
@@ -64,7 +64,7 @@ module MPI
   </receiver>
   <sender typeCode="SND">
     <device classCode="DEV" determinerCode="INSTANCE">
-      <id extension="200DSLF" root="1.2.840.114350.1.13.99997.2.7788" />
+      <id extension="200CFL" root="1.2.840.114350.1.13.99997.2.7788" />
       <asAgent classCode="AGNT">
         <representedOrganization classCode="ORG" determinerCode="INSTANCE">
           <id root="2.16.840.1.113883.4.349" extension="200CFL" />

--- a/lib/connect_mpi/mpi/base.rb
+++ b/lib/connect_mpi/mpi/base.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require "savon"
+require "nokogiri"
+
+module MPI
+  class Base
+    def initialize(ssl_cert_file:, ssl_cert_key_file:, ssl_ca_cert:,
+                   env: nil, application: nil, log: false, logger: nil)
+      @env = env
+      @application = application
+      @ssl_cert_file = ssl_cert_file
+      @ssl_cert_key_file = ssl_cert_key_file
+      @ssl_ca_cert = ssl_ca_cert
+      @log = log
+      @logger = logger
+    end
+
+    def self.service_name
+      raise NoMethodError
+    end
+
+    private
+
+    def wsdl
+      "https://int.services.eauth.va.gov:9303/psim_webservice/dev/IdMWebService?WSDL"
+    end
+
+    def client
+      savon_client_params = {
+        wsdl: wsdl,
+        ssl_cert_file: @ssl_cert_file,
+        ssl_cert_key_file: @ssl_cert_key_file,
+        ssl_ca_cert_file: @ssl_ca_cert,
+        log: @log,
+        namespaces: { "xmlns" => "urn:hl7-org:v3" },
+        open_timeout: 10, # in seconds
+        read_timeout: 600, # in seconds
+        convert_request_keys_to: :lower_camelcase
+      }
+      savon_client_params[:logger] = @logger if @logger
+      @client ||= Savon.client(savon_client_params)
+    end
+
+    def build_request_xml(method, query)
+      request_xml = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+<s:Body>
+<ps:PRPA_IN201305UV02 xmlns:ps="http://vaww.oed.oit.va.gov" 
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="urn:hl7-org:v3 ../../schema/HL7V3/NE2008/multicacheschemas/PRPA_IN201305UV02.xsd" xmlns="urn:hl7-org:v3" ITSVersion="XML_1.0">
+  <id root="2.16.840.1.113883.4.349" extension="MCID-124147"/> <!-- unique msg id-->
+  <creationTime value="20211026150301" /> <!-- date of request -->
+  <versionCode code="4.1"/> <!-- should be this value unless specified otherwise -->
+  <interactionId root="2.16.840.1.113883.1.6" extension="PRPA_IN201305UV02" />
+  <processingCode code="T" /> <!-- T=test, all non-PROD;  P=PROD -->
+  <processingModeCode code="T" />
+  <acceptAckCode code="AL" />
+  <receiver typeCode="RCV">
+    <device classCode="DEV" determinerCode="INSTANCE">
+      <id root="1.2.840.114350.1.13.999.234" />
+      <telecom value="http://servicelocation/PDQuery" />
+    </device>
+  </receiver>
+  <sender typeCode="SND">
+    <device classCode="DEV" determinerCode="INSTANCE">
+      <id extension="200DSLF" root="1.2.840.114350.1.13.99997.2.7788" />
+      <asAgent classCode="AGNT">
+        <representedOrganization classCode="ORG" determinerCode="INSTANCE">
+          <id root="2.16.840.1.113883.4.349" extension="200CFL" />
+        </representedOrganization>
+      </asAgent>
+    </device>
+  </sender>
+  <controlActProcess classCode="CACT" moodCode="EVN">
+    <code code="PRPA_TE201301UV02" codeSystem="2.16.840.1.113883.1.6"/>
+    <dataEnterer typeCode="ENT" contextControlCode="AP">
+      <assignedPerson classCode="ASSIGNED">
+        <id extension="CASEFLOWUSER" root="2.16.840.1.113883.4.349"/>
+        <assignedPerson determinerCode="INSTANCE" classCode="PSN">
+          <name>
+            <given>CASEFLOW</given>
+            <family>USER</family>
+          </name>
+        </assignedPerson>
+      </assignedPerson>
+    </dataEnterer>
+  </controlActProcess>
+</ps:PRPA_IN201305UV02>
+</s:Body>
+</s:Envelope>
+EOXML
+      request_xml.at_xpath(".//*[name()='controlActProcess']").add_child(query)
+      dt = DateTime.now
+      request_xml.at_xpath(".//*[name()='id']")["extension"] = "MCID-" + dt.strftime("%Y%m%d%H%M%S%L")
+      request_xml.at_xpath(".//*[name()='creationTime']")["value"] = dt.strftime("%Y%m%d%H%M%S")
+      request_xml
+    end
+
+    def request(method, xml)
+      client.call(method, xml: xml.to_xml).hash[:envelope][:body]
+    end
+  end
+end

--- a/lib/connect_mpi/mpi/errors.rb
+++ b/lib/connect_mpi/mpi/errors.rb
@@ -3,4 +3,8 @@ module MPI
   class QueryError < StandardError; end
 
   class NotFoundError < QueryError; end
+
+  class QueryResultError < QueryError; end
+
+  class ApplicationError < QueryError; end
 end

--- a/lib/connect_mpi/mpi/errors.rb
+++ b/lib/connect_mpi/mpi/errors.rb
@@ -1,0 +1,6 @@
+
+module MPI
+  class QueryError < StandardError; end
+
+  class NotFoundError < QueryError; end
+end

--- a/lib/connect_mpi/mpi/services.rb
+++ b/lib/connect_mpi/mpi/services.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative "services/person"
+
+module MPI
+  class Services
+    class << self
+      def all
+        ObjectSpace.each_object(Class).select { |klass| klass < MPI::Base }
+      end
+
+      def register_services
+        all.each do |service|
+          define_method(service.service_name) do
+            service.new @config
+          end
+        end
+      end
+    end
+
+    # call register on init
+    MPI::Services.register_services
+
+    def initialize(ssl_cert_file:, ssl_cert_key_file:, ssl_ca_cert:,
+                   env: nil, application: nil, log: false, logger: nil)
+      @config = {
+        env: env, application: application,
+        ssl_cert_file: ssl_cert_file, ssl_cert_key_file: ssl_cert_key_file, ssl_ca_cert: ssl_ca_cert,
+        log: log, logger: logger
+      }
+    end
+
+    def application
+      config[:application]
+    end
+
+    private
+
+    attr_accessor :config
+  end
+end

--- a/lib/connect_mpi/mpi/services/person.rb
+++ b/lib/connect_mpi/mpi/services/person.rb
@@ -105,7 +105,7 @@ module MPI
 
     def parametrize_telephone(value)
       value = value[1..] if value[0] == "1" && value.length == 11
-      value = "+1-#{value[0..2]}-#{value[3..5]}-#{value[6-9]}" if value.length == 10
+      value = "+1-#{value[0..2]}-#{value[3..5]}-#{value[6..9]}" if value.length == 10
       element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
         <patientTelecom>
           <value value="tel:+1-555-638-7259"/>

--- a/lib/connect_mpi/mpi/services/person.rb
+++ b/lib/connect_mpi/mpi/services/person.rb
@@ -32,12 +32,14 @@ module MPI
 
     def parametrize_ssn(value)
       # value must be \d{9}
-      Nokogiri::XML::DocumentFragment.parse <<-EOXML
+      element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
         <livingSubjectId>
           <value root="2.16.840.1.113883.4.1" extension="627014683"/>
           <semanticsText>SSN</semanticsText>
         </livingSubjectId>
       EOXML
+      element.at_xpath(".//*[name()='value']")["extension"] = value
+      element
     end
 
     def parametrize_name(last_name:, first_name: nil, middle_name: nil)
@@ -117,7 +119,7 @@ module MPI
     end
 
     def search_people_info(last_name:, first_name: nil, middle_name: nil,
-                           date_of_birth: nil, gender: nil, address: nil, telephone: nil)
+                           ssn: nil, date_of_birth: nil, gender: nil, address: nil, telephone: nil)
       query = Nokogiri::XML::DocumentFragment.parse <<-EOXML
   <queryByParameter>
       <!-- Unique identifier for the query  -->
@@ -139,6 +141,7 @@ module MPI
 EOXML
       params = query.at_xpath(".//*[name()='parameterList']")
       params.add_child(parametrize_name(last_name: last_name, first_name: first_name, middle_name: middle_name))
+      params.add_child(parametrize_ssn(ssn)) if ssn.present?
       params.add_child(parametrize_date_of_birth(date_of_birth)) if date_of_birth.present?
       params.add_child(parametrize_gender(gender)) if gender.present?
       params.add_child(parametrize_address(address)) if address.present?

--- a/lib/connect_mpi/mpi/services/person.rb
+++ b/lib/connect_mpi/mpi/services/person.rb
@@ -34,7 +34,7 @@ module MPI
       # value must be \d{9}
       element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
         <livingSubjectId>
-          <value root="2.16.840.1.113883.4.1" extension="627014683"/>
+          <value root="2.16.840.1.113883.4.1" extension=""/>
           <semanticsText>SSN</semanticsText>
         </livingSubjectId>
       EOXML
@@ -72,7 +72,7 @@ module MPI
       element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
         <livingSubjectName>
           <value use="C">
-            <family>Farnsworth</family>
+            <family/>
           </value>
           <semanticsText>Mother's Maiden Name</semanticsText>
         </livingSubjectName>
@@ -110,7 +110,7 @@ module MPI
       value = "+1-#{value[0..2]}-#{value[3..5]}-#{value[6..9]}" if value.length == 10
       element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
         <patientTelecom>
-          <value value="tel:+1-555-638-7259"/>
+          <value/>
           <semanticsText>Home Phone</semanticsText>
         </patientTelecom>
       EOXML

--- a/lib/connect_mpi/mpi/services/person.rb
+++ b/lib/connect_mpi/mpi/services/person.rb
@@ -152,6 +152,8 @@ EOXML
       cap = response[:prpa_in201306_uv02][:control_act_process]
       response_code = cap[:query_ack][:query_response_code][:@code]
       raise NotFoundError if response_code == "NF"
+      raise QueryResultError if response_code == "QE"
+      raise ApplicationError if response_code == "AE"
 
       [cap[:subject]].flatten
     end

--- a/lib/connect_mpi/mpi/services/person.rb
+++ b/lib/connect_mpi/mpi/services/person.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+module MPI
+  class PersonWebService < MPI::Base
+    def self.service_name
+      "people"
+    end
+
+    def method
+      :prpa_in201305_uv02
+    end
+
+    def parametrize_gender(value)
+      # value may be "F" or "M"
+      Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <livingSubjectAdministrativeGender>
+          <value code="#{value}" />
+          <semanticsText>Gender</semanticsText>
+        </livingSubjectAdministrativeGender>
+      EOXML
+    end
+
+    def parametrize_date_of_birth(value)
+      # value must be in "YYYYMMDD" format
+      Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <livingSubjectBirthTime>
+          <value value="#{value}" />
+          <semanticsText>Date of Birth</semanticsText>
+        </livingSubjectBirthTime>
+      EOXML
+    end
+
+    def parametrize_ssn(value)
+      # value must be \d{9}
+      Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <livingSubjectId>
+          <value root="2.16.840.1.113883.4.1" extension="627014683"/>
+          <semanticsText>SSN</semanticsText>
+        </livingSubjectId>
+      EOXML
+    end
+
+    def parametrize_name(last_name:, first_name: nil, middle_name: nil)
+      element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <livingSubjectName>
+          <value use="L"></value>
+          <semanticsText>Legal Name</semanticsText>
+        </livingSubjectName>
+      EOXML
+      value = element.at_xpath(".//*[name()='value']")
+      if first_name.present?
+        node = Nokogiri::XML::DocumentFragment.parse("<given/>")
+        node.children[0].content = first_name
+        value.add_child(node)
+        if middle_name.present?
+          node = Nokogiri::XML::DocumentFragment.parse("<given/>")  # second <given> is middle name
+          node.children[0].content = middle_name
+          value.add_child(node)
+        end
+      end
+      if last_name.present?
+        node = Nokogiri::XML::DocumentFragment.parse("<family/>")
+        node.children[0].content = last_name
+        value.add_child(node)
+      end
+      element
+    end
+
+    def parametrize_mothers_maiden_name(value)
+      element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <livingSubjectName>
+          <value use="C">
+            <family>Farnsworth</family>
+          </value>
+          <semanticsText>Mother's Maiden Name</semanticsText>
+        </livingSubjectName>
+      EOXML
+      element.at_xpath(".//*[name()='family']").content = value
+      element
+    end
+
+    def parametrize_address(address)
+      element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <patientAddress>
+          <value use="PHYS"/>
+          <semanticsText>Physical Address</semanticsText>
+        </patientAddress>
+      EOXML
+      value = element.at_xpath(".//*[name()='value']")
+      {
+        street: "streetAddressLine",
+        city: "city",
+        state: "state",
+        postal_code: "postalCode",
+        country: "country"
+      }.each do |key, name|
+        if address[key].present?
+          fragment = Nokogiri::XML::DocumentFragment.parse("<#{name}/>")
+          fragment.children[0].content = address[key]
+          value.add_child(fragment)
+        end
+      end
+      element
+    end
+
+    def parametrize_telephone(value)
+      value = value[1..] if value[0] == "1" && value.length == 11
+      value = "+1-#{value[0..2]}-#{value[3..5]}-#{value[6-9]}" if value.length == 10
+      element = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+        <patientTelecom>
+          <value value="tel:+1-555-638-7259"/>
+          <semanticsText>Home Phone</semanticsText>
+        </patientTelecom>
+      EOXML
+      element.at_xpath(".//*[name()='value']")["value"] = "tel:#{value}"
+      element
+    end
+
+    def search_people_info(last_name:, first_name: nil, middle_name: nil,
+                           date_of_birth: nil, gender: nil, address: nil, telephone: nil)
+      query = Nokogiri::XML::DocumentFragment.parse <<-EOXML
+  <queryByParameter>
+      <!-- Unique identifier for the query  -->
+      <queryId extension="18204" root="1.2.840.114350.1.13.28.1.18.5.999"/>
+      <!-- The status of the query, default is "new" -->
+      <statusCode code="new"/>
+      <!-- MVI.COMP1=Add GetCorIds only Correlations MVI.COMP2=Add GetCorIds with Correlations and ICN History -->
+      <modifyCode code="MVI.COMP1"/>
+      <!-- Attribute 'responseElementGroupId' indicates if Response should be the Primary View or Correlation, default is Primary View. -->
+      <!-- extension="PV" root="2.16.840.1.113883.4.349  = Return Primary View -->
+      <!-- extension="COR" root="2.16.840.1.113883.4.349 = Return Correlation -->
+      <responseElementGroupId extension="PV" root="2.16.840.1.113883.4.349"/>
+      <!-- The return quantity should always be 1 for the retrieve -->
+      <!-- For Attended Searches initialQuantity should always GREATER than '1' -->
+      <initialQuantity value="10" />
+      <parameterList>
+      </parameterList>
+  </queryByParameter>
+EOXML
+      params = query.at_xpath(".//*[name()='parameterList']")
+      params.add_child(parametrize_name(last_name: last_name, first_name: first_name, middle_name: middle_name))
+      params.add_child(parametrize_date_of_birth(date_of_birth)) if date_of_birth.present?
+      params.add_child(parametrize_gender(gender)) if gender.present?
+      params.add_child(parametrize_address(address)) if address.present?
+      params.add_child(parametrize_telephone(telephone)) if telephone.present?
+
+      response = request(method, build_request_xml(method, query))
+
+      cap = response[:prpa_in201306_uv02][:control_act_process]
+      response_code = cap[:query_ack][:query_response_code][:@code]
+      raise NotFoundError if response_code == "NF"
+
+      [cap[:subject]].flatten
+    end
+  end
+end

--- a/lib/fakes/mpi_service.rb
+++ b/lib/fakes/mpi_service.rb
@@ -1,0 +1,528 @@
+# frozen_string_literal: true
+
+class Fakes::MPIService
+  def search_people_info(last_name:, first_name: nil, middle_name: nil,
+                         ssn: nil, date_of_birth: nil, gender: nil, address: nil, telephone: nil)
+    [{:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028056V759470^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005638^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "I"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930126"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014691", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005638^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"BOISE", :state=>"ID", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"100"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028054V494652^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005636^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "G"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014689", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005636^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"MARIETTA", :state=>"GA", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>
+             {:@code=>"EMP~HPT~VET",
+              :"@xsi:type"=>"CD",
+              :@display_name=>"Employee, Unknown, Veteran"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028049V170427^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005631^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "B"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014684", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005631^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"WALNUT CREEK", :state=>"CA", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>{:@code=>"EMP~PAT", :"@xsi:type"=>"CD", :@display_name=>"Employee, Patient"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028050V275598^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005632^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "C"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014685", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005632^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"SALEM", :state=>"MA", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>{:@code=>"EMP~VET", :"@xsi:type"=>"CD", :@display_name=>"Employee, Veteran"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028052V102835^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005634^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "E"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014687", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005634^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"KENOSHA", :state=>"WI", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>
+             {:@code=>"CON~EMP~VET",
+              :"@xsi:type"=>"CD",
+              :@display_name=>"Contractor, Employee, Veteran"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028051V040983^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005633^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "D"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014686", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005633^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"TOLEDO", :state=>"OH", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>{:@code=>"EMP", :"@xsi:type"=>"CD", :@display_name=>"Employee"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028048V015105^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005630^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"0000001200028048V015105000000^PI^200ESR^USVHA^A",
+           :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"627014683^PI^200BRLS^USVBA^A", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"32436762^PI^200CORP^USVBA^A", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"2021091518^EI^200HRS^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>
+           [{:given=>["MADISON", "ANNE"], :family=>"WESTBROOK", :@use=>"L"},
+            {:family=>"GRANGER", :@use=>"C"}],
+          :telecom=>{:@use=>"HP", :@value=>"(555)463-1987"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930114"},
+          :multiple_birth_ind=>{:@value=>"false"},
+          :addr=>
+           {:street_address_line=>"3318 GONDAR AVENUE",
+            :city=>"LONG BEACH",
+            :state=>"CA",
+            :postal_code=>"90808",
+            :country=>"USA",
+            :@use=>"PHYS"},
+          :as_other_i_ds=>
+           {:id=>{:@extension=>"627014683", :@root=>"2.16.840.1.113883.4.1"},
+            :status_code=>{:@code=>"4"},
+            :scoping_organization=>
+             {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+              :@class_code=>"ORG",
+              :@determiner_code=>"INSTANCE"},
+            :@class_code=>"SSN"},
+          :birth_place=>{:addr=>{:city=>"CERRITOS", :state=>"CA", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"151"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>
+             {:@code=>"EMP~PAT~VET",
+              :"@xsi:type"=>"CD",
+              :@display_name=>"Employee, Patient, Veteran"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028053V386767^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005635^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "F"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930125"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014688", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005635^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"ORLANDO", :state=>"FL", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"135"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>{:@code=>"EMP~HPT", :"@xsi:type"=>"CD", :@display_name=>"Employee, Unknown"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200028055V623111^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005637^PN^200EDR^USDVA^PCE", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>{:given=>["MADISON", "H"], :family=>"WESTBROOK", :@use=>"L"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930126"},
+          :as_other_i_ds=>
+           [{:id=>{:@extension=>"627014690", :@root=>"2.16.840.1.113883.4.1"},
+             :status_code=>{:@code=>"4"},
+             :scoping_organization=>
+              {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"SSN"},
+            {:id=>{:@extension=>"6005637^PN^200EDR^USDVA^PCE", :@root=>"2.16.840.1.113883.4.349"},
+             :scoping_organization=>
+              {:id=>{:@root=>"2.16.840.1.113883.4.349"},
+               :@class_code=>"ORG",
+               :@determiner_code=>"INSTANCE"},
+             :@class_code=>"PAT"}],
+          :birth_place=>{:addr=>{:city=>"ALBANY", :state=>"NY", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"100"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"},
+ {:registration_event=>
+   {:id=>{:@null_flavor=>"NA"},
+    :status_code=>{:@code=>"active"},
+    :subject1=>
+     {:patient=>
+       {:id=>
+         [{:@extension=>"1200047905V909525^NI^200M^USVHA^P", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"627014682^PI^200BRLS^USVBA^A", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"32437994^PI^200CORP^USVBA^A", :@root=>"2.16.840.1.113883.4.349"},
+          {:@extension=>"6005629^PN^200EDR^USDVA^A", :@root=>"2.16.840.1.113883.4.349"}],
+        :status_code=>{:@code=>"active"},
+        :patient_person=>
+         {:name=>
+           [{:given=>["MADISON", "ANNA"], :family=>"WESTBROOK", :@use=>"L"},
+            {:family=>"FARNSWORTH", :@use=>"C"}],
+          :telecom=>{:@use=>"HP", :@value=>"(555)496-8237"},
+          :administrative_gender_code=>{:@code=>"F"},
+          :birth_time=>{:@value=>"19930113"},
+          :multiple_birth_ind=>{:@value=>"false"},
+          :addr=>
+           {:street_address_line=>"4958 Pearce Ave",
+            :city=>"Lakewood",
+            :state=>"CA",
+            :postal_code=>"90712",
+            :country=>"USA",
+            :@use=>"PHYS"},
+          :as_other_i_ds=>
+           {:id=>{:@extension=>"627014682", :@root=>"2.16.840.1.113883.4.1"},
+            :status_code=>{:@code=>"4"},
+            :scoping_organization=>
+             {:id=>{:@root=>"1.2.840.114350.1.13.99997.2.3412"},
+              :@class_code=>"ORG",
+              :@determiner_code=>"INSTANCE"},
+            :@class_code=>"SSN"},
+          :birth_place=>{:addr=>{:city=>"ARTESIA", :state=>"CA", :country=>"USA"}}},
+        :subject_of1=>
+         {:query_match_observation=>
+           {:code=>{:@code=>"IHE_PDQ"},
+            :value=>{:"@xsi:type"=>"INT", :@value=>"142"},
+            :@class_code=>"COND",
+            :@mood_code=>"EVN"}},
+        :subject_of2=>
+         {:administrative_observation=>
+           {:code=>
+             {:@code=>"PERSON_TYPE",
+              :@code_system=>"2.16.840.1.113883.4.349",
+              :@display_name=>"Person Type"},
+            :value=>
+             {:@code=>"EMP~PAT~VET",
+              :"@xsi:type"=>"CD",
+              :@display_name=>"Employee, Patient, Veteran"},
+            :@class_code=>"VERIF"},
+          :@type_code=>"SBJ"},
+        :@class_code=>"PAT"},
+      :@type_code=>"SBJ"},
+    :custodian=>
+     {:assigned_entity=>{:id=>{:@root=>"2.16.840.1.113883.4.349"}, :@class_code=>"ASSIGNED"},
+      :@type_code=>"CST"},
+    :@class_code=>"REG",
+    :@mood_code=>"EVN"},
+  :@type_code=>"SUBJ"}]
+  end
+end

--- a/lib/fakes/mpi_service.rb
+++ b/lib/fakes/mpi_service.rb
@@ -6,6 +6,7 @@ class Fakes::MPIService
     fail MPI::NotFoundError if [first_name, last_name] == ["Not", "Found"]
     fail MPI::QueryResultError if [first_name, last_name] == ["Too", "Vague"]
     fail MPI::ApplicationError if [first_name, last_name] == ["Database", "Down"]
+    fail Savon::SOAPFault.new(nil, Nori.new, '<?xml version="1.0" ?><env:Envelope xmlns:env="http://schemas.xmlsoap.org/soap/envelope/"><env:Body><env:Fault><faultcode>env:Client</faultcode><faultstring>Internal Error</faultstring></env:Fault></env:Body></env:Envelope>') if [first_name, last_name] == ["System", "Unreachable"]
 
     [{:registration_event=>
    {:id=>{:@null_flavor=>"NA"},

--- a/lib/fakes/mpi_service.rb
+++ b/lib/fakes/mpi_service.rb
@@ -3,6 +3,10 @@
 class Fakes::MPIService
   def search_people_info(last_name:, first_name: nil, middle_name: nil,
                          ssn: nil, date_of_birth: nil, gender: nil, address: nil, telephone: nil)
+    fail MPI::NotFoundError if [first_name, last_name] == ["Not", "Found"]
+    fail MPI::QueryResultError if [first_name, last_name] == ["Too", "Vague"]
+    fail MPI::ApplicationError if [first_name, last_name] == ["Database", "Down"]
+
     [{:registration_event=>
    {:id=>{:@null_flavor=>"NA"},
     :status_code=>{:@code=>"active"},

--- a/lib/helpers/mpi_test.rb
+++ b/lib/helpers/mpi_test.rb
@@ -1,0 +1,66 @@
+class MpiTest
+  attr_accessor :last_results
+
+  def mpi
+    @mpi ||= MPIService.new
+  end
+
+  def search_people(hash)
+    results = mpi.client.people.search_people_info(hash)
+    puts "\n\nFound #{results.count} search results"
+    results.each do |res|
+      puts
+      print_patient(res[:registration_event][:subject1][:patient])
+    end
+    @last_results = results
+    nil
+  end
+
+  def print_patient(hash)
+    person = hash[:patient_person]
+    [
+      format_name(person),
+      format_gender(person),
+      format_ssn(person),
+      format_status(hash),
+      format_phone(person),
+      format_birthtime(person),
+      format_address(person),
+    ].compact.each { |line| puts line }
+  end
+
+  def format_name(person)
+    given_names = [person[:name][:given]].flatten.join(" ")
+    "#{person[:name][:family]}, #{given_names}"
+  end
+
+  def format_status(hash)
+    "Status: #{hash[:status_code][:@code]}"
+  end
+
+  def format_phone(person)
+    value = person&.dig(:telecom, :@value)
+    "Phone: #{value}" if value.present?
+  end
+
+  def format_gender(person)
+    value = person&.dig(:administrative_gender_code, :@code)
+    "Gender: #{value}" if value.present?
+  end
+
+  def format_ssn(person)
+    other_ids = [person[:as_other_i_ds]].flatten
+    ssns = other_ids.select { |other_id| other_id[:@class_code] == "SSN" }.map { |other_id| other_id.dig(:id, :@extension) }.compact
+    "SSN: #{ssns[0]}" if ssns.any?
+  end
+
+  def format_birthtime(person)
+    value = person&.dig(:birthtime, :@value)
+    "Born: #{value}" if value.present?
+  end
+
+  def format_address(person)
+    value = person&.dig(:addr)
+    "Address: #{value[:street_address_line]}, #{value[:city]} #{value[:state]} #{value[:postal_code]}" if value.present?
+  end
+end

--- a/lib/helpers/mpi_test.rb
+++ b/lib/helpers/mpi_test.rb
@@ -6,7 +6,7 @@ class MpiTest
   end
 
   def search_people(hash)
-    results = mpi.client.people.search_people_info(hash)
+    results = mpi.search_people_info(hash)
     puts "\n\nFound #{results.count} search results"
     results.each do |res|
       puts
@@ -30,8 +30,9 @@ class MpiTest
   end
 
   def format_name(person)
-    given_names = [person[:name][:given]].flatten.join(" ")
-    "#{person[:name][:family]}, #{given_names}"
+    name = [person[:name]].flatten.find { |hash| hash[:@use] == "L" } # legal name only
+    given_names = [name[:given]].flatten.join(" ")
+    "#{name[:family]}, #{given_names}"
   end
 
   def format_status(hash)


### PR DESCRIPTION
### Description
This PR is a temporary workaround for the fact that the [connect-mpi repo](https://github.com/department-of-veterans-affairs/connect-mpi), which would be the canonical location for the connect_mpi Ruby gem, currently has visibility Internal. It needs to have visibility Public in order to be included as a Caseflow external dependency, but this change is pending DSVA GitHub admin review.

For the time being, that codebase can be added to the `lib/` directory so that Caseflow code can start to use it. Once the repo is made Public, this code can be removed in favor of updating the Gemfile to point to the other repo.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Caseflow and MPI conducted a 2-day integration test between our UAT environment and their iDev environment. For this test, I used an `MpiTest` helper class to do some basic formatting of the SOAP responses, which I've added to the `lib/helpers/` directory.

To facilitate working with the MPI data locally, there is a simple `Fakes::MPIService` implementation with a hard-coded response of 10 people. The `MpiTest` helper class is compatible with this in local environments:

```ruby
mt = MpiTest.new
mt.search_people(first_name: "Madison", last_name: "Westbrook")
# it prints out the 10 results in a human-readable form
```

To load the fake data directly, just do

```ruby
Fakes::MPIService.new.search_people_info(first_name: "Madison", last_name: "Westbrook")
# this will return an enormous Ruby hash
```