### PR TITLE
Removed excess space in Google Chrome repo address.

### DIFF
--- a/scripts/ubuntu_setup.sh
+++ b/scripts/ubuntu_setup.sh
@@ -96,7 +96,7 @@ else
     sudo apt-get update
     sudo apt-get install -y xvfb libxi6 libgconf-2-4
     sudo curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add
-    sudo su -c "echo 'deb [arch=amd64]  http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list"
+    sudo su -c "echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list"
     sudo apt-get -y update
     sudo apt-get -y install google-chrome-stable
     wget https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip


### PR DESCRIPTION
Removed an excess space character in the apt source entry for the Google Chrome repo that caused it to not be able to be resolved whenever running `apt-get update`.
