### PR TITLE
CASEFLOW-3723 - Added appeal_email_recipients update to if else block

### DIFF
--- a/app/models/concerns/has_hearing_email_recipients_concern.rb
+++ b/app/models/concerns/has_hearing_email_recipients_concern.rb
@@ -72,8 +72,17 @@ module HasHearingEmailRecipientsConcern
     # Reload the hearing first
     reload
     recipient = email_recipients.find_by(type: type.name)
-
-    if recipient.blank?
+    
+    appeal_email_recipient = appeal.email_recipients.find_by(type: type.name)
+    
+    if appeal_email_recipient
+      appeal_email_recipient.update!(
+        hearing: self,
+        email_address: email_address,
+        timezone: timezone,
+        email_sent: email_sent
+      )
+    elsif recipient.blank?
       type.create!(
         hearing: self,
         email_address: email_address,

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -37,6 +37,7 @@ class LegacyAppeal < CaseflowRecord
       .order(closed_at: :desc, assigned_at: :desc)
       .where(type: [InformalHearingPresentationTask.name, IhpColocatedTask.name], appeal_type: LegacyAppeal.name)
   }, class_name: "Task", foreign_key: :appeal_id
+  has_many :email_recipients, class_name: "HearingEmailRecipient", foreign_key: :appeal_id
   accepts_nested_attributes_for :worksheet_issues, allow_destroy: true
 
   class UnknownLocationError < StandardError; end


### PR DESCRIPTION
Resolves [CASEFLOW-3723](https://vajira.max.gov/browse/CASEFLOW-3723) 

### Description
As a Developer, I need to modify the Hearing's Form backend logic so that the records applicable to the Appellant/Veteran and the POA are uniquely stored in the hearing_email_recipient_table when a hearing is scheduled.

### Acceptance Criteria
- [ ] When Scheduling a Hearing, the applicable columns in the Veteran and POA rows is updated with following info in the the hearing_email_recipient_table:
      - [ ] hearing_id
      - [ ] hearing_type
      - [ ] Veteran/Appellant email
      - [ ] Veteran/Appellant timezone
      - [ ] POA/Representative email
      - [ ] POA/Representative timezone
- [ ] a unique record exists (duplicate date not inserted into hearing_email_recipient_table)
       - [ ] 1 row for Veteran & 1 row for POA