### PR TITLE
Add test to verify old tasks remain

### DIFF
--- a/spec/feature/queue/bva_intake_completed_tasks_tab_spec.rb
+++ b/spec/feature/queue/bva_intake_completed_tasks_tab_spec.rb
@@ -37,6 +37,11 @@ describe BvaIntakeCompletedTab, :postgres do
         expect(subject).to match_array(assignee_completed_tasks)
       end
 
+      it "returns assignee's completed tasks that are older than 7 days" do
+        assignee_completed_tasks.first.created_at = Time.zone.now - 1.year
+        expect(subject).to match_array(assignee_completed_tasks)
+      end
+
       context "when the assignee is a user" do
         let(:assignee) { create(:user) }
 

--- a/spec/feature/queue/bva_intake_completed_tasks_tab_spec.rb
+++ b/spec/feature/queue/bva_intake_completed_tasks_tab_spec.rb
@@ -39,6 +39,10 @@ describe BvaIntakeCompletedTab, :postgres do
 
       it "returns assignee's completed tasks that are older than 7 days" do
         assignee_completed_tasks.first.created_at = Time.zone.now - 1.year
+        assignee_completed_tasks.first.updated_at = Time.zone.now - 1.year
+        assignee_completed_tasks.first.assigned_at = Time.zone.now - 1.year
+        assignee_completed_tasks.first.closed_at = Time.zone.now - 1.year
+        assignee_completed_tasks.first.save
         expect(subject).to match_array(assignee_completed_tasks)
       end
 


### PR DESCRIPTION
Resolves [CASEFLOW-2561](https://vajira.max.gov/browse/CASEFLOW-2561)

### Description
Add a test to verify BVA Intake Completed Tab doesn't filter out appeals that are more than 7 days old.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass, including new test

