### PR TITLE
API-11905 Lighthouse supplemental claims contestable issues

### DIFF
--- a/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
+++ b/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Api
+  module V3
+    module DecisionReviews
+      module SupplementalClaims
+        class ContestableIssuesController < BaseContestableIssuesController
+          include ApiV3FeatureToggleConcern
+
+          before_action only: [:index] do
+            api_released?(:api_v3_supplemental_claims_contestable_issues)
+          end
+
+          private
+
+          def standin_decision_review
+            @standin_decision_review ||= SupplementalClaim.new(
+              veteran_file_number: veteran.file_number,
+              receipt_date: receipt_date,
+              # must be in ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE for can_contest_rating_issues?
+              benefit_type: benefit_type
+            )
+          end
+
+          def validate_params
+            super && benefit_type_valid?
+          end
+
+          def benefit_type_valid?
+            unless benefit_type.in? benefit_types
+              render_invalid_benefit_type
+              return false
+            end
+            true
+          end
+
+          def benefit_type
+            @benefit_type ||= params[:benefit_type]
+          end
+
+          def benefit_types
+            Constants::BENEFIT_TYPES.keys
+          end
+
+          def render_invalid_benefit_type
+            render_errors(
+              status: 422,
+              code: :invalid_benefit_type,
+              title: "Invalid Benefit Type",
+              detail: "Benefit type #{benefit_type.inspect} is invalid. Must be one of: #{benefit_types.inspect}"
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
+++ b/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
@@ -1,51 +1,57 @@
 # frozen_string_literal: true
 
-module Api::V3::DecisionReviews::SupplementalClaims
-  class ContestableIssuesController < BaseContestableIssuesController
-    include ApiV3FeatureToggleConcern
+module Api
+  module V3
+    module DecisionReviews
+      module SupplementalClaims
+        class ContestableIssuesController < BaseContestableIssuesController
+          include ApiV3FeatureToggleConcern
 
-    before_action only: [:index] do
-      api_released?(:api_v3_supplemental_claims_contestable_issues)
-    end
+          before_action only: [:index] do
+            api_released?(:api_v3_supplemental_claims_contestable_issues)
+          end
 
-    private
+          private
 
-    def standin_decision_review
-      @standin_decision_review ||= SupplementalClaim.new(
-        veteran_file_number: veteran.file_number,
-        receipt_date: receipt_date,
-        # must be in ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE for can_contest_rating_issues?
-        benefit_type: benefit_type
-      )
-    end
+          def standin_decision_review
+            @standin_decision_review ||= SupplementalClaim.new(
+              veteran_file_number: veteran.file_number,
+              receipt_date: receipt_date,
+              # must be in ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE for can_contest_rating_issues?
+              benefit_type: benefit_type
+            )
+          end
 
-    def validate_params
-      super && benefit_type_valid?
-    end
+          def validate_params
+            super && benefit_type_valid?
+          end
 
-    def benefit_type_valid?
-      unless benefit_type.in? benefit_types
-        render_invalid_benefit_type
-        return false
-      end
-      true
-    end
+          def benefit_type_valid?
+            unless benefit_type.in? benefit_types
+              render_invalid_benefit_type
+              return false
+            end
+            true
+          end
 
-    def benefit_type
-      @benefit_type ||= params[:benefit_type]
-    end
+          def benefit_type
+            @benefit_type ||= params[:benefit_type]
+          end
 
-    def benefit_types
-      Constants::BENEFIT_TYPES.keys
-    end
+          def benefit_types
+            Constants::BENEFIT_TYPES.keys
+          end
 
-    def render_invalid_benefit_type
-      render_errors(
-        status: 422,
-        code: :invalid_benefit_type,
-        title: "Invalid Benefit Type",
-        detail: "Benefit type #{benefit_type.inspect} is invalid. Must be one of: #{benefit_types.inspect}"
-      )
+          def render_invalid_benefit_type
+            render_errors(
+              status: 422,
+              code: :invalid_benefit_type,
+              title: "Invalid Benefit Type",
+              detail: "Benefit type #{benefit_type.inspect} is invalid. Must be one of: #{benefit_types.inspect}"
+            )
+          end
+        end
+        end
     end
   end
 end

--- a/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
+++ b/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
@@ -51,7 +51,7 @@ module Api
             )
           end
         end
