### PR TITLE
Aiman&MattT/CASEFLOW-4519 RPO -> EMO Task Action and Modal

### DIFF
--- a/app/models/queue_tabs/education_rpo_in_progress_tasks_tab.rb
+++ b/app/models/queue_tabs/education_rpo_in_progress_tasks_tab.rb
@@ -22,6 +22,12 @@ class EducationRpoInProgressTasksTab < QueueTab
   end
 
   def column_names
+    build_column_names
+  end
+
+  private
+
+  def build_column_names
     EduRegionalProcessingOffice::COLUMN_NAMES +
       [
         Constants.QUEUE_CONFIG.COLUMNS.DAYS_SINCE_LAST_ACTION.name,

--- a/app/models/tasks/pre_docket/education_assess_documentation_task.rb
+++ b/app/models/tasks/pre_docket/education_assess_documentation_task.rb
@@ -9,7 +9,7 @@ class EducationAssessDocumentationTask < Task
                      on: :create
 
   TASK_ACTIONS = [
-    # TODO
+    Constants.TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.to_h
   ].freeze
 
   def available_actions(user)

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -598,6 +598,21 @@ class TaskActionRepository
       }
     end
 
+    def regional_processing_office_return_to_emo(task, _user)
+      org = Organization.find(task.assigned_to_id)
+      queue_url = org.url
+      {
+        modal_title: COPY::EDU_REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO_MODAL_TITLE,
+        message_title: format(
+          COPY::EDU_REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO_CONFIRMATION,
+          task.appeal.veteran_full_name
+        ),
+        type: EducationAssessDocumentationTask.name,
+        redirect_after: "/organizations/#{queue_url}",
+        modal_button_text: COPY::MODAL_RETURN_BUTTON
+      }
+    end
+
     private
 
     def select_ama_review_decision_action(task)

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1217,7 +1217,7 @@
   "REVIEW_DOCUMENTATION_TASK_LABEL": "Review Documentation",
   "VHA_ASSIGN_TO_PROGRAM_OFFICE_MODAL_TITLE": "Assign to Program Office",
   "VHA_ASSIGN_TO_REGIONAL_OFFICE_MODAL_TITLE": "Assign to VISN/VA Medical Center",
-  "PRE_DOCKET_MODAL_BODY": "Provide instructions and context for this action.",
+  "PRE_DOCKET_MODAL_BODY": "Provide instructions and context for this action:",
   "VHA_PROGRAM_OFFICE_SELECTOR_PLACEHOLDER": "Select Program Office",
   "VHA_REGIONAL_OFFICE_SELECTOR_PLACEHOLDER": "Select VISN/VA Medical Center",
   "VHA_COMPLETE_TASK_LABEL": "Ready for Review",
@@ -1263,5 +1263,7 @@
   "EMO_SEND_TO_BOARD_INTAKE_FOR_REVIEW_CONFIRMATION_PO": "You have successfully sent %s's case to Board Intake for review.",
   "EMO_ASSIGN_TO_REGIONAL_PROCESSING_OFFICE_MODAL_TITLE": "Assign to RPO",
   "EMO_ASSIGN_TO_REGIONAL_PROCESSING_OFFICE_MODAL_BODY": "Regional Processing Office",
-  "EDU_REGIONAL_PROCESSING_OFFICE_SELECTOR_PLACEHOLDER": "Select RPO"
+  "EDU_REGIONAL_PROCESSING_OFFICE_SELECTOR_PLACEHOLDER": "Select RPO",
+  "EDU_REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO_MODAL_TITLE": "Return to Executive Management Office",
+  "EDU_REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO_CONFIRMATION": "You have successfully returned %s's case to the Executive Management Office"
 }

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -364,6 +364,11 @@ class QueueApp extends React.PureComponent {
     <CancelTaskModal {...props.match.params} />
   );
 
+  routedRegionalProcessingOfficeReturnToEmo = (props) => (
+    <CancelTaskModal {...props.match.params} />
+
+  );
+
   routedCancelTaskModal = (props) => (
     <CancelTaskModal {...props.match.params} />
   );
