### PR TITLE
MattT/APPEALS-4457: Prevent VSOs From Viewing the Hearing Details Page

### DIFF
--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -14,6 +14,7 @@ import {
   updateHearingDispatcher,
   RESET_HEARING
 } from '../contexts/HearingsFormContext';
+import { HearingsUserContext } from '../contexts/HearingsUserContext';
 import {
   deepDiff,
   getChanges,
@@ -49,6 +50,7 @@ import { VIRTUAL_HEARING_LABEL } from '../constants';
 const HearingDetails = (props) => {
   // Map the state and dispatch to relevant names
   const { state: { initialHearing, hearing, formsUpdated }, dispatch } = useContext(HearingsFormContext);
+  const { userVsoEmployee } = useContext(HearingsUserContext);
 
   // Create the update hearing dispatcher
   const updateHearing = updateHearingDispatcher(hearing, dispatch);
@@ -89,6 +91,8 @@ const HearingDetails = (props) => {
 
   // Create an effect to remove stale alerts on unmount
   useEffect(() => () => props.clearAlerts(), []);
+
+  useEffect(() => userVsoEmployee ? convertHearing('change_to_virtual') : null, []);
 
   const openEmailConfirmationModal = ({ type }) => {
     setEmailConfirmationModalOpen(true);

--- a/client/app/hearings/containers/DailyDocketContainer.jsx
+++ b/client/app/hearings/containers/DailyDocketContainer.jsx
@@ -378,6 +378,7 @@ DailyDocketContainer.propTypes = {
   onResetLockHearingAfterError: PropTypes.func,
   onResetLockSuccessMessage: PropTypes.func,
   onResetDailyDocketAfterError: PropTypes.func,
+  onHandleConferenceLinkError: PropTypes.func,
   onUpdateLock: PropTypes.func,
   onHearingDayModified: PropTypes.func,
   print: PropTypes.bool,

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -837,4 +837,13 @@ RSpec.feature "Hearing Details", :all_dbs do
       end
     end
   end
+
+  context "with VSO user role" do
+    let!(:current_user) { User.authenticate!(roles: ["VSO"]) }
+
+    scenario "user is immediately redirected to the Convert to Virtual form" do
+      visit "hearings/" + hearing.external_id.to_s + "/details"
+      expect(page).to have_content(format(COPY::CONVERT_HEARING_TITLE, "Virtual"))
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-4457](https://vajira.max.gov/browse/APPEALS-4457)

### Description
Redirect VSO users directly to the Convert to Virtual Hearing form upon navigation to the hearing details page.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] VSO users are immediately routed to the `HearingConversion` component upon navigating to `/hearings/:hearingId/details`

### Testing Plan
1. Open the Rails console, and obtain a UUID for a hearing:

```ruby
Hearing.where(disposition: nil).order('RANDOM()').first.uuid
```

2. Switch to a VSO user.

3. Navigate to `/hearings/<hearing-uuid>/details`

4. You should be seeing the "Convert to Virtual Hearing" form at this point.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)