### PR TITLE
APPEALS-6497: VSO Hearing Conversion Form Email Validation Fix

### DIFF
--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -70,7 +70,7 @@ const HearingDetails = (props) => {
   const [emailConfirmationModalType, setEmailConfirmationModalType] = useState(null);
   const [shouldStartPolling, setShouldStartPolling] = useState(null);
   const [VSOConvertSuccessful, setVSOConvertSuccessful] = useState(false);
-  const [isValidEmail, setIsValidEmail] = useState(true);
+  const [isValidEmail, setIsValidEmail] = useState(hearing?.appellantEmailAddress);
   const [formSubmittable, setFormSubmittable] = useState(false);
   const [hearingConversionCheckboxes, setHearingConversionCheckboxes] = useState(false);
 

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -70,7 +70,7 @@ const HearingDetails = (props) => {
   const [emailConfirmationModalType, setEmailConfirmationModalType] = useState(null);
   const [shouldStartPolling, setShouldStartPolling] = useState(null);
   const [VSOConvertSuccessful, setVSOConvertSuccessful] = useState(false);
-  const [isNotValidEmail, setIsNotValidEmail] = useState(userVsoEmployee);
+  const [isNotValidEmail, setIsNotValidEmail] = useState(false);
   const [formSubmittable, setFormSubmittable] = useState(false);
   const [hearingConversionCheckboxes, setHearingConversionCheckboxes] = useState(false);
 
@@ -119,6 +119,9 @@ const HearingDetails = (props) => {
     if (userVsoEmployee) {
       convertHearing('change_to_virtual');
       updateHearing('virtualHearing', { requestCancelled: false });
+
+      // Predetermine whether or not appellant email is valid
+      setIsNotValidEmail(!(/\S+@\S+\.\S+/).test(hearing?.appellantEmailAddress));
     }
   }, []);
 

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -119,9 +119,6 @@ const HearingDetails = (props) => {
     if (userVsoEmployee) {
       convertHearing('change_to_virtual');
       updateHearing('virtualHearing', { requestCancelled: false });
-
-      // Predetermine whether or not appellant email is valid
-      setIsValidEmail((/\S+@\S+\.\S+/).test(hearing?.appellantEmailAddress));
     }
   }, []);
 

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -70,13 +70,13 @@ const HearingDetails = (props) => {
   const [emailConfirmationModalType, setEmailConfirmationModalType] = useState(null);
   const [shouldStartPolling, setShouldStartPolling] = useState(null);
   const [VSOConvertSuccessful, setVSOConvertSuccessful] = useState(false);
-  const [isNotValidEmail, setIsNotValidEmail] = useState(false);
+  const [isValidEmail, setIsValidEmail] = useState(true);
   const [formSubmittable, setFormSubmittable] = useState(false);
   const [hearingConversionCheckboxes, setHearingConversionCheckboxes] = useState(false);
 
   const canSubmit = () => {
     let emailFieldsValid = (
-      !isNotValidEmail &&
+      isValidEmail &&
       hearing?.appellantEmailAddress &&
       hearing?.appellantTz &&
       hearing?.representativeTz &&
@@ -89,7 +89,7 @@ const HearingDetails = (props) => {
 
   useEffect(() => {
     canSubmit();
-  }, [hearing, isNotValidEmail, hearingConversionCheckboxes]);
+  }, [hearing, isValidEmail, hearingConversionCheckboxes]);
 
   const appellantTitle = getAppellantTitle(hearing?.appellantIsNotVeteran);
   const convertingToVirtual = converting === 'change_to_virtual';
@@ -121,7 +121,7 @@ const HearingDetails = (props) => {
       updateHearing('virtualHearing', { requestCancelled: false });
 
       // Predetermine whether or not appellant email is valid
-      setIsNotValidEmail(!(/\S+@\S+\.\S+/).test(hearing?.appellantEmailAddress));
+      setIsValidEmail((/\S+@\S+\.\S+/).test(hearing?.appellantEmailAddress));
     }
   }, []);
 
