### PR TITLE
StuckAppealsChecker: ignore post-dispatch tasks when checking for open child tasks with closed RootTask

### DIFF
--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -6,7 +6,7 @@ class AppealsWithClosedRootTaskOpenChildrenQuery
   end
 
   def active_tasks
-    Task.open.active.where(appeal: appeals_with_open_child_tasks_and_closed_root_tasks)
+    Task.active.where(appeal: appeals_with_open_child_tasks_and_closed_root_tasks)
   end
 
   private

--- a/app/queries/appeals_with_closed_root_task_open_children_query.rb
+++ b/app/queries/appeals_with_closed_root_task_open_children_query.rb
@@ -5,6 +5,10 @@ class AppealsWithClosedRootTaskOpenChildrenQuery
     appeals_with_open_child_tasks_and_closed_root_tasks
   end
 
+  def active_tasks
+    Task.open.active.where(appeal: appeals_with_open_child_tasks_and_closed_root_tasks)
+  end
+
   private
 
   def appeals_with_open_child_tasks_and_closed_root_tasks

--- a/app/services/open_tasks_with_parent_not_on_hold.rb
+++ b/app/services/open_tasks_with_parent_not_on_hold.rb
@@ -46,10 +46,10 @@ class OpenTasksWithParentNotOnHold < DataIntegrityChecker
 
     # Post-dispatch tasks:
     BoardGrantEffectuationTask.name, # https://dsva.slack.com/archives/C2ZAMLK88/p1558555785005300?thread_ts=1558539407.494100&cid=C2ZAMLK88
-    VeteranRecordRequest.name # https://dsva.slack.com/archives/CQTDX9BF0/p1635969424041800?thread_ts=1635968729.041500&cid=CQTDX9BF0
+    VeteranRecordRequest.name, # https://dsva.slack.com/archives/CQTDX9BF0/p1635969424041800?thread_ts=1635968729.041500&cid=CQTDX9BF0
 
     # Mail can arrive after appeal is dispatched
-    *MailTask.descendants.map(&:name), # https://dsva.slack.com/archives/CJL810329/p1634239591067100?thread_ts=1634224678.055200&cid=CJL810329
+    *MailTask.descendants.map(&:name) # https://dsva.slack.com/archives/CJL810329/p1634239591067100?thread_ts=1634224678.055200&cid=CJL810329
   ].freeze
 
   def ignored_tasks_with_closed_root_task_parent

--- a/app/services/open_tasks_with_parent_not_on_hold.rb
+++ b/app/services/open_tasks_with_parent_not_on_hold.rb
@@ -35,15 +35,21 @@ class OpenTasksWithParentNotOnHold < DataIntegrityChecker
     See https://query.prod.appeals.va.gov/question/309-parent-tasks-not-on-hold-with-open-children-tasks
   )
 
