### PR TITLE
Caseflow 5066 sync changehearingrequesttypetask with representative change

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -57,7 +57,6 @@ plugins:
     - 'spec/controllers/idt/api/appeals_controller_spec.rb'
     - 'spec/controllers/tasks_controller_spec.rb'
     - 'spec/controllers/decision_reviews_controller_spec.rb'
-    - 'app/models/tasks/change_hearing_request_type_task.rb'
   eslint:
     enabled: true
   fixme:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -57,6 +57,7 @@ plugins:
     - 'spec/controllers/idt/api/appeals_controller_spec.rb'
     - 'spec/controllers/tasks_controller_spec.rb'
     - 'spec/controllers/decision_reviews_controller_spec.rb'
+    - 'app/models/tasks/change_hearing_request_type_task.rb'
   eslint:
     enabled: true
   fixme:

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -20,15 +20,11 @@ class UpdateAppellantRepresentationJob < CaseflowJob
 
     appeals_to_update.each do |appeal|
       sync_record = appeal.record_synced_by_job.find_or_create_by(sync_job_name: UpdateAppellantRepresentationJob.name)
-      byebug
       new_task_count, closed_task_count = TrackVeteranTask.sync_tracking_tasks(appeal)
-      #{}new_task_count2, closed_task_count2 = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
-      byebug
+      new_task_count_vso, closed_task_count_vso = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
       sync_record.update!(processed_at: Time.zone.now)
-
-      increment_task_count("new", appeal.id, new_task_count + new_task_count2)
-      increment_task_count("closed", appeal.id, closed_task_count + closed_task_count2)
-
+      increment_task_count("new", appeal.id, new_task_count + new_task_count_vso)
+      increment_task_count("closed", appeal.id, closed_task_count + closed_task_count_vso)
       # TODO: Add an alert if we've been running for longer than x number of minutes?
     rescue StandardError => error
       # Rescue from errors when looping over appeals so that we attempt to sync tracking tasks for each appeal.

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -22,10 +22,12 @@ class UpdateAppellantRepresentationJob < CaseflowJob
       sync_record = appeal.record_synced_by_job.find_or_create_by(sync_job_name: UpdateAppellantRepresentationJob.name)
 
       new_task_count, closed_task_count = TrackVeteranTask.sync_tracking_tasks(appeal)
+      new_task_count2, closed_task_count2 = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
+
       sync_record.update!(processed_at: Time.zone.now)
 
-      increment_task_count("new", appeal.id, new_task_count)
-      increment_task_count("closed", appeal.id, closed_task_count)
+      increment_task_count("new", appeal.id, new_task_count + new_task_count2)
+      increment_task_count("closed", appeal.id, closed_task_count + closed_task_count2)
 
       # TODO: Add an alert if we've been running for longer than x number of minutes?
     rescue StandardError => error

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -20,10 +20,10 @@ class UpdateAppellantRepresentationJob < CaseflowJob
 
     appeals_to_update.each do |appeal|
       sync_record = appeal.record_synced_by_job.find_or_create_by(sync_job_name: UpdateAppellantRepresentationJob.name)
-
+      byebug
       new_task_count, closed_task_count = TrackVeteranTask.sync_tracking_tasks(appeal)
-      new_task_count2, closed_task_count2 = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
-
+      #{}new_task_count2, closed_task_count2 = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
+      byebug
       sync_record.update!(processed_at: Time.zone.now)
 
       increment_task_count("new", appeal.id, new_task_count + new_task_count2)

--- a/app/jobs/update_appellant_representation_job.rb
+++ b/app/jobs/update_appellant_representation_job.rb
@@ -20,11 +20,13 @@ class UpdateAppellantRepresentationJob < CaseflowJob
 
     appeals_to_update.each do |appeal|
       sync_record = appeal.record_synced_by_job.find_or_create_by(sync_job_name: UpdateAppellantRepresentationJob.name)
+
       new_task_count, closed_task_count = TrackVeteranTask.sync_tracking_tasks(appeal)
-      new_task_count_vso, closed_task_count_vso = ChangeHearingRequestTypeTask.sync_tracking_tasks(appeal)
       sync_record.update!(processed_at: Time.zone.now)
-      increment_task_count("new", appeal.id, new_task_count + new_task_count_vso)
-      increment_task_count("closed", appeal.id, closed_task_count + closed_task_count_vso)
+
+      increment_task_count("new", appeal.id, new_task_count)
+      increment_task_count("closed", appeal.id, closed_task_count)
+
       # TODO: Add an alert if we've been running for longer than x number of minutes?
     rescue StandardError => error
       # Rescue from errors when looping over appeals so that we attempt to sync tracking tasks for each appeal.

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,6 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
+  after_save :update_changehearingrequesttype_task, if: :update_ihp_enabled?
+  after_destroy :update_changehearingrequesttype_task, if: :update_ihp_enabled?
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,
@@ -157,6 +159,12 @@ class BgsPowerOfAttorney < CaseflowRecord
   def update_ihp_task
     related_appeals.each do |appeal|
       InformalHearingPresentationTask.update_to_new_poa(appeal) if appeal.active?
+    end
+  end
+
+  def update_changehearingrequesttype_task
+    related_appeals.each do |appeal|
+      ChangeHearingRequestTypeTask.update_to_new_poa(appeal) if appeal.active?
     end
   end
 

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,8 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
-  after_save :update_changehearingrequesttype_task, if: :update_changehearingrequesttype_enabled?
-  after_destroy :update_changehearingrequesttype_task, if: :update_changehearingrequesttype_enabled?
+  after_save :update_change_hearing_request_type_task, if: :update_change_hearing_request_type_enabled?
+  after_destroy :update_change_hearing_request_type_task, if: :update_change_hearing_request_type_enabled?
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,
@@ -162,7 +162,7 @@ class BgsPowerOfAttorney < CaseflowRecord
     end
   end
 
-  def update_changehearingrequesttype_task
+  def update_change_hearing_request_type_task
     related_appeals.each do |appeal|
       ChangeHearingRequestTypeTask.update_to_new_poa(appeal) if appeal.active?
     end
@@ -252,8 +252,8 @@ class BgsPowerOfAttorney < CaseflowRecord
       saved_change_to_poa_participant_id?
   end
 
