### PR TITLE
Update copy_with_ancestors method to deflake spec for same appeal substitution tasks factory

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -636,7 +636,7 @@ class Task < CaseflowRecord
 
     # This method recurses until the parent is nil or a task of its type is already present on the new stream
     # We reload the new_appeal_stream to ensure we are always working off an updated snapshot of task tree
-    existing_new_parent = new_appeal_stream.reload.tasks.find { |task| task.type == parent.type }
+    existing_new_parent = new_appeal_stream.reload.tasks.find { |task| task.id == parent_id }
     new_parent = existing_new_parent || parent.copy_with_ancestors_to_stream(new_appeal_stream)
 
     # Do not copy orphaned branches


### PR DESCRIPTION
Resolves jira ticket 2796: [Fix flaky test that blocked PRs from merging](https://vajira.max.gov/browse/CASEFLOW-2796).

### Description
The task method `copy_with_ancestors` previously located a task's parent by searching for the parent type.  If an appeal had multiple tasks of the parent's type, this method could cause the wrong task to get copied.  As a result, a test about [reopening the most recently created AttorneyTask and JudgeDecisionReviewTask](https://app.circleci.com/pipelines/github/department-of-veterans-affairs/caseflow/50509/workflows/6a98a6e6-7ffd-477e-a00e-904e37ae21b6/jobs/201947) was flaking.  `copy_with_ancestors` now finds the parent task by its id, which fixes the flake.



### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The previously flaking test now passes when locally run with `ensure_stable`

### Testing Plan
1. Locally run the previously flaking test with `ensure_stable`
