### PR TITLE
Caseflow-4908 Connect the New Virtual Opt In Form to the Backend Logic

### DIFF
--- a/app/models/concerns/has_hearing_email_recipients_concern.rb
+++ b/app/models/concerns/has_hearing_email_recipients_concern.rb
@@ -72,9 +72,9 @@ module HasHearingEmailRecipientsConcern
     # Reload the hearing first
     reload
     recipient = email_recipients.find_by(type: type.name)
-    
+
     appeal_email_recipient = appeal.email_recipients.find_by(type: type.name)
-    
+
     if appeal_email_recipient
       appeal_email_recipient.update!(
         hearing: self,

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -43,41 +43,44 @@ export const HearingTypeConversion = ({
 
     return { title, detail };
   };
-  //Set Payload based on whether user is VSO or not
+
+  // Set Payload based on whether user is VSO or not
   const submit = async () => {
+    let data = {};
+
     try {
       const changedRequestType = formatChangeRequestType(type);
-      if (userIsVsoEmployee) {        
-        const data = {
-        task: {
-          status: TASK_STATUSES.completed,
-          business_payloads: {
-            values: {
-              changed_hearing_request_type: changedRequestType,
-              closest_regional_office: appeal?.closestRegionalOffice || appeal?.regionalOffice?.key,
-              email_recipients: {
-                appellant_tz: appeal?.appellantTz,
-                representative_tz: appeal?.powerOfAttorney?.representative_tz,
-                appellant_email: appeal?.veteranInfo?.veteran?.email_address,
-                representative_email: appeal?.powerOfAttorney?.representative_email_address,
-              }
-            }
-          }
-        }
-        }
-      }
-      else {
-        const data = {
+
+      if (userIsVsoEmployee) {
+        data = {
           task: {
             status: TASK_STATUSES.completed,
             business_payloads: {
               values: {
                 changed_hearing_request_type: changedRequestType,
-                closest_regional_office: appeal?.closestRegionalOffice || appeal?.regionalOffice?.key,              
+                closest_regional_office: appeal?.closestRegionalOffice || appeal?.regionalOffice?.key,
+                email_recipients: {
+                  appellant_tz: appeal?.appellantTz,
+                  representative_tz: appeal?.powerOfAttorney?.representative_tz,
+                  appellant_email: appeal?.veteranInfo?.veteran?.email_address,
+                  representative_email: appeal?.powerOfAttorney?.representative_email_address,
+                }
               }
             }
           }
-        }
+        };
+      } else {
+        data = {
+          task: {
+            status: TASK_STATUSES.completed,
+            business_payloads: {
+              values: {
+                changed_hearing_request_type: changedRequestType,
+                closest_regional_office: appeal?.closestRegionalOffice || appeal?.regionalOffice?.key,
+              }
+            }
+          }
+        };
       }
       setLoading(true);
 
@@ -102,9 +105,11 @@ export const HearingTypeConversion = ({
       history.push(`/queue/appeals/${appeal.externalId}`);
     }
   };
-  //Render Convert to Virtual Form Depending on VSO User Status
+
+  // Render Convert to Virtual Form Depending on VSO User Status
+
   return (
-     userIsVsoEmployee ? (
+    userIsVsoEmployee ? (
       <VSOHearingTypeConversionForm
         appeal={appeal}
         history={history}
@@ -115,19 +120,18 @@ export const HearingTypeConversion = ({
         type={type}
       />
     ) : (
-        <HearingTypeConversionForm
-          appeal={appeal}
-          history={history}
-          isLoading={loading}
-          onCancel={() => history.goBack()}
-          onSubmit={submit}
-          task={task}
-          type={type}
-        />
+      <HearingTypeConversionForm
+        appeal={appeal}
+        history={history}
+        isLoading={loading}
+        onCancel={() => history.goBack()}
+        onSubmit={submit}
+        task={task}
+        type={type}
+      />
     )
-  )
-}
-  
+  );
+};
 
 HearingTypeConversion.propTypes = {
   appeal: PropTypes.object,

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -46,8 +46,8 @@ export const HearingTypeConversion = ({
   //Set Payload based on whether user is VSO or not
   const submit = async () => {
     try {
-      if (userIsVsoEmployee) {
-        const changedRequestType = formatChangeRequestType(type);
+      const changedRequestType = formatChangeRequestType(type);
+      if (userIsVsoEmployee) {        
         const data = {
         task: {
           status: TASK_STATUSES.completed,
@@ -67,7 +67,6 @@ export const HearingTypeConversion = ({
         }
       }
       else {
-        const changedRequestType = formatChangeRequestType(type);
         const data = {
           task: {
             status: TASK_STATUSES.completed,

--- a/client/app/hearings/components/HearingTypeConversion.jsx
+++ b/client/app/hearings/components/HearingTypeConversion.jsx
@@ -17,7 +17,7 @@ import {
 import ApiUtil from '../../util/ApiUtil';
 import COPY from '../../../COPY';
 import TASK_STATUSES from '../../../constants/TASK_STATUSES';
-import { filterCurrentIssues, formatChangeRequestType } from '../utils';
+import { formatChangeRequestType } from '../utils';
 
 export const HearingTypeConversion = ({
   appeal,

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -249,7 +249,7 @@ describe InitialTasksFactory, :postgres do
                    create(:claimant, participant_id: participant_id_with_no_vso)
                  ])
         end
-                
+
         it "blocks distribution with schedule hearing task" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(DistributionTask.find_by(appeal: appeal).status).to eq("on_hold")

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -249,7 +249,7 @@ describe InitialTasksFactory, :postgres do
                    create(:claimant, participant_id: participant_id_with_no_vso)
                  ])
         end
-        
+                
         it "blocks distribution with schedule hearing task" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(DistributionTask.find_by(appeal: appeal).status).to eq("on_hold")


### PR DESCRIPTION
Resolves #CASEFLOW-4908

### Description
Updated the HearingTypeConversion.jsx form by adding conditional statements, updated payload and VSOHearingTypeConversionForm to render the correct payload and form based on whether current user is VSO.  As a Developer, I need to update the virtual opt-in Form to include connections to the backend logic so that the Form is fully operational after the virtual opt-in process UI enhancements are implemented.

Assumptions

### Acceptance Criteria
Updates to the Virtual Opt-In Form Include:
- [ ] On Submit, the form will post the payload data to the Update method of the Task controller
Payload will include:
- [ ] Appellant/Veteran Email Address
- [ ] Appellant/Veteran Timezone
- [ ] Representative Email Address
- [ ] Representative Timezone
- [ ] Payload format and parameter names align with what the backend is setup to receive

