### PR TITLE
Allow nil SSOC dates

### DIFF
--- a/app/models/appeal_events.rb
+++ b/app/models/appeal_events.rb
@@ -87,7 +87,7 @@ class AppealEvents
   end
 
   def ssoc_events
-    appeal.ssoc_dates.map { |ssoc_date| AppealEvent.new(type: :ssoc, date: ssoc_date) }
+    appeal.ssoc_dates&.map { |ssoc_date| AppealEvent.new(type: :ssoc, date: ssoc_date) }
   end
 
   def decision_event

--- a/app/models/appeal_series.rb
+++ b/app/models/appeal_series.rb
@@ -203,7 +203,7 @@ class AppealSeries < CaseflowRecord
     end
 
     if latest_appeal.form9_date
-      return :pending_certification_ssoc if !latest_appeal.ssoc_dates.empty?
+      return :pending_certification_ssoc if latest_appeal.ssoc_dates.present?
 
       return :pending_certification
     end
@@ -257,7 +257,7 @@ class AppealSeries < CaseflowRecord
   end
 
   def disambiguate_status_remand
-    post_decision_ssocs = latest_appeal.ssoc_dates.select { |ssoc| ssoc > latest_appeal.decision_date }
+    post_decision_ssocs = latest_appeal.ssoc_dates&.select { |ssoc| ssoc > latest_appeal.decision_date }
     return :remand_ssoc if !post_decision_ssocs.empty?
 
     :remand

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -79,7 +79,7 @@ class Form8 < CaseflowRecord
       representative_type: appeal.representative_type,
       hearing_requested: appeal.hearing_requested ? "Yes" : "No",
       hearing_held: appeal.hearing_held ? "Yes" : "No",
-      ssoc_required: appeal.ssoc_dates.empty? ? "Not required" : "Required and furnished",
+      ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished" : "Not required",
       certifying_office: appeal.regional_office_name,
       certifying_username: appeal.regional_office_key,
       certification_date: Time.zone.now.to_date,
@@ -93,7 +93,7 @@ class Form8 < CaseflowRecord
       _initial_representative_name: appeal.representative_name,
       _initial_representative_type: appeal.representative_type,
       _initial_hearing_requested: appeal.hearing_requested ? "Yes" : "No",
-      _initial_ssoc_required: appeal.ssoc_dates.empty? ? "Not required" : "Required and furnished"
+      _initial_ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished": "Not required"
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -93,7 +93,7 @@ class Form8 < CaseflowRecord
       _initial_representative_name: appeal.representative_name,
       _initial_representative_type: appeal.representative_type,
       _initial_hearing_requested: appeal.hearing_requested ? "Yes" : "No",
-      _initial_ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished": "Not required"
+      _initial_ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished" : "Not required"
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/form8.rb
+++ b/app/models/form8.rb
@@ -57,7 +57,8 @@ class Form8 < CaseflowRecord
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/AbcSize
   def assign_attributes_from_appeal(appeal)
-    ssoc_dates = appeal.ssoc_dates.present? ? appeal.ssoc_dates.sort : []
+    ssoc_dates = appeal.ssoc_dates&.sort || []
+    ssoc_required = appeal.ssoc_dates.present? ? "Required and furnished" : "Not required"
 
     assign_attributes(
       vacols_id: appeal.vacols_id,
@@ -79,7 +80,7 @@ class Form8 < CaseflowRecord
       representative_type: appeal.representative_type,
       hearing_requested: appeal.hearing_requested ? "Yes" : "No",
       hearing_held: appeal.hearing_held ? "Yes" : "No",
-      ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished" : "Not required",
+      ssoc_required: ssoc_required,
       certifying_office: appeal.regional_office_name,
       certifying_username: appeal.regional_office_key,
       certification_date: Time.zone.now.to_date,
@@ -93,7 +94,7 @@ class Form8 < CaseflowRecord
       _initial_representative_name: appeal.representative_name,
       _initial_representative_type: appeal.representative_type,
       _initial_hearing_requested: appeal.hearing_requested ? "Yes" : "No",
-      _initial_ssoc_required: appeal.ssoc_dates.present? ? "Required and furnished" : "Not required"
+      _initial_ssoc_required: ssoc_required
     )
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -253,7 +253,7 @@ class Issue
     # the close_date is our local normalized disposition_date
     return close_date > legacy_appeal.soc_date if legacy_appeal.soc_date
 
