### PR TITLE
CASEFLOW-3704 Update hearing_email_recipients table to include appeal_id and appeal_type columns

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -19,6 +19,7 @@ class Appeal < DecisionReview
   has_many :appeal_views, as: :appeal
   has_many :claims_folder_searches, as: :appeal
   has_many :hearings
+  has_many :email_recipients, class_name: "HearingEmailRecipient"
   has_many :available_hearing_locations, as: :appeal, class_name: "AvailableHearingLocations"
 
   # decision_documents is effectively a has_one until post decisional motions are supported

--- a/app/models/hearings/hearing_email_recipient.rb
+++ b/app/models/hearings/hearing_email_recipient.rb
@@ -23,6 +23,7 @@ class HearingEmailRecipient < CaseflowRecord
 
   include BelongsToPolymorphicHearingConcern
   belongs_to_polymorphic_hearing(:hearing)
+  belongs_to :appeal, polymorphic: true
 
   def reminder_sent_at
     email_events

--- a/app/models/hearings/hearing_email_recipient.rb
+++ b/app/models/hearings/hearing_email_recipient.rb
@@ -23,7 +23,9 @@ class HearingEmailRecipient < CaseflowRecord
 
   include BelongsToPolymorphicHearingConcern
   belongs_to_polymorphic_hearing(:hearing)
-  belongs_to :appeal, polymorphic: true
+  include HasAppealUpdatedSince
+  include BelongsToPolymorphicAppealConcern
+  belongs_to_polymorphic_appeal(:appeal)
 
   def reminder_sent_at
     email_events

--- a/db/migrate/20220330152622_add_appeal_association_to_hearing_email_recipients.rb
+++ b/db/migrate/20220330152622_add_appeal_association_to_hearing_email_recipients.rb
@@ -1,0 +1,8 @@
+class AddAppealAssociationToHearingEmailRecipients < Caseflow::Migration
+  def change
+    add_column :hearing_email_recipients, :appeal_id, :bigint, comment: "The ID of the appeal this email recipient is associated with"
+    add_column :hearing_email_recipients, :appeal_type, :string, comment: "The type of appeal this email recipient is associated with"
+
+    add_safe_index :hearing_email_recipients, [:appeal_type, :appeal_id]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_28_180019) do
+ActiveRecord::Schema.define(version: 2022_03_30_152622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -754,8 +754,8 @@ ActiveRecord::Schema.define(version: 2022_03_28_180019) do
   end
 
   create_table "hearing_email_recipients", comment: "Recipients of hearings-related emails", force: :cascade do |t|
-    t.integer "appeal_id", null: false, comment: "ID of the associated Appeal"
-    t.string "appeal_type", null: false
+    t.bigint "appeal_id", comment: "The ID of the appeal this email recipient is associated with"
+    t.string "appeal_type", comment: "The type of appeal this email recipient is associated with"
     t.datetime "created_at", null: false
     t.string "email_address", comment: "PII. The recipient's email address"
     t.boolean "email_sent", default: false, null: false, comment: "Indicates if a notification email was sent to the recipient."
@@ -764,6 +764,7 @@ ActiveRecord::Schema.define(version: 2022_03_28_180019) do
     t.string "timezone", limit: 50, comment: "The recipient's timezone"
     t.string "type", comment: "The subclass name (i.e. AppellantHearingEmailRecipient)"
     t.datetime "updated_at", null: false
+    t.index ["appeal_type", "appeal_id"], name: "index_hearing_email_recipients_on_appeal_type_and_appeal_id"
     t.index ["hearing_type", "hearing_id"], name: "index_hearing_email_recipients_on_hearing_type_and_hearing_id"
   end
 
@@ -1733,7 +1734,6 @@ ActiveRecord::Schema.define(version: 2022_03_28_180019) do
   add_foreign_key "hearing_days", "users", column: "created_by_id"
   add_foreign_key "hearing_days", "users", column: "judge_id"
   add_foreign_key "hearing_days", "users", column: "updated_by_id"
-  add_foreign_key "hearing_email_recipients", "appeals"
   add_foreign_key "hearing_issue_notes", "hearings"
   add_foreign_key "hearing_issue_notes", "request_issues"
   add_foreign_key "hearing_task_associations", "tasks", column: "hearing_task_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_07_213343) do
+ActiveRecord::Schema.define(version: 2022_03_28_180019) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -754,6 +754,8 @@ ActiveRecord::Schema.define(version: 2022_03_07_213343) do
   end
 
   create_table "hearing_email_recipients", comment: "Recipients of hearings-related emails", force: :cascade do |t|
+    t.integer "appeal_id", null: false, comment: "ID of the associated Appeal"
+    t.string "appeal_type", null: false
     t.datetime "created_at", null: false
     t.string "email_address", comment: "PII. The recipient's email address"
     t.boolean "email_sent", default: false, null: false, comment: "Indicates if a notification email was sent to the recipient."
@@ -1731,6 +1733,7 @@ ActiveRecord::Schema.define(version: 2022_03_07_213343) do
   add_foreign_key "hearing_days", "users", column: "created_by_id"
   add_foreign_key "hearing_days", "users", column: "judge_id"
   add_foreign_key "hearing_days", "users", column: "updated_by_id"
+  add_foreign_key "hearing_email_recipients", "appeals"
   add_foreign_key "hearing_issue_notes", "hearings"
   add_foreign_key "hearing_issue_notes", "request_issues"
   add_foreign_key "hearing_task_associations", "tasks", column: "hearing_task_id"


### PR DESCRIPTION
### Resolves #[CASEFLOW-3704](https://vajira.max.gov/browse/CASEFLOW-3704)

### Description
As a Developer, I need the Hearing Email Recipients Table to be updated with additional columns so that the Veteran/Appellant Email information can be stored and available for notification when the Hearing is Scheduled.

### Acceptance Criteria

- [ ] hearing_email_recipients table updated to include appeal_id column
- [ ] data type for the appeal_id column defined int
- [ ] hearing_email_recipients table updated to include the appeal_type column
- [ ] data type for the appeal_type column defined VARCHAR
