### PR TITLE
Add Comments for HearingEmailRecipients

### DIFF
--- a/app/models/concerns/has_hearing_email_recipients_concern.rb
+++ b/app/models/concerns/has_hearing_email_recipients_concern.rb
@@ -1,12 +1,29 @@
 # frozen_string_literal: true
 
+# When virtual hearings were first added as an option (2019/2020) email related information was stored directly
+# on the VirtualHearing. Emails were not being sent for any non-virtual hearings. In 2021 HearingEmailRecipient
+# and related code as added to allow sending emails for all hearings (not just virtual ones).
+#
+# Instead of doing a big migration to move all email related information from VirtualHearing objects to new
+# HearingEmailRecipient objects, the code in this file was set up to do an in place migration.
+#
+# The idea is that
+# - As new hearings (of any type) are created, HearingEmailRecipient objects are added (the new way).
+# - If a hearing is accessed where the email information is stored on the VirtualHearing (the old way).
+#   - This concern creates the appropriate HearingEmailRecipient objects (the new way).
+# That's why there are so many checks like virtual_hearing[:appellant_email] in this file. It's looking to
+# see if this record might have data stored on VirtualHearing and if it does it's migrating it to the new
+# HearingEmailRecipient.
+
 # rubocop:disable Metrics/ModuleLength
 module HasHearingEmailRecipientsConcern
   extend ActiveSupport::Concern
 
   def appellant_recipient
+    # Is there an existing appellant recipient for this hearing? Return it if yes
     recipient = email_recipients.find_by(type: "AppellantHearingEmailRecipient")
 
+    # There's no recipient, but there is an email address on the VirtualHearing, create a HearingEmailRecipient
     if recipient.blank? && appellant_email_address.present?
       recipient = create_or_update_recipients(
         type: AppellantHearingEmailRecipient,
@@ -15,6 +32,7 @@ module HasHearingEmailRecipientsConcern
         email_sent: virtual_hearing.present? ? virtual_hearing[:appellant_email_sent] : true
       )
 
+      # Change the email events to point to the new HearingEmailRecipient
       update_email_events(recipient, recipient.roles)
     end
 
@@ -22,8 +40,10 @@ module HasHearingEmailRecipientsConcern
   end
 
   def representative_recipient
+    # Is there an existing representative recipient for this hearing? Return it if yes
     recipient = email_recipients.find_by(type: "RepresentativeHearingEmailRecipient")
 
+    # There's no recipient, but there is an email address on the VirtualHearing, create a HearingEmailRecipient
     if recipient.blank? && representative_email_address.present?
       recipient = create_or_update_recipients(
         type: RepresentativeHearingEmailRecipient,
@@ -32,6 +52,7 @@ module HasHearingEmailRecipientsConcern
         email_sent: virtual_hearing.present? ? virtual_hearing[:representative_email_sent] : true
       )
 
+      # Change the email events to point to the new HearingEmailRecipient
       update_email_events(recipient, recipient.roles)
     end
 
@@ -39,8 +60,10 @@ module HasHearingEmailRecipientsConcern
   end
 
   def judge_recipient
+    # Is there an existing judge recipient for this hearing? Return it if yes
     recipient = JudgeHearingEmailRecipient.find_by(hearing: self)
 
+    # There's no recipient, but there is an email address on the VirtualHearing, create a HearingEmailRecipient
     if recipient.blank? && virtual_hearing.present?
       judge_email = virtual_hearing[:judge_email]
 
@@ -51,6 +74,7 @@ module HasHearingEmailRecipientsConcern
           email_sent: virtual_hearing[:judge_email_sent]
         )
 
+        # Change the email events to point to the new HearingEmailRecipient
         update_email_events(recipient, recipient.roles)
       end
     end
@@ -58,17 +82,23 @@ module HasHearingEmailRecipientsConcern
     recipient
   end
 
+  # Check that the appellant email has been sent and that the representative, and judge either:
+  # - Have email addresses and the emails have been sent
+  # - Have no email addresses so no emails have been sent
   def all_emails_sent?
     appellant_recipient&.email_sent &&
       (judge_recipient&.email_address.nil? || judge_recipient&.email_sent) &&
       (representative_recipient&.email_address.nil? || representative_recipient&.email_sent)
   end
 
