### PR TITLE
Update modal text

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1160,7 +1160,7 @@
   "VHA_COMPLETE_TASK_CONFIRMATION_PO": "Appeal has been marked as ready for review and sent to the CAMO team for review.",
   "VHA_COMPLETE_TASK_CONFIRMATION_VISN": "Appeal has been marked as ready for review and sent to the Program Office team for review.",
   "VHA_SEND_TO_BOARD_INTAKE_MODAL_TITLE": "Send to Board Intake",
-  "VHA_SEND_TO_BOARD_INTAKE_MODAL_BODY": "Please review the information from Program Offices and VISNs. If documents were not found, or the appeal is invalid, please indicate that here. If you recommend docketing, please include information on document locations.",
+  "VHA_SEND_TO_BOARD_INTAKE_MODAL_BODY": "Please review the information from Program Offices and VISNs. If you recommend docketing, please include information on document locations.",
   "VHA_SEND_TO_BOARD_INTAKE_CONFIRMATION": "%s's case has been sent to the Board Intake team for review.",
   "VHA_PROGRAM_OFFICE_RETURN_TO_CAMO_MODAL_TITLE": "Return to CAMO team",
   "VHA_PROGRAM_OFFICE_RETURN_TO_CAMO_CONFIRMATION_TITLE": "You have successfully returned this appeal to the CAMO team",


### PR DESCRIPTION
Resolves [CASEFLOW-2587](https://vajira.max.gov/browse/CASEFLOW-2587)

### Description
Removes text from confirmation modal.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Select the "Send to board intake" option from the case details page of a case assigned to CAMO
2. Ensure the modal text reads "Please review the information from Program Offices and VISNs. If you recommend docketing, please include information on document locations."

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![Screen Shot 2021-11-22 at 1 19 10 PM](https://user-images.githubusercontent.com/640182/142914583-d61ea7be-4649-4f57-9ddc-13415fae1244.png)|![Screen Shot 2021-11-22 at 1 20 51 PM](https://user-images.githubusercontent.com/640182/142914701-e0b97d62-9fe8-4dfa-a9d1-fd0ff715d627.png)

