### PR TITLE
CASEFLOW-4575 Remove San Antonio 

### DIFF
--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -67,10 +67,6 @@ class VaDotGovAddressValidator
     @closest_regional_office ||= begin
       return unless closest_ro_response.success?
 
-      # Note: In `ro_facility_ids_to_geomatch`, the San Antonio facility ID is passed
-      # as a valid RO for any veteran living in Texas.
-      return "RO62" if closest_regional_office_facility_id_is_san_antonio?
-
       RegionalOffice
         .cities
         .detect do |ro|
@@ -124,17 +120,7 @@ class VaDotGovAddressValidator
       return RegionalOffice.ro_facility_ids - ["vba_372"]
     end
 
-    facility_ids = RegionalOffice.ro_facility_ids_for_state(state_code)
-
-    # veterans whose closest AHL is San Antonio should have Houston as the RO
-    # even though Waco may be closer. This is a RO/AHL policy quirk.
-    # see https://github.com/department-of-veterans-affairs/caseflow/issues/9858
-    #
-    # Note: In the logic to determine the closest RO, there is logic that maps this
-    # facility ID to the Houston RO.
-    facility_ids << "vha_671BY" if veteran_lives_in_texas? # include San Antonio facility id
-
-    facility_ids
+    RegionalOffice.ro_facility_ids_for_state(state_code)
   end
 
   private

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -1151,15 +1151,6 @@
       "zip" : "83814-2531",
       "timezone" : "America/Boise"
    },
-   "vha_671BY" : {
-      "address_1" : "5788 Eckert Road",
-      "address_2" : null,
-      "address_3" : null,
-      "city" : "San Antonio",
-      "state" : "TX",
-      "zip" : "78240-3900",
-      "timezone" : "America/Chicago"
-   },
    "vha_676" : {
       "address_1" : "500 East Veterans Street",
       "address_2" : null,

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -1,3 +1,5 @@
+
+   
 {
    "vba_301" : {
       "address_1" : "15 New Sudbury Street",

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -1153,13 +1153,13 @@
       "zip" : "83814-2531",
       "timezone" : "America/Boise"
    },
-   "vha_671BY" : {
-      "address_1" : "5788 Eckert Road",
+   "vha_671GS" : {
+      "address_1" : "9939 State Hwy 151",
       "address_2" : null,
       "address_3" : null,
       "city" : "San Antonio",
       "state" : "TX",
-      "zip" : "78240-3900",
+      "zip" : "78251-1900",
       "timezone" : "America/Chicago"
    },
    "vha_676" : {

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -1151,6 +1151,15 @@
       "zip" : "83814-2531",
       "timezone" : "America/Boise"
    },
+   "vha_671BY" : {
+      "address_1" : "5788 Eckert Road",
+      "address_2" : null,
+      "address_3" : null,
+      "city" : "San Antonio",
+      "state" : "TX",
+      "zip" : "78240-3900",
+      "timezone" : "America/Chicago"
+   },
    "vha_676" : {
       "address_1" : "500 East Veterans Street",
       "address_2" : null,

--- a/client/constants/REGIONAL_OFFICE_INFORMATION.json
+++ b/client/constants/REGIONAL_OFFICE_INFORMATION.json
@@ -590,7 +590,7 @@
     "timezone": "America/Chicago",
     "hold_hearings": true,
     "facility_locator_id": "vba_362",
-    "alternate_locations": ["vha_740GB"]
+    "alternate_locations": ["vha_671GS", "vha_740GB"]
   },
   "RO63": {
     "label": "Anchorage regional office",

--- a/client/constants/REGIONAL_OFFICE_INFORMATION.json
+++ b/client/constants/REGIONAL_OFFICE_INFORMATION.json
@@ -590,7 +590,7 @@
     "timezone": "America/Chicago",
     "hold_hearings": true,
     "facility_locator_id": "vba_362",
-    "alternate_locations": ["vha_671BY", "vha_740GB"]
+    "alternate_locations": ["vha_740GB"]
   },
   "RO63": {
     "label": "Anchorage regional office",

--- a/client/constants/SATELLITE_OFFICE_INFORMATION.json
+++ b/client/constants/SATELLITE_OFFICE_INFORMATION.json
@@ -1,11 +1,4 @@
 {
-  "SO62": {
-    "label": "San Antonio satellite office",
-    "city": "San Antonio",
-    "state": "TX",
-    "timezone": "America/Chicago",
-    "regional_office": "RO62"
-  },
   "SO06": {
     "label": "Albany satellite office",
     "city": "Albany",

--- a/client/constants/SATELLITE_OFFICE_INFORMATION.json
+++ b/client/constants/SATELLITE_OFFICE_INFORMATION.json
@@ -1,11 +1,4 @@
-{  
-  "SO62": {
-  "label": "San Antonio satellite office",
-  "city": "San Antonio",
-  "state": "TX",
-  "timezone": "America/Chicago",
-  "regional_office": "RO62"
-  },
+{
   "SO06": {
     "label": "Albany satellite office",
     "city": "Albany",

--- a/client/constants/SATELLITE_OFFICE_INFORMATION.json
+++ b/client/constants/SATELLITE_OFFICE_INFORMATION.json
@@ -1,4 +1,11 @@
 {
+  "SO62": {
+    "label": "San Antonio satellite office",
+    "city": "San Antonio",
+    "state": "TX",
+    "timezone": "America/Chicago",
+    "regional_office": "RO62"
+    },
   "SO06": {
     "label": "Albany satellite office",
     "city": "Albany",

--- a/client/constants/SATELLITE_OFFICE_INFORMATION.json
+++ b/client/constants/SATELLITE_OFFICE_INFORMATION.json
@@ -1,4 +1,11 @@
-{
+{  
+  "SO62": {
+  "label": "San Antonio satellite office",
+  "city": "San Antonio",
+  "state": "TX",
+  "timezone": "America/Chicago",
+  "regional_office": "RO62"
+  },
   "SO06": {
     "label": "Albany satellite office",
     "city": "Albany",

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -1608,7 +1608,7 @@ describe LegacyAppeal, :all_dbs do
     end
 
     context "when regional office key is not mapped to a station" do
-      let(:regional_office_key) { "SO62" }
+      let(:regional_office_key) { "SO54" }
       it { is_expected.to be_nil }
     end
   end

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -31,14 +31,6 @@ describe VaDotGovAddressValidator do
       end
     end
 
-    context "when the closest RO is San Antonio" do
-      let(:ro_facility_id) { "vha_671BY" } # San Antonio
-
-      it "returns RO62 (Houston)" do
-        expect(subject).to eq("RO62")
-      end
-    end
-
     context "when va dot gov service returns a Caseflow::Error::VaDotGovMissingFacilityError" do
       let(:ro_facility_id) { "vba_301" } # Boston RO
       let(:missing_facility_id) { "vba_9999" }
@@ -309,10 +301,6 @@ describe VaDotGovAddressValidator do
     context "when veteran with legacy appeal lives in TX" do
       let!(:appeal) { create(:legacy_appeal, vacols_case: create(:case)) }
       let!(:valid_address_state_code) { "TX" }
-
-      it "adds San Antonio Satellite Office" do
-        expect(subject).to match_array %w[vba_349 vba_362 vha_671BY]
-      end
     end
 
     context "when veteran with legacy appeal requests travel board" do


### PR DESCRIPTION
### Description
- Reverted code changes regarding San Antonio from github issue 9858
-  Reverted unit tests testing for issue 9858 change
- Removed San Antonio as an alternative location for the Houston RO
- Removed San Antonio from facilities list