-        end
+      end
     end
   end
 end

--- a/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
+++ b/app/controllers/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller.rb
@@ -1,57 +1,51 @@
 # frozen_string_literal: true
 
-module Api
-  module V3
-    module DecisionReviews
-      module SupplementalClaims
-        class ContestableIssuesController < BaseContestableIssuesController
-          include ApiV3FeatureToggleConcern
+module Api::V3::DecisionReviews::SupplementalClaims
+  class ContestableIssuesController < BaseContestableIssuesController
+    include ApiV3FeatureToggleConcern
 
-          before_action only: [:index] do
-            api_released?(:api_v3_supplemental_claims_contestable_issues)
-          end
+    before_action only: [:index] do
+      api_released?(:api_v3_supplemental_claims_contestable_issues)
+    end
 
-          private
+    private
 
-          def standin_decision_review
-            @standin_decision_review ||= SupplementalClaim.new(
-              veteran_file_number: veteran.file_number,
-              receipt_date: receipt_date,
-              # must be in ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE for can_contest_rating_issues?
-              benefit_type: benefit_type
-            )
-          end
+    def standin_decision_review
+      @standin_decision_review ||= SupplementalClaim.new(
+        veteran_file_number: veteran.file_number,
+        receipt_date: receipt_date,
+        # must be in ClaimantValidator::BENEFIT_TYPE_REQUIRES_PAYEE_CODE for can_contest_rating_issues?
+        benefit_type: benefit_type
+      )
+    end
 
-          def validate_params
-            super && benefit_type_valid?
-          end
+    def validate_params
+      super && benefit_type_valid?
+    end
 
-          def benefit_type_valid?
-            unless benefit_type.in? benefit_types
-              render_invalid_benefit_type
-              return false
-            end
-            true
-          end
-
-          def benefit_type
-            @benefit_type ||= params[:benefit_type]
-          end
-
-          def benefit_types
-            Constants::BENEFIT_TYPES.keys
-          end
-
-          def render_invalid_benefit_type
-            render_errors(
-              status: 422,
-              code: :invalid_benefit_type,
-              title: "Invalid Benefit Type",
-              detail: "Benefit type #{benefit_type.inspect} is invalid. Must be one of: #{benefit_types.inspect}"
-            )
-          end
-        end
+    def benefit_type_valid?
+      unless benefit_type.in? benefit_types
+        render_invalid_benefit_type
+        return false
       end
+      true
+    end
+
+    def benefit_type
+      @benefit_type ||= params[:benefit_type]
+    end
+
+    def benefit_types
+      Constants::BENEFIT_TYPES.keys
+    end
+
+    def render_invalid_benefit_type
+      render_errors(
+        status: 422,
+        code: :invalid_benefit_type,
+        title: "Invalid Benefit Type",
+        detail: "Benefit type #{benefit_type.inspect} is invalid. Must be one of: #{benefit_types.inspect}"
+      )
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,9 @@ Rails.application.routes.draw do
           get "contestable_issues(/:benefit_type)", to: "contestable_issues#index"
         end
         resources :higher_level_reviews, only: [:create, :show]
+        namespace :supplemental_claims do
+          get "contestable_issues(/:benefit_type)", to: "contestable_issues#index"
+        end
         resources :supplemental_claims, only: [:create, :show]
         namespace :appeals do
           get 'contestable_issues', to: "contestable_issues#index"

