### PR TITLE
Send deploy env to MPI client to toggle processing code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "bootsnap", require: false
 gem "browser"
 gem "business_time", "~> 0.9.3"
 gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fb6fa9658825c143eb8d202b87128f34ca7e210b"
-gem "connect_mpi", git: "https://github.com/department-of-veterans-affairs/connect-mpi.git", ref: "a3a58c64f85b980a8b5ea6347430dd73a99ea74c"
+gem "connect_mpi", git: "https://github.com/department-of-veterans-affairs/connect-mpi.git", ref: "71c8f3419ae66c6a56ec18b7c2e5d6ccc8f4d5f2"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "049b3c5068fa6c6d1cae0b58654529316b84be57"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"
 gem "countries"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,8 +25,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/connect-mpi.git
-  revision: a3a58c64f85b980a8b5ea6347430dd73a99ea74c
-  ref: a3a58c64f85b980a8b5ea6347430dd73a99ea74c
+  revision: 71c8f3419ae66c6a56ec18b7c2e5d6ccc8f4d5f2
+  ref: 71c8f3419ae66c6a56ec18b7c2e5d6ccc8f4d5f2
   specs:
     connect_mpi (0.1)
       httpclient

--- a/app/controllers/mpi_controller.rb
+++ b/app/controllers/mpi_controller.rb
@@ -75,7 +75,7 @@ class MpiController < ApplicationController
 
     def format_address(person)
       address = person&.dig(:addr)
-      "#{value[:street_address_line]}, #{address[:city]} #{value[:state]} #{address[:postal_code]}" if address.present?
+      "#{address[:street_address_line]}, #{address[:city]} #{address[:state]} #{address[:postal_code]}" if address.present?
     end
   end
 

--- a/app/services/external_api/mpi_service.rb
+++ b/app/services/external_api/mpi_service.rb
@@ -64,6 +64,7 @@ class ExternalApi::MPIService
 
   def init_client
     MPI::Services.new(
+      env: ENV["DEPLOY_ENV"],
       ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],
       ssl_cert_file: ENV["BGS_CERT_LOCATION"],
       ssl_ca_cert: ENV["BGS_CA_CERT_LOCATION"],


### PR DESCRIPTION
### Description
This PR matches up with the latest change in the [MPI repo](https://github.com/department-of-veterans-affairs/connect-mpi/pull/1) which incorporates some minor feedback from the Caseflow-MPI prod integration test to toggle between processing codes `T` (test) and `P` (prod).

### Deployment
The Git hash referenced in this repo's Ruby `Gemfile` must match that of a commit in the [MPI repo](https://github.com/department-of-veterans-affairs/connect-mpi). This PR can be merged and deployed at any time; however, I recommend eventually merging the [connect-mpi PR](https://github.com/department-of-veterans-affairs/connect-mpi/pull/1), and updating the Git hash here as appropriate.

### Testing Plan
In a rails console:

```ruby
# use some data for a recent veteran we know should be in MPI
args = Veteran.last.slice(:first_name, :last_name, :ssn)
# search MPI for this veteran
MPIService.new.search_people_info(**args.to_options)
```

This should print the request and response payloads. If successful, the return value is a Ruby hash of search results. In lower environments with minimal data, it can also raise an application-level `MPI::QueryError` which is expected (rather than something like an unexpected `Savon::SOAPFault`).