### PR TITLE
Add aasm_state index on dispatch_tasks

### DIFF
--- a/db/migrate/20211206223908_add_index_aasm_state_to_dispatch_tasks.rb
+++ b/db/migrate/20211206223908_add_index_aasm_state_to_dispatch_tasks.rb
@@ -1,0 +1,5 @@
+class AddIndexAasmStateToDispatchTasks < Caseflow::Migration
+  def change
+    add_safe_index :dispatch_tasks, [:aasm_state]
+  end
+end

--- a/db/migrate/20211206223908_add_index_aasm_state_to_dispatch_tasks.rb
+++ b/db/migrate/20211206223908_add_index_aasm_state_to_dispatch_tasks.rb
@@ -1,5 +1,7 @@
 class AddIndexAasmStateToDispatchTasks < Caseflow::Migration
   def change
     add_safe_index :dispatch_tasks, [:aasm_state]
+
+    change_column_comment :dispatch_tasks, :aasm_state, "Current task state: unprepared, unassigned, assigned, started, reviewed, completed"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -457,7 +457,7 @@ ActiveRecord::Schema.define(version: 2021_12_06_223908) do
   end
 
   create_table "dispatch_tasks", id: :serial, force: :cascade do |t|
-    t.string "aasm_state"
+    t.string "aasm_state", comment: "Current task state: unprepared, unassigned, assigned, started, reviewed, completed"
     t.integer "appeal_id", null: false
     t.datetime "assigned_at"
     t.string "comment"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_30_175237) do
+ActiveRecord::Schema.define(version: 2021_12_06_223908) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -471,6 +471,7 @@ ActiveRecord::Schema.define(version: 2021_11_30_175237) do
     t.string "type", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id"
+    t.index ["aasm_state"], name: "index_dispatch_tasks_on_aasm_state"
     t.index ["updated_at"], name: "index_dispatch_tasks_on_updated_at"
     t.index ["user_id"], name: "index_dispatch_tasks_on_user_id"
   end


### PR DESCRIPTION
Resolves potential DB query performance problems for class `Dispatch::Task`, which queries for `aasm_state` values.

### Description
Add `aasm_state` index on dispatch_tasks.

Motivated by [JC's comment](https://github.com/department-of-veterans-affairs/caseflow/pull/17009#discussion_r763448831)

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
None

### Database Changes
*Only for Schema Changes*

* [x] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [x] Post this PR in #appeals-schema with a summary