@@ -342,7 +342,7 @@ const HearingDetails = (props) => {
           scheduledFor={hearing?.scheduledFor}
           errors={virtualHearingErrors}
           userVsoEmployee={userVsoEmployee}
-          setIsNotValidEmail={setIsNotValidEmail}
+          setIsValidEmail={setIsValidEmail}
           updateCheckboxes={setHearingConversionCheckboxes}
         />
       ) : (

--- a/client/app/hearings/components/HearingConversion.jsx
+++ b/client/app/hearings/components/HearingConversion.jsx
@@ -29,7 +29,7 @@ export const HearingConversion = ({
   errors,
   update,
   userVsoEmployee,
-  setIsNotValidEmail,
+  setIsValidEmail,
   updateCheckboxes
 }) => {
   const appellantTitle = getAppellantTitle(hearing?.appellantIsNotVeteran);
@@ -67,7 +67,7 @@ export const HearingConversion = ({
     schedulingToVirtual: virtual,
     userVsoEmployee,
     actionType: 'hearing',
-    setIsNotValidEmail
+    setIsValidEmail
   };
 
   const prefillFields = () => {
@@ -182,6 +182,6 @@ HearingConversion.propTypes = {
   update: PropTypes.func,
   hearing: PropTypes.object.isRequired,
   userVsoEmployee: PropTypes.bool,
-  setIsNotValidEmail: PropTypes.func,
+  setIsValidEmail: PropTypes.func,
   updateCheckboxes: PropTypes.func
 };

--- a/client/app/hearings/components/VSOHearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/VSOHearingTypeConversionForm.jsx
@@ -81,7 +81,7 @@ export const VSOHearingTypeConversionForm = ({
   }, []);
 
   const preventSubmission = () => {
-    return isValidEmail ||
+    return !isValidEmail ||
       !updatedAppeal?.appellantEmailAddress ||
       !checkedAccess ||
       !checkedPermissions ||

--- a/client/app/hearings/components/VSOHearingTypeConversionForm.jsx
+++ b/client/app/hearings/components/VSOHearingTypeConversionForm.jsx
@@ -21,8 +21,8 @@ export const VSOHearingTypeConversionForm = ({
   const {
     updatedAppeal,
     dispatchAppeal,
-    isNotValidEmail,
-    setIsNotValidEmail
+    isValidEmail,
+    setIsValidEmail
   } = useContext(HearingTypeConversionContext);
 
   const updateAppeal = updateAppealDispatcher(updatedAppeal, dispatchAppeal);
@@ -62,7 +62,7 @@ export const VSOHearingTypeConversionForm = ({
     showMissingEmailAlert: true,
     actionType: 'appeal',
     update: updateAppeal,
-    setIsNotValidEmail,
+    setIsValidEmail,
     type
   };
   const convertTitle = sprintf(COPY.CONVERT_HEARING_TYPE_TITLE, type);
@@ -81,7 +81,7 @@ export const VSOHearingTypeConversionForm = ({
   }, []);
 
   const preventSubmission = () => {
-    return isNotValidEmail ||
+    return isValidEmail ||
       !updatedAppeal?.appellantEmailAddress ||
       !checkedAccess ||
       !checkedPermissions ||

--- a/client/app/hearings/components/VirtualHearings/VSOAppellantSection.jsx
+++ b/client/app/hearings/components/VirtualHearings/VSOAppellantSection.jsx
@@ -9,7 +9,7 @@ export const VSOAppellantSection = ({
   showDivider,
   appellantTitle,
   formFieldsOnly,
-  setIsNotValidEmail,
+  setIsValidEmail,
   update,
   actionType
 }) => {
@@ -32,7 +32,7 @@ export const VSOAppellantSection = ({
         <VSOEmailNotificationsFields
           hearing={hearing}
           update={update}
-          setIsNotValidEmail={setIsNotValidEmail}
+          setIsValidEmail={setIsValidEmail}
           actionType={actionType}
           errors={errors}
         />
@@ -62,6 +62,6 @@ VSOAppellantSection.propTypes = {
   userCanCollectVideoCentralEmails: PropTypes.bool,
   schedulingToVirtual: PropTypes.bool,
   formFieldsOnly: PropTypes.bool,
-  setIsNotValidEmail: PropTypes.func,
+  setIsValidEmail: PropTypes.func,
   actionType: PropTypes.string
 };

--- a/client/app/hearings/components/details/VSOEmailNotificationsFields.jsx
+++ b/client/app/hearings/components/details/VSOEmailNotificationsFields.jsx
@@ -14,7 +14,7 @@ export const VSOEmailNotificationsFields = ({
   readOnly,
   time,
   roTimezone,
-  setIsNotValidEmail,
+  setIsValidEmail,
   actionType,
   update
 }) => {
@@ -34,7 +34,7 @@ export const VSOEmailNotificationsFields = ({
           email={hearing?.appellantEmailAddress}
           update={update}
           hearing={hearing}
-          setIsNotValidEmail={setIsNotValidEmail}
+          setIsValidEmail={setIsValidEmail}
           actionType={actionType}
         />
         <VSOHearingEmail
@@ -87,7 +87,7 @@ VSOEmailNotificationsFields.propTypes = {
   initialRepresentativeTz: PropTypes.string,
   header: PropTypes.string,
   setEmailsMismatch: PropTypes.func,
-  setIsNotValidEmail: PropTypes.func,
+  setIsValidEmail: PropTypes.func,
   setConfirmIsEmpty: PropTypes.func,
   confirmIsEmpty: PropTypes.bool,
   actionType: PropTypes.string

--- a/client/app/hearings/components/details/VSOHearingEmail.jsx
+++ b/client/app/hearings/components/details/VSOHearingEmail.jsx
@@ -21,7 +21,7 @@ export const VSOHearingEmail = ({
   confirmEmail,
   emailType,
   actionType,
-  setIsNotValidEmail,
+  setIsValidEmail,
   update
 }) => {
 
@@ -33,13 +33,13 @@ export const VSOHearingEmail = ({
   const validateEmail = (newEmail, unFocused) => {
     if (emailRegex.test(newEmail)) {
       setMessage('');
-      setIsNotValidEmail(false);
+      setIsValidEmail(true);
     } else if (unFocused) {
       // Only display error message if field focus is exited.
       setMessage(COPY.CONVERT_HEARING_VALIDATE_EMAIL);
-      setIsNotValidEmail(true);
+      setIsValidEmail(false);
     } else {
-      setIsNotValidEmail(true);
+      setIsValidEmail(false);
     }
   };
 
@@ -134,5 +134,5 @@ VSOHearingEmail.propTypes = {
   confirmEmail: PropTypes.bool,
   update: PropTypes.func,
   actionType: PropTypes.string,
-  setIsNotValidEmail: PropTypes.func
+  setIsValidEmail: PropTypes.func
 };

--- a/client/app/hearings/components/details/VSOHearingEmail.jsx
+++ b/client/app/hearings/components/details/VSOHearingEmail.jsx
@@ -28,7 +28,8 @@ export const VSOHearingEmail = ({
   const [message, setMessage] = useState('');
 
   // Regex to validate email input in real time
-  const emailRegex = /\S+@\S+\.\S+/;
+  // eslint-disable-next-line max-len
+  const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
 
   const validateEmail = (newEmail, unFocused) => {
     if (emailRegex.test(newEmail)) {

--- a/client/app/hearings/contexts/HearingTypeConversionContext.jsx
+++ b/client/app/hearings/contexts/HearingTypeConversionContext.jsx
@@ -10,7 +10,7 @@ const setUpdated = (appeal, value) => {
 
 export const HearingTypeConversionProvider = ({ children, initialAppeal }) => {
   // initiliaze hook to manage state for email validation
-  const [isNotValidEmail, setIsNotValidEmail] = useState(false);
+  const [isValidEmail, setIsValidEmail] = useState(true);
 
   const reducer = (appeal, action) => {
     switch (action.type) {
@@ -25,8 +25,8 @@ export const HearingTypeConversionProvider = ({ children, initialAppeal }) => {
 
   const contextData = {
     updatedAppeal,
-    isNotValidEmail,
-    setIsNotValidEmail,
+    isValidEmail,
+    setIsValidEmail,
     dispatchAppeal
   };
 

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
@@ -84,7 +84,7 @@ RSpec.feature "Convert hearing request type" do
           expect(page).to have_button("button-Convert-Hearing-To-Virtual", disabled: true)
 
           # Fill out email field and expect validation message on invalid email
-          fill_in "#{appellant_title} Email", with: "appellant@te"
+          fill_in "#{appellant_title} Email", with: "appellant@test.c"
           find("body").click
           expect(page).to have_content(COPY::CONVERT_HEARING_VALIDATE_EMAIL)
           fill_in "#{appellant_title} Email", with: "appellant@test.com"
@@ -154,7 +154,7 @@ RSpec.feature "Convert hearing request type" do
         expect(page).to have_button("Convert to Virtual Hearing", disabled: true)
 
         # Fill out email field and expect validation message on invalid email
-        fill_in "#{appellant_title} Email", with: "appellant@te"
+        fill_in "#{appellant_title} Email", with: "appellant@test.c"
         find("body").click
         expect(page).to have_content(COPY::CONVERT_HEARING_VALIDATE_EMAIL)
         fill_in "#{appellant_title} Email", with: "appellant@test.com"


### PR DESCRIPTION
Resolves [APPEALS-6497](https://vajira.max.gov/browse/APPEALS-6497)

### Description
Properly initialize the validity of the appellant's email on the Convert to Virtual form in Hearings whenever accessing it as a VSO user.

I also renamed a state variable to remove a double negative that was confusing.

### Acceptance Criteria
- [x] On the Queue Convert to Virtual Form, as a VSO user:
   - [x]  The submission button remains disabled until all required fields have been populated with valid inputs.
   - [x] The submission button is enabled once all required fields have been populated with valid input. 
- [x] On the Hearings Convert to Virtual Form, as a VSO user:
   - [x]  The submission button remains disabled until all required fields have been populated with valid inputs.
   - [x] The submission button is enabled once all required fields have been populated with valid input. 

### Testing Plan

1. Open the Rails console, and establish the following variables:

```ruby
# AMA Appeal with a docket type of hearing with no scheduled hearings.
a = Appeal.all.filter { |a| a.docket_type == "hearing" && a.hearings.empty?}.first

# AMA Hearing that has been scheduled.
h = Hearing.where(disposition: nil).reject(&:virtual?).first
# Ensure hearing is scheduled for 10+ days from now.
h.hearing_day.update!(scheduled_for: 20.days.from_now)

# Legacy Appeal with not scheduled hearings associated with it.
la = LegacyAppeal.all.filter { |a| a.hearings.empty?}.first

# A Legacy Hearing that has been scheduled.
lh = LegacyHearing.all.reject(&:virtual?).first
# Ensure legacy hearing is scheduled for 10+ days from now.
lh.hearing_day.update!(scheduled_for: 20.days.from_now)
```

2. Log into Caseflow as a VSO user that has an email address (ex: `BILLIE_VSO`)

3. Navigate to the Case Details page for the unscheduled hearing:
`/queue/appeals/<a.uuid>`

4. Scroll down to the Hearings section, and click on the "Convert to virtual" link.

5. If any fields have not been pre-populated, fill in all except for the Confirm Appellant/Veteran Email field.

6. Confirm that the submission button in the bottom-right corner of the page is disabled.

7. Manually type in the email requested in the email confirmation field.

8. Make sure that the submission button is enabled.

9. Go through each field, and set each one to an invalid input. After doing so for each one, make sure that the submission button is disabled. Set each field back to a valid value, and check that the button is re-enabled.

10. Repeat the above steps for the AMA Hearing, Legacy Appeal, and Legacy Hearing. Here are the following urls you will navigate to for each:

   - AMA Appeal: `/queue/appeals/<a.uuid>`
   - AMA Hearing: `/queue/appeals/<h.appeal.uuid>`
   - Legacy Appeal: `/queue/appeals/<la.vacols_id>`
   - Legacy Hearing: `/queue/appeals/<lh.appeal.vacols_id>`
   
Note that the issue this PR aims to fix was noticed in the Hearings form. However, some of the changes did pertain to the Queue form as well which is why those scenarios have been included.

11. On both the Hearings and Queue conversion forms we've updated the regular expression in use for validating the email. Please ensure that the following emails are viewed as invalid:

   - dsfasfs#@$@
   - testing@
   - testing@test
   - testing@test.
   - testing@test.c

12. This is an example of a valid email: `something@else.co` where the TLD is at least two characters in length.