### PR TITLE
ETL: remove non-null constraint on appeals.docket_type

### DIFF
--- a/db/etl/migrate/20220107125705_remove_non_null_constraint_on_appeal_docket_type.rb
+++ b/db/etl/migrate/20220107125705_remove_non_null_constraint_on_appeal_docket_type.rb
@@ -1,9 +1,9 @@
 class RemoveNonNullConstraintOnAppealDocketType < Caseflow::Migration
   def up
-    change_column_null :appeals, :docket_type, false
+    change_column_null :appeals, :docket_type, true
   end
 
   def down
-    change_column_null :appeals, :docket_type, true
+    change_column_null :appeals, :docket_type, false
   end
 end

--- a/db/etl/migrate/20220107125705_remove_non_null_constraint_on_appeal_docket_type.rb
+++ b/db/etl/migrate/20220107125705_remove_non_null_constraint_on_appeal_docket_type.rb
@@ -1,0 +1,9 @@
+class RemoveNonNullConstraintOnAppealDocketType < Caseflow::Migration
+  def up
+    change_column_null :appeals, :docket_type, false
+  end
+
+  def down
+    change_column_null :appeals, :docket_type, true
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_18_172716) do
+ActiveRecord::Schema.define(version: 2022_01_07_125705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2021_08_18_172716) do
     t.integer "decision_status_sort_key", null: false, comment: "Integer for sorting status in display order"
     t.string "docket_number", limit: 50, null: false, comment: "Docket number"
     t.date "docket_range_date", comment: "Date that appeal was added to hearing docket range."
-    t.string "docket_type", limit: 50, null: false, comment: "Docket type"
+    t.string "docket_type", limit: 50, comment: "Docket type"
     t.datetime "established_at", null: false, comment: "Timestamp for when the appeal was intaken successfully"
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
     t.string "poa_participant_id", limit: 20, comment: "Used to identify the power of attorney (POA)"

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -84,6 +84,19 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
       end
     end
 
+    context "Appeal is predocket" do
+      # An appeal is "established" when all issues have been added and 
+      # not necessarily docketed (so it's still "pre-docket")
+      let!(:appeal) { create(:appeal).tap{|appeal| appeal.update(docket_type: nil)} }
+
+      it "syncs" do
+        expect(appeal.docket_type).to eq nil
+        expect { subject }.to_not raise_error
+
+        expect(ETL::Appeal.count).to eq(15)
+      end
+    end
+
     context "decision issue is deleted" do
       let(:appeal) { Appeal.last }
       let!(:decision_issue) { create(:decision_issue, decision_review: appeal) }

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -85,9 +85,9 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
     end
 
     context "Appeal is predocket" do
-      # An appeal is "established" when all issues have been added and 
+      # An appeal is "established" when all issues have been added and
       # not necessarily docketed (so it's still "pre-docket")
-      let!(:appeal) { create(:appeal).tap{|appeal| appeal.update(docket_type: nil)} }
+      let!(:appeal) { create(:appeal).tap { |appeal| appeal.update(docket_type: nil) } }
 
       it "syncs" do
         expect(appeal.docket_type).to eq nil


### PR DESCRIPTION
Resolves ETL job failure when given pre-docket appeals -- see [Slack thread](https://dsva.slack.com/archives/CQTDX9BF0/p1641537439018100)

### Description
In ETL DB, remove non-null constraint on `appeals.docket_type`.
Will result in pre-docket appeals being present in the ETL DB, which doesn't impact any _current_ downstream processing.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] ETL job does not fail when given pre-docket appeals

### Testing Plan
See new RSpec
1. Run the new RSpec test (`bundle exec rspec spec/services/etl/appeal_syncer_spec.rb:93`). It fails with `ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  null value in column "docket_type"`
2. `DB=etl bundle exec rake db:migrate` and `make etl-test-prepare`
3. Run the new RSpec test again. It passes.

(Remember to `DB=etl bundle exec rake db:rollback` when you're done reviewing this PR.)

### Database Changes
*Only for Schema Changes*

* [ ] ~Add typical timestamps (`created_at`, `updated_at`) for new tables~
* [ ] ~Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)~
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] ~Perform query profiling (eyeball Rails log, check bullet and fasterer output)~
* [ ] ~Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)~
* [ ] ~Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))~
* [ ] ~Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated~
* [x] Post this PR in #appeals-schema with a summary
* [ ] ~Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)~
