### PR TITLE
Change expected alert text to fix failing test

### DIFF
--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -157,7 +157,7 @@ RSpec.feature "Hearing Details", :all_dbs do
         expect(page).to have_content("Scheduling in progress")
       end
 
-      expect(page).to have_content(virtual_hearing_success_alert)
+      expect(page).to have_content(expected_alert)
       check_virtual_hearings_links(hearing.reload.virtual_hearing)
 
       # Check the Email Notification History


### PR DESCRIPTION
### Description
Fixes: 
```
Failure/Error: expect(page).to have_content(virtual_hearing_success_alert)
  expected to find text "You have successfully scheduled Bob Smith's hearing." in "CaseflowHearings\n  |  Switch product\nBVATWARNER (VACO)\nYou have successfully updated Bob Smith's hearing.
```
Because the page does display "You have successfully updated..." when converting a hearing to virtual (see screenshot), it seemed reasonable to update the expected alert text in this failing test. However, I'm not sure why it started failing at this time, rather than earlier.  

![updated_alert](https://user-images.githubusercontent.com/92495948/144521236-28e0bdc8-6540-4bbb-9f02-c4b5437754af.jpg)