+  # Same idea as all_emails_sent
   def cancellation_emails_sent?
     appellant_recipient&.email_sent &&
       (representative_recipient&.email_address.nil? || representative_recipient&.email_sent)
   end
 
+  # Each Hearing/LegacyHearing can only have one HearingEmailRecipient of each type, so either
+  # update or create it when the email address or timezone changes.
   def create_or_update_recipients(type:, email_address:, timezone: nil, email_sent: false)
     recipient = type.find_by(hearing: self)
 
@@ -88,20 +118,23 @@ module HasHearingEmailRecipientsConcern
     end
   end
 
+  # Alias
   def veteran_email_address
     appellant_email_address
   end
 
+  # Get the appellant email address from the HearingEmailRecipient or the VirtualHearing
   def appellant_email_address
     recipient = email_recipients.find_by(type: "AppellantHearingEmailRecipient")
 
     if recipient.blank?
-      virtual_hearing.present? ? virtual_hearing[:appellant_email] : appeal&.appellant_email_address
+      virtual_hearing.present? ? virtual_hearing[:appellant_email] : appeal&.appellant_email_address # TODO this fallback is a problem
     else
       recipient&.email_address
     end
   end
 
+  # Get the appellant timezone from the HearingEmailRecipient or the VirtualHearing
   def appellant_tz
     recipient = email_recipients.find_by(type: "AppellantHearingEmailRecipient")
 
@@ -112,6 +145,7 @@ module HasHearingEmailRecipientsConcern
     end
   end
 
+  # Get the representative from the HearingEmailRecipient or the VirtualHearing
   def representative_email_address
     recipient = email_recipients.find_by(type: "RepresentativeHearingEmailRecipient")
 
@@ -126,6 +160,7 @@ module HasHearingEmailRecipientsConcern
     end
   end
 
+  # Get the representative timezone from the HearingEmailRecipient or the VirtualHearing
   def representative_tz
     recipient = email_recipients.find_by(type: "RepresentativeHearingEmailRecipient")
 
@@ -142,6 +177,7 @@ module HasHearingEmailRecipientsConcern
 
   private
 
+  # Change email events for a role to point to the specified HearingEmailRecipient
   def update_email_events(recipient, roles)
     events = email_events.where(recipient_role: roles)
 

--- a/app/models/concerns/has_hearing_email_recipients_concern.rb
+++ b/app/models/concerns/has_hearing_email_recipients_concern.rb
@@ -14,6 +14,9 @@
 # That's why there are so many checks like virtual_hearing[:appellant_email] in this file. It's looking to
 # see if this record might have data stored on VirtualHearing and if it does it's migrating it to the new
 # HearingEmailRecipient.
+#
+# This fallback would ideally only be in this file, but it is also in:
+# - HearingTimeService::poa_time and HearingTimeService::appellant_time
 
 # rubocop:disable Metrics/ModuleLength
 module HasHearingEmailRecipientsConcern

--- a/app/models/concerns/has_hearing_email_recipients_concern.rb
+++ b/app/models/concerns/has_hearing_email_recipients_concern.rb
@@ -128,7 +128,7 @@ module HasHearingEmailRecipientsConcern
     recipient = email_recipients.find_by(type: "AppellantHearingEmailRecipient")
 
     if recipient.blank?
-      virtual_hearing.present? ? virtual_hearing[:appellant_email] : appeal&.appellant_email_address # TODO this fallback is a problem
+      virtual_hearing.present? ? virtual_hearing[:appellant_email] : appeal&.appellant_email_address
     else
       recipient&.email_address
     end

--- a/app/models/hearings/hearing_email_recipient.rb
+++ b/app/models/hearings/hearing_email_recipient.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# See has_hearing_email_recipients_concern.rb for context on this class.
 class HearingEmailRecipient < CaseflowRecord
   def self.email_error_message
     fail Caseflow::Error::MustImplementInSubclass


### PR DESCRIPTION
### Description
This PR is documentation only: It clarifies the "Why" of HearingEmailRecipients in the place a new developer is most likely to find it (the code).

### Acceptance Criteria
- [ ] These comments make sense to you.
- [ ] There's no obviously missing background, information, or things you'd like to know.