### PR TITLE
Remove vha_irregular_appeals FeatureToggle

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -43,7 +43,6 @@
       listed_granted_substitution_before_dismissal: FeatureToggle.enabled?(:listed_granted_substitution_before_dismissal, user: current_user),
       restrict_poa_visibility: FeatureToggle.enabled?(:restrict_poa_visibility, user: current_user),
       vha_predocket_workflow: FeatureToggle.enabled?(:vha_predocket_workflow, user: current_user),
-      vha_irregular_appeals: FeatureToggle.enabled?(:vha_irregular_appeals, user: current_user),
       vso_virtual_opt_in: FeatureToggle.enabled?(:vso_virtual_opt_in, user: current_user)
     }
   }) %>

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -162,14 +162,6 @@ const SendToBoardIntakeModal = ({ props, state, setState }) => {
     return task && task.assignedTo.type === 'VhaProgramOffice' && task.instructions[1];
   });
 
-  let filteredSendToBoardOpts = sendToBoardOpts;
-
-  if (!props.featureToggles.vha_irregular_appeals) {
-    filteredSendToBoardOpts = sendToBoardOpts.filter((opt) => {
-      return opt.displayText === COPY.VHA_SEND_TO_BOARD_INTAKE_MODAL_CORRECT_DOCUMENTS;
-    });
-  }
-
   return (
     <React.Fragment>
       {programOfficeInstructions.some((i) => i) &&
@@ -193,7 +185,7 @@ const SendToBoardIntakeModal = ({ props, state, setState }) => {
             vertical
             onChange={(value) => setState({ radio: value })}
             value={state.radio}
-            options={filteredSendToBoardOpts}
+            options={sendToBoardOpts}
             errorMessage={props.highlightInvalid && !validRadio(state.radio) ? COPY.SELECT_RADIO_ERROR : null}
           />
           <TextareaField

--- a/spec/feature/queue/camo_cancellation_spec.rb
+++ b/spec/feature/queue/camo_cancellation_spec.rb
@@ -20,7 +20,6 @@ RSpec.feature "CAMO can recommend cancellation to BVA Intake", :all_dbs do
   before do
     FeatureToggle.enable!(:vha_predocket_appeals)
     FeatureToggle.enable!(:vha_predocket_workflow)
-    FeatureToggle.enable!(:vha_irregular_appeals)
     camo_org.add_user(camo_user)
     bva_intake_org.add_user(bva_intake_user)
   end
@@ -28,7 +27,6 @@ RSpec.feature "CAMO can recommend cancellation to BVA Intake", :all_dbs do
   after do
     FeatureToggle.disable!(:vha_predocket_appeals)
     FeatureToggle.disable!(:vha_predocket_workflow)
-    FeatureToggle.disable!(:vha_irregular_appeals)
   end
 
   context "CAMO user can assign a case to BVA intake, recommending cancellation" do


### PR DESCRIPTION
Remove usage of the `:vha_irregular_appeals` FeatureToggle as it is no longer needed. The options it was used to restrict on the CompleteTaskModal.jsx component are being opened up to every user.