### PR TITLE
Create Education EMO seeds

### DIFF
--- a/db/seeds/education.rb
+++ b/db/seeds/education.rb
@@ -3,36 +3,38 @@
 # Education related seeds
 
 module Seeds
-    class Education < Base
-      REGIONAL_PROCESSING_OFFICES = [
-        "Buffalo RPO - Buffalo Regional Processing Office",
-        "Central Office RPO - Central Office Regional Processing Office",
-        "Muskogee RPO - Muskogee Regional Processing Office",
-      ].freeze
-  
-      def seed!
-        #setup_emo_org
-        setup_regional_processing_offices!
-      end
-  
-      private
+  class Education < Base
+    REGIONAL_PROCESSING_OFFICES = [
+      "Buffalo RPO - Buffalo Regional Processing Office",
+      "Central Office RPO - Central Office Regional Processing Office",
+      "Muskogee RPO - Muskogee Regional Processing Office"
+    ].freeze
 
-      #def setup_emo_org
-      #end
+    def seed!
+      setup_emo_org
+      setup_regional_processing_offices!
+    end
 
-  
-      def setup_regional_processing_offices!
-        REGIONAL_PROCESSING_OFFICES.each { |name| EduRegionalProcessingOffice.create!(name: name, url: name) }
-  
-        regular_user = create(:user, full_name: "Peter EDURPOUSER Campbell", css_id: "EDURPOUSER") 
-        admin_user = create(:user, full_name: "Samuel EDURPOADMIN Clemens", css_id: "EDURPOADMIN") 
-  
-        EduRegionalProcessingOffice.all.each do |org|
-          org.add_user(regular_user)
-          OrganizationsUser.make_user_admin(admin_user, org)
-        end
+    private
+
+    def setup_emo_org
+      regular_user = create(:user, full_name: "Paul EMOUser Camo", css_id: "EMOUSER")
+      admin_user = create(:user, full_name: "Julie EMOAdmin Camo", css_id: "EMOADMIN")
+      emo = EducationEmo.singleton
+      emo.add_user(regular_user)
+      OrganizationsUser.make_user_admin(admin_user, emo)
+    end
+
+    def setup_regional_processing_offices!
+      REGIONAL_PROCESSING_OFFICES.each { |name| EduRegionalProcessingOffice.create!(name: name, url: name) }
+
+      regular_user = create(:user, full_name: "Peter EDURPOUSER Campbell", css_id: "EDURPOUSER")
+      admin_user = create(:user, full_name: "Samuel EDURPOADMIN Clemens", css_id: "EDURPOADMIN")
+
+      EduRegionalProcessingOffice.all.each do |org|
+        org.add_user(regular_user)
+        OrganizationsUser.make_user_admin(admin_user, org)
       end
-  
-      
     end
   end
+end

--- a/spec/seeds/education_spec.rb
+++ b/spec/seeds/education_spec.rb
@@ -1,13 +1,17 @@
 # frozen_string_literal: true
 
 describe Seeds::Education do
-    describe "#seed!" do
-      subject { described_class.new.seed! }
-  
-      it "creates all regional processing offices" do
-        expect { subject }.to_not raise_error
-        expect(EduRegionalProcessingOffice.count).to eq(3)
-      end
+  describe "#seed!" do
+    subject { described_class.new.seed! }
+
+    it "creates the Executive Management Office" do
+      expect { subject }.to_not raise_error
+      expect(EducationEmo.count).to eq(1)
     end
 
+    it "creates all Regional Processing Offices" do
+      expect { subject }.to_not raise_error
+      expect(EduRegionalProcessingOffice.count).to eq(3)
+    end
+  end
 end

--- a/spec/seeds/veterans_health_administration_spec.rb
+++ b/spec/seeds/veterans_health_administration_spec.rb
@@ -4,7 +4,12 @@ describe Seeds::VeteransHealthAdministration do
   describe "#seed!" do
     subject { described_class.new.seed! }
 
-    it "creates all kinds of decision reviews" do
+    it "creates the CAMO Office" do
+      expect { subject }.to_not raise_error
+      expect(VhaCamo.count).to eq(1)
+    end
+
+    it "creates all Program Offices" do
       expect { subject }.to_not raise_error
       expect(VhaProgramOffice.count).to eq(6)
     end


### PR DESCRIPTION
Resolves [CASEFLOW-4591](https://vajira.max.gov/browse/CASEFLOW-4591)

### Description
Adds the Education EMO organization to the education seeds

### Acceptance Criteria
- [ ] EducationEMO office is successfully created

### Testing Plan
1. Seed your local db using `make seed-dbs`
2. Make sure that `EducationEmo.count => 1`:
<img width="236" alt="Screen Shot 2022-04-07 at 4 08 32 PM" src="https://user-images.githubusercontent.com/18618189/162287606-fb0e8034-d8aa-4be7-95e8-da40fa6754cb.png">
3. In your local env, sign in as the `TEAM_ADMIN` user and select the "Caseflow team management" option located in the dropdown on the top righthand corner of the screen:
<img width="265" alt="Screen Shot 2022-04-07 at 4 18 06 PM" src="https://user-images.githubusercontent.com/18618189/162288972-10c1a82c-b1f4-466b-ac24-7b6e4bfe524d.png">
4. Scroll down and under the "Other teams" section make sure that you see the "Executive Management Office" team now listed
<img width="954" alt="Screen Shot 2022-04-07 at 4 19 12 PM" src="https://user-images.githubusercontent.com/18618189/162289255-0a469513-4adb-4d85-80e0-008becbd803d.png">