### PR TITLE
Aiman/CASEFLOW-3132-Create-RPO-Org

### DIFF
--- a/app/models/organizations/edu_regional_processing_office.rb
+++ b/app/models/organizations/edu_regional_processing_office.rb
@@ -5,44 +5,5 @@ class EduRegionalProcessingOffice < Organization
       false
     end
   
-    def queue_tabs
-      [
-        assigned_tasks_tab,
-        in_progress_tasks_tab,
-        ready_for_review_tasks_tab,
-        on_hold_tasks_tab,
-        completed_tasks_tab
-      ]
-    end
-  
-    def assigned_tasks_tab
-      ::VhaProgramOfficeAssignedTasksTab.new(assignee: self)
-    end
-  
-    def in_progress_tasks_tab
-      ::VhaProgramOfficeInProgressTasksTab.new(assignee: self)
-    end
-  
-    def ready_for_review_tasks_tab
-      ::VhaProgramOfficeReadyForReviewTasksTab.new(assignee: self)
-    end
-  
-    def on_hold_tasks_tab
-      ::VhaProgramOfficeOnHoldTasksTab.new(assignee: self)
-    end
-  
-    def completed_tasks_tab
-      ::VhaProgramOfficeCompletedTasksTab.new(assignee: self)
-    end
-  
-    COLUMN_NAMES = [
-      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
-      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
-      Constants.QUEUE_CONFIG.COLUMNS.TASK_OWNER.name,
-      # Constants.QUEUE_CONFIG.COLUMNS.VAMC_OWNER.name,
-      Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
-      Constants.QUEUE_CONFIG.COLUMNS.LAST_ACTION.name,
-      Constants.QUEUE_CONFIG.COLUMNS.BOARD_INTAKE.name
-    ].compact
-  end
+end
   

--- a/app/models/organizations/edu_regional_processing_office.rb
+++ b/app/models/organizations/edu_regional_processing_office.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class EduRegionalProcessingOffice < Organization
+    def can_receive_task?(_task)
+      false
+    end
+  
+    def queue_tabs
+      [
+        assigned_tasks_tab,
+        in_progress_tasks_tab,
+        ready_for_review_tasks_tab,
+        on_hold_tasks_tab,
+        completed_tasks_tab
+      ]
+    end
+  
+    def assigned_tasks_tab
+      ::VhaProgramOfficeAssignedTasksTab.new(assignee: self)
+    end
+  
+    def in_progress_tasks_tab
+      ::VhaProgramOfficeInProgressTasksTab.new(assignee: self)
+    end
+  
+    def ready_for_review_tasks_tab
+      ::VhaProgramOfficeReadyForReviewTasksTab.new(assignee: self)
+    end
+  
+    def on_hold_tasks_tab
+      ::VhaProgramOfficeOnHoldTasksTab.new(assignee: self)
+    end
+  
+    def completed_tasks_tab
+      ::VhaProgramOfficeCompletedTasksTab.new(assignee: self)
+    end
+  
+    COLUMN_NAMES = [
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_OWNER.name,
+      # Constants.QUEUE_CONFIG.COLUMNS.VAMC_OWNER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
+      Constants.QUEUE_CONFIG.COLUMNS.LAST_ACTION.name,
+      Constants.QUEUE_CONFIG.COLUMNS.BOARD_INTAKE.name
+    ].compact
+  end
+  

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,6 +48,7 @@ class SeedDB
     call_and_log_seed_step Seeds::SanitizedJsonSeeds
     call_and_log_seed_step Seeds::VeteransHealthAdministration
     call_and_log_seed_step Seeds::MTV
+    call_and_log_seed_step Seeds::Education # new line added to Seeds file necessary?
   end
 end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -48,7 +48,7 @@ class SeedDB
     call_and_log_seed_step Seeds::SanitizedJsonSeeds
     call_and_log_seed_step Seeds::VeteransHealthAdministration
     call_and_log_seed_step Seeds::MTV
-    call_and_log_seed_step Seeds::Education # new line added to Seeds file necessary?
+    call_and_log_seed_step Seeds::Education
   end
 end
 

--- a/db/seeds/education.rb
+++ b/db/seeds/education.rb
@@ -24,8 +24,8 @@ module Seeds
       def setup_regional_processing_offices!
         REGIONAL_PROCESSING_OFFICES.each { |name| EduRegionalProcessingOffice.create!(name: name, url: name) }
   
-        regular_user = create(:user, full_name: "Stevie EduRPOUser Amana", css_id: "VHAPOUSER") # Need CSSID from Stakeholders, unsure about user naming conventions? See line
-        admin_user = create(:user, full_name: "Channing EduRPOAdmin Katz", css_id: "VHAPOADMIN") # Need CSSID from Stakeholders, unure about admin naming conventions? See line
+        regular_user = create(:user, full_name: "Peter EDURPOUSER Campbell", css_id: "EDURPOUSER") 
+        admin_user = create(:user, full_name: "Samuel EDURPOADMIN Clemens", css_id: "EDURPOADMIN") 
   
         EduRegionalProcessingOffice.all.each do |org|
           org.add_user(regular_user)

