### PR TITLE
Change scope names to prevent collisions if both concerns are included as mixins to the same class

### DIFF
--- a/app/models/concerns/belongs_to_polymorphic_appeal_concern.rb
+++ b/app/models/concerns/belongs_to_polymorphic_appeal_concern.rb
@@ -47,8 +47,8 @@ module BelongsToPolymorphicAppealConcern
         .select_associations.first
 
       type_column = association.foreign_type
-      scope :ama_appeal, -> { where(type_column => "Appeal") }
-      scope :legacy_appeal, -> { where(type_column => "LegacyAppeal") }
+      scope :ama, -> { where(type_column => "Appeal") }
+      scope :legacy, -> { where(type_column => "LegacyAppeal") }
 
       # Use `:ama_appeal` instead of `:appeal`
       # because `.appeal` is already defined by `belongs_to associated_class_symbol, polymorphic: true` above

--- a/app/models/concerns/belongs_to_polymorphic_appeal_concern.rb
+++ b/app/models/concerns/belongs_to_polymorphic_appeal_concern.rb
@@ -47,8 +47,8 @@ module BelongsToPolymorphicAppealConcern
         .select_associations.first
 
       type_column = association.foreign_type
-      scope :ama, -> { where(type_column => "Appeal") }
-      scope :legacy, -> { where(type_column => "LegacyAppeal") }
+      scope :ama_appeal, -> { where(type_column => "Appeal") }
+      scope :legacy_appeal, -> { where(type_column => "LegacyAppeal") }
 
       # Use `:ama_appeal` instead of `:appeal`
       # because `.appeal` is already defined by `belongs_to associated_class_symbol, polymorphic: true` above

--- a/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
+++ b/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
@@ -47,8 +47,8 @@ module BelongsToPolymorphicHearingConcern
         .select_associations.first
 
       type_column = association.foreign_type
-      scope :ama_hearing, -> { where(type_column => "Hearing") }
-      scope :legacy_hearing, -> { where(type_column => "LegacyHearing") }
+      scope :ama, -> { where(type_column => "Hearing") }
+      scope :legacy, -> { where(type_column => "LegacyHearing") }
 
       # Use `:ama_hearing` instead of `:hearing`
       # because `.hearing` is already defined by `belongs_to associated_class_symbol, polymorphic: true` above

--- a/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
+++ b/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
@@ -47,8 +47,8 @@ module BelongsToPolymorphicHearingConcern
         .select_associations.first
 
       type_column = association.foreign_type
-      scope :ama, -> { where(type_column => "Hearing") }
-      scope :legacy, -> { where(type_column => "LegacyHearing") }
+      scope :ama_h, -> { where(type_column => "Hearing") }
+      scope :legacy_h, -> { where(type_column => "LegacyHearing") }
 
       # Use `:ama_hearing` instead of `:hearing`
       # because `.hearing` is already defined by `belongs_to associated_class_symbol, polymorphic: true` above

--- a/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
+++ b/app/models/concerns/belongs_to_polymorphic_hearing_concern.rb
@@ -47,8 +47,8 @@ module BelongsToPolymorphicHearingConcern
         .select_associations.first
 
       type_column = association.foreign_type
-      scope :ama, -> { where(type_column => "Hearing") }
-      scope :legacy, -> { where(type_column => "LegacyHearing") }
+      scope :ama_hearing, -> { where(type_column => "Hearing") }
+      scope :legacy_hearing, -> { where(type_column => "LegacyHearing") }
 
       # Use `:ama_hearing` instead of `:hearing`
       # because `.hearing` is already defined by `belongs_to associated_class_symbol, polymorphic: true` above

--- a/app/models/hearings/hearing_email_recipient.rb
+++ b/app/models/hearings/hearing_email_recipient.rb
@@ -21,10 +21,11 @@ class HearingEmailRecipient < CaseflowRecord
   validates :email_address, presence: true, on: :create
   has_many :email_events, class_name: "SentHearingEmailEvent", foreign_key: :email_recipient_id
 
-  include BelongsToPolymorphicHearingConcern
-  belongs_to_polymorphic_hearing(:hearing)
   include HasAppealUpdatedSince
+  include BelongsToPolymorphicHearingConcern
   include BelongsToPolymorphicAppealConcern
+
+  belongs_to_polymorphic_hearing(:hearing)
   belongs_to_polymorphic_appeal(:appeal)
 
   def reminder_sent_at


### PR DESCRIPTION
This PR aims to prevent the following warning messages from appearing upon boot:

```
[2022-07-15 22:46:37 -0400] Creating scope :ama. Overwriting existing method HearingEmailRecipient.ama.
[2022-07-15 22:46:37 -0400] Creating scope :legacy. Overwriting existing method HearingEmailRecipient.legacy.
```

These have been occurring due to a name collision between scopes in BelongsToPolymorphicAppealConcern and BelongsToPolymorphicHearingConcern in HearingEmailRecipient.