-  def update_changehearingrequesttype_enabled?
-    FeatureToggle.enabled?(:poa_auto_changetype_update, user: RequestStore.store[:current_user]) &&
+  def update_change_hearing_request_type_enabled?
+    FeatureToggle.enabled?(:poa_auto_change_type_update, user: RequestStore.store[:current_user]) &&
       saved_change_to_poa_participant_id?
   end
 end

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,8 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
-  after_save :update_changehearingrequesttype_task, if: :update_ihp_enabled?
-  after_destroy :update_changehearingrequesttype_task, if: :update_ihp_enabled?
+  after_save :update_changehearingrequesttype_task
+  after_destroy :update_changehearingrequesttype_task
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,8 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
-  after_save :update_changehearingrequesttype_task
-  after_destroy :update_changehearingrequesttype_task
+  after_save :update_changehearingrequesttype_task, if: :update_changehearingrequesttype_enabled?
+  after_destroy :update_changehearingrequesttype_task, if: :update_changehearingrequesttype_enabled?
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,
@@ -249,6 +249,11 @@ class BgsPowerOfAttorney < CaseflowRecord
 
   def update_ihp_enabled?
     FeatureToggle.enabled?(:poa_auto_ihp_update, user: RequestStore.store[:current_user]) &&
+      saved_change_to_poa_participant_id?
+  end
+
+  def update_changehearingrequesttype_enabled?
+    FeatureToggle.enabled?(:poa_auto_changetype_update, user: RequestStore.store[:current_user]) &&
       saved_change_to_poa_participant_id?
   end
 end

--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,8 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
-  after_save :update_change_hearing_request_type_task, if: :update_change_hearing_request_type_enabled?
-  after_destroy :update_change_hearing_request_type_task, if: :update_change_hearing_request_type_enabled?
+  after_save :update_change_hearing_request_type_task
+  after_destroy :update_change_hearing_request_type_task
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,
@@ -249,11 +249,6 @@ class BgsPowerOfAttorney < CaseflowRecord
 
   def update_ihp_enabled?
     FeatureToggle.enabled?(:poa_auto_ihp_update, user: RequestStore.store[:current_user]) &&
-      saved_change_to_poa_participant_id?
-  end
-
-  def update_change_hearing_request_type_enabled?
-    FeatureToggle.enabled?(:poa_auto_change_type_update, user: RequestStore.store[:current_user]) &&
       saved_change_to_poa_participant_id?
   end
 end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -86,7 +86,7 @@ class ChangeHearingRequestTypeTask < Task
     fresh_representatives = appeal.representatives
     new_representatives = fresh_representatives - cached_representatives
 
-    # Create a TrackVeteranTask for each VSO that does not already have one.
+    # Create a ChangeHearingRequestTypeTask for each VSO that does not already have one.
     new_representatives.each do |new_vso|
       ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
       new_task_count += 1

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -148,4 +148,37 @@ class ChangeHearingRequestTypeTask < Task
   def set_assignee
     self.assigned_to ||= Bva.singleton
   end
