### PR TITLE
Removes `already initialized constant` warning during `make check-fks`

### DIFF
--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -2,7 +2,7 @@
 
 require "rainbow"
 
-CODE_COVERAGE_THRESHOLD = 90
+CODE_COVERAGE_THRESHOLD ||= 90
 
 task(:default).clear
 task default: ["ci:warning", :spec, "ci:other"]

--- a/lib/tasks/support/validate_sql_queries.rb
+++ b/lib/tasks/support/validate_sql_queries.rb
@@ -111,7 +111,7 @@ class ValidateSqlQueries
       FileUtils.identical?(rb_out_file, out_file)
     end
 
-    MAP_TO_STRING = "map{|r| r.map(&:inspect).join(',')}.join('\n')"
+    MAP_TO_STRING ||= "map{|r| r.map(&:inspect).join(',')}.join('\n')"
 
     def eval_rails_query(query)
       # Use default postprocessing to split results into separate lines if "array_output" appears in query
@@ -210,21 +210,21 @@ class ValidateSqlQueries
     end
 
     # identifies block of Rails code that is equivalent to the SQL query
-    RAILS_EQUIV_PREFIX = "RAILS_EQUIV"
+    RAILS_EQUIV_PREFIX ||= "RAILS_EQUIV"
 
     def rails_query
       extract_block_contents(RAILS_EQUIV_PREFIX)
     end
 
     # identifies block of Rails code to postprocess SQL query results
-    POSTPROC_SQL_RESULT_PREFIX = "POSTPROC_SQL_RESULT"
+    POSTPROC_SQL_RESULT_PREFIX ||= "POSTPROC_SQL_RESULT"
 
     def postprocess_cmds
       extract_block_contents(POSTPROC_SQL_RESULT_PREFIX)
     end
 
     # identifies the class on which to call `.connection` to execute the SQL query
-    DATABASE_CONNECTION = "-- SQL_DB_CONNECTION:"
+    DATABASE_CONNECTION ||= "-- SQL_DB_CONNECTION:"
 
     # :reek:FeatureEnvy
     def db_connection


### PR DESCRIPTION
Resolves `warning: already initialized constant` when running `make check-fks` (check foreign keys):

```ruby
make check-fks
bundle exec rake immigrant:check_keys
...
/Users/yoomlam/dev/caseflow/lib/tasks/ci.rake:5: warning: already initialized constant CODE_COVERAGE_THRESHOLD
/Users/yoomlam/dev/caseflow/lib/tasks/ci.rake:5: warning: previous definition of CODE_COVERAGE_THRESHOLD was here
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:114: warning: already initialized constant Class::MAP_TO_STRING
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:114: warning: previous definition of MAP_TO_STRING was here
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:213: warning: already initialized constant ValidateSqlQueries::SqlQueryParser::RAILS_EQUIV_PREFIX
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:213: warning: previous definition of RAILS_EQUIV_PREFIX was here
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:220: warning: already initialized constant ValidateSqlQueries::SqlQueryParser::POSTPROC_SQL_RESULT_PREFIX
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:220: warning: previous definition of POSTPROC_SQL_RESULT_PREFIX was here
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:227: warning: already initialized constant ValidateSqlQueries::SqlQueryParser::DATABASE_CONNECTION
/Users/yoomlam/dev/caseflow/lib/tasks/support/validate_sql_queries.rb:227: warning: previous definition of DATABASE_CONNECTION was here
...
```

### Description
If the constants are already defined, don't set the constants.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Run `make check-fks` before and after this PR's changes. Note the lack of `warning: already initialized constant`.

