### PR TITLE
Matt/appeals 4353 feature toggle

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -44,7 +44,8 @@
       restrict_poa_visibility: FeatureToggle.enabled?(:restrict_poa_visibility, user: current_user),
       vha_predocket_workflow: FeatureToggle.enabled?(:vha_predocket_workflow, user: current_user),
       vha_irregular_appeals: FeatureToggle.enabled?(:vha_irregular_appeals, user: current_user),
-      vso_virtual_opt_in: FeatureToggle.enabled?(:vso_virtual_opt_in, user: current_user)
+      vso_virtual_opt_in: FeatureToggle.enabled?(:vso_virtual_opt_in, user: current_user),
+      split_appeal_workflow: FeatureToggle.enabled?(:split_appeal_workflow, user: current_user)
     }
   }) %>
 <% end %>


### PR DESCRIPTION
Resolves APPEALS-4353

### Description
Small addition - added a feature toggle flag to be used during split appeals development

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Code compiles correctly, no split appeals functionality is currently being gated by this feature toggle so nothing to test yet.

### User Facing Changes
 - None