@@ -925,6 +930,12 @@ class QueueApp extends React.PureComponent {
                   TASK_ACTIONS.VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE.value
                 }`}
               render={this.routedReturnToProgramOffice}
+            />
+            <Route
+              path={`/queue/appeals/:appealId/tasks/:taskId/${
+                  TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.value
+                }`}
+              render={this.routedRegionalProcessingOfficeReturnToEmo}
             />
             <Route
               path={`/queue/appeals/:appealId/tasks/:taskId/${

--- a/client/app/queue/components/CancelTaskModal.jsx
+++ b/client/app/queue/components/CancelTaskModal.jsx
@@ -48,7 +48,7 @@ const CancelTaskModal = (props) => {
         </Link>
       </p> : null;
     const successMsg = {
-      title: taskData.message_title,
+      title: taskData?.message_title ?? 'Task was cancelled successfully.',
       detail: (
         <span>
           <span dangerouslySetInnerHTML={{ __html: taskData.message_detail }} />
@@ -63,6 +63,7 @@ const CancelTaskModal = (props) => {
   return (
     <QueueFlowModal
       title={taskData?.modal_title ?? ''}
+      button={taskData?.modal_button_text ?? COPY.MODAL_SUBMIT_BUTTON}
       pathAfterSubmit={taskData?.redirect_after ?? '/queue'}
       submit={submit}
       validateForm={validateForm}

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -423,5 +423,10 @@
     "label": "Assign to Regional Processing Office",
     "value": "modal/emo_assign_to_regional_processing_office",
     "func": "emo_assign_to_regional_processing_office_data"
+  },
+  "REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO": {
+    "label": "Return to Executive Management Office",
+    "value": "modal/regional_processing_office_return_to_emo",
+    "func": "regional_processing_office_return_to_emo"
   }
 }

--- a/client/test/app/queue/components/__snapshots__/CancelTaskModal.test.js.snap
+++ b/client/test/app/queue/components/__snapshots__/CancelTaskModal.test.js.snap
@@ -206,12 +206,14 @@ exports[`CancelTaskModal for cancel change hearing request type action 1`] = `
       taskId="2"
     >
       <withRouter(Connect(QueueFlowModal))
+        button="Submit"
         pathAfterSubmit="/queue/appeals/1986897"
         submit={[Function]}
         title="Cancel convert hearing to virtual task"
         validateForm={[Function]}
       >
         <Connect(QueueFlowModal)
+          button="Submit"
           history={
             Object {
               "action": "POP",
@@ -264,6 +266,7 @@ exports[`CancelTaskModal for cancel change hearing request type action 1`] = `
           validateForm={[Function]}
         >
           <QueueFlowModal
+            button="Submit"
             highlightInvalidFormItems={[Function]}
             history={
               Object {

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -588,7 +588,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         expect(page).to_not have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
       end
 
-      step "Task returned to the EMO shows up in the EMO's assigned tab" do
+      step "Task returned to the EMO shows up in the EMO's unassigned tab" do
         User.authenticate!(user: emo_user)
         visit "/organizations/edu-emo?tab=education_emo_unassigned"
         expect(page).to have_content("#{appeal.veteran.name} (#{appeal.veteran.file_number})")

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -564,7 +564,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         )
       end
 
-      step "Task is now cancelled, and does not show up in another of the RPOs queue tabs" do
+      step "Task is now cancelled, and does not show up in any of the RPOs queue tabs" do
         expect(EducationDocumentSearchTask.last).to have_attributes(
           type: "EducationDocumentSearchTask",
           status: Constants.TASK_STATUSES.assigned,

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -13,7 +13,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
     emo.add_user(emo_user)
     program_office.add_user(program_office_user)
     regional_office.add_user(regional_office_user)
-    regional_processing_office.add_user(regional_processing_office_user)
+    edu_regional_processing_office.add_user(edu_regional_processing_office_user)
   end
 
   after do
@@ -33,8 +33,8 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
   let(:program_office_user) { create(:user) }
   let(:regional_office) { create(:vha_regional_office) }
   let(:regional_office_user) { create(:user) }
-  let(:regional_processing_office) { create(:edu_regional_processing_office) }
-  let(:regional_processing_office_user) { create(:user) }
+  let(:edu_regional_processing_office) { create(:edu_regional_processing_office) }
+  let(:edu_regional_processing_office_user) { create(:user) }
 
   let(:veteran) { create(:veteran) }
   let(:po_instructions) { "Please look for this veteran's documents." }
@@ -422,11 +422,11 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         expect(page).to have_content(COPY::PRE_DOCKET_MODAL_BODY)
         find(".cf-select__control", text: COPY::EDU_REGIONAL_PROCESSING_OFFICE_SELECTOR_PLACEHOLDER).click
 
-        find("div", class: "cf-select__option", text: regional_processing_office.name).click
+        find("div", class: "cf-select__option", text: edu_regional_processing_office.name).click
         find("button", class: "usa-button", text: "Submit").click
 
         expect(page).to have_current_path("/organizations/#{emo.url}?tab=education_emo_unassigned&page=1")
-        expect(page).to have_content("Task assigned to #{regional_processing_office.name}")
+        expect(page).to have_content("Task assigned to #{edu_regional_processing_office.name}")
 
         expect(EducationDocumentSearchTask.last).to have_attributes(
           type: "EducationDocumentSearchTask",
@@ -439,7 +439,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           type: "EducationAssessDocumentationTask",
           status: Constants.TASK_STATUSES.assigned,
           assigned_by: emo_user,
-          assigned_to_id: regional_processing_office.id
+          assigned_to_id: edu_regional_processing_office.id
         )
       end
 
@@ -452,8 +452,8 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
       end
 
       step "RPO Task appears in RPO's assigned tab" do
-        User.authenticate!(user: regional_processing_office_user)
-        visit "/organizations/#{regional_processing_office.url}?tab=education_rpo_assigned&page=1"
+        User.authenticate!(user: edu_regional_processing_office_user)
+        visit "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_assigned&page=1"
         expect(page).to have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
         expect(page).to have_content("#{appeal.veteran.name} (#{appeal.veteran.file_number})")
       end
@@ -524,6 +524,74 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
 
         find("button", text: COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TAB_TITLE.split.first.chomp).click
         expect(page).to_not have_content("#{appeal.veteran.name} (#{appeal.veteran.file_number})")
+      end
+    end
+
+    it "RPO user can return an appeal to the EMO" do
+      appeal = create(
+        :education_assess_documentation_task,
+        :assigned,
+        assigned_to: edu_regional_processing_office,
+        assigned_by: emo_user
+      ).appeal
+
+      step "RPO user navigates to the appeal's queue page and returns it to the EMO" do
+        User.authenticate!(user: edu_regional_processing_office_user)
+
+        visit "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_assigned&page=1"
+        expect(page).to have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
+
+        find_link("#{appeal.veteran.name} (#{appeal.veteran.file_number})").click
+        find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+        find(
+          "div",
+          class: "cf-select__option",
+          text: Constants.TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.label
+        ).click
+
+        expect(page).to have_content(COPY::EDU_REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO_MODAL_TITLE)
+        expect(page).to have_content(COPY::PRE_DOCKET_MODAL_BODY)
+
+        find("button", text: COPY::MODAL_RETURN_BUTTON).click
+        expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+
+        instructions_textarea = find("textarea", id: "taskInstructions")
+        instructions_textarea.send_keys("Incorrect RPO. Please review.")
+        find("button", class: "usa-button-secondary", text: COPY::MODAL_RETURN_BUTTON).click
+
+        expect(page).to have_current_path(
+          "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_assigned&page=1"
+        )
+      end
+
+      step "Task is now cancelled, and does not show up in another of the RPOs queue tabs" do
+        expect(EducationDocumentSearchTask.last).to have_attributes(
+          type: "EducationDocumentSearchTask",
+          status: Constants.TASK_STATUSES.assigned,
+          assigned_to_id: emo.id
+        )
+
+        expect(EducationAssessDocumentationTask.last).to have_attributes(
+          type: "EducationAssessDocumentationTask",
+          status: Constants.TASK_STATUSES.cancelled,
+          assigned_by: emo_user,
+          assigned_to_id: edu_regional_processing_office.id
+        )
+
+        visit "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_assigned"
+        expect(page).to_not have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
+
+        visit "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_in_progress"
+        expect(page).to_not have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
+
+        visit "/organizations/#{edu_regional_processing_office.url}?tab=education_rpo_completed"
+        expect(page).to_not have_content(COPY::ASSESS_DOCUMENTATION_TASK_LABEL)
+      end
+
+      step "Task returned to the EMO shows up in the EMO's assigned tab" do
+        User.authenticate!(user: emo_user)
+        visit "/organizations/edu-emo?tab=education_emo_unassigned"
+        expect(page).to have_content("#{appeal.veteran.name} (#{appeal.veteran.file_number})")
       end
     end
   end

--- a/spec/models/tasks/education_assess_documentation_task_spec.rb
+++ b/spec/models/tasks/education_assess_documentation_task_spec.rb
@@ -19,7 +19,7 @@ describe EducationAssessDocumentationTask, :postgres do
 
       subject { regional_processing_office_task.available_actions(user) }
 
-      available_actions = []
+      available_actions = [Constants.TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.to_h]
 
       it { is_expected.to eq available_actions }
     end

--- a/spec/models/tasks/education_assess_documentation_task_spec.rb
+++ b/spec/models/tasks/education_assess_documentation_task_spec.rb
@@ -2,11 +2,14 @@
 
 describe EducationAssessDocumentationTask, :postgres do
   let(:user) { create(:user) }
+  let(:regional_processing_office) { create(:edu_regional_processing_office) }
+
+  before { regional_processing_office.add_user(user) }
 
   describe "#available_actions" do
-    context "for regional processing office user" do
-      let(:regional_processing_office) { create(:edu_regional_processing_office) }
+    subject { regional_processing_office_task.available_actions(user) }
 
+    context "for regional processing office user" do
       let(:regional_processing_office_task) do
         create(:education_assess_documentation_task, assigned_to: regional_processing_office)
       end
@@ -15,13 +18,9 @@ describe EducationAssessDocumentationTask, :postgres do
         expect(regional_processing_office_task.assigned_to).to eq(regional_processing_office)
       end
 
-      before { regional_processing_office.add_user(user) }
-
-      subject { regional_processing_office_task.available_actions(user) }
-
-      available_actions = [Constants.TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.to_h]
-
-      it { is_expected.to eq available_actions }
+      it "available tasks actions includes Return to EMO action" do
+        is_expected.to include Constants.TASK_ACTIONS.REGIONAL_PROCESSING_OFFICE_RETURN_TO_EMO.to_h
+      end
     end
   end
 end

--- a/spec/models/tasks/education_assess_documentation_task_spec.rb
+++ b/spec/models/tasks/education_assess_documentation_task_spec.rb
@@ -3,8 +3,8 @@
 describe EducationAssessDocumentationTask, :postgres do
   let(:user) { create(:user) }
 
-  context "#available_actions" do
-    describe "for regional processing office user" do
+  describe "#available_actions" do
+    context "for regional processing office user" do
       let(:regional_processing_office) { create(:edu_regional_processing_office) }
 
       let(:regional_processing_office_task) do


### PR DESCRIPTION
Resolves [CASEFLOW-4519](https://vajira.max.gov/browse/CASEFLOW-4519)

### Description
We need to implement a new task action and subsequent modal for RPO users to successfully return pre-docket appeals to the EMO.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] "Return to Executive Management Office" task action is created
- [x] "Return to Executive Management Office" modal is created
- [x] Instructions are enforced per designs
- [x] RPO can successfully return a predocket appeal to EMO
- [x] Upon success, show the appropriate success banner (most likely a Success Alert in the Queue view however awaiting design feedback)
- [x] Upon fail, show a failure (most likely a Slim Error Alert in the modal)
- [x] After assignment the RPO task has a status of "cancelled"
- [x] The EMO task should be shifted from a status of "on hold" to a status of "assigned"


### Testing Plan
0. Run the Caseflow frontend and backend separately: `make run-frontend` & `make run-backend`.

1. Log into Caseflow as an RPO user.

2. Create an appeal with an `EducationAssessDocumentationTask` using the Rails console:
```ruby
rpo_task = FactoryBot.create(:education_assess_documentation_task, :assigned)
appeal = rpo_task.appeal
```
Feel free to use `EMOUSER` for the CSS_ID that you will be prompted for.

`appeal.treee`:
```ruby                 ┌───────────────────────────────────────────────────────────────────────────────────┐
Appeal 1670 (E 220502-1670 Original) ─────────── │ ID   │ STATUS   │ ASGN_BY │ ASGN_TO                     │ UPDATED_AT              │
└── RootTask                                     │ 7142 │ on_hold  │         │ Bva                         │ 2022-05-03 19:37:12 UTC │
    └── PreDocketTask                            │ 7143 │ on_hold  │         │ BvaIntake                   │ 2022-05-03 19:37:16 UTC │
        └── EducationDocumentSearchTask          │ 7144 │ on_hold  │         │ EducationEmo                │ 2022-05-03 19:37:16 UTC │
            └── EducationAssessDocumentationTask │ 7145 │ assigned │         │ EduRegionalProcessingOffice │ 2022-05-03 19:37:16 UTC │
                                                 └───────────────────────────────────────────────────────────────────────────────────┘
```

3. Go to the appeal's queue page: `http://localhost:3000/queue/appeals/<appeal.uuid>`
You can also access it by going to the Buffalo RPO's assigned tab.

4. Select `Return to Executive Management Office` from the task actions dropdown.

5. Hit the `Return` button **without** entering any text into the text area. You should be presented with an error stating that you must enter information: "This field is required."

6. Kill your backend. Enter text into the text area and then hit the `Return` button again. This time you should receive an error message stating that you may need to reach out to technical support: "There was an error processing your request. Please retry your action and contact support if errors persist."

7. Restart your backend. Hit the `Return` button one last time.

8. Make sure that the appeal does **not** appear in **any** of the RPOs tabs. The task has been `cancelled` and should not be visible.

9. Switch to an EMO user and go to the EMO organization's unassigned tab. The appeal should now reside there.

`appeal.treee`:

```ruby                                      ┌────────────────────────────────────────────────────────────────────────────────────┐
Appeal 1670 (E 220502-1670 Original) ─────────── │ ID   │ STATUS    │ ASGN_BY │ ASGN_TO                     │ UPDATED_AT              │
└── RootTask                                     │ 7142 │ on_hold   │         │ Bva                         │ 2022-05-03 19:37:12 UTC │
    └── PreDocketTask                            │ 7143 │ on_hold   │         │ BvaIntake                   │ 2022-05-03 19:37:16 UTC │
        └── EducationDocumentSearchTask          │ 7144 │ assigned  │         │ EducationEmo                │ 2022-05-03 19:48:58 UTC │
            └── EducationAssessDocumentationTask │ 7145 │ cancelled │         │ EduRegionalProcessingOffice │ 2022-05-03 19:48:58 UTC │
                                                 └────────────────────────────────────────────────────────────────────────────────────┘
```

Final timeline:

<img width="428" alt="rpo-cancel-timeline" src="https://user-images.githubusercontent.com/99351305/166555488-ee318d69-051b-4374-814a-1efb29771d42.PNG">

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

![rpo-to-emo](https://user-images.githubusercontent.com/99351305/166551893-40802cdd-a600-4e38-b6eb-b8ab6265b957.gif)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.