+
+  def self.update_to_new_poa(appeal)
+    new_task_count = 0
+    closed_task_count = 0
+
+    tasks_to_sync = appeal.tasks.open.where(
+      type: [ChangeHearingRequestTypeTask.name],
+      assigned_to_type: Organization.name
+    )
+    cached_representatives = tasks_to_sync.map(&:assigned_to)
+    fresh_representatives = appeal.representatives
+    new_representatives = fresh_representatives - cached_representatives
+
+    # Create a TrackVeteranTask for each VSO that does not already have one.
+    new_representatives.each do |new_vso|
+      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
+      new_task_count += 1
+    end
+
+    # Close all ChangeHearingRequestTypeTasks for now-former VSO representatives.
+    outdated_representatives = cached_representatives - fresh_representatives
+    tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
+      task.update!(status: Constants.TASK_STATUSES.cancelled,
+                   cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
+      task.children.open.each do |child_task|
+        child_task.update!(status: Constants.TASK_STATUSES.cancelled,
+                           cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
+      end
+      closed_task_count += 1
+    end
+
+    [new_task_count, closed_task_count]
+  end
 end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -72,6 +72,39 @@ class ChangeHearingRequestTypeTask < Task
     end
   end
 
+  def self.update_to_new_poa(appeal)
+    new_task_count = 0
+    closed_task_count = 0
+
+    tasks_to_sync = appeal.tasks.open.where(
+      type: [ChangeHearingRequestTypeTask.name],
+      assigned_to_type: Organization.name
+    )
+    cached_representatives = tasks_to_sync.map(&:assigned_to)
+    fresh_representatives = appeal.representatives
+    new_representatives = fresh_representatives - cached_representatives
+
+    # Create a TrackVeteranTask for each VSO that does not already have one.
+    new_representatives.each do |new_vso|
+      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
+      new_task_count += 1
+    end
+
+    # Close all ChangeHearingRequestTypeTasks for now-former VSO representatives.
+    outdated_representatives = cached_representatives - fresh_representatives
+    tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
+      task.update!(status: Constants.TASK_STATUSES.cancelled,
+                   cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
+      task.children.open.each do |child_task|
+        child_task.update!(status: Constants.TASK_STATUSES.cancelled,
+                           cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
+      end
+      closed_task_count += 1
+    end
+
+    [new_task_count, closed_task_count]
+  end
+
   private
 
   # If a ChangeHearingRequestTypeTask is being canceled, we want to revert the task tree to an
@@ -149,36 +182,4 @@ class ChangeHearingRequestTypeTask < Task
     self.assigned_to ||= Bva.singleton
   end
 
-  def self.update_to_new_poa(appeal)
-    new_task_count = 0
-    closed_task_count = 0
-
-    tasks_to_sync = appeal.tasks.open.where(
-      type: [ChangeHearingRequestTypeTask.name],
-      assigned_to_type: Organization.name
-    )
-    cached_representatives = tasks_to_sync.map(&:assigned_to)
-    fresh_representatives = appeal.representatives
-    new_representatives = fresh_representatives - cached_representatives
-
-    # Create a TrackVeteranTask for each VSO that does not already have one.
-    new_representatives.each do |new_vso|
-      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
-      new_task_count += 1
-    end
-
-    # Close all ChangeHearingRequestTypeTasks for now-former VSO representatives.
-    outdated_representatives = cached_representatives - fresh_representatives
-    tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
-      task.update!(status: Constants.TASK_STATUSES.cancelled,
-                   cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
-      task.children.open.each do |child_task|
-        child_task.update!(status: Constants.TASK_STATUSES.cancelled,
-                           cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
-      end
-      closed_task_count += 1
-    end
-
-    [new_task_count, closed_task_count]
-  end
 end

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -103,7 +103,6 @@ class ChangeHearingRequestTypeTask < Task
       end
       closed_task_count += 1
     end
-    byebug
     [new_task_count, closed_task_count]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -85,10 +85,10 @@ class ChangeHearingRequestTypeTask < Task
     cached_representatives = tasks_to_sync.map(&:assigned_to)
     fresh_representatives = appeal.representatives
     new_representatives = fresh_representatives - cached_representatives
-
+    schedule_hearing_task = ScheduleHearingTask.find_by(appeal_id: appeal.id)
     # Create a ChangeHearingRequestTypeTask for each VSO that does not already have one.
     new_representatives.each do |new_vso|
-      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
+      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: schedule_hearing_task, assigned_to: new_vso)
       new_task_count += 1
     end
 
@@ -103,7 +103,7 @@ class ChangeHearingRequestTypeTask < Task
       end
       closed_task_count += 1
     end
-
+    byebug
     [new_task_count, closed_task_count]
   end
   # rubocop:enable Metrics/MethodLength

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -73,14 +73,16 @@ class ChangeHearingRequestTypeTask < Task
   end
 
   def self.update_to_new_poa(appeal)
-    new_task_count, closed_task_count = 0
+    new_task_count = 0
+    closed_task_count = 0
 
     tasks_to_sync = appeal.tasks.open.where(
       type: [ChangeHearingRequestTypeTask.name],
       assigned_to_type: Organization.name
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
-    new_representatives = appeal.representatives - cached_representatives
+    fresh_representatives = appeal.representatives
+    new_representatives = fresh_representatives - cached_representatives
 
     # Create a TrackVeteranTask for each VSO that does not already have one.
     new_representatives.each do |new_vso|
@@ -89,8 +91,8 @@ class ChangeHearingRequestTypeTask < Task
     end
 
     # Close all ChangeHearingRequestTypeTasks for now-former VSO representatives.
-    outdated_representatives = cached_representatives - appeal.representatives
-    tasks_to_sync.select { |t_inc| outdated_representatives.include?(t_inc.assigned_to) }.each do |task|
+    outdated_representatives = cached_representatives - fresh_representatives
+    tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
       task.update!(status: Constants.TASK_STATUSES.cancelled,
                    cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
       task.children.open.each do |child_task|

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -80,7 +80,7 @@ class ChangeHearingRequestTypeTask < Task
 
     tasks_to_sync = appeal.tasks.open.where(
       type: [ChangeHearingRequestTypeTask.name],
-      assigned_to_type: Organization.name
+      assigned_to_type: User.name
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
     fresh_representatives = appeal.representatives

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -74,13 +74,18 @@ class ChangeHearingRequestTypeTask < Task
 
   # rubocop:disable Metrics/MethodLength
   # rubocop:disable Metrics/AbcSize
-  def poa_update(appeal, assigned_to_name)
+  def self.update_to_new_poa(appeal)
+    # check if parent tasks exists
+    schedule_hearing_task = ScheduleHearingTask.find_by(appeal_id: appeal.id)
+    if schedule_hearing_task.nil?
+      return
+    end
+
     new_task_count = 0
     closed_task_count = 0
 
     tasks_to_sync = appeal.tasks.open.where(
-      type: [ChangeHearingRequestTypeTask.name],
-      assigned_to_type: assigned_to_name
+      type: [ChangeHearingRequestTypeTask.name]
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
     fresh_representatives = appeal.representatives
@@ -106,17 +111,6 @@ class ChangeHearingRequestTypeTask < Task
   end
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/AbcSize
-
-  def self.update_to_new_poa(appeal)
-    # check if parent tasks exists
-    schedule_hearing_task = ScheduleHearingTask.find_by(appeal_id: appeal.id)
-    if schedule_hearing_task.nil?
-      return
-    end
-
-    poa_update(appeal, User.name)
-    poa_update(appeal, Organization.name)
-  end
 
   private
 

--- a/app/models/tasks/change_hearing_request_type_task.rb
+++ b/app/models/tasks/change_hearing_request_type_task.rb
@@ -72,6 +72,8 @@ class ChangeHearingRequestTypeTask < Task
     end
   end
 
+  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/AbcSize
   def self.update_to_new_poa(appeal)
     new_task_count = 0
     closed_task_count = 0
@@ -92,7 +94,7 @@ class ChangeHearingRequestTypeTask < Task
 
     # Close all ChangeHearingRequestTypeTasks for now-former VSO representatives.
     outdated_representatives = cached_representatives - fresh_representatives
-    tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
+    tasks_to_sync.select { |t_inc| outdated_representatives.include?(t_inc.assigned_to) }.each do |task|
       task.update!(status: Constants.TASK_STATUSES.cancelled,
                    cancellation_reason: Constants.TASK_CANCELLATION_REASONS.poa_change)
       task.children.open.each do |child_task|
@@ -104,6 +106,8 @@ class ChangeHearingRequestTypeTask < Task
 
     [new_task_count, closed_task_count]
   end
+  # rubocop:enable Metrics/MethodLength
+  # rubocop:enable Metrics/AbcSize
 
   private
 

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -50,7 +50,7 @@ class TrackVeteranTask < Task
     closed_task_count = 0
 
     tasks_to_sync = appeal.tasks.open.where(
-      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name, ChangeHearingRequestTypeTask.name],
+      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name],
       assigned_to_type: Organization.name
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
@@ -60,8 +60,7 @@ class TrackVeteranTask < Task
     # Create a TrackVeteranTask for each VSO that does not already have one.
     new_representatives.each do |new_vso|
       TrackVeteranTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
-      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
-      new_task_count += 2
+      new_task_count += 1
 
       next unless appeal.is_a?(Appeal) && new_vso.should_write_ihp?(appeal)
 
@@ -76,7 +75,7 @@ class TrackVeteranTask < Task
       )
     end
 
-    # Close all TrackVeteranTasks, ChangeHearingRequestTypeTask, and InformalHearingPresentationTasks for now-former VSO representatives.
+    # Close all TrackVeteranTasks and InformalHearingPresentationTasks for now-former VSO representatives.
     outdated_representatives = cached_representatives - fresh_representatives
     tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
       task.update!(status: Constants.TASK_STATUSES.cancelled,

--- a/app/models/tasks/track_veteran_task.rb
+++ b/app/models/tasks/track_veteran_task.rb
@@ -50,7 +50,7 @@ class TrackVeteranTask < Task
     closed_task_count = 0
 
     tasks_to_sync = appeal.tasks.open.where(
-      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name],
+      type: [TrackVeteranTask.name, InformalHearingPresentationTask.name, ChangeHearingRequestTypeTask.name],
       assigned_to_type: Organization.name
     )
     cached_representatives = tasks_to_sync.map(&:assigned_to)
@@ -60,7 +60,8 @@ class TrackVeteranTask < Task
     # Create a TrackVeteranTask for each VSO that does not already have one.
     new_representatives.each do |new_vso|
       TrackVeteranTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
-      new_task_count += 1
+      ChangeHearingRequestTypeTask.create!(appeal: appeal, parent: appeal.root_task, assigned_to: new_vso)
+      new_task_count += 2
 
       next unless appeal.is_a?(Appeal) && new_vso.should_write_ihp?(appeal)
 
@@ -75,7 +76,7 @@ class TrackVeteranTask < Task
       )
     end
 
-    # Close all TrackVeteranTasks and InformalHearingPresentationTasks for now-former VSO representatives.
+    # Close all TrackVeteranTasks, ChangeHearingRequestTypeTask, and InformalHearingPresentationTasks for now-former VSO representatives.
     outdated_representatives = cached_representatives - fresh_representatives
     tasks_to_sync.select { |t| outdated_representatives.include?(t.assigned_to) }.each do |task|
       task.update!(status: Constants.TASK_STATUSES.cancelled,

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -37,7 +37,6 @@
       poa_button_refresh: FeatureToggle.enabled?(:poa_button_refresh, user: current_user),
       poa_auto_refresh: FeatureToggle.enabled?(:poa_auto_refresh, user: current_user),
       poa_auto_ihp_update: FeatureToggle.enabled?(:poa_auto_ihp_update, user: current_user),
-      poa_auto_change_type_update: FeatureToggle.enabled?(:poa_auto_change_type_update, user: current_user),
       edit_unrecognized_appellant: FeatureToggle.enabled?(:edit_unrecognized_appellant, user: current_user),
       edit_unrecognized_appellant_poa: FeatureToggle.enabled?(:edit_unrecognized_appellant_poa, user: current_user),
       listed_granted_substitution_before_dismissal: FeatureToggle.enabled?(:listed_granted_substitution_before_dismissal, user: current_user),

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -37,6 +37,7 @@
       poa_button_refresh: FeatureToggle.enabled?(:poa_button_refresh, user: current_user),
       poa_auto_refresh: FeatureToggle.enabled?(:poa_auto_refresh, user: current_user),
       poa_auto_ihp_update: FeatureToggle.enabled?(:poa_auto_ihp_update, user: current_user),
+      poa_auto_changetype_update: FeatureToggle.enabled?(:poa_auto_changetype_update, user: current_user),
       edit_unrecognized_appellant: FeatureToggle.enabled?(:edit_unrecognized_appellant, user: current_user),
       edit_unrecognized_appellant_poa: FeatureToggle.enabled?(:edit_unrecognized_appellant_poa, user: current_user),
       listed_granted_substitution_before_dismissal: FeatureToggle.enabled?(:listed_granted_substitution_before_dismissal, user: current_user),

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -37,7 +37,7 @@
       poa_button_refresh: FeatureToggle.enabled?(:poa_button_refresh, user: current_user),
       poa_auto_refresh: FeatureToggle.enabled?(:poa_auto_refresh, user: current_user),
       poa_auto_ihp_update: FeatureToggle.enabled?(:poa_auto_ihp_update, user: current_user),
-      poa_auto_changetype_update: FeatureToggle.enabled?(:poa_auto_changetype_update, user: current_user),
+      poa_auto_change_type_update: FeatureToggle.enabled?(:poa_auto_change_type_update, user: current_user),
       edit_unrecognized_appellant: FeatureToggle.enabled?(:edit_unrecognized_appellant, user: current_user),
       edit_unrecognized_appellant_poa: FeatureToggle.enabled?(:edit_unrecognized_appellant_poa, user: current_user),
       listed_granted_substitution_before_dismissal: FeatureToggle.enabled?(:listed_granted_substitution_before_dismissal, user: current_user),

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -42,7 +42,6 @@ class InitialTasksFactory
 
   def create_vso_hearing_request_type_task
     appeal_views = AppealView.where(appeal_id: @appeal.id).to_a
-    byebug
     appeal_views.each do |view|
       user = @appeal.appeal_views.find_by(user_id: view.user_id).user
       if ChangeHearingRequestTypeTask.where(appeal: @appeal, assigned_to: user).empty? &&
@@ -55,7 +54,6 @@ class InitialTasksFactory
   # rubocop:disable Metrics/CyclomaticComplexity
   def create_subtasks!
     distribution_task # ensure distribution_task exists
-
     if @appeal.appellant_substitution?
       create_selected_tasks
     elsif @appeal.cavc?

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -23,6 +23,7 @@ class InitialTasksFactory
 
   def create_root_and_sub_tasks!
     create_vso_tracking_tasks
+    create_vso_hearing_request_type_task
     ActiveRecord::Base.transaction do
       create_subtasks! if @appeal.original? || @appeal.cavc? || @appeal.appellant_substitution?
     end
@@ -36,9 +37,17 @@ class InitialTasksFactory
       if TrackVeteranTask.where(appeal: @appeal, assigned_to: rep).empty?
         TrackVeteranTask.create!(appeal: @appeal, parent: @root_task, assigned_to: rep)
       end
-      if ChangeHearingRequestTypeTask.where(appeal: @appeal, assigned_to: rep).empty? &&
+    end
+  end
+
+  def create_vso_hearing_request_type_task
+    appeal_views = AppealView.where(appeal_id: @appeal.id).to_a
+    byebug
+    appeal_views.each do |view|
+      user = @appeal.appeal_views.find_by(user_id: view.user_id).user
+      if ChangeHearingRequestTypeTask.where(appeal: @appeal, assigned_to: user).empty? &&
          @appeal.docket_type == "hearing"
-        ChangeHearingRequestTypeTask.create!(appeal: @appeal, parent: @root_task, assigned_to: rep)
+        ChangeHearingRequestTypeTask.create!(appeal: @appeal, parent: @root_task, assigned_to: user)
       end
     end
   end

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-SingleCov.covered!
+
 describe UpdateAppellantRepresentationJob, :all_dbs do
   context "when the job runs successfully" do
     let(:new_task_count) { 3 }
@@ -15,8 +15,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       correct_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
-        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
-
         vso_for_appeal[appeal.id] = [vso]
       end
 
@@ -28,8 +26,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       closed_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
-        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
-
         vso_for_appeal[appeal.id] = []
       end
 
@@ -74,8 +70,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
           expect(appeal.reload.record_synced_by_job.first.processed_at.nil?).to eq(false)
           expect(appeal.tasks.of_type(:TrackVeteranTask).first.assigned_to)
             .to eq(vso_for_legacy_appeal[appeal.id].first)
-          expect(appeal.tasks.of_type(:ChangeHearingRequestTypeTask).first.assigned_to)
-            .to eq(vso_for_legacy_appeal[appeal.id].first)
         end
       end
     end
@@ -100,8 +94,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       correct_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
-        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
-
         vso_for_appeal[appeal.id] = [vso]
       end
 
@@ -113,8 +105,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       closed_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
-        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
-
         vso_for_appeal[appeal.id] = []
       end
 
@@ -122,8 +112,6 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       error_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
-        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
-
         vso_for_appeal[appeal.id] = error_indicator
       end
 

--- a/spec/jobs/update_appellant_representation_job_spec.rb
+++ b/spec/jobs/update_appellant_representation_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-
+SingleCov.covered!
 describe UpdateAppellantRepresentationJob, :all_dbs do
   context "when the job runs successfully" do
     let(:new_task_count) { 3 }
@@ -15,6 +15,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       correct_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+
         vso_for_appeal[appeal.id] = [vso]
       end
 
@@ -26,6 +28,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       closed_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+
         vso_for_appeal[appeal.id] = []
       end
 
@@ -70,6 +74,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
           expect(appeal.reload.record_synced_by_job.first.processed_at.nil?).to eq(false)
           expect(appeal.tasks.of_type(:TrackVeteranTask).first.assigned_to)
             .to eq(vso_for_legacy_appeal[appeal.id].first)
+          expect(appeal.tasks.of_type(:ChangeHearingRequestTypeTask).first.assigned_to)
+            .to eq(vso_for_legacy_appeal[appeal.id].first)
         end
       end
     end
@@ -94,6 +100,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       correct_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+
         vso_for_appeal[appeal.id] = [vso]
       end
 
@@ -105,6 +113,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       closed_task_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+
         vso_for_appeal[appeal.id] = []
       end
 
@@ -112,6 +122,8 @@ describe UpdateAppellantRepresentationJob, :all_dbs do
       error_count.times do |_|
         appeal, vso = create_appeal_and_vso
         create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+        create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+
         vso_for_appeal[appeal.id] = error_indicator
       end
 

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -376,7 +376,6 @@ describe BgsPowerOfAttorney do
         allow_any_instance_of(described_class).to receive(:update_changehearingrequesttype_task)
       end
       after { FeatureToggle.disable!(:poa_auto_changetype_update) }
-
       it "update changehearingrequesttype task method is called" do
         before_poa_pid = poa.poa_participant_id
         expect(before_poa_pid).to_not be_nil

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -357,37 +357,6 @@ describe BgsPowerOfAttorney do
       end
     end
 
-    context "when poa_auto_change_type_update feature toggle is disabled" do
-      before do
-        FeatureToggle.disable!(:poa_auto_change_type_update)
-        allow_any_instance_of(described_class).to receive(:update_change_hearing_request_type_task)
-      end
-
-      it "update changehearingrequesttypetask method isn't called" do
-        poa.save_with_updated_bgs_record!
-        expect_any_instance_of(described_class).to_not receive(:update_change_hearing_request_type_task)
-        expect(poa.send(:update_change_hearing_request_type_enabled?)).to eq(false)
-      end
-    end
-
-    context "when poa_auto_change_type_update feature toggle is enabled" do
-      before do
-        FeatureToggle.enable!(:poa_auto_change_type_update)
-        allow_any_instance_of(described_class).to receive(:update_change_hearing_request_type_task)
-      end
-      after { FeatureToggle.disable!(:poa_auto_change_type_update) }
-      it "update changehearingrequesttypetask method is called" do
-        before_poa_pid = poa.poa_participant_id
-        expect(before_poa_pid).to_not be_nil
-
-        poa.save_with_updated_bgs_record!
-
-        expect(poa.poa_participant_id).to_not eq before_poa_pid
-        expect(poa.send(:update_change_hearing_request_type_enabled?)).to eq(true)
-        expect(poa).to have_received(:update_change_hearing_request_type_task)
-      end
-    end
-
     context "2 records exist with same PID but different FNs" do
       before do
         allow(bgs).to receive(:fetch_poa_by_file_number)

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -357,34 +357,34 @@ describe BgsPowerOfAttorney do
       end
     end
 
-    context "when poa_auto_changetype_update feature toggle is disabled" do
+    context "when poa_auto_change_type_update feature toggle is disabled" do
       before do
-        FeatureToggle.disable!(:poa_auto_changetype_update)
-        allow_any_instance_of(described_class).to receive(:update_changehearingrequesttype_task)
+        FeatureToggle.disable!(:poa_auto_change_type_update)
+        allow_any_instance_of(described_class).to receive(:update_change_hearing_request_type_task)
       end
 
-      it "update changehearingrequesttype task method isn't called" do
+      it "update changehearingrequesttypetask method isn't called" do
         poa.save_with_updated_bgs_record!
-        expect_any_instance_of(described_class).to_not receive(:update_changehearingrequesttype_task)
-        expect(poa.send(:update_changehearingrequesttype_enabled?)).to eq(false)
+        expect_any_instance_of(described_class).to_not receive(:update_change_hearing_request_type_task)
+        expect(poa.send(:update_change_hearing_request_type_enabled?)).to eq(false)
       end
     end
 
-    context "when poa_auto_changetype_update feature toggle is enabled" do
+    context "when poa_auto_change_type_update feature toggle is enabled" do
       before do
-        FeatureToggle.enable!(:poa_auto_changetype_update)
-        allow_any_instance_of(described_class).to receive(:update_changehearingrequesttype_task)
+        FeatureToggle.enable!(:poa_auto_change_type_update)
+        allow_any_instance_of(described_class).to receive(:update_change_hearing_request_type_task)
       end
-      after { FeatureToggle.disable!(:poa_auto_changetype_update) }
-      it "update changehearingrequesttype task method is called" do
+      after { FeatureToggle.disable!(:poa_auto_change_type_update) }
+      it "update changehearingrequesttypetask method is called" do
         before_poa_pid = poa.poa_participant_id
         expect(before_poa_pid).to_not be_nil
 
         poa.save_with_updated_bgs_record!
 
         expect(poa.poa_participant_id).to_not eq before_poa_pid
-        expect(poa.send(:update_changehearingrequesttype_enabled?)).to eq(true)
-        expect(poa).to have_received(:update_changehearingrequesttype_task)
+        expect(poa.send(:update_change_hearing_request_type_enabled?)).to eq(true)
+        expect(poa).to have_received(:update_change_hearing_request_type_task)
       end
     end
 

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -357,6 +357,38 @@ describe BgsPowerOfAttorney do
       end
     end
 
+    context "when poa_auto_changetype_update feature toggle is disabled" do
+      before do
+        FeatureToggle.disable!(:poa_auto_changetype_update)
+        allow_any_instance_of(described_class).to receive(:update_changehearingrequesttype_task)
+      end
+
+      it "update changehearingrequesttype task method isn't called" do
+        poa.save_with_updated_bgs_record!
+        expect_any_instance_of(described_class).to_not receive(:update_changehearingrequesttype_task)
+        expect(poa.send(:update_changehearingrequesttype_enabled?)).to eq(false)
+      end
+    end
+
+    context "when poa_auto_changetype_update feature toggle is enabled" do
+      before do
+        FeatureToggle.enable!(:poa_auto_changetype_update)
+        allow_any_instance_of(described_class).to receive(:update_changehearingrequesttype_task)
+      end
+      after { FeatureToggle.disable!(:poa_auto_changetype_update) }
+
+      it "update changehearingrequesttype task method is called" do
+        before_poa_pid = poa.poa_participant_id
+        expect(before_poa_pid).to_not be_nil
+
+        poa.save_with_updated_bgs_record!
+
+        expect(poa.poa_participant_id).to_not eq before_poa_pid
+        expect(poa.send(:update_changehearingrequesttype_enabled?)).to eq(true)
+        expect(poa).to have_received(:update_changehearingrequesttype_task)
+      end
+    end
+
     context "2 records exist with same PID but different FNs" do
       before do
         allow(bgs).to receive(:fetch_poa_by_file_number)

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -301,7 +301,14 @@ describe ChangeHearingRequestTypeTask do
     let!(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
     let!(:vso_org) { create(:vso) }
     let!(:vso_org_new) { create(:vso) }
-    let!(:schedule_hearing_task) { create(:schedule_hearing_task, appeal: appeal, parent: hearing_task, assigned_to: vso_org) }
+    let!(:schedule_hearing_task) do
+      create(
+        :schedule_hearing_task,
+        parent: hearing_task,
+        appeal: root_task.appeal,
+        assigned_to: vso_org
+      )
+    end
     let!(:old_vso) { create(:user, roles: ["VSO"], full_name: "old") }
     let!(:new_vso) { create(:user, roles: ["VSO"], full_name: "new") }
 

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -36,7 +36,6 @@ describe ChangeHearingRequestTypeTask do
           expect(hearing_task).to_not receive(:when_child_task_completed)
 
           subject
-
           expect(task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
           expect(schedule_hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
           expect(hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
@@ -296,56 +295,55 @@ describe ChangeHearingRequestTypeTask do
     end
   end
   describe "update to new poa" do
+    subject { ChangeHearingRequestTypeTask.update_to_new_poa(appeal) }
     let!(:appeal) { create(:appeal) }
     let!(:root_task) { create(:root_task, appeal: appeal) }
 
-    subject { TrackVeteranTask.sync_tracking_tasks(appeal) }
+    context "When former representative VSO is assigned non-Tracking tasks" do
+      let(:old_vso) { create(:vso, name: "Remember Korea") }
+      let(:new_vso) { create(:vso) }
 
-    context "When former represenative VSO is assigned non-Tracking tasks" do
-      let!(:old_vso) { create(:vso, name: "Remember Korea") }
-      let!(:new_vso) { create(:vso) }
-      let!(:root_task) { create(:root_task, appeal: appeal) }
-    end
-    let!(:change_type_task) do
-      create(
-        :change_hearing_request_type_task,
-        parent: root_task,
-        appeal: root_task.appeal,
-        assigned_to: old_vso
-      )
-    end
-    before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([new_vso]) }
+      let!(:change_type_task) do
+        create(
+          :change_hearing_request_type_task,
+          parent: root_task,
+          appeal: root_task.appeal,
+          assigned_to: old_vso
+        )
+      end
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([new_vso]) }
 
-    it "cancels all tasks of former VSO" do
-      subject
-      expect(ihp_org_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
-    end
-    it "makes duplicates of active tasks for new representation" do
-      expect(new_vso.tasks.count).to eq(0)
-      expect(subject).to eq([1, 2])
-      expect(new_vso.tasks.count).to eq(2)
+      it "cancels all tasks of former VSO" do
+        subject
+        expect(change_type_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+      end
+      it "makes duplicates of active tasks for new representation" do
+        expect(new_vso.tasks.count).to eq(0)
+        expect(subject).to eq([1, 1])
+        expect(new_vso.tasks.count).to eq(1)
+      end
     end
     context "when the appeal has no VSOs" do
       before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([]) }
 
-      context "when there are no existing TrackVeteranTasks" do
-        it "does not create or cancel any TrackVeteranTasks" do
-          task_count_before = TrackVeteranTask.count
+      context "when there are no existing Change" do
+        it "does not create or cancel any ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
 
           expect(subject).to eq([0, 0])
-          expect(TrackVeteranTask.count).to eq(task_count_before)
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before)
         end
       end
 
-      context "when there is an existing open TrackVeteranTasks" do
+      context "when there is an existing open ChangeHearingRequestTypeTask" do
         let(:vso) { create(:vso) }
-        let!(:tracking_task) { create(:track_veteran_task, appeal: appeal, assigned_to: vso) }
+        let!(:change_task) { create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso) }
 
-        it "cancels old TrackVeteranTask, does not create any new tasks" do
-          active_task_count_before = TrackVeteranTask.open.count
+        it "cancels old ChangeHearingRequestTypeTask, does not create any new tasks" do
+          active_task_count_before = ChangeHearingRequestTypeTask.open.count
 
           expect(subject).to eq([0, 1])
-          expect(TrackVeteranTask.open.count).to eq(active_task_count_before - 1)
+          expect(ChangeHearingRequestTypeTask.open.count).to eq(active_task_count_before - 1)
         end
       end
     end
@@ -353,40 +351,40 @@ describe ChangeHearingRequestTypeTask do
       let(:representing_vsos) { create_list(:vso, 2) }
       before { allow_any_instance_of(Appeal).to receive(:representatives).and_return(representing_vsos) }
 
-      context "when there are no existing TrackVeteranTasks" do
-        it "creates 2 new TrackVeteranTasks and 2 IHP Tasks" do
-          task_count_before = TrackVeteranTask.count
+      context "when there are no existing ChangeHearingRequestTypeTasks" do
+        it "creates 2 new ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
 
           expect(subject).to eq([2, 0])
-          expect(TrackVeteranTask.count).to eq(task_count_before + 2)
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before + 2)
         end
       end
 
-      context "when there is an existing open TrackVeteranTasks for a different VSO" do
+      context "when there is an existing open ChangeHearingRequestTypeTasks for a different VSO" do
         before do
-          create(:track_veteran_task, appeal: appeal, assigned_to: create(:vso))
+          create(:change_hearing_request_type_task, appeal: appeal, assigned_to: create(:vso))
         end
 
-        it "cancels old TrackVeteranTask, creates 2 new TrackVeteran and 2 new IHP tasks" do
+        it "cancels old ChangeHearingRequestTypeTask, creates 2 new ChangeHearingRequestTypeTasks" do
           expect(subject).to eq([2, 1])
         end
       end
 
-      context "when there are already TrackVeteranTasks for both VSOs" do
+      context "when there are already ChangeHearingRequestTypeTask for both VSOs" do
         before do
           representing_vsos.each do |vso|
-            create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+            create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
           end
         end
 
-        it "does not create or cancel any TrackVeteranTasks" do
-          task_count_before = TrackVeteranTask.count
+        it "does not create or cancel any ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
 
           expect(subject).to eq([0, 0])
-          expect(TrackVeteranTask.count).to eq(task_count_before)
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before)
         end
       end
     end
-    
+
   end
 end

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -295,4 +295,98 @@ describe ChangeHearingRequestTypeTask do
       end
     end
   end
+  describe "update to new poa" do
+    let!(:appeal) { create(:appeal) }
+    let!(:root_task) { create(:root_task, appeal: appeal) }
+
+    subject { TrackVeteranTask.sync_tracking_tasks(appeal) }
+
+    context "When former represenative VSO is assigned non-Tracking tasks" do
+      let!(:old_vso) { create(:vso, name: "Remember Korea") }
+      let!(:new_vso) { create(:vso) }
+      let!(:root_task) { create(:root_task, appeal: appeal) }
+    end
+    let!(:change_type_task) do
+      create(
+        :change_hearing_request_type_task,
+        parent: root_task,
+        appeal: root_task.appeal,
+        assigned_to: old_vso
+      )
+    end
+    before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([new_vso]) }
+
+    it "cancels all tasks of former VSO" do
+      subject
+      expect(ihp_org_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+    end
+    it "makes duplicates of active tasks for new representation" do
+      expect(new_vso.tasks.count).to eq(0)
+      expect(subject).to eq([1, 2])
+      expect(new_vso.tasks.count).to eq(2)
+    end
+    context "when the appeal has no VSOs" do
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([]) }
+
+      context "when there are no existing TrackVeteranTasks" do
+        it "does not create or cancel any TrackVeteranTasks" do
+          task_count_before = TrackVeteranTask.count
+
+          expect(subject).to eq([0, 0])
+          expect(TrackVeteranTask.count).to eq(task_count_before)
+        end
+      end
+
+      context "when there is an existing open TrackVeteranTasks" do
+        let(:vso) { create(:vso) }
+        let!(:tracking_task) { create(:track_veteran_task, appeal: appeal, assigned_to: vso) }
+
+        it "cancels old TrackVeteranTask, does not create any new tasks" do
+          active_task_count_before = TrackVeteranTask.open.count
+
+          expect(subject).to eq([0, 1])
+          expect(TrackVeteranTask.open.count).to eq(active_task_count_before - 1)
+        end
+      end
+    end
+    context "when the appeal has two VSOs" do
+      let(:representing_vsos) { create_list(:vso, 2) }
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return(representing_vsos) }
+
+      context "when there are no existing TrackVeteranTasks" do
+        it "creates 2 new TrackVeteranTasks and 2 IHP Tasks" do
+          task_count_before = TrackVeteranTask.count
+
+          expect(subject).to eq([2, 0])
+          expect(TrackVeteranTask.count).to eq(task_count_before + 2)
+        end
+      end
+
+      context "when there is an existing open TrackVeteranTasks for a different VSO" do
+        before do
+          create(:track_veteran_task, appeal: appeal, assigned_to: create(:vso))
+        end
+
+        it "cancels old TrackVeteranTask, creates 2 new TrackVeteran and 2 new IHP tasks" do
+          expect(subject).to eq([2, 1])
+        end
+      end
+
+      context "when there are already TrackVeteranTasks for both VSOs" do
+        before do
+          representing_vsos.each do |vso|
+            create(:track_veteran_task, appeal: appeal, assigned_to: vso)
+          end
+        end
+
+        it "does not create or cancel any TrackVeteranTasks" do
+          task_count_before = TrackVeteranTask.count
+
+          expect(subject).to eq([0, 0])
+          expect(TrackVeteranTask.count).to eq(task_count_before)
+        end
+      end
+    end
+    
+  end
 end

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -385,6 +385,5 @@ describe ChangeHearingRequestTypeTask do
         end
       end
     end
-
   end
 end

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -249,7 +249,7 @@ describe InitialTasksFactory, :postgres do
                    create(:claimant, participant_id: participant_id_with_no_vso)
                  ])
         end
-        
+
         it "blocks distribution with schedule hearing task" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(DistributionTask.find_by(appeal: appeal).status).to eq("on_hold")

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -44,7 +44,6 @@ describe InitialTasksFactory, :postgres do
         participant_id: Fakes::BGSServicePOA::PARALYZED_VETERANS_VSO_PARTICIPANT_ID
       )
     end
-    let!(:vso_user) { create(:user, roles: ["VSO"], full_name: "test") }
 
     context "when an original appeal" do
       context "on the direct docket is created" do
@@ -117,27 +116,13 @@ describe InitialTasksFactory, :postgres do
                        create(:claimant, participant_id: participant_id_with_aml)
                      ])
             end