-    legacy_appeal.ssoc_dates.any? { |ssoc_date| close_date > ssoc_date }
+    legacy_appeal.ssoc_dates&.any? { |ssoc_date| close_date > ssoc_date }
   end
 
   def friendly_description_for_codes(code_array)

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -216,7 +216,7 @@ class LegacyAppeal < CaseflowRecord
   end
 
   def soc_opt_in_due_date
-    return unless soc_date || !ssoc_dates.empty?
+    return unless soc_date || ssoc_dates.present?
 
     ([soc_date] + ssoc_dates).max.to_date + 60.days
   end
@@ -525,7 +525,7 @@ class LegacyAppeal < CaseflowRecord
   def ssocs
     # an appeal might have multiple SSOC documents so match vacols date
     # to each VBMS document
-    @ssocs ||= ssoc_dates.sort.inject([]) do |docs, ssoc_date|
+    @ssocs ||= ssoc_dates&.sort.inject([]) do |docs, ssoc_date|
       docs << fuzzy_matched_document("SSOC", ssoc_date, excluding: docs)
     end
   end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -525,7 +525,7 @@ class LegacyAppeal < CaseflowRecord
   def ssocs
     # an appeal might have multiple SSOC documents so match vacols date
     # to each VBMS document
-    @ssocs ||= ssoc_dates&.sort.inject([]) do |docs, ssoc_date|
+    @ssocs ||= ssoc_dates&.sort&.inject([]) do |docs, ssoc_date|
       docs << fuzzy_matched_document("SSOC", ssoc_date, excluding: docs)
     end
   end

--- a/app/services/mismatch_report.rb
+++ b/app/services/mismatch_report.rb
@@ -105,7 +105,7 @@ class MismatchReport < Report
     appeal.documents_with_type("SSOC")
       .map(&:received_at)
       .select do |date|
-      appeal.ssoc_dates.any? do |appdate|
+      appeal.ssoc_dates&.any? do |appdate|
         appdate.to_date != date.to_date &&
           (appeal.soc_date.to_date - date.to_date).abs <= ALTERNATIVE_AGE_THRESHOLD
       end

--- a/client/app/util/DateUtil.js
+++ b/client/app/util/DateUtil.js
@@ -58,9 +58,13 @@ export const formatDateStrUtc = (dateString, expectedFormat = dateFormatString) 
 };
 
 export const formatArrayOfDateStrings = function(arrayOfDateStrings) {
-  return arrayOfDateStrings.map((dateString) => {
-    return formatDateStr(dateString);
-  }).join(', ');
+  if (Array.isArray(arrayOfDateStrings) {
+    return arrayOfDateStrings.map((dateString) => {
+      return formatDateStr(dateString);
+    }).join(', ');
+  } else {
+    return ""
+  }
 };
 
 export const DateString = ({ date, dateFormat = 'MM/DD/YY', inputFormat = 'YYYY-MM-DD', style }) => <span {...style}>

--- a/client/app/util/DateUtil.js
+++ b/client/app/util/DateUtil.js
@@ -58,7 +58,7 @@ export const formatDateStrUtc = (dateString, expectedFormat = dateFormatString) 
 };
 
 export const formatArrayOfDateStrings = function(arrayOfDateStrings) {
-  if (Array.isArray(arrayOfDateStrings) {
+  if (Array.isArray(arrayOfDateStrings)) {
     return arrayOfDateStrings.map((dateString) => {
       return formatDateStr(dateString);
     }).join(', ');


### PR DESCRIPTION
Resolves [Batteam Slack](https://dsva.slack.com/archives/CHX8FMP28/p1636728203280300)

### Description
When trying to load the hearing worksheet page for legacy appeal vacols ID 3328055, the nil SSOC dates on legacy appeal vacols ID 3982246 is causing an error when trying map over them.

This PR removes reliance on ssoc_dates (which comes from VACOLS) from being an array.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.