### PR TITLE
APPEALS-3661 OverTime Flag functionality updated to no longer reset when a Judge Reassigns a case to another Judge

### DIFF
--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -65,7 +65,7 @@ class AttorneyTask < Task
   end
 
   def reassign_clears_overtime?
-    true
+    false
   end
 
   def send_back_to_judge_assign!(params = {})

--- a/app/models/tasks/judge_task.rb
+++ b/app/models/tasks/judge_task.rb
@@ -43,6 +43,6 @@ class JudgeTask < Task
   end
 
   def reassign_clears_overtime?
-    true
+    false
   end
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -981,11 +981,11 @@ describe Task, :all_dbs do
     end
 
     context "When the appeal has been marked for overtime" do
-      shared_examples "clears overtime" do
-        it "sets overtime to false" do
+      shared_examples "overtime status is unchanged" do
+        it "does not clear overtime status on reassignment" do
           expect(appeal.overtime?).to be true
           subject
-          expect(appeal.overtime?).to be false
+          expect(appeal.overtime?).to be true
         end
       end
 
@@ -999,7 +999,7 @@ describe Task, :all_dbs do
       after { FeatureToggle.disable!(:overtime_revamp) }
 
       context "when the task type is not a judge or attorney task" do
-        it "does not clear the overtime status" do
+        it "does not clear the overtime status on reassignment" do
           expect(appeal.overtime?).to be true
           subject
           expect(appeal.overtime?).to be true
@@ -1009,7 +1009,7 @@ describe Task, :all_dbs do
       context "when the task is a judge task" do
         let(:task) { create(:ama_judge_assign_task, appeal: appeal) }
 
-        it_behaves_like "clears overtime"
+        it_behaves_like "overtime status is unchanged"
       end
 
       context "when the task is an attorney task" do
@@ -1020,7 +1020,7 @@ describe Task, :all_dbs do
 
         subject { task.reassign(params, judge) }
 
-        it_behaves_like "clears overtime"
+        it_behaves_like "overtime status is unchanged"
       end
     end
   end


### PR DESCRIPTION
Resolves Jira([APPEALS-3661](https://vajira.max.gov/browse/APPEALS-3661))

### Description
OverTime Flag functionality updated to no longer reset when a Judge Reassigns a case to another Judge