### PR TITLE
Fix Issue Preventing Selection of "All cases" for "Request More Cases Distribution"

### DIFF
--- a/client/app/queue/teamManagement/OrgRow.jsx
+++ b/client/app/queue/teamManagement/OrgRow.jsx
@@ -83,7 +83,7 @@ export const OrgRow = React.memo((props) => {
   const handleRequestedCaseDistribution = ({ value }) => {
     setRequestedCaseDistribution(value);
     const payload = {
-      ama_only_request: ['all', 'amaOnly'].includes(value),
+      ama_only_request: ['amaOnly'].includes(value),
     };
 
     props.onUpdate?.(props.id, payload);

--- a/client/test/app/queue/teamManagement/OrgRow.test.js
+++ b/client/test/app/queue/teamManagement/OrgRow.test.js
@@ -148,16 +148,43 @@ describe('OrgRow', () => {
         });
       });
 
-      it('allows editing of requested case distribution dropdown', async () => {
-        setup(props);
+      describe('request cases dropdown', () => {
+        const labelText = 'requestedDistribution-1';
+        const dropdownOpts = requestCasesOpts.map((opt) => opt.label);
+        const testOpts = [
+          { label: requestCasesOpts[0].label, payload: { ama_only_request: false } },
+          { label: requestCasesOpts[1].label, payload: { ama_only_request: true } },
+        ];
 
-        // Try to open menu
-        await selectEvent.openMenu(screen.getByLabelText('requestedDistribution-1'));
+        it('allows editing of requested case distribution dropdown', async () => {
+          setup(props);
 
-        ['AMA cases only'].forEach((choice) => {
-          expect(screen.queryByText(choice)).toBeInTheDocument();
+          // Try to open menu
+          await selectEvent.openMenu(screen.getByLabelText('requestedDistribution-1'));
+
+          ['AMA cases only'].forEach((choice) => {
+            expect(screen.queryByText(choice)).toBeInTheDocument();
+          });
+        });
+
+        it.each(testOpts)('correctly fires callback for $label', async ({ label, payload }) => {
+          const { container } = setup(props);
+
+          const control = container.getElementsByClassName(`dropdown-${labelText}`)[0];
+
+          // Try to open menu
+          await selectEvent.openMenu(within(control).getByLabelText(labelText));
+
+          // Select "AMA cases only"
+          await selectEvent.select(
+            within(control).getByLabelText(labelText),
+            label
+          );
+
+          expect(onUpdate).toHaveBeenLastCalledWith(judgeTeam.id, payload);
         });
       });
+
     });
   });
 


### PR DESCRIPTION
Fixes issue from [Bat Team request](https://dsva.slack.com/archives/CHX8FMP28/p1641563130036100) (INC20906194)

### Description
This fixes an issue that prevented the proper selection of "All cases" from the "Request More Cases Distribution" dropdown on the Team Management page.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Selecting from "AMA cases only" to "All cases" gets properly stored in DB

### Testing Plan
1. Log in as DVC user (BVATCOLLIER)
2. Go to "Caseflow Team management" page
3. Switch one of the judge teams to "AMA cases only" for the "Request More Cases" dropdown
4. Reload the page, confirm that remains set
5. Switch that same judge team back to "All cases"
6. Reload the page, confirm that remains set
