### PR TITLE
CASEFLOW-5960 Ability for VSO to opt-in Veteran / Appellant into a virtual hearing

### DIFF
--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -49,7 +49,7 @@ class TasksForAppeal
       .select do |task|
       task.assigned_to.is_a?(Representative) || task.assigned_to_vso_user? || user == task.assigned_to ||
         (task.is_a?(HearingTask) && task&.hearing&.disposition == Constants.HEARING_DISPOSITION_TYPES.held) ||
-        task.is_a?(DistributionTask)
+        task.is_a?(DistributionTask) || task.is_a?(HearingTask) || task.is_a?(ScheduleHearingTask)
     end
   end
 

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -13,7 +13,8 @@ import {
   appealWithDetailSelector,
   getAllTasksForAppeal,
   openScheduleHearingTasksForAppeal,
-  allHearingTasksForAppeal
+  allHearingTasksForAppeal,
+  scheduleHearingTasksForAppeal
 } from './selectors';
 import {
   stopPollingHearing,
@@ -198,6 +199,9 @@ export const CaseDetailsView = (props) => {
   const openScheduledHearingTasks = useSelector(
     (state) => openScheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
+  const scheduleHearingTasks= useSelector(
+    (state) => scheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
+  );
   const allHearingTasks = useSelector(
     (state) => allHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
@@ -305,7 +309,7 @@ export const CaseDetailsView = (props) => {
             <CaseHearingsDetail
               title="Hearings"
               appeal={appeal}
-              hearingTasks={parentHearingTasks}
+              hearingTasks={userIsVsoEmployee ? scheduleHearingTasks : parentTasks(openScheduledHearingTasks, allHearingTasks)}
             />
           )}
           <VeteranDetail title="About the Veteran" appealId={appealId} />

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -199,7 +199,7 @@ export const CaseDetailsView = (props) => {
   const openScheduledHearingTasks = useSelector(
     (state) => openScheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
-  const scheduleHearingTasks= useSelector(
+  const scheduleHearingTasks = useSelector(
     (state) => scheduleHearingTasksForAppeal(state, { appealId: appeal.externalId })
   );
   const allHearingTasks = useSelector(
@@ -309,7 +309,7 @@ export const CaseDetailsView = (props) => {
             <CaseHearingsDetail
               title="Hearings"
               appeal={appeal}
-              hearingTasks={userIsVsoEmployee ? scheduleHearingTasks : parentTasks(openScheduledHearingTasks, allHearingTasks)}
+              hearingTasks={userIsVsoEmployee ? scheduleHearingTasks : parentHearingTasks}
             />
           )}
           <VeteranDetail title="About the Veteran" appealId={appealId} />

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -15,6 +15,7 @@ import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/comp
 import Tooltip from '../components/Tooltip';
 import { PencilIcon } from '../components/icons/PencilIcon';
 import Button from '../components/Button';
+import Alert from '../components/Alert';
 
 import EditUnscheduledNotesModal from '../hearings/components/EditUnscheduledNotesModal';
 import { UnscheduledNotes } from '../hearings/components/UnscheduledNotes';
@@ -23,7 +24,7 @@ import COPY from '../../COPY';
 import { DateString } from '../util/DateUtil';
 import { showVeteranCaseList } from './uiReducer/uiActions';
 import { dispositionLabel } from '../hearings/utils';
-import { openScheduleHearingTasksForAppeal } from './selectors';
+import TASK_ACTIONS from '../../constants/TASK_ACTIONS';
 
 const appealSummaryUlStyling = css({
   paddingLeft: 0,
@@ -184,44 +185,56 @@ class CaseHearingsDetail extends React.PureComponent {
 
   closeModal = () => this.setState({ modalOpen: false, selectedTask: null })
 
-  unscheduledHearingConversion = (appeal, userIsVsoEmployee) => {
-    appeal?.readableHearingRequestType
-    if(userIsVsoEmployee) {
-      route = `/queue/appeals/${appeal.externalId}/tasks/${openScheduleHearingTasksForAppeal.uniqueId}/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`
-      history.push(route)
-      return <Link to={route}>Convert to virtual</Link>
-    }
-  };
-
   getUnscheduledHearingAttrs = (task, appeal, userIsVsoEmployee, history) => {
-    return [
-      {
-        label: 'Type',
-        value: 
-        <React.Fragment>
-           {this.unscheduledHearingConversion(appeal, userIsVsoEmployee)} 
-          <br />
-        </React.Fragment>
-      },
-      {
-        label: 'Notes',
-        value: <React.Fragment>
-          <Button styling={css({ padding: 0 })} linkStyling onClick={() => this.openModal(task)} >
-            <span {...css({ position: 'absolute' })}><PencilIcon size={25} /></span>
-            <span {...css({ marginLeft: '24px' })}>Edit</span>
-          </Button>
-          <br />
-          {task?.unscheduledHearingNotes?.notes && <UnscheduledNotes
-            readonly
-            styling={{ marginLeft: '2rem' }}
-            unscheduledNotes={task?.unscheduledHearingNotes?.notes}
-            updatedAt={task?.unscheduledHearingNotes?.updatedAt}
-            updatedByCssId={task?.unscheduledHearingNotes?.updatedByCssId}
-            uniqueId={task?.taskId} />
-          }
-        </React.Fragment>
-      },
-    ];
+    if (userIsVsoEmployee){
+      return [
+        {
+          label: 'Type',
+          value: 
+            <React.Fragment>
+              {appeal?.readableHearingRequestType}&nbsp;&nbsp;
+              {appeal?.readableHearingRequestType !== "Virtual" && 
+               <Link to={`/queue/appeals/${appeal.externalId}/tasks/` + 
+               `${task.uniqueId}/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`}>Convert to virtual</Link>}
+               {//FIXME
+               appeal?.readableHearingRequestType == "Virtual" && 
+                <div className="cf-sg-alert-slim">
+                  <Alert
+                    type="info">
+                    Hearing already virtual
+                  </Alert>
+                </div>}
+            </React.Fragment>
+        },
+      ];
+    }
+    else {
+      return [
+        {
+          label: 'Type',
+          value: 
+            appeal?.readableHearingRequestType
+        },
+        {
+          label: 'Notes',
+          value: <React.Fragment>
+            <Button styling={css({ padding: 0 })} linkStyling onClick={() => this.openModal(task)} >
+              <span {...css({ position: 'absolute' })}><PencilIcon size={25} /></span>
+              <span {...css({ marginLeft: '24px' })}>Edit</span>
+            </Button>
+            <br />
+            {task?.unscheduledHearingNotes?.notes && <UnscheduledNotes
+              readonly
+              styling={{ marginLeft: '2rem' }}
+              unscheduledNotes={task?.unscheduledHearingNotes?.notes}
+              updatedAt={task?.unscheduledHearingNotes?.updatedAt}
+              updatedByCssId={task?.unscheduledHearingNotes?.updatedByCssId}
+              uniqueId={task?.taskId} />
+            }
+          </React.Fragment>
+        },
+      ];
+    }
   }
 
   getUnscheduledHearingElements = () => {
@@ -239,7 +252,7 @@ class CaseHearingsDetail extends React.PureComponent {
       <BareList compact
         listStyle={css(marginLeft, noTopBottomMargin)}
         ListElementComponent="ul"
-        items={this.getUnscheduledHearingAttrs(task, appeal).map(this.getDetailField)} />
+        items={this.getUnscheduledHearingAttrs(task, appeal, userIsVsoEmployee).map(this.getDetailField)} />
     </div>);
   }
 

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -64,7 +64,7 @@ class CaseHearingsDetail extends React.PureComponent {
 
   getHearingAttrs = (appeal, hearing, userIsVsoEmployee) => {
     const today = new Date();
-    const deadline = today.setDate(today.getDate() + 11)
+    const deadline = today.setDate(today.getDate() + 11);
     const hearingDay = new Date(hearing.date);
     // show convert to virtual link if user is vso, hearing isn't virtual, and scheduled date is not within deadline
     const hearingAttrs = [{

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -65,23 +65,23 @@ class CaseHearingsDetail extends React.PureComponent {
   getHearingAttrs = (appeal, hearing, userIsVsoEmployee) => {
     const today = new Date();
     const deadline = today.setDate(today.getDate() + 11)
-    const hearing_day = new Date(hearing.date);
+    const hearingDay = new Date(hearing.date);
     // show convert to virtual link if user is vso, hearing isn't virtual, and scheduled date is not within deadline
     const hearingAttrs = [{
-        label: 'Type',
-        value: 
-        <React.Fragment>
-          {hearing.isVirtual ? 'Virtual' : hearing.type}&nbsp;&nbsp;
-          {userIsVsoEmployee && !hearing.isVirtual && hearing_day > deadline && 
-           <Link to={`/hearings/${appeal.externalId}/details`}>Convert to virtual</Link> }
-        </React.Fragment>
-      },
-      {
-        label: 'Disposition',
-        value: <React.Fragment>
-          {dispositionLabel(hearing?.disposition)}
-        </React.Fragment>
-      }];
+      label: 'Type',
+      value:
+      <React.Fragment>
+        {hearing.isVirtual ? 'Virtual' : hearing.type}&nbsp;&nbsp;
+        {userIsVsoEmployee && !hearing.isVirtual && hearingDay > deadline &&
+         <Link to={`/hearings/${appeal.externalId}/details`}>Convert to virtual</Link> }
+      </React.Fragment>
+    },
+    {
+      label: 'Disposition',
+      value: <React.Fragment>
+        {dispositionLabel(hearing?.disposition)}
+      </React.Fragment>
+    }];
 
     if (!userIsVsoEmployee) {
       hearingAttrs.push(
@@ -109,20 +109,9 @@ class CaseHearingsDetail extends React.PureComponent {
         value: <DateString date={hearing.date} dateFormat="M/D/YY" style={marginRight} />
       }
     );
-
-    if (!userIsVsoEmployee) {
-      hearingAttrs.push(
-        {
-          label: '',
-          value: <Link href={`/hearings/${hearing.externalId}/details`}>
-            {COPY.CASE_DETAILS_HEARING_DETAILS_LINK_COPY}
-          </Link>
-        }
-      );
-    }
-    //info alert for hearings within 11 days of scheduled date
-    else {
-      if (!hearing.isVirtual && hearing_day <= deadline) {
+    // info alert for hearings within 11 days of scheduled date
+    if (userIsVsoEmployee) {
+      if (!hearing.isVirtual && hearingDay <= deadline) {
         hearingAttrs.push(
           {
             label: '',
@@ -133,9 +122,20 @@ class CaseHearingsDetail extends React.PureComponent {
                 </Alert>
               </div>
           }
-        )
+        );
       }
-    }   
+    }
+    else {
+      hearingAttrs.push(
+        {
+          label: '',
+          value: <Link href={`/hearings/${hearing.externalId}/details`}>
+            {COPY.CASE_DETAILS_HEARING_DETAILS_LINK_COPY}
+          </Link>
+        }
+      );
+    }
+
     return hearingAttrs;
   }
 

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -65,13 +65,24 @@ class CaseHearingsDetail extends React.PureComponent {
     const hearingAttrs = [{
       label: 'Type',
       value: hearing.isVirtual ? 'Virtual' : hearing.type
-    },
-    {
-      label: 'Disposition',
-      value: <React.Fragment>
-        {dispositionLabel(hearing?.disposition)}
-      </React.Fragment>
     }];
+    if (userIsVsoEmployee) {
+      if(hearings[0].type != 'virtual' && today + 11 < hearings[0].date) {
+        route = `/hearings/${appeal.externalId}/details`
+        history.push(route)
+        hearingAttrs.push(
+          <Link to={route}>Convert to virtual</Link>
+        )
+      }
+    }
+    hearingAttrs.push(
+      {
+        label: 'Disposition',
+        value: <React.Fragment>
+          {dispositionLabel(hearing?.disposition)}
+        </React.Fragment>
+      }
+    )
 
     if (!userIsVsoEmployee) {
       hearingAttrs.push(
@@ -109,6 +120,12 @@ class CaseHearingsDetail extends React.PureComponent {
           </Link>
         }
       );
+    }
+    //FIXME
+    else {
+      if (hearings[0].type != 'virtual' && today + 11 >= hearings[0].date) {
+        // put in the banner here
+      }
     }
 
     return hearingAttrs;
@@ -174,23 +191,6 @@ class CaseHearingsDetail extends React.PureComponent {
       route = `/queue/appeals/${appeal.externalId}/tasks/${openScheduleHearingTasksForAppeal.uniqueId}/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`
       history.push(route)
       return <Link to={route}>Convert to virtual</Link>
-    }
-    // if hearing is scheduled
-    //FIXME this is all pseudocode
-    else {
-      // if hearing is already virtual
-      if(hearings[0].type == 'virtual') {
-        return
-      }
-      // if hearing is within 11 days
-      else if(today + 11 == hearings[0].date) {
-        // insert banner here
-      }
-      else {
-        route = `/hearings/${appeal.externalId}/details`
-        history.push(route)
-        return <Link to={route}>Convert to virtual</Link>
-      }
     }
   };
 

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -62,15 +62,17 @@ class CaseHearingsDetail extends React.PureComponent {
     };
   }
 
-  getHearingAttrs = (hearing, userIsVsoEmployee) => {
-    //FIXME
-    const today = new Date().toLocaleDateString();      // convert to virtual link
+  getHearingAttrs = (appeal, hearing, userIsVsoEmployee) => {
+    const today = new Date();
+    const deadline = today.setDate(today.getDate() + 11)
+    const hearing_day = new Date(hearing.date);
+    // show convert to virtual link if user is vso, hearing isn't virtual, and scheduled date is not within deadline
     const hearingAttrs = [{
         label: 'Type',
         value: 
         <React.Fragment>
-          {hearing.isVirtual ? 'Virtual' : hearing.type}
-          {userIsVsoEmployee && !hearing.isVirtual && today + 11 < hearing.date && 
+          {hearing.isVirtual ? 'Virtual' : hearing.type}&nbsp;&nbsp;
+          {userIsVsoEmployee && !hearing.isVirtual && hearing_day > deadline && 
            <Link to={`/hearings/${appeal.externalId}/details`}>Convert to virtual</Link> }
         </React.Fragment>
       },
@@ -118,22 +120,25 @@ class CaseHearingsDetail extends React.PureComponent {
         }
       );
     }
-    //info alerts
+    //info alert for hearings within 11 days of scheduled date
     else {
-      if (!hearing.isVirtual && today + 11 >= hearing.date) {
+      if (!hearing.isVirtual && hearing_day <= deadline) {
         hearingAttrs.push(
-          <div className="cf-sg-alert-slim">
-            <Alert type="info">
-              Hearing within next 10 days; 
-              <a href="https://www.bva.va.gov/docs/RO_Coordinator_Assignments.pdf" target="_blank" rel="noreferrer">
-                contact Hearing Coordinator to convert to Virtual.
-              </a>
-            </Alert>
-          </div>
+          {
+            label: '',
+            value:
+              <div className="cf-sg-alert-slim">
+                <Alert type="info">
+                  Hearing within next 10 days;&nbsp;
+                  <a href="https://www.bva.va.gov/docs/RO_Coordinator_Assignments.pdf" target="_blank" rel="noreferrer">
+                    contact Hearing Coordinator to convert to Virtual.
+                  </a>
+                </Alert>
+              </div>
+          }
         )
       }
-    }
-
+    }   
     return hearingAttrs;
   }
 
@@ -158,7 +163,7 @@ class CaseHearingsDetail extends React.PureComponent {
       <BareList compact
         listStyle={css(marginLeft, noTopBottomMargin)}
         ListElementComponent="ul"
-        items={this.getHearingAttrs(hearing, userIsVsoEmployee).map(this.getDetailField)} />
+        items={this.getHearingAttrs(this.props.appeal, hearing, userIsVsoEmployee).map(this.getDetailField)} />
     </div>);
 
     return <React.Fragment>

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -66,12 +66,16 @@ class CaseHearingsDetail extends React.PureComponent {
       label: 'Type',
       value: hearing.isVirtual ? 'Virtual' : hearing.type
     }];
+    //FIXME
     if (userIsVsoEmployee) {
-      if(hearings[0].type != 'virtual' && today + 11 < hearings[0].date) {
+      if(hearing.type != 'virtual' && today + 11 < hearing.date) {
         route = `/hearings/${appeal.externalId}/details`
         history.push(route)
         hearingAttrs.push(
-          <Link to={route}>Convert to virtual</Link>
+          {
+            label: '',
+            value: <Link to={route}>Convert to virtual</Link>
+          }
         )
       }
     }
@@ -180,14 +184,9 @@ class CaseHearingsDetail extends React.PureComponent {
 
   closeModal = () => this.setState({ modalOpen: false, selectedTask: null })
 
-  changeRoute = () => {
-    const {
-      appeal: { hearings },
-      openScheduleHearingTasksForAppeal,
-      userIsVsoEmployee
-    } = this.props;
-    // if hearing is unscheduled
-    if(!_.isEmpty(hearings)) {
+  unscheduledHearingConversion = (appeal, userIsVsoEmployee) => {
+    appeal?.readableHearingRequestType
+    if(userIsVsoEmployee) {
       route = `/queue/appeals/${appeal.externalId}/tasks/${openScheduleHearingTasksForAppeal.uniqueId}/${TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}`
       history.push(route)
       return <Link to={route}>Convert to virtual</Link>
@@ -200,10 +199,7 @@ class CaseHearingsDetail extends React.PureComponent {
         label: 'Type',
         value: 
         <React.Fragment>
-          {
-          appeal?.readableHearingRequestType
-          if (userIsVsoEmployee) {this.changeRoute} 
-          }
+           {this.unscheduledHearingConversion(appeal, userIsVsoEmployee)} 
           <br />
         </React.Fragment>
       },

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -129,10 +129,7 @@ class CaseHearingsDetail extends React.PureComponent {
             value:
               <div className="cf-sg-alert-slim">
                 <Alert type="info">
-                  Hearing within next 10 days;&nbsp;
-                  <a href="https://www.bva.va.gov/docs/RO_Coordinator_Assignments.pdf" target="_blank" rel="noreferrer">
-                    contact Hearing Coordinator to convert to Virtual.
-                  </a>
+                  Hearing within next 10 days; contact Hearing Coordinator to convert to Virtual.
                 </Alert>
               </div>
           }

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -162,10 +162,21 @@ class CaseHearingsDetail extends React.PureComponent {
   closeModal = () => this.setState({ modalOpen: false, selectedTask: null })
 
   getUnscheduledHearingAttrs = (task, appeal) => {
+    const routeChange = () =>{ 
+      let path = `newPath`; 
+      navigate(path);
+    }
     return [
       {
         label: 'Type',
-        value: appeal?.readableHearingRequestType
+        value: 
+        <React.Fragment>
+          appeal?.readableHearingRequestType
+          <Link to={this.props.myroute} onClick={routeChange}>Convert to virtual</Link>
+          <br />
+        </React.Fragment>
+        
+
       },
       {
         label: 'Notes',

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -146,7 +146,7 @@ const actionableTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
   (tasks) => filter(tasks, (task) => task.availableActions.length)
 );
-//FIXME
+
 export const scheduleHearingTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
   (tasks) => filter(incompleteTasksSelector(tasks), (task) => task.type === 'ScheduleHearingTask')

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -146,6 +146,11 @@ const actionableTasksForAppeal = createSelector(
   [getAllTasksForAppeal],
   (tasks) => filter(tasks, (task) => task.availableActions.length)
 );
+//FIXME
+export const scheduleHearingTasksForAppeal = createSelector(
+  [getAllTasksForAppeal],
+  (tasks) => filter(incompleteTasksSelector(tasks), (task) => task.type === 'ScheduleHearingTask')
+);
 
 export const openScheduleHearingTasksForAppeal = createSelector(
   [actionableTasksForAppeal],

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
@@ -7,6 +7,12 @@ RSpec.feature "Convert hearing request type" do
     a
   end
 
+  let!(:appeal_deadline) do
+    a = create(:appeal, :with_schedule_hearing_tasks, :hearing_docket)
+    a.update!(changed_hearing_request_type: Constants.HEARING_REQUEST_TYPES.video)
+    a
+  end
+
   before do
     vso.add_user(vso_user)
     User.authenticate!(user: vso_user)
@@ -19,26 +25,15 @@ RSpec.feature "Convert hearing request type" do
     scenario "Convert appeal to Virtual hearing type" do
       step "navigate to the VSO Form" do
         visit "queue/appeals/#{appeal.uuid}"
-
         expect(page).to have_content("Video")
-
+        expect(page).to have_link("Convert to virtual")
         click_link("Convert to virtual")
 
         expect(page).to have_current_path("/queue/appeals/#{appeal.external_id}" \
           "/tasks/#{appeal.tasks.last.id}/#{Constants.TASK_ACTIONS.CHANGE_HEARING_REQUEST_TYPE_TO_VIRTUAL.value}")
       end
-
-      step "fill out the Form" do
-        expect(page).to have_content("Convert Hearing To Virtual")
-        # TODO: add front end validation checks here once changes are merged
-        click_button("Convert Hearing To Virtual")
-      end
-
-      step "Confirm success message" do
-        expect(page).to have_content(
-          "You have successfully converted #{appeal.veteran_full_name}'s hearing to virtual"
-        )
-        expect(page).to have_content(COPY::VSO_CONVERT_HEARING_TYPE_SUCCESS_DETAIL)
+      step "cancel the step that starts the schedule workflow to test the next step" do
+        click_button("Cancel")
       end
     end
   end

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_scheduled_hearing_type.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_scheduled_hearing_type.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.feature "Convert scheduled hearing type" do
+  before { FeatureToggle.enable!(:schedule_veteran_virtual_hearing) }
+  after { FeatureToggle.disable!(:schedule_veteran_virtual_hearing) }
   let!(:appeal) do
     a = create(:appeal, :with_schedule_hearing_tasks, :hearing_docket)
     a.update!(changed_hearing_request_type: Constants.HEARING_REQUEST_TYPES.video)
@@ -13,30 +15,38 @@ RSpec.feature "Convert scheduled hearing type" do
     a
   end
 
-  let!(:hearing_day) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 12.days) }
-  let(:hearing_day_deadline) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 7.days) }
-
   context "for Hearing coordinator user" do
-    let!(:current_user) { User.authenticate!(roles: ["Edit HearSched"]) }
     before do
+      current_user = User.authenticate!(roles: ["Edit HearSched", "Build HearSched"])
       HearingsManagement.singleton.add_user(current_user)
     end
+    let!(:hearing_day) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 14.days) }
+    let(:hearing_day_deadline) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 7.days) }
+
     scenario "Schedule veteran" do
       step "select from dropdown" do
+        visit "queue/appeals/#{appeal.uuid}"
         click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.label)
+      end
 
+      step "fill in form" do
+        fill_in "Notes", with: "asfsefdsfdf"
+        click_dropdown(prompt: "Hearing Type", text: "Video")
+        click_dropdown(prompt: "Regional Office", text: "Boston, MA")
+        click_dropdown(prompt: "Hearing Location", text: "Holdrege, NE (VHA) 0 miles away")
+        choose("8:30 AM Eastern Time (US & Canada)")
+        click_button(text: "Schedule")
       end
     end
   end
 
-  before do
-    vso.add_user(vso_user)
-    User.authenticate!(user: vso_user)
-  end
-  let!(:vso) { create(:vso, name: "VSO", role: "VSO", url: "vso-url", participant_id: "8054") }
-  let!(:vso_user) { create(:user, :vso_role) }
-
   context "for VSO users" do
+    before do
+      vso.add_user(vso_user)
+      User.authenticate!(user: vso_user)
+    end
+    let!(:vso) { create(:vso, name: "VSO", role: "VSO", url: "vso-url", participant_id: "8054") }
+    let!(:vso_user) { create(:user, :vso_role) }
     scenario "Convert scheduled hearing to Virtual" do
       step "navigate to the hearings form" do
         visit "queue/appeals/#{appeal.uuid}"

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_scheduled_hearing_type.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_scheduled_hearing_type.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+RSpec.feature "Convert scheduled hearing type" do
+  let!(:appeal) do
+    a = create(:appeal, :with_schedule_hearing_tasks, :hearing_docket)
+    a.update!(changed_hearing_request_type: Constants.HEARING_REQUEST_TYPES.video)
+    a
+  end
+
+  let!(:appeal_deadline) do
+    a = create(:appeal, :with_schedule_hearing_tasks, :hearing_docket)
+    a.update!(changed_hearing_request_type: Constants.HEARING_REQUEST_TYPES.video)
+    a
+  end
+
+  let!(:hearing_day) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 12.days) }
+  let(:hearing_day_deadline) { create(:hearing_day, :video, scheduled_for: Time.zone.today + 7.days) }
+
+  context "for Hearing coordinator user" do
+    let!(:current_user) { User.authenticate!(roles: ["Edit HearSched"]) }
+    before do
+      HearingsManagement.singleton.add_user(current_user)
+    end
+    scenario "Schedule veteran" do
+      step "select from dropdown" do
+        click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.label)
+
+      end
+    end
+  end
+
+  before do
+    vso.add_user(vso_user)
+    User.authenticate!(user: vso_user)
+  end
+  let!(:vso) { create(:vso, name: "VSO", role: "VSO", url: "vso-url", participant_id: "8054") }
+  let!(:vso_user) { create(:user, :vso_role) }
+
+  context "for VSO users" do
+    scenario "Convert scheduled hearing to Virtual" do
+      step "navigate to the hearings form" do
+        visit "queue/appeals/#{appeal.uuid}"
+        expect(page).to have_content("Video")
+        expect(page).to have_link("Convert to virtual")
+        click_link("Convert to virtual")
+        expect(page).to have_current_path("/hearings/#{appeal.external_id}/details")
+      end
+      step "cancel the step that starts the schedule workflow to test the next step" do
+        click_button("Cancel")
+      end
+    end
+
+    scenario "Hearing will be held within 11 days" do
+      visit "queue/appeals/#{appeal_deadline.uuid}"
+      step "info alert will show instead of link" do
+        expect(page).not_to have_link("Convert to virtual")
+        expect(page).to have_content("Hearing within next 10 days; contact Hearing Coordinator to convert to Virtual.")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #[CASEFLOW-5960](https://vajira.max.gov/browse/CASEFLOW-5960)
**Description**
As a VSO representative user I need the ability to opt-in a Veteran / Appellant into a virtual hearing so that the appellant can attend the case's hearing. This is only for hearing types.

**Acceptance Criteria**

- [ ] A link appears in the [hearings section](https://github.com/department-of-veterans-affairs/caseflow/blob/276884ca2d1c56d24e2ee0c760674ff495217687/client/app/queue/CaseHearingsDetail.jsx#L74) on the Case Details page when a case's docket type is hearing for  the VSO/Representative user to opt appellant into Virtual hearing when the following is true:
&ensp;1. Hearing has not yet been scheduled, OR
&ensp;2. Schedule hearing type is non-Virtual
&ensp;&ensp;&ensp;&ensp;- today's date is greater than or equal to 11 calendar days from the scheduled hearing date
- [ ] When the hearing has not been scheduled, upon link selection, the VSO user is directed to the Convert to Virtual form in the Queue application to convert hearing request to virtual
- [ ] When the hearing has been scheduled, upon link selection, the VSO user is directed to the Convert to Virtual form in the Hearings application to convert the scheduled hearing to Virtual
- [ ] A link does not appear in the [hearings section](https://github.com/department-of-veterans-affairs/caseflow/blob/276884ca2d1c56d24e2ee0c760674ff495217687/client/app/queue/CaseHearingsDetail.jsx#L164) for the VSO user to Opt appellant into Virtual hearing when the following is true:
&ensp;1. Scheduled hearing type is Virtual, OR
&ensp;2. Today's date is equal to or less than10 calendar days of the scheduled hearing date
- [ ] When today's date is equal to or less than 10 calendar days from the scheduled hearing date, a message appears in the Hearings sction informing VSO/Representative to contact hearing coordinator  to make changes (message only visible to representative users - will not appear for all other users)
&ensp;- Message text: Hearing within next 10 days; contact Hearing Coordinator to convert to Virtual.
- [ ] Once hearing has been scheduled, no information for the unscheduled hearing appear in the Hearings component on the Case Details screen
- [ ] The VSO virtual opt-in link does not appear for non-VSO users

**Testing Plan** (work in progress)
1. Open Caseflow app in localhost:3000
2. Change user to BVADWISE
3. Go to "Mail Intake" tab and start an intake
    a. Select VA form 10182 and continue to the next step.
    b. Enter 500000000 for the Veteran ID and continue to the next step.
    c. Select a date in the past for Receipt Date, select "Hearing" for the review option, and select Yes for "Is the claimant someone other than the Veteran?", then select Bob Vance. Bob Vance is a claimant with a VSO representative. The other option selections don't matter. Continue to the next step.
    d. Click on the "Add Issue" button and choose "Compensation" for Benefit Type and "Unknown Issue Type" for Issue Category. Choose a date in the past for Decision Date and fill in anything for the Issue description. Click on the "Add Issue" button, then click on the "Establish Appeal" button. 
4. Once the page says "Intake completed", click on "correct the issues"
5. Open a new tab and switch user to BVASYELLOW
6. The URL path should be in this form on the intake page: `/appeals/<appeal uuid>/edit`. 
    Copy and paste it into BVASYELLOW tab and change it to `/explain/appeals/<appeal uuid>`.
7. In the actions dropdown, select "Schedule a Veteran" and 