### PR TITLE
APPEALS/5875: Update the physical address for the Memphis Vet Center and Little Rock Regional Office

### DIFF
--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -408,11 +408,11 @@
    },
    "vba_350" : {
       "address_1" : "2200 Fort Roots Drive",
-      "address_2" : "Building 111",
+      "address_2" : "Bldg. 65",
       "address_3" : null,
       "city" : "North Little Rock",
       "state" : "AR",
-      "zip" : "72114-1756",
+      "zip" : "72114",
       "timezone" : "America/Chicago"
    },
    "vba_351" : {

--- a/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
+++ b/client/constants/REGIONAL_OFFICE_FACILITY_ADDRESS.json
@@ -408,11 +408,11 @@
    },
    "vba_350" : {
       "address_1" : "2200 Fort Roots Drive",
-      "address_2" : "Bldg. 65",
+      "address_2" : "Building 111",
       "address_3" : null,
       "city" : "North Little Rock",
       "state" : "AR",
-      "zip" : "72114",
+      "zip" : "72114-1756",
       "timezone" : "America/Chicago"
    },
    "vba_351" : {
@@ -677,12 +677,12 @@
       "timezone" : "America/Kentucky/Louisville"
    },
    "vc_0719V" : {
-      "address_1" : "1407 Union Avenue",
-      "address_2" : "Suite 410",
+      "address_1" : "2605 Nonconnah Blvd",
+      "address_2" : "Suite 160",
       "address_3" : null,
       "city" : "Memphis",
       "state" : "TN",
-      "zip" : "38104",
+      "zip" : "38132",
       "timezone" : "America/Kentucky/Louisville"
    },
    "vc_0720V" : {

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -147,7 +147,7 @@ describe RegionalOffice do
     it "RO50 has correct address" do
       ro = RegionalOffice.find!("RO50")
 
-      expect(ro.full_address).to eq "2200 Fort Roots Drive Bldg. 65, Little Rock AR 72114"
+      expect(ro.full_address).to eq "2200 Fort Roots Drive Building 111, Little Rock AR 72114-1756"
     end
   end
 

--- a/spec/models/regional_office_spec.rb
+++ b/spec/models/regional_office_spec.rb
@@ -147,7 +147,7 @@ describe RegionalOffice do
     it "RO50 has correct address" do
       ro = RegionalOffice.find!("RO50")
 
-      expect(ro.full_address).to eq "2200 Fort Roots Drive Building 111, Little Rock AR 72114-1756"
+      expect(ro.full_address).to eq "2200 Fort Roots Drive Bldg. 65, Little Rock AR 72114"
     end
   end
 


### PR DESCRIPTION

### Description
Update the Addresses constant file and the rspec coverage. 

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Memphis AHL (vc_0719V) (Alternative Hearing Location) address is updated to:
2605 Nonconnah Blvd., Suite 160
Memphis, TN 38132
- [ ]  North Little Rock AHL (vba_350) address is updated to:
2200 Fort Roots Drive, Building 111
North Little Rock, AR 72114-1756

### Testing Plan
1. Go to ...
