### PR TITLE
Bug fix: VLJ Name Display Has Extra Symbols On Daily Docket

### DIFF
--- a/client/app/hearings/components/dailyDocket/DailyDocket.jsx
+++ b/client/app/hearings/components/dailyDocket/DailyDocket.jsx
@@ -258,7 +258,7 @@ export default class DailyDocket extends React.Component {
           <div className="cf-push-right">
             {!user.userVsoEmployee && (
               <React.Fragment>
-                `VLJ: ${dailyDocket.judgeFirstName} ${dailyDocket.judgeLastName}`
+                VLJ: {dailyDocket.judgeFirstName} {dailyDocket.judgeLastName}
                 <br />
               </React.Fragment>
             )}


### PR DESCRIPTION
### Description
While working on something else I noticed that the VLJ name on daily docket has some weird symbols in it. Probably left over from a conversion from a JS string to JSX.

### Acceptance Criteria
- [ ] VLJ name displays correctly on daily docket, without extraneous symbols.

### Testing Plan
1. Go to http://localhost:3000/hearings/schedule/docket/11 and look at the VLJ Name

### Screenshots
#### Before (currently in master)
<img width="1631" alt="current" src="https://user-images.githubusercontent.com/6818839/145109985-cc6d5fd3-aa42-42b1-8388-3d2529b249b7.png">

#### After
<img width="1626" alt="after_pr" src="https://user-images.githubusercontent.com/6818839/145110012-9e51bc9a-4005-44f8-94d7-63643ce044aa.png">