-  # It's acceptable to have a closed RootTask parent for:
-  # - MailTasks -- https://dsva.slack.com/archives/CJL810329/p1634239591067100?thread_ts=1634224678.055200&cid=CJL810329
-  # - TrackVeteranTask -- https://dsva.slack.com/archives/CJL810329/p1634581182080100?thread_ts=1634553075.073600&cid=CJL810329
-  IGNORED_TASKS_WITH_CLOSED_ROOTTASK_PARENT = [
-    *MailTask.descendants.map(&:name),
-    "TrackVeteranTask",
-    "FoiaTask", # https://github.com/department-of-veterans-affairs/dsva-vacols/issues/255#issuecomment-992758936
-    "BoardGrantEffectuationTask", # https://dsva.slack.com/archives/C2ZAMLK88/p1558555785005300?thread_ts=1558539407.494100&cid=C2ZAMLK88
-    "VeteranRecordRequest" # https://dsva.slack.com/archives/CQTDX9BF0/p1635969424041800?thread_ts=1635968729.041500&cid=CQTDX9BF0
+  # It's acceptable to have a closed RootTask parent for these tasks
+  IGNORED_TASKS_WITH_CLOSED_ROOTTASK_PARENT ||= [
+    # POAs may still want access after an appeal is completed
+    # https://dsva.slack.com/archives/C01DFC41BPV/p1634756194393000?thread_ts=1633042678.442600&cid=C01DFC41BPV
+    TrackVeteranTask.name, # https://dsva.slack.com/archives/CJL810329/p1634581182080100?thread_ts=1634553075.073600&cid=CJL810329
+
+    # FOIA tasks must be completed regardless of appeal state
+    FoiaTask.name, # https://github.com/department-of-veterans-affairs/dsva-vacols/issues/255#issuecomment-992758936
+
+    # Post-dispatch tasks:
+    BoardGrantEffectuationTask.name, # https://dsva.slack.com/archives/C2ZAMLK88/p1558555785005300?thread_ts=1558539407.494100&cid=C2ZAMLK88
+    VeteranRecordRequest.name # https://dsva.slack.com/archives/CQTDX9BF0/p1635969424041800?thread_ts=1635968729.041500&cid=CQTDX9BF0
+
+    # Mail can arrive after appeal is dispatched
+    *MailTask.descendants.map(&:name), # https://dsva.slack.com/archives/CJL810329/p1634239591067100?thread_ts=1634224678.055200&cid=CJL810329
   ].freeze
 
   def ignored_tasks_with_closed_root_task_parent

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -25,7 +25,7 @@ class StuckAppealsChecker < DataIntegrityChecker
 
   def build_report_no_active_task
     add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
-    add_to_report stuck_appeals.map { |a| [a.class.name, a.id].join(" ") }.join("\n")
+    add_to_report "  Appeal ids: #{stuck_appeals.pluck(:id)}"
   end
 
   def build_report_closed_root_open_children

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -15,11 +15,7 @@ class StuckAppealsChecker < DataIntegrityChecker
     build_report_closed_root_open_children
   end
 
-  ACCEPTABLE_POST_DISPATCH_TASKS ||= [
-    TrackVeteranTask.name, # https://dsva.slack.com/archives/C01DFC41BPV/p1634756194393000?thread_ts=1633042678.442600&cid=C01DFC41BPV
-    BoardGrantEffectuationTask.name, # A post-dispatch task
-    *MailTask.descendants.map(&:name) # Mail can arrive after appeal is dispatched
-  ].freeze
+  ACCEPTABLE_POST_DISPATCH_TASKS ||= OpenTasksWithParentNotOnHold::IGNORED_TASKS_WITH_CLOSED_ROOTTASK_PARENT
 
   private
 

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -11,6 +11,7 @@ class StuckAppealsChecker < DataIntegrityChecker
     add_to_report "To resolve, see https://github.com/department-of-veterans-affairs/caseflow/wiki/Resolving-Background-Job-Alerts#stuckappealschecker\n"
 
     build_report_no_active_task
+    add_to_report ""
     build_report_closed_root_open_children
   end
 

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -9,14 +9,37 @@ class StuckAppealsChecker < DataIntegrityChecker
     return if stuck_appeals.count == 0 && appeals_maybe_not_closed.count == 0
 
     add_to_report "To resolve, see https://github.com/department-of-veterans-affairs/caseflow/wiki/Resolving-Background-Job-Alerts#stuckappealschecker\n"
-    add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
-    add_to_report "AppealsWithClosedRootTaskOpenChildrenQuery: #{appeals_maybe_not_closed.count}"
+
+    build_report_no_active_task
+    build_report_closed_root_open_children
   end
+
+  ACCEPTABLE_POST_DISPATCH_TASKS ||= [
+    TrackVeteranTask.name, # https://dsva.slack.com/archives/C01DFC41BPV/p1634756194393000?thread_ts=1633042678.442600&cid=C01DFC41BPV
+    BoardGrantEffectuationTask.name, # A post-dispatch task
+    *MailTask.descendants.map(&:name) # Mail can arrive after appeal is dispatched
+  ].freeze
 
   private
 
+  def build_report_no_active_task
+    add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
+    add_to_report stuck_appeals.map { |a| [a.class.name, a.id].join(" ") }.join("\n")
+  end
+
+  def build_report_closed_root_open_children
+    add_to_report "AppealsWithClosedRootTaskOpenChildrenQuery: #{appeals_maybe_not_closed.count}"
+    non_acceptable_tasks = appeals_maybe_not_closed_query.active_tasks.where.not(type: ACCEPTABLE_POST_DISPATCH_TASKS)
+    add_to_report "  ignoring MailTask, TrackVeteranTask, BoardGrantEffectuationTask: #{non_acceptable_tasks.count}"
+    add_to_report non_acceptable_tasks.group(:type).count.to_s.tr(",", "\n")
+  end
+
+  def appeals_maybe_not_closed_query
+    @appeals_maybe_not_closed_query ||= AppealsWithClosedRootTaskOpenChildrenQuery.new
+  end
+
   def appeals_maybe_not_closed
-    @appeals_maybe_not_closed ||= AppealsWithClosedRootTaskOpenChildrenQuery.new.call
+    @appeals_maybe_not_closed ||= appeals_maybe_not_closed_query.call
   end
 
   def stuck_appeals

--- a/app/services/stuck_appeals_checker.rb
+++ b/app/services/stuck_appeals_checker.rb
@@ -25,7 +25,7 @@ class StuckAppealsChecker < DataIntegrityChecker
 
   def build_report_no_active_task
     add_to_report "AppealsWithNoTasksOrAllTasksOnHoldQuery: #{stuck_appeals.count}"
-    add_to_report "  Appeal ids: #{stuck_appeals.pluck(:id)}"
+    add_to_report "  Appeal ids: #{stuck_appeals.pluck(:id).sort}"
   end
 
   def build_report_closed_root_open_children

--- a/spec/services/stuck_appeals_checker_spec.rb
+++ b/spec/services/stuck_appeals_checker_spec.rb
@@ -32,6 +32,25 @@ describe StuckAppealsChecker, :postgres do
     appeal.root_task.completed!
     appeal
   end
+  let!(:dispatched_appeal_with_open_track_vet) do
+    appeal = create(:appeal, :dispatched)
+    create(:track_veteran_task, parent: appeal.root_task)
+    appeal
+  end
+
+  let(:appeals_with_no_active_task) do
+    [appeal_with_zero_tasks,
+     appeal_with_all_tasks_on_hold,
+     dispatched_appeal_on_hold,
+     appeal_with_fully_on_hold_subtree]
+  end
+
+  let(:appeals_with_closed_root_open_child) do
+    [appeal_with_closed_root_open_child, dispatched_appeal_with_open_track_vet]
+  end
+  let(:acceptable_appeals_with_closed_root_open_child) do
+    [dispatched_appeal_with_open_track_vet]
+  end
 
   describe "#call" do
     it "reports 5 appeals stuck" do
@@ -39,7 +58,13 @@ describe StuckAppealsChecker, :postgres do
 
       expect(subject.report?).to eq(true)
       expect(subject.report).to match(/AppealsWithNoTasksOrAllTasksOnHoldQuery: 4/)
-      expect(subject.report).to match(/AppealsWithClosedRootTaskOpenChildrenQuery: 1/)
+      expect(subject.report).to include "  Appeal ids: #{appeals_with_no_active_task.pluck(:id).sort}"
+
+      closed_root_appeals_count = appeals_with_closed_root_open_child.size
+      expect(subject.report).to match(/AppealsWithClosedRootTaskOpenChildrenQuery: #{closed_root_appeals_count}/)
+      non_acceptable_count = (appeals_with_closed_root_open_child - acceptable_appeals_with_closed_root_open_child).size
+      expect(subject.report).to match(/ignoring .*: #{non_acceptable_count}/)
+      expect(subject.report).not_to match(/"TrackVeteranTask"=>/)
     end
   end
 end


### PR DESCRIPTION
Reduces false alerts on certain task types that are expected to be open after the appeal is dispatched (i.e., the RootTask is closed).

### Description
In StuckAppealsChecker, ignore post-dispatch tasks when checking for open child tasks with closed RootTask.
Plus add details to the alert, like appeal id and a histogram over task types.

See [Slack thread](https://dsva.slack.com/archives/CJL810329/p1639132296051600) for example.

Related: PR #16500

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] More details in the alert message
- [ ] Ignores post-dispatch tasks

### Testing Plan
Add a `binding.pry` after https://github.com/department-of-veterans-affairs/caseflow/blob/b52d36dcb065ebb37750857e6eec4ae1eeddeef0/spec/services/stuck_appeals_checker_spec.rb#L38
and run `puts subject.report` to see:
```ruby
AppealsWithClosedRootTaskOpenChildrenQuery: 1
AppealsWithNoTasksOrAllTasksOnHoldQuery: 4
  Appeal ids: [1, 3, 5, 6]

AppealsWithClosedRootTaskOpenChildrenQuery: 2
  ignoring MailTask, TrackVeteranTask, BoardGrantEffectuationTask: 1
{"EvidenceSubmissionWindowTask"=>1}
```