### PR TITLE
Fix blank hearings schedule CSV download

### DIFF
--- a/client/app/hearings/components/ListSchedule.jsx
+++ b/client/app/hearings/components/ListSchedule.jsx
@@ -187,7 +187,7 @@ class ListSchedule extends React.Component {
           <div className="cf-push-right list-schedule-buttons" {...downloadButtonStyling} >
             {this.props.user.userHasHearingPrepRole && <SwitchViewDropdown onSwitchView={this.props.switchListView} />}
             <CSVLink
-              data={this.state.columns}
+              data={this.state.rows}
               headers={this.state.headers}
               target="_blank"
               filename={`HearingSchedule ${this.props.startDate}-${this.props.endDate}.csv`}>


### PR DESCRIPTION
Resolves [CASEFLOW-2601](https://vajira.max.gov/browse/CASEFLOW-2601)

### Description
Fix blank download of hearings schedule by passing `this.state.rows` instead of columns. 

### Testing Plan
1. Log in as BVASYELLOW
2. Navigate to the Hearings page
3. Set your desired date range and click "Apply"
4. Click "Download Current View"

