### PR TITLE
Replacing Docker Desktop with Podman

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,8 @@ services:
     environment:
       - SERVICES=sqs
     volumes:
-      - ./local/sqs/conf:/conf
+      - sqsconf:/conf
 
 volumes:
   postgresdata:
+  sqsconf:


### PR DESCRIPTION
Addresses [licensing changes with Docker Desktop](https://www.docker.com/blog/updating-product-subscriptions/), which engineers are using for local testing for MacOS.


### Description
This PR is not intended to be merged without further testing. This documents my exploration of one alternative to Docker Desktop, [Podman](https://podman.io). Another alternative is moving to Kubernetes and [using hyperkit+minikube](https://arnon.me/2021/09/replace-docker-with-minikube/), or replacing the use of `docker-compose.yml` with something else and using a containerd-based [lima/colima/nerdctl](https://medium.com/nttlabs/containerd-and-lima-39e0b64d2a59) [tool](https://opensource.com/article/21/9/run-containers-mac-lima) suite. [Other alternatives](https://devopstales.github.io/home/docker-desktop-alternatives/).

I chose Podman because it is well supported (by RedHat) and has [other good features](https://developers.redhat.com/blog/2020/11/19/transitioning-from-docker-to-podman), albeit still in development (as noted in the Setup section below. [Other distinctions](https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/When-to-use-Docker-vs-Podman-A-developers-perspective).

Caveat to the instructions below: I may have missed some steps since I was learning and fumbling along my way to get things working.

## Setup

This PR modifies `docker-compose.yml` to use a volume because [Podman cannot (yet) mount directories on the host to the VM that is running the containers](https://github.com/containers/podman/issues/8016#issuecomment-1015907938), which would allow containers to access those directories.

Ensure that all calls to `docker` is replaced with a call to `podman` using (1) an alias for commands you run in the command-line, (2) adding a `docker` script in your `PATH`, and/or (3) replacing the existing `docker` executable with a link to the `podman` executable.

## Initialize Podman

Reading https://github.com/department-of-veterans-affairs/caseflow/wiki/FACOLS#debugging-facols, I create the VM with sufficient resources for FACOLS and start it:
```sh
podman machine init --disk-size=80 --cpus 4 --memory 4096
podman machine start
```

## Download FACOLS container image from private repo

Examining `bundle exec rake local:build`, then `lib/tasks/local/build.rake` and `local/vacols/build_push.sh:107`, I ran the following after enabling socks proxy:
```sh
aws ecr get-login-password --region us-gov-west-1 | docker login --username AWS --password-stdin
facols_image=`cat .circleci/config.yml | grep -m 1 facols | awk '{print $3}'`
podman pull $facols_image
podman tag $facols_image vacols_db:latest
```
Now, the downloaded container image will be used when the `vacols_db:latest` container is requested.

## Start up containers

Using the `docker-compose.yml` in this PR, I start the 4 containers:
```sh
podman-compose up
```
It outputs the individual podman commands so we could run them individually if we wanted to deprecate `docker-compose.yml`. 

In another shell, I examine the containers:
```sh
podman ps

['podman', '--version', '']
using podman version: 3.4.4
podman ps -a --filter label=io.podman.compose.project=caseflow
CONTAINER ID  IMAGE                                   COMMAND               CREATED         STATUS           PORTS                                                     NAMES
a843e2aecf6e  localhost/vacols_db:latest              /bin/sh -c exec $...  33 minutes ago  Up 33 minutes ago (unhealthy)  0.0.0.0:1521->1521/tcp                                    VACOLS_DB
3689e2e4b247  docker.io/library/redis:2.8.23          redis-server          33 minutes ago  Up 33 minutes ago           0.0.0.0:6379->6379/tcp                                    appeals-redis
adb6a8179306  docker.io/library/postgres:11.7         postgres              33 minutes ago  Up 33 minutes ago           0.0.0.0:5432->5432/tcp                                    appeals-db
29c01accb0b5  docker.io/localstack/localstack:0.11.4                        33 minutes ago  Up 33 minutes ago           0.0.0.0:4567-4583->4567-4583/tcp, 0.0.0.0:8082->8080/tcp  localstack
exit code: 0
```

## Caseflow initialization
Seed the databases:
```sh
make reset
```

Start backend (see `Procfile`):
```sh
REACT_ON_RAILS_ENV=HOT bundle exec rails s -p 3000
```

Start frontend:
```sh
cd client && yarn run dev:hot
```

## Testing

Tested backend via the Rails console:
```sh
bundle exec rails console
# run some commands
```

Tested frontend at http://localhost:3000.

Everything seems to work.