### PR TITLE
Update Payee code script to use the current claimant

### DIFF
--- a/lib/helpers/payee_code_update.rb
+++ b/lib/helpers/payee_code_update.rb
@@ -16,6 +16,19 @@ module WarRoom
             #Sets the variable End Product Establishment by the reference_id/Claim ID
             epe=EndProductEstablishment.find_by(reference_id: reference_id)
 
+            if epe.nil?
+                puts("Unable to find EPE for that reference id. Aborting...")
+                fail Interrupt
+            end
+
+            source = epe.source
+            if source.nil?
+                puts("Could not find a source for the orgional EPE. Aborting...")
+                fail Interrupt
+            end
+
+            claimant = source.claimant
+
             #Re establish new end product with the correct payee code and origine EPE source information.
             epe2=EndProductEstablishment.create(
                 source_type: epe.source_type,
@@ -24,7 +37,7 @@ module WarRoom
                 claim_date: epe.claim_date,
                 code: epe.code,
                 station: epe.station,
-                claimant_participant_id: epe.claimant_participant_id,
+                claimant_participant_id: !claimant.nil? ? claimant.participant_id : epe.claimant_participant_id,
                 payee_code: correct_payee_code,
                 doc_reference_id: epe.doc_reference_id,
                 development_item_reference_id: epe.development_item_reference_id,


### PR DESCRIPTION
### Description
The payee code update script uses the claimant used on the original End Product established. This update is to take into account that the claimant may have changed since the EP was created. The script will now use the claimant currently assigned to the source (HLR, SC, Appeal) incase the wrong claimant was established and has been changed

