### PR TITLE
LegacyAppealsWithNoVacolsCase: ignore cases backfilled for foreign key

### DIFF
--- a/app/services/legacy_appeals_with_no_vacols_case.rb
+++ b/app/services/legacy_appeals_with_no_vacols_case.rb
@@ -16,7 +16,8 @@ class LegacyAppealsWithNoVacolsCase < DataIntegrityChecker
   def check_legacy_appeals(legacy_appeals, batch)
     Rails.logger.debug("Starting LegacyAppeal/VACOLS check batch #{batch}")
 
-    vacols_ids = legacy_appeals.pluck(:vacols_id)
+    # Skip those that start with 'for '
+    vacols_ids = legacy_appeals.pluck(:vacols_id).reject{|id| id.start_with?('for ')}
     vacols_ids_count = vacols_ids.count
 
     Rails.logger.debug("Found #{vacols_ids_count} vacols_id values")

--- a/app/services/legacy_appeals_with_no_vacols_case.rb
+++ b/app/services/legacy_appeals_with_no_vacols_case.rb
@@ -17,7 +17,7 @@ class LegacyAppealsWithNoVacolsCase < DataIntegrityChecker
     Rails.logger.debug("Starting LegacyAppeal/VACOLS check batch #{batch}")
 
     # Skip those that start with 'for '
-    vacols_ids = legacy_appeals.pluck(:vacols_id).reject{|id| id.start_with?('for ')}
+    vacols_ids = legacy_appeals.pluck(:vacols_id).reject { |id| id.start_with?("for ") }
     vacols_ids_count = vacols_ids.count
 
     Rails.logger.debug("Found #{vacols_ids_count} vacols_id values")

--- a/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
+++ b/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
@@ -38,7 +38,7 @@ describe LegacyAppealsWithNoVacolsCase do
     # Their vacols_id are 'for Dispatch::Task' or 'for WorksheetIssue'.
     # These records should be ignored by this job since there is no action required.
     context "when VACOLS case ID starts with 'for '" do
-      let!(:legacy_appeal) { create(:legacy_appeal, vacols_id: 'for Dispatch::Task 123') }
+      let!(:legacy_appeal) { create(:legacy_appeal, vacols_id: "for Dispatch::Task 123") }
 
       it "reports zero missing cases" do
         subject.call

--- a/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
+++ b/spec/services/legacy_appeals_with_no_vacols_case_spec.rb
@@ -33,5 +33,18 @@ describe LegacyAppealsWithNoVacolsCase do
         end
       end
     end
+
+    # LegacyAppeal records were created to satisfy new foreign key constraints.
+    # Their vacols_id are 'for Dispatch::Task' or 'for WorksheetIssue'.
+    # These records should be ignored by this job since there is no action required.
+    context "when VACOLS case ID starts with 'for '" do
+      let!(:legacy_appeal) { create(:legacy_appeal, vacols_id: 'for Dispatch::Task 123') }
+
+      it "reports zero missing cases" do
+        subject.call
+        expect(subject.report?).to be_falsey
+        expect(subject.buffer).to eq []
+      end
+    end
   end
 end


### PR DESCRIPTION
Eliminates extraneous warning for `LegacyAppeals` that were created to satisfy new foreign key constraints. 

[Slack](https://dsva.slack.com/archives/CN3FQR4A1/p1637773067004400?thread_ts=1637749360.004200&cid=CN3FQR4A1)

### Description
Ignore `LegacyAppeal` records that were created to satisfy new foreign key constraints. Their `vacols_id` are `'for Dispatch::Task'` or `'for WorksheetIssue'`. These records should be ignored by this job since there is no action required.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `LegacyAppealsWithNoVacolsCase` ignores LegacyAppeal records that start with `'for '`

### Testing Plan
See RSpec
