### PR TITLE
Exclude predocket appeals from update representative job

### DIFF
--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -53,8 +53,8 @@ class UpdateAppellantRepresentationJob < CaseflowJob
   end
 
   def retrieve_number_to_update
-    number_of_legacy_appeals = legacy_appeals_with_hearings.size
-    number_of_ama_appeals = active_docketed_appeals.size
+    number_of_legacy_appeals = legacy_appeals_with_hearings.length
+    number_of_ama_appeals = active_docketed_appeals.length
 
     {
       number_of_legacy_appeals_to_update:
@@ -77,10 +77,7 @@ class UpdateAppellantRepresentationJob < CaseflowJob
   end
 
   def active_docketed_appeals
-    current_predocket_appeals = Appeal
-      .joins(:tasks).where("tasks.type = ? AND tasks.status NOT IN (?)", "PreDocketTask", Task.closed_statuses)
-
-    active_appeals - current_predocket_appeals
+    active_appeals.where.not(id: Appeal.pre_docket.map(&:id))
   end
 
   def increment_task_count(task_effect, appeal_id, count = 1)

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -90,6 +90,13 @@ class Appeal < DecisionReview
               RootTask.name, Task.closed_statuses, 1)
   }
 
+  scope :pre_docket, lambda {
+    joins(:tasks)
+      .group("appeals.id")
+      .having("count(case when tasks.type = ? and tasks.status not in (?) then 1 end) >= ?",
+              PreDocketTask.name, Task.closed_statuses, 1)
+  }
+
   scope :established, -> { where.not(established_at: nil) }
 
   UUID_REGEX = /^\h{8}-\h{4}-\h{4}-\h{4}-\h{12}$/.freeze

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -272,6 +272,13 @@ FactoryBot.define do
       end
     end
 
+    trait :with_pre_docket_task do
+      after(:create) do |appeal, _evaluator|
+        bva = BvaIntake.singleton
+        create(:pre_docket_task, appeal: appeal, assigned_to: bva)
+      end
+    end
+
     ## Appeal with a realistic task tree
     ## Appeal has finished intake
     trait :with_post_intake_tasks do

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -201,11 +201,13 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
     context "#appeals_to_update" do
       let(:legacy_appeal_count) { 10 }
       let(:appeal_count) { 10 }
+      let!(:predocket_appeal) { create(:appeal, :with_pre_docket_task) }
 
       it "returns both legacy and ama appeals" do
         all_appeals = UpdateAppellantRepresentationJob.new.appeals_to_update
 
         expect(all_appeals).to match_array(legacy_appeals + appeals)
+        expect(all_appeals.include?(predocket_appeal)).to be false
       end
     end
 


### PR DESCRIPTION
Resolves [Slack thread](https://dsva.slack.com/archives/C01DFC41BPV/p1637770547081500)

### Description
The update appeal representative job was looking at all active appeals, but we do not want to start doing this until an appeal is docketed. So this excludes pre-docketed appeals from the job.

This will be followed up by deleting the erroneously created tasks. Will post a script below.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

 BEFORE|AFTER
 ---|---

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.