### PR TITLE
Hide alert for pending appeal, display for death dismissal substitutions

### DIFF
--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -133,8 +133,6 @@ const mapStateToProps = (state, ownProps) => {
 
   const appeal = appealWithDetailSelector(state, { appealId: ownProps.appealId });
 
-  window.console.log(`Substitution appeal info - ${JSON.stringify(appeal)}`);
-
   return {
     veteranInfo: appeal?.veteranInfo,
     substitutions: appeal?.substitutions,

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -85,7 +85,7 @@ export const VeteranDetail = ({ veteran, substitutionAppealId, hasSameAppealSubs
       <div {...detailListStyling}>
         <BareList ListElementComponent="ul" items={details.map(getDetailField)} />
         <p><em>{COPY.CASE_DETAILS_VETERAN_ADDRESS_SOURCE}</em></p>
-        {substitutionAppealId && (
+        {!substitutionAppealId && (
           <AppealHasSubstitutionAlert
             targetAppealId={substitutionAppealId}
             hasSameAppealSubstitution={hasSameAppealSubstitution}
@@ -132,6 +132,8 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   const appeal = appealWithDetailSelector(state, { appealId: ownProps.appealId });
+
+  window.console.log(`Substitution appeal info - ${JSON.stringify(appeal)}`);
 
   return {
     veteranInfo: appeal?.veteranInfo,

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -133,8 +133,6 @@ const mapStateToProps = (state, ownProps) => {
 
   const appeal = appealWithDetailSelector(state, { appealId: ownProps.appealId });
 
-  window.console.log(`appeal: ${JSON.stringify(appeal)}`);
-
   return {
     veteranInfo: appeal?.veteranInfo,
     substitutions: appeal?.substitutions,

--- a/client/app/queue/VeteranDetail.jsx
+++ b/client/app/queue/VeteranDetail.jsx
@@ -85,7 +85,7 @@ export const VeteranDetail = ({ veteran, substitutionAppealId, hasSameAppealSubs
       <div {...detailListStyling}>
         <BareList ListElementComponent="ul" items={details.map(getDetailField)} />
         <p><em>{COPY.CASE_DETAILS_VETERAN_ADDRESS_SOURCE}</em></p>
-        {!substitutionAppealId && (
+        {!hasSameAppealSubstitution && (
           <AppealHasSubstitutionAlert
             targetAppealId={substitutionAppealId}
             hasSameAppealSubstitution={hasSameAppealSubstitution}
@@ -132,6 +132,8 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   const appeal = appealWithDetailSelector(state, { appealId: ownProps.appealId });
+
+  window.console.log(`appeal: ${JSON.stringify(appeal)}`);
 
   return {
     veteranInfo: appeal?.veteranInfo,

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -218,10 +218,8 @@ RSpec.shared_examples("fill substitution form") do
       visit "/queue/appeals/#{appeal.uuid}"
 
       expect(page).to_not have_content "+ Add Substitute"
+      # expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
 
-      if source_appeal.request_issues.none?(&:death_dismissed?)
-        expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
-      end
     end
   end
 end

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -218,8 +218,8 @@ RSpec.shared_examples("fill substitution form") do
       visit "/queue/appeals/#{appeal.uuid}"
 
       expect(page).to_not have_content "+ Add Substitute"
-
-      if appeal_death_dismissal?(appeal)
+      # Only display message if it does not have same appeal substitution.
+      unless appeal.hasSameAppealSubstitution == true
         expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
       end
     end
@@ -229,8 +229,4 @@ end
 def same_appeal_substitution_allowed?(source_appeal)
   (ClerkOfTheBoard.singleton.user_is_admin?(current_user) || !!source_appeal.veteran.date_of_death) &&
     source_appeal.request_issues.none?(&:death_dismissed?)
-end
-
-def appeal_death_dismissal?(source_appeal)
-  source_appeal.request_issues.none?(&:death_dismissed?)
 end

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -219,7 +219,9 @@ RSpec.shared_examples("fill substitution form") do
 
       expect(page).to_not have_content "+ Add Substitute"
 
-      expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
+      if source_appeal.request_issues.none?(&:death_dismissed?)
+        expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
+      end
     end
   end
 end

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -219,7 +219,6 @@ RSpec.shared_examples("fill substitution form") do
 
       expect(page).to_not have_content "+ Add Substitute"
       # expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
-
     end
   end
 end

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -218,7 +218,10 @@ RSpec.shared_examples("fill substitution form") do
       visit "/queue/appeals/#{appeal.uuid}"
 
       expect(page).to_not have_content "+ Add Substitute"
-      # expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
+
+      if appeal_death_dismissal?(appeal)
+        expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
+      end
     end
   end
 end
@@ -226,4 +229,8 @@ end
 def same_appeal_substitution_allowed?(source_appeal)
   (ClerkOfTheBoard.singleton.user_is_admin?(current_user) || !!source_appeal.veteran.date_of_death) &&
     source_appeal.request_issues.none?(&:death_dismissed?)
+end
+
+def appeal_death_dismissal?(source_appeal)
+  source_appeal.request_issues.none?(&:death_dismissed?)
 end

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -216,10 +216,9 @@ RSpec.shared_examples("fill substitution form") do
 
     step "verify items on original appeal" do
       visit "/queue/appeals/#{appeal.uuid}"
-
+      appellant_substitution = AppellantSubstitution.find_by(source_appeal_id: appeal.id)
       expect(page).to_not have_content "+ Add Substitute"
-      # Only display message if it does not have same appeal substitution.
-      unless appeal.hasSameAppealSubstitution == true
+      unless appellant_substitution.source_appeal_id == appellant_substitution.target_appeal_id
         expect(page).to have_content COPY::SUBSTITUTE_APPELLANT_SOURCE_APPEAL_ALERT_DESCRIPTION
       end
     end


### PR DESCRIPTION
Resolves [CASEFLOW-1658](https://vajira.max.gov/browse/CASEFLOW-1658) - Informational Banner in About the Appellant

### Description
In the "About the Veteran" section ("This appeal has been reactivated for a substitute appellant"). This alert should be hidden for pending-appeal substitutions, but should remain for death-dismissal substitutions.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] PART 1 - For death-dismissal substitutions, in the "About the Veteran" section, message should show "This appeal has been reactivated for a substitute appellant".
- [ ] PART 2 - For pending-appeal substitutions, there should be no message shown.

### Testing Plan

PART 1 -
- [ ] Login as COB admin.
- [ ] Search for case '54545454'.
- [ ] Create a substitution appeal for a Post-decision case.
- [ ] Check that a message appears in the "About the Veteran" section - "This appeal has been reactivated for a substitute appellant".

<img width="1274" alt="Screen Shot 2021-11-23 at 8 55 58 AM" src="https://user-images.githubusercontent.com/91557726/143069330-6baaa2c2-c3bc-4d10-831a-ed025d5b310a.png">

PART 2 -
- [ ] Login as COB admin.
- [ ] Search for case '54545454'.
- [ ] Create a substitution appeal for a non Post-decision case.
- [ ] Check that no message appears in the  "About the Veteran" section.

<img width="1284" alt="Screen Shot 2021-11-23 at 8 56 36 AM" src="https://user-images.githubusercontent.com/91557726/143069377-c5813236-a81f-43bd-8b79-a0f2196b4a61.png">


