### PR TITLE
DataDogService: set default start_time value in case it is nil

### DIFF
--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -18,6 +18,7 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
     @genpop_distributions = distribute_genpop_priority_appeals
     send_job_report
   rescue StandardError => error
+    start_time ||= Time.zone.now # temporary fix to get this job to succeed
     duration = time_ago_in_words(start_time)
     slack_msg = "[ERROR] after running for #{duration}: #{error.message}"
     slack_service.send_notification(slack_msg, self.class.name, "#appeals-echo")

--- a/app/services/data_dog_service.rb
+++ b/app/services/data_dog_service.rb
@@ -11,7 +11,7 @@ class DataDogService
     @statsd.increment(stat_name, tags: tags, by: by)
   end
 
-  def self.record_runtime(metric_group:, app_name:, start_time:)
+  def self.record_runtime(metric_group:, app_name:, start_time: Time.zone.now)
     metric_name = "runtime"
     job_duration_seconds = Time.zone.now - start_time
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -1745,7 +1745,7 @@ RSpec.feature "Case details", :all_dbs do
 
         let(:veteran_full_name) { veteran.first_name + veteran.last_name }
         let(:nod_date) { "11/11/2020" }
-        let(:later_nod_date) { Time.zone.now.next_year(2).mdY }
+        let(:later_nod_date) { Time.zone.now.next_year(3).mdY }
         let(:before_earliest_date) { "12/31/2017" }
         before { FeatureToggle.enable!(:edit_nod_date) }
         after { FeatureToggle.disable!(:edit_nod_date) }


### PR DESCRIPTION
Resolves `PushPriorityAppealsToJudgesJob` not being able to report error - see https://dsva.slack.com/archives/CJL810329/p1641301977217200?thread_ts=1641301718.217100&cid=CJL810329

### Description
In `DataDogService`, set a default value start_time in case it is nil.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
Deploy to prod and rerun job to see if we can get an error message revealing the job's problem
