### PR TITLE
distributed_cases table: add index on distribution_id

### DIFF
--- a/db/migrate/20220106205609_add_distribution_id_index_to_distributed_cases.rb
+++ b/db/migrate/20220106205609_add_distribution_id_index_to_distributed_cases.rb
@@ -1,0 +1,5 @@
+class AddDistributionIdIndexToDistributedCases < Caseflow::Migration
+  def change
+    add_safe_index :distributed_cases, :distribution_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_13_180551) do
+ActiveRecord::Schema.define(version: 2022_01_06_205609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -490,6 +490,7 @@ ActiveRecord::Schema.define(version: 2021_12_13_180551) do
     t.integer "task_id"
     t.datetime "updated_at"
     t.index ["case_id"], name: "index_distributed_cases_on_case_id", unique: true
+    t.index ["distribution_id"], name: "index_distributed_cases_on_distribution_id"
     t.index ["updated_at"], name: "index_distributed_cases_on_updated_at"
   end
 


### PR DESCRIPTION
Improves query performance of `distribution.distributed_cases`, such as
* https://github.com/department-of-veterans-affairs/caseflow/blob/584b81855142fac311425afb2696ece7ad7034a9/app/models/docket.rb#L78
* https://github.com/department-of-veterans-affairs/caseflow/blob/a5f2d0ffea8d412d5f86db2db66364f5ab053b7b/app/workflows/hearing_request_case_distributor.rb#L43

### Description
Add index on `distribution_id` to improve query performance. 
`distributed_cases.distribution_id` is a foreign key to `distributions` records. https://sqlperformance.com/2012/11/t-sql-queries/benefits-indexing-foreign-keys

Note the `WHERE` clause in the SQL query:
```ruby
# pick a random EstablishClaim
d=Distribution.last

d.distributed_cases
[2022-01-06 16:15:46 -0500]   DistributedCase Load (14.4ms)  
SELECT "distributed_cases".* FROM "distributed_cases" 
WHERE "distributed_cases"."distribution_id" = $1  [["distribution_id", 27005]]
```
Without an index, this query is slower.

### Acceptance Criteria
- [x] Code compiles correctly

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [x] Post this PR in #appeals-schema with a summary