### PR TITLE
claim_establishments table: add task_id index

### DIFF
--- a/db/migrate/20220106201637_add_task_id_index_to_claim_establishments.rb
+++ b/db/migrate/20220106201637_add_task_id_index_to_claim_establishments.rb
@@ -1,0 +1,5 @@
+class AddTaskIdIndexToClaimEstablishments < Caseflow::Migration
+  def change
+    add_safe_index :claim_establishments, :task_id
+  end
+end

--- a/db/migrate/20220106201637_add_task_id_index_to_claim_establishments.rb
+++ b/db/migrate/20220106201637_add_task_id_index_to_claim_establishments.rb
@@ -1,5 +1,7 @@
 class AddTaskIdIndexToClaimEstablishments < Caseflow::Migration
   def change
+    change_column_comment :claim_establishments, :task_id, "references dispatch_tasks"
+
     add_safe_index :claim_establishments, :task_id
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -380,7 +380,7 @@ ActiveRecord::Schema.define(version: 2022_01_06_201637) do
     t.string "email_ro_id"
     t.string "ep_code"
     t.datetime "outcoding_date"
-    t.integer "task_id"
+    t.integer "task_id", comment: "references dispatch_tasks"
     t.datetime "updated_at", null: false
     t.index ["task_id"], name: "index_claim_establishments_on_task_id"
     t.index ["updated_at"], name: "index_claim_establishments_on_updated_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_13_180551) do
+ActiveRecord::Schema.define(version: 2022_01_06_201637) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -382,6 +382,7 @@ ActiveRecord::Schema.define(version: 2021_12_13_180551) do
     t.datetime "outcoding_date"
     t.integer "task_id"
     t.datetime "updated_at", null: false
+    t.index ["task_id"], name: "index_claim_establishments_on_task_id"
     t.index ["updated_at"], name: "index_claim_establishments_on_updated_at"
   end
 


### PR DESCRIPTION
Improves performance when querying from a `Dispatch::Task` (such as the `EstablishClaim` task) to `claim_establishments`:
* https://github.com/department-of-veterans-affairs/caseflow/blob/5706e4520f69bd940da351f1bccb5a35e14967d9/app/models/establish_claim.rb#L187
* https://github.com/department-of-veterans-affairs/caseflow/blob/5706e4520f69bd940da351f1bccb5a35e14967d9/app/models/establish_claim.rb#L253

### Description
Add index on `task_id` to improve query performance. 
`claim_establishments.task_id` is a foreign key to `dispatch_tasks` records. https://sqlperformance.com/2012/11/t-sql-queries/benefits-indexing-foreign-keys

Note the `WHERE` clause in the SQL query:
```ruby
# pick a random EstablishClaim
ec=EstablishClaim.last(100).first

ec.claim_establishment
[2022-01-06 16:12:05 -0500]   ClaimEstablishment Load (15.3ms)  
SELECT  "claim_establishments".* FROM "claim_establishments" 
WHERE "claim_establishments"."task_id" = $1 
LIMIT $2[["task_id", 284155], ["LIMIT", 1]]
```
Without an index, this query is slower.

### Acceptance Criteria
- [x] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [x] Post this PR in #appeals-schema with a summary