-            let!(:pva_vso) { create(:user, roles: ["VSO"], full_name: "pva") }
-            let!(:aml_vso) { create(:user, roles: ["VSO"], full_name: "aml") }
+
             subject { InitialTasksFactory.new(appeal).create_root_and_sub_tasks! }
 
             it "creates a changehearingrequesttypetask assigned to the VSO" do
-              AppealView.create(user: pva_vso, appeal: appeal)
               subject
               expect(appeal.tasks.count { |t| t.is_a?(ChangeHearingRequestTypeTask) }).to eq(1)
-              expect(appeal.tasks.detect { |t| t.is_a?(ChangeHearingRequestTypeTask) }.assigned_to).to eq(pva_vso)
-            end
-            it "creates a changehearingrequesttypetask assigned to multiple VSOs" do
-              AppealView.create(user: pva_vso, appeal: appeal)
-              AppealView.create(user: aml_vso, appeal: appeal)
-              subject
-              expect(appeal.tasks.count { |t| t.is_a?(ChangeHearingRequestTypeTask) }).to eq(2)
-              change_tasks = appeal.tasks.open.where(
-                type: [ChangeHearingRequestTypeTask.name],
-                assigned_to_type: User.name
-              )
-              expect(change_tasks[0].assigned_to).to eq(aml_vso)
-              expect(change_tasks[1].assigned_to).to eq(pva_vso)
+              expect(appeal.tasks.detect { |t| t.is_a?(ChangeHearingRequestTypeTask) }.assigned_to).to eq(pva)
             end
           end
         end