--- a/spec/requests/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller_spec.rb
+++ b/spec/requests/api/v3/decision_reviews/supplemental_claims/contestable_issues_controller_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+describe Api::V3::DecisionReviews::SupplementalClaims::ContestableIssuesController, :postgres, type: :request do
+  let(:decision_review_type) { :supplemental_claim }
+  let(:source) { create(:supplemental_claim, veteran_file_number: veteran.file_number) }
+  let(:benefit_type) { "compensation" }
+
+  include IntakeHelpers
+
+  before do
+    FeatureToggle.enable!(:api_v3_supplemental_claims_contestable_issues)
+
+    Timecop.freeze(post_ama_start_date)
+  end
+
+  after { FeatureToggle.disable!(:api_v3_supplemental_claims_contestable_issues) }
+
+  include_examples "contestable issues index requests"
+
+  describe "#index" do
+    include_context "contestable issues request context", include_shared: true
+    include_context "contestable issues request index context", include_shared: true
+
+    context do
+      let(:benefit_type) { "Greetings!" }
+      it "should return a 422 when the benefit type is unknown" do
+        get_issues
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context do
+      let(:benefit_type) { nil }
+      it "should return a 422 when the benefit type is missing" do
+        get_issues
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context do
+      let(:benefit_type) { "" }
+      it "should return a 422 when the benefit type is blank" do
+        get_issues
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+    end
+
+    context "when feature toggle is not enabled" do
+      before { FeatureToggle.disable!(:api_v3_supplemental_claims_contestable_issues) }
+
+      it "should return a 501 response" do
+        get_issues
+        expect(response).to have_http_status(:not_implemented)
+      end
+
+      it "should have a jsonapi error response" do
+        get_issues
+        expect { JSON.parse(response.body) }.to_not raise_error
+        parsed_response = JSON.parse(response.body)
+        expect(parsed_response["errors"]).to be_a Array
+        expect(parsed_response["errors"].first).to include("status", "title", "detail")
+      end
+    end
+  end
+end

--- a/spec/support/shared_examples/requests/api/v3/decision_reviews/shared_examples_contestable_issues.rb
+++ b/spec/support/shared_examples/requests/api/v3/decision_reviews/shared_examples_contestable_issues.rb
@@ -51,6 +51,9 @@ RSpec.shared_examples "contestable issues index requests" do
       let(:claim_id) { "12345" }
       let(:rating_issue_reference_id) { "99999" }
 
+      let(:higher_level_review) { create(:higher_level_review, veteran_file_number: veteran.file_number, same_office: true) }
+      let(:supplemental_claim) { create(:supplemental_claim, veteran_file_number: veteran.file_number) }
+
       let(:end_product_establishment) do
         create(
           :end_product_establishment,
@@ -227,7 +230,8 @@ RSpec.shared_examples "contestable issues index requests" do
       end
 
       it "should have titleOfActiveReview attribute" do
-        decision_review = create(:supplemental_claim, veteran_file_number: veteran.file_number)
+        decision_review =  decision_review_type == :supplemental_claim ? higher_level_review : supplemental_claim
+
         create(
           :request_issue,
           decision_review: decision_review,

--- a/spec/support/shared_examples/requests/api/v3/decision_reviews/shared_examples_contestable_issues.rb
+++ b/spec/support/shared_examples/requests/api/v3/decision_reviews/shared_examples_contestable_issues.rb
@@ -51,7 +51,9 @@ RSpec.shared_examples "contestable issues index requests" do
       let(:claim_id) { "12345" }
       let(:rating_issue_reference_id) { "99999" }
 
-      let(:higher_level_review) { create(:higher_level_review, veteran_file_number: veteran.file_number, same_office: true) }
+      let(:higher_level_review) do
+        create(:higher_level_review, veteran_file_number: veteran.file_number, same_office: true)
+      end
       let(:supplemental_claim) { create(:supplemental_claim, veteran_file_number: veteran.file_number) }
 
       let(:end_product_establishment) do
@@ -230,7 +232,7 @@ RSpec.shared_examples "contestable issues index requests" do
       end
 
       it "should have titleOfActiveReview attribute" do
-        decision_review =  decision_review_type == :supplemental_claim ? higher_level_review : supplemental_claim
+        decision_review = (decision_review_type == :supplemental_claim) ? higher_level_review : supplemental_claim
 
         create(
           :request_issue,


### PR DESCRIPTION
### Description
The Lighthouse API has completed our work on the Supplemental Claim form submission and need to be able to retrieve contestable issues for these decision reviews. The work is nearly identical to the work done before for Appeals and Higher Level Reviews under api/v3
