### PR TITLE
Hide conversion link for scheduled hearings behind FeatureToggle (vso_virtual_opt_in). Updated a set of feature tests to validate behavior

### DIFF
--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -61,7 +61,6 @@ class CaseHearingsDetail extends React.PureComponent {
     };
   }
 
-
   getHearingAttrs = (hearing, userIsVsoEmployee, vsoVirtualOptIn) => {
 
     const today = new Date();

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -73,7 +73,7 @@ class CaseHearingsDetail extends React.PureComponent {
       value:
         <React.Fragment>
           {hearing.isVirtual ? 'Virtual' : hearing.type}&nbsp;&nbsp;
-          {userIsVsoEmployee && !hearing.isVirtual && hearingDay > deadline &&
+          {userIsVsoEmployee && !hearing.isVirtual && hearingDay > deadline && vsoVirtualOptIn &&
             <Link href={`/hearings/${hearing.externalId}/details`}>{COPY.VSO_CONVERT_TO_VIRTUAL_TEXT}</Link>}
         </React.Fragment>
     },

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -63,7 +63,7 @@ class CaseHearingsDetail extends React.PureComponent {
 
   getHearingAttrs = (hearing, userIsVsoEmployee, vsoVirtualOptIn) => {
     const today = new Date();
-    const deadline = today.setDate(today.getDate() + 10);
+    const deadline = today.setDate(today.getDate() + 11);
     const hearingDay = new Date(hearing.date);
     // show convert to virtual link if user is vso, hearing isn't virtual, and scheduled date is not within deadline
     const hearingAttrs = [{

--- a/client/app/queue/CaseHearingsDetail.jsx
+++ b/client/app/queue/CaseHearingsDetail.jsx
@@ -62,9 +62,8 @@ class CaseHearingsDetail extends React.PureComponent {
   }
 
   getHearingAttrs = (hearing, userIsVsoEmployee, vsoVirtualOptIn) => {
-
     const today = new Date();
-    const deadline = today.setDate(today.getDate() + 11);
+    const deadline = today.setDate(today.getDate() + 10);
     const hearingDay = new Date(hearing.date);
     // show convert to virtual link if user is vso, hearing isn't virtual, and scheduled date is not within deadline
     const hearingAttrs = [{

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -2366,6 +2366,7 @@ RSpec.feature "Case details", :all_dbs do
         visit "/queue/appeals/#{hearing_beyond_10_days.appeal.uuid}"
 
         expect(page.has_content?("Hearings")).to eq(true)
+        expect(page.has_no_content?(COPY::VSO_CONVERT_TO_VIRTUAL_TEXT)).to eq(true)
         expect(page.has_no_content?(COPY::CASE_DETAILS_HEARING_DETAILS_LINK_COPY)).to eq(true)
       end
 
@@ -2373,6 +2374,7 @@ RSpec.feature "Case details", :all_dbs do
         visit "/queue/appeals/#{hearing_within_10_days.appeal.uuid}"
 
         expect(page.has_content?("Hearings")).to eq(true)
+        expect(page.has_no_content?(COPY::VSO_CONVERT_TO_VIRTUAL_TEXT)).to eq(true)
         expect(page.has_no_content?(COPY::CASE_DETAILS_HEARING_DETAILS_LINK_COPY)).to eq(true)
         expect(page.has_no_content?(COPY::VSO_UNABLE_TO_CONVERT_TO_VIRTUAL_TEXT)).to eq(true)
       end


### PR DESCRIPTION
Adds check for value of `vso_virtual_opt_in` FeatureToggle in the chain of conditional used to determine whether or not to display the hearing conversion link for a scheduled hearing to a VSO user.