### PR TITLE
Don't use veteran's SSN for VACOLS appellant if appellant is not veteran

### DIFF
--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -278,6 +278,7 @@ class LegacyAppeal < CaseflowRecord
 
   def person_for_appellant
     return nil if appellant_ssn.blank?
+    return nil if appellant_is_not_veteran && appellant_ssn == veteran.ssn
 
     Person.find_or_create_by_ssn(appellant_ssn)
   end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -1888,7 +1888,9 @@ describe LegacyAppeal, :all_dbs do
         end
       end
 
-      let(:vacols_case) { create(:case, :representative_american_legion, correspondent: correspondent) }
+      let(:vacols_case) do
+        create(:case, :representative_american_legion, correspondent: correspondent, bfcorlid: appellant_ssn)
+      end
       let(:appellant_ssn) { "666001234" }
       let(:appellant_pid) { "1234" }
       let(:poa_pid) { "600153863" } # defined in Fakes::BGSService
@@ -1901,10 +1903,11 @@ describe LegacyAppeal, :all_dbs do
           ssn: appellant_ssn
         )
       end
+      let!(:veteran) { create(:veteran, ssn: appellant_ssn) }
 
       it "uses appellant to load BGS POA" do
-        expect(appeal.power_of_attorney.bgs_representative_name).to eq "Clarence Darrow"
-        expect(appeal.power_of_attorney.bgs_participant_id).to eq poa_pid
+        expect(appeal.power_of_attorney.bgs_representative_name).to eq nil
+        expect(appeal.power_of_attorney.bgs_participant_id).to eq nil
       end
     end
 


### PR DESCRIPTION
Resolves [INC19452345](https://dsva.slack.com/archives/CHX8FMP28/p1631043547190300)

### Description
This does not use the veteran to create a "person for appellant" for a legacy appeal, if the appellant is not the veteran, but the veteran's SSN is stored in the CORRES table.  This allows the address to be fetched from the CORRES table directly in these cases.

Re-creates https://github.com/department-of-veterans-affairs/caseflow/pull/16737 since I accidentally pulled in a TON of commits when trying to update the tests.