### PR TITLE
ETL: remove non-null constraint on appeals.receipt_date

### DIFF
--- a/db/etl/migrate/20220110143457_remove_non_null_constraint_on_appeal_receipt_date.rb
+++ b/db/etl/migrate/20220110143457_remove_non_null_constraint_on_appeal_receipt_date.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RemoveNonNullConstraintOnAppealReceiptDate < Caseflow::Migration
+  def up
+    change_column_null :appeals, :receipt_date, true
+  end
+
+  def down
+    change_column_null :appeals, :receipt_date, false
+  end
+end

--- a/db/etl/schema.rb
+++ b/db/etl/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_07_125705) do
+ActiveRecord::Schema.define(version: 2022_01_10_143457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2022_01_07_125705) do
     t.datetime "established_at", null: false, comment: "Timestamp for when the appeal was intaken successfully"
     t.boolean "legacy_opt_in_approved", comment: "Indicates whether a Veteran opted to withdraw matching issues from the legacy process. If there is a matching legacy issue and it is not withdrawn then it is ineligible for the decision review."
     t.string "poa_participant_id", limit: 20, comment: "Used to identify the power of attorney (POA)"
-    t.date "receipt_date", null: false, comment: "Receipt date of the NOD form"
+    t.date "receipt_date", comment: "Receipt date of the NOD form"
     t.string "status", limit: 32, null: false, comment: "Calculated BVA status based on Tasks"
     t.date "target_decision_date", comment: "If the appeal docket is direct review, this sets the target decision date for the appeal, which is one year after the receipt date."
     t.datetime "updated_at", null: false, comment: "Updated timestamp for the ETL record"

--- a/spec/services/etl/appeal_syncer_spec.rb
+++ b/spec/services/etl/appeal_syncer_spec.rb
@@ -87,7 +87,12 @@ describe ETL::AppealSyncer, :etl, :all_dbs do
     context "Appeal is predocket" do
       # An appeal is "established" when all issues have been added and
       # not necessarily docketed (so it's still "pre-docket")
-      let!(:appeal) { create(:appeal).tap { |appeal| appeal.update(docket_type: nil) } }
+      let!(:appeal) do
+        create(:appeal).tap do |appeal|
+          appeal.update(docket_type: nil)
+          appeal.update(receipt_date: nil)
+        end
+      end
 
       it "syncs" do
         expect(appeal.docket_type).to eq nil


### PR DESCRIPTION
Resolves ETL job failure when given pre-docket appeals -- see [Slack thread](https://dsva.slack.com/archives/CQTDX9BF0/p1641818616040600https://dsva.slack.com/archives/CQTDX9BF0/p1641818616040600)

### Description
In ETL DB, remove non-null constraint on `appeals.receipt_date`.
Will result in pre-docket appeals being present in the ETL DB, which doesn't impact any _current_ downstream processing.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] ETL job does not fail when given pre-docket appeals

### Testing Plan
See new RSpec
1. Run the new RSpec test (`bundle exec rspec spec/services/etl/appeal_syncer_spec.rb:93`). It fails with `ActiveRecord::NotNullViolation: PG::NotNullViolation: ERROR:  null value in column "receipt_date"`
2. `DB=etl bundle exec rake db:migrate` and `make etl-test-prepare`
3. Run the new RSpec test again. It passes.

(Remember to `DB=etl bundle exec rake db:rollback` when you're done reviewing this PR.)

### Database Changes
*Only for Schema Changes*

* [ ] ~Add typical timestamps (`created_at`, `updated_at`) for new tables~
* [ ] ~Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)~
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] ~Perform query profiling (eyeball Rails log, check bullet and fasterer output)~
* [ ] ~Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)~
* [ ] ~Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))~
* [ ] ~Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated~
* [x] Post this PR in #appeals-schema with a summary
* [ ] ~Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)~
