### PR TITLE
Appeals-7169 Configure SQS local stack setup for VA Notify

### DIFF
--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -13,8 +13,10 @@ end
 
 if Rails.application.config.sqs_create_queues
   # create the development queues
-  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_low_priority' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: 'ActiveJob::Base.queue_name_prefix + '_low_priority'' })
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_high_priority' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: 'send_notifications' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: 'receive_notifications' })
 end
 
 Shoryuken.configure_server do |config|

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -13,7 +13,7 @@ end
 
 if Rails.application.config.sqs_create_queues
   # create the development queues
-  Shoryuken::Client.sqs.create_queue({ queue_name: 'ActiveJob::Base.queue_name_prefix + '_low_priority'' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_low_priority' })
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_high_priority' })
   Shoryuken::Client.sqs.create_queue({ queue_name: 'send_notifications' })
   Shoryuken::Client.sqs.create_queue({ queue_name: 'receive_notifications' })

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -15,8 +15,8 @@ if Rails.application.config.sqs_create_queues
   # create the development queues
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_low_priority' })
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_high_priority' })
-  Shoryuken::Client.sqs.create_queue({ queue_name: 'send_notifications' })
-  Shoryuken::Client.sqs.create_queue({ queue_name: 'receive_notifications' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_send_notifications' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_receive_notifications' })
 end
 
 Shoryuken.configure_server do |config|


### PR DESCRIPTION
Resolves [APPEALS-7169](https://vajira.max.gov/browse/APPEALS-7169)

### Description
As an appeals developer, I need the ability to configure my local environment to use SQS Queues using local stack.

### Acceptance Criteria

- [x] The shoryuken.rb initializer is updated to with the following SQS queues:
    1. "send_notifications"
    2. "receive_notifications"
- [x] When the local development environment spins up the two sqs queues are created in local stack
- [ ] Document exists on how to access local stack to check SQS queues

### Testing Plan
1. See documentation file at https://vajira.max.gov/browse/APPEALS-7169
