### PR TITLE
Caseflow 5066 sync change hearing request type task with poa changes

### DIFF
--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -15,6 +15,8 @@ class BgsPowerOfAttorney < CaseflowRecord
   before_save :update_cached_attributes!
   after_save :update_ihp_task, if: :update_ihp_enabled?
   after_destroy :update_ihp_task, if: :update_ihp_enabled?
+  after_save :update_change_hearing_request_type_task
+  after_destroy :update_change_hearing_request_type_task
 
   CACHED_BGS_ATTRIBUTES = [
     :representative_name,
@@ -157,6 +159,12 @@ class BgsPowerOfAttorney < CaseflowRecord
   def update_ihp_task
     related_appeals.each do |appeal|
       InformalHearingPresentationTask.update_to_new_poa(appeal) if appeal.active?
+    end
+  end
+
+  def update_change_hearing_request_type_task
+    related_appeals.each do |appeal|
+      ChangeHearingRequestTypeTask.update_to_new_poa(appeal) if appeal.active?
     end
   end
 

--- a/spec/models/tasks/change_hearing_request_type_task_spec.rb
+++ b/spec/models/tasks/change_hearing_request_type_task_spec.rb
@@ -36,7 +36,6 @@ describe ChangeHearingRequestTypeTask do
           expect(hearing_task).to_not receive(:when_child_task_completed)
 
           subject
-
           expect(task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
           expect(schedule_hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
           expect(hearing_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
@@ -292,6 +291,130 @@ describe ChangeHearingRequestTypeTask do
         expect(new_her_r.timezone).to eq("America/Los_Angeles")
         expect(new_her_a.email_address).not_to eq(existing_her_a.email_address)
         expect(new_her_r.timezone).not_to eq(existing_her_r.timezone)
+      end
+    end
+  end
+  describe "update to new poa" do
+    subject { ChangeHearingRequestTypeTask.update_to_new_poa(appeal) }
+    let!(:appeal) { create(:appeal) }
+    let!(:root_task) { create(:root_task, appeal: appeal) }
+    let!(:hearing_task) { create(:hearing_task, appeal: appeal, parent: root_task) }
+    let!(:vso_org) { create(:vso) }
+    let!(:vso_org_new) { create(:vso) }
+    let!(:schedule_hearing_task) do
+      create(
+        :schedule_hearing_task,
+        parent: hearing_task,
+        appeal: root_task.appeal,
+        assigned_to: vso_org
+      )
+    end
+    let!(:old_vso) { create(:user, roles: ["VSO"], full_name: "old") }
+    let!(:new_vso) { create(:user, roles: ["VSO"], full_name: "new") }
+
+    context "When former representative VSO user is assigned tasks" do
+      let!(:change_type_task) do
+        create(
+          :change_hearing_request_type_task,
+          parent: schedule_hearing_task,
+          appeal: root_task.appeal,
+          assigned_to: old_vso
+        )
+      end
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([new_vso]) }
+
+      it "cancels all tasks of former VSO" do
+        subject
+        expect(change_type_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+      end
+      it "makes duplicates of active tasks for new representation" do
+        expect(new_vso.tasks.count).to eq(0)
+        expect(subject).to eq([1, 1])
+        expect(new_vso.tasks.count).to eq(1)
+      end
+    end
+    context "When former representative VSO organization is assigned tasks" do
+      let!(:change_type_task) do
+        create(
+          :change_hearing_request_type_task,
+          parent: schedule_hearing_task,
+          appeal: root_task.appeal,
+          assigned_to: vso_org
+        )
+      end
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([vso_org_new]) }
+
+      it "cancels all tasks of former VSO" do
+        subject
+        expect(change_type_task.reload.status).to eq(Constants.TASK_STATUSES.cancelled)
+      end
+      it "makes duplicates of active tasks for new representation" do
+        expect(vso_org_new.tasks.count).to eq(0)
+        expect(subject).to eq([1, 1])
+        expect(vso_org_new.tasks.count).to eq(1)
+      end
+    end
+    context "when the appeal has no VSOs" do
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return([]) }
+
+      context "when there are no existing Change" do
+        it "does not create or cancel any ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
+          expect(subject).to eq([0, 0])
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before)
+        end
+      end
+
+      context "when there is an existing open ChangeHearingRequestTypeTask" do
+        let(:vso) { create(:vso) }
+        let!(:vso_user) { create(:user, roles: ["VSO"], full_name: "singular") }
+        let!(:change_task) { create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso_user) }
+
+        it "cancels old ChangeHearingRequestTypeTask, does not create any new tasks" do
+          active_task_count_before = ChangeHearingRequestTypeTask.open.count
+          expect(subject).to eq([0, 1])
+          expect(ChangeHearingRequestTypeTask.open.count).to eq(active_task_count_before - 1)
+        end
+      end
+    end
+    context "when the appeal has two VSOs" do
+      let!(:vso_one) { create(:user, roles: ["VSO"], full_name: "thingone") }
+      let!(:vso_two) { create(:user, roles: ["VSO"], full_name: "thingtwo") }
+      let(:representing_vsos) { [vso_one, vso_two] }
+      before { allow_any_instance_of(Appeal).to receive(:representatives).and_return(representing_vsos) }
+
+      context "when there are no existing ChangeHearingRequestTypeTasks" do
+        it "creates 2 new ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
+          expect(subject).to eq([2, 0])
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before + 2)
+        end
+      end
+
+      context "when there is an existing open ChangeHearingRequestTypeTasks for a different VSO" do
+        let!(:diff_vso) { create(:user, roles: ["VSO"], full_name: "different") }
+        before do
+          create(:change_hearing_request_type_task, appeal: appeal, assigned_to: diff_vso)
+        end
+
+        it "cancels old ChangeHearingRequestTypeTask, creates 2 new ChangeHearingRequestTypeTasks" do
+          expect(subject).to eq([2, 1])
+        end
+      end
+
+      context "when there are already ChangeHearingRequestTypeTask for both VSOs" do
+        before do
+          representing_vsos.each do |vso|
+            create(:change_hearing_request_type_task, appeal: appeal, assigned_to: vso)
+          end
+        end
+
+        it "does not create or cancel any ChangeHearingRequestTypeTask" do
+          task_count_before = ChangeHearingRequestTypeTask.count
+
+          expect(subject).to eq([0, 0])
+          expect(ChangeHearingRequestTypeTask.count).to eq(task_count_before)
+        end
       end
     end
   end


### PR DESCRIPTION
Resolves #[CASEFLOW-5066](https://vajira.max.gov/browse/CASEFLOW-5066)
Description
As a newly appointed rep I need to the ability Veteran with a new representative - when the representative of an appeal changes, the change hearing request type task is reassigned to the new representative

Update Appellant Representation Job needs to be updated to ensure the ChangeHearingRequestTypeTask for a given Appeal is assigned to the correct VSO user when there is a change in representation for the appeal.

Acceptance Criteria

When the representative of an appeal changes:
- [ ] the change hearing request type task is unassigned from the prior representative (can no longer convert to virtual)
- [ ] the change hearing request type task is assigned to the new representative (can convert to virtual)
 