@@ -217,6 +202,7 @@ describe InitialTasksFactory, :postgres do
         it "creates a task for each VSO" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(RootTask.count).to eq(1)
+
           expect(InformalHearingPresentationTask.count).to eq(2)
           # sort order is non-deterministic so load by assignee
           expect(pva.tasks.map(&:type)).to include("InformalHearingPresentationTask")

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -130,11 +130,14 @@ describe InitialTasksFactory, :postgres do
             it "creates a changehearingrequesttypetask assigned to multiple VSOs" do
               AppealView.create(user: pva_vso, appeal: appeal)
               AppealView.create(user: aml_vso, appeal: appeal)
-              byebug
               subject
               expect(appeal.tasks.count { |t| t.is_a?(ChangeHearingRequestTypeTask) }).to eq(2)
-              expect(appeal.tasks.detect { |t| t.is_a?(ChangeHearingRequestTypeTask) }.assigned_to).to eq(pva_vso)
-              expect(appeal.tasks.detect { |t| t.is_a?(ChangeHearingRequestTypeTask) }.assigned_to).to eq(aml_vso)
+              change_tasks = appeal.tasks.open.where(
+                type: [ChangeHearingRequestTypeTask.name],
+                assigned_to_type: User.name
+              )
+              expect(change_tasks[0].assigned_to).to eq(aml_vso)
+              expect(change_tasks[1].assigned_to).to eq(pva_vso)
             end
           end
         end
