### PR TITLE
Add appeal index to AodMotions table

### DIFF
--- a/db/migrate/20211213180551_add_appeal_index_to_aod_motions.rb
+++ b/db/migrate/20211213180551_add_appeal_index_to_aod_motions.rb
@@ -1,0 +1,5 @@
+class AddAppealIndexToAodMotions < Caseflow::Migration
+  def change
+    add_safe_index :advance_on_docket_motions, ["appeal_type", "appeal_id"], name: "index_aod_motion_on_appeal_id_and_appeal_type"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_06_223908) do
+ActiveRecord::Schema.define(version: 2021_12_13_180551) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,6 +25,7 @@ ActiveRecord::Schema.define(version: 2021_12_06_223908) do
     t.string "reason", comment: "VLJ's rationale for their decision on motion to AOD."
     t.datetime "updated_at", null: false
     t.bigint "user_id"
+    t.index ["appeal_type", "appeal_id"], name: "index_aod_motion_on_appeal_id_and_appeal_type"
     t.index ["granted"], name: "index_advance_on_docket_motions_on_granted"
     t.index ["person_id"], name: "index_advance_on_docket_motions_on_person_id"
     t.index ["updated_at"], name: "index_advance_on_docket_motions_on_updated_at"


### PR DESCRIPTION
Resolves slow queries like:
* https://github.com/department-of-veterans-affairs/caseflow/blob/878b7734fbe71418e41bd099d35e1cad49962032/app/models/advance_on_docket_motion.rb#L47
* https://github.com/department-of-veterans-affairs/caseflow/blob/cdee5c0a4e353766b58764ad4aa67bb079b62e89/app/models/other_claimant.rb#L26

### Description
Add `["appeal_type", "appeal_id"]` index on `advance_on_docket_motions` table.

### Acceptance Criteria
- [ ] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [x] Post this PR in #appeals-schema with a summary
