### PR TITLE
MattT/CASEFLOW-5770

### DIFF
--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -701,7 +701,7 @@ export const taskActionData = ({ task, match }) => {
     return relevantAction.data;
   }
 
-  return null;
+  return {};
 };
 
 export const parentTasks = (childrenTasks, allTasks) => {

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -727,7 +727,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         :education_document_search_task,
         :assigned,
         assigned_to: emo,
-        assigned_by: emo_user
+        assigned_by: bva_intake_user
       )
 
       emo_task.completed!

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -721,5 +721,42 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
       expect(emo_task.reload.status).to eq Constants.TASK_STATUSES.completed
       expect(open_rpo_task.reload.status).to eq Constants.TASK_STATUSES.completed
     end
+
+    it "BVA Intake user can return an appeal to the EMO" do
+      emo_task = create(
+        :education_document_search_task,
+        :assigned,
+        assigned_to: emo,
+        assigned_by: emo_user
+      )
+
+      emo_task.completed!
+
+      User.authenticate!(user: bva_intake_user)
+
+      visit "/queue/appeals/#{emo_task.appeal.uuid}"
+
+      find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+      find(
+        "div",
+        class: "cf-select__option",
+        text: Constants.TASK_ACTIONS.BVA_INTAKE_RETURN_TO_EMO.label
+      ).click
+
+      expect(page).to have_content(COPY::BVA_INTAKE_RETURN_TO_EMO_MODAL_TITLE)
+      expect(page).to have_content(COPY::BVA_INTAKE_RETURN_TO_EMO_MODAL_BODY)
+
+      instructions_textarea = find("textarea", id: "taskInstructions")
+      instructions_textarea.send_keys("Please review this appeal, EMO.")
+
+      find("button", text: COPY::MODAL_SUBMIT_BUTTON).click
+
+      expect(page).to have_current_path("/organizations/#{bva_intake.url}?tab=pending&page=1")
+
+      expect(page).to have_content(COPY::BVA_INTAKE_RETURN_TO_EMO_CONFIRMATION_TITLE)
+      expect(page).to have_content(COPY::BVA_INTAKE_RETURN_TO_EMO_CONFIRMATION_DETAIL)
+
+      expect(emo_task.appeal.tasks.last.assigned_to). to eq emo
+    end
   end
 end


### PR DESCRIPTION
Resolves [CASEFLOW-5770](https://vajira.max.gov/browse/CASEFLOW-5770)

### Description
Resolves a bug where, while processing a task action submission to return an appeal from BVA Intake to the EMO, multiple renderings of the task action modal would subsequently cause the frontend to crash due to a value no longer being present (the Return to EMO task action).

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] A BVA Intake user can send an appeal back to the EMO, and be redirected back to their organization's queue, without an error occurring.

### Testing Plan
1. Create an appeal with an EducationDocumentSearchTask:
```ruby
emo_task = FactoryBot.create(:education_document_search_task, :assigned)
```

2. Complete the task, sending it back to BVA Intake:
```ruby
emo_task.completed!
```

3. Log into Caseflow as a BVA Intake user, and navigate to [BVA Intake's Ready for Review tab](http://localhost:3000/organizations/bva-intake?tab=bvaReadyForReview&page=1).

4. Go to the Case Details page for the appeal you've created. Select the "Return to Education Service" option from the actions dropdown. Enter some text in the text area on the modal that appears, and then hit "Submit".

5. At this point is where the error was occurring prior to the fix. Make sure that you are redirected back to the BVA Intake queue, and that you see the correct success banner as well as the appeal from step 1 in the Pending tab.

<img width="949" alt="success-return-to-emo" src="https://user-images.githubusercontent.com/99351305/169528112-26788bdf-d649-454f-948b-c7e65e500459.PNG">


- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