@@ -214,7 +217,7 @@ describe InitialTasksFactory, :postgres do
         it "creates a task for each VSO" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(RootTask.count).to eq(1)
-
+          byebug
           expect(InformalHearingPresentationTask.count).to eq(2)
           # sort order is non-deterministic so load by assignee
           expect(pva.tasks.map(&:type)).to include("InformalHearingPresentationTask")

--- a/spec/workflows/initial_tasks_factory_spec.rb
+++ b/spec/workflows/initial_tasks_factory_spec.rb
@@ -217,7 +217,6 @@ describe InitialTasksFactory, :postgres do
         it "creates a task for each VSO" do
           InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
           expect(RootTask.count).to eq(1)
-          byebug
           expect(InformalHearingPresentationTask.count).to eq(2)
           # sort order is non-deterministic so load by assignee
           expect(pva.tasks.map(&:type)).to include("InformalHearingPresentationTask")


### PR DESCRIPTION
Resolves #[CASEFLOW-5066](https://vajira.max.gov/browse/CASEFLOW-5066)
Description
As a newly appointed rep I need to the ability Veteran with a new representative - when the representative of an appeal changes, the change hearing request type task is reassigned to the new representative

Update Appellant Representation Job needs to be updated to ensure the ChangeHearingRequestTypeTask for a given Appeal is assigned to the correct VSO user when there is a change in representation for the appeal.

Acceptance Criteria

When the representative of an appeal changes:
- [ ] the change hearing request type task is unassigned from the prior representative (can no longer convert to virtual)
- [ ] the change hearing request type task is assigned to the new representative (can convert to virtual)
 