--- a/db/seeds/education.rb
+++ b/db/seeds/education.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# Education related seeds
+
+module Seeds
+    class Education < Base
+      REGIONAL_PROCESSING_OFFICES = [
+        "Buffalo RPO - Buffalo Regional Processing Office",
+        "Central Office RPO - Central Office Regional Processing Office",
+        "Muskogee RPO - Muskogee Regional Processing Office",
+      ].freeze
+  
+      def seed!
+        #setup_emo_org
+        setup_regional_processing_offices!
+      end
+  
+      private
+
+      #def setup_emo_org
+      #end
+
+  
+      def setup_regional_processing_offices!
+        REGIONAL_PROCESSING_OFFICES.each { |name| EduRegionalProcessingOffice.create!(name: name, url: name) }
+  
+        regular_user = create(:user, full_name: "Stevie EduRPOUser Amana", css_id: "VHAPOUSER") # Need CSSID from Stakeholders, unsure about user naming conventions? See line
+        admin_user = create(:user, full_name: "Channing EduRPOAdmin Katz", css_id: "VHAPOADMIN") # Need CSSID from Stakeholders, unure about admin naming conventions? See line
+  
+        EduRegionalProcessingOffice.all.each do |org|
+          org.add_user(regular_user)
+          OrganizationsUser.make_user_admin(admin_user, org)
+        end
+      end
+  
+      
+    end
+  end

--- a/spec/models/organizations/edu_regional_processing_office_spec.rb
+++ b/spec/models/organizations/edu_regional_processing_office_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe EduRegionalProcessingOffice, :postgres do
+    let(:regional_processing_office) { VhaRegionalOffice.create!(name: "Regional Office", url: "regional-office") }
+  
+  
+    describe ".can_receive_task?" do
+      let(:appeal) { create(:appeal) }
+      let(:doc_task) { create(:vha_document_search_task, appeal: appeal) }
+  
+      it "returns false because program offices should not have vha document search tasks assigned to them" do
+        expect(regional_processing_office.can_receive_task?(doc_task)).to eq(false)
+      end
+    end
+  end

--- a/spec/models/organizations/edu_regional_processing_office_spec.rb
+++ b/spec/models/organizations/edu_regional_processing_office_spec.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 describe EduRegionalProcessingOffice, :postgres do
-    let(:regional_processing_office) { VhaRegionalOffice.create!(name: "Regional Office", url: "regional-office") }
+    let(:regional_processing_office) { EduRegionalProcessingOffice.create!(name: "Regional Processing Office", url: "Regional Processing Office") }
+
+    describe ".create!" do
+        it "creates a Regional Processing Office" do
+          expect(regional_processing_office.name).to eq("Regional Processing Office")
+        end
+      end
   
   
     describe ".can_receive_task?" do
       let(:appeal) { create(:appeal) }
-      let(:doc_task) { create(:vha_document_search_task, appeal: appeal) }
+      let(:doc_task) { create(:education_document_search_task, appeal: appeal) }
   
       it "returns false because program offices should not have vha document search tasks assigned to them" do
         expect(regional_processing_office.can_receive_task?(doc_task)).to eq(false)

--- a/spec/models/organizations/edu_regional_processing_office_spec.rb
+++ b/spec/models/organizations/edu_regional_processing_office_spec.rb
@@ -14,7 +14,7 @@ describe EduRegionalProcessingOffice, :postgres do
       let(:appeal) { create(:appeal) }
       let(:doc_task) { create(:education_document_search_task, appeal: appeal) }
   
-      it "returns false because program offices should not have vha document search tasks assigned to them" do
+      it "returns false because program offices should not have edu document search tasks assigned to them" do
         expect(regional_processing_office.can_receive_task?(doc_task)).to eq(false)
       end
     end

--- a/spec/seeds/education_spec.rb
+++ b/spec/seeds/education_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe Seeds::Education do
+    describe "#seed!" do
+      subject { described_class.new.seed! }
+  
+      it "creates all regional processing offices" do
+        expect { subject }.to_not raise_error
+        expect(EduRegionalProcessingOffice.count).to eq(3)
+      end
+    end
+
+end


### PR DESCRIPTION
Resolves [#{CASEFLOW-3132}](https://vajira.max.gov/secure/RapidBoard.jspa?rapidView=5548&projectKey=CASEFLOW&view=planning&selectedIssue=CASEFLOW-3132&issueLimit=100)

### Description
As a developer, in order to satisfy the requirements for Education Pre-Docket, I need to create a new organization under the Executive Management Office (EMO) organization for the purpose of routing Education appeals thru the new Education Pre-Docket. This new organization will be the Regional Processing Office organization and will contain three offices (please see AC). The new organization will be able to send cases to be docketed or return them to the EMO.

### Acceptance Criteria
1.) A new organization is created within Caseflow. The RPO organization.
2.) Creation of RPO instances including:
- Buffalo RPO
- Central Office RPO
- Muskogee RPO


### Testing Plan
Result of running education_spec.rb
![CASEFLOW-3132-Testing-Screens](https://user-images.githubusercontent.com/22192993/161798372-b2fb0185-de83-43ef-aca2-29d1b0d04d8f.png)


- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
