### PR TITLE
APPEALS-4295: Development - Create Supervisory Senior Council (SSC) organization

### DIFF
--- a/app/models/organizations/supervisory_senior_council.rb
+++ b/app/models/organizations/supervisory_senior_council.rb
@@ -17,4 +17,4 @@ class SupervisorySeniorCouncil < Organization
   def users_can_create_mail_task?
     true
   end
-  end
+end

--- a/app/models/organizations/supervisory_senior_council.rb
+++ b/app/models/organizations/supervisory_senior_council.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SupervisorySeniorCouncil < Organization
+  alias_attribute :full_name, :name
+
+  def self.singleton
+    SupervisorySeniorCouncil.first || SupervisorySeniorCouncil.create(
+      name: "Supervisory Senior Council",
+      url: "supervisory-senior-council"
+    )
+  end
+
+  def can_receive_task?(_task)
+    false
+  end
+
+  def users_can_create_mail_task?
+    true
+  end
+  end

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -31,7 +31,6 @@ namespace :add_admins do
             input = STDIN.gets.chomp
             user_array = input.split(",")
             user_array.each {|n| n.strip}
-            STDOUT.puts("array: #{user_array}")
             user_array.each do |id| 
                 Rake::Task["add_admins:add_single_admin"].reenable
                 Rake.application.invoke_task("add_admins:add_single_admin[#{org_id}, #{id}]")
@@ -42,20 +41,34 @@ namespace :add_admins do
     end
 
     desc "given a user id and a role, assign the role to the user"
-    task :assign_role_to_user, [:user_id] => :environment do |t, args| 
+    task :assign_role_to_user, [:user_id, :role] => :environment do |t, args| 
         user = User.find(args[:user_id].to_i)
-        STDOUT.puts("Enter the role to assign to the user")
-        role = STDIN.gets.chomp
-        STDOUT.puts("Do you want to assign #{user.full_name} the role of #{role}?")
+        STDOUT.puts("Do you want to assign #{user.full_name} the role of #{args[:role]}?")
         STDOUT.puts("y/n?")
         input = STDIN.gets.chomp
         if input.downcase == 'y'
             user_roles = user.roles
-            new_roles = user_roles << role
+            new_roles = user_roles << args[:role]
             user.update!(roles: new_roles)
             STDOUT.puts("The user's roles are now #{user.roles}")
         else 
             STDOUT.puts("Aborting...")
+        end
+    end
+
+    desc "given a list of user ids, batch assign roles to the users"
+    task :batch_assign_roles do
+        STDOUT.puts("Enter the role to assign to the users.")
+        role = STDIN.gets.chomp
+
+        STDOUT.puts("Enter the user ids to be assigned the role #{role} separated by commas (ex: 1, 2, 3...)")
+        input = STDIN.gets.chomp
+        user_array = input.split(",")
+        user_array.each {|n| n.strip}
+
+        user_array.each do |id|
+            Rake::Task["add_admins:assign_role_to_user"].reenable
+            Rake.application.invoke_task("add_admins:assign_role_to_user[#{id},#{role}]")
         end
     end
 end

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -23,7 +23,7 @@ namespace :add_admins do
   end
 
   desc "given the org id and an array of user ids, batch add users as admins"
-  task :batch_add_admin do
+  task :batch_add_admins do
     STDOUT.puts("Enter the organization id")
     org_id = STDIN.gets.chomp
     if org_id.to_i.is_a? Integer
@@ -58,7 +58,7 @@ namespace :add_admins do
 
   desc "given a list of user ids, batch assign roles to the users"
   task :batch_assign_roles do
-    STDOUT.puts("Enter the role to assign to the users.")
+    STDOUT.puts("Enter the role to assign to the users. (example: Case Details, Reader, etc.)")
     role = STDIN.gets.chomp
 
     STDOUT.puts("Enter the user ids to be assigned the role #{role} separated by commas (ex: 1, 2, 3...)")

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -5,7 +5,6 @@ namespace :add_admins do
     task :add_single_admin, [:org_id, :user_id] => :environment do |t, args| 
         org = Organization.find(args[:org_id].to_i)
         user = User.find(args[:user_id].to_i)
-
         STDOUT.puts("Organization: #{org.name}")
         STDOUT.puts("User to be admin: #{user.full_name}")
         STDOUT.puts("Is this correct? (y/n)")
@@ -39,6 +38,24 @@ namespace :add_admins do
             end
         else
             STDOUT.puts("Improper input... exiting")
+        end
+    end
+
+    desc "given a user id and a role, assign the role to the user"
+    task :assign_role_to_user, [:user_id] => :environment do |t, args| 
+        user = User.find(args[:user_id].to_i)
+        STDOUT.puts("Enter the role to assign to the user")
+        role = STDIN.gets.chomp
+        STDOUT.puts("Do you want to assign #{user.full_name} the role of #{role}?")
+        STDOUT.puts("y/n?")
+        input = STDIN.gets.chomp
+        if input.downcase == 'y'
+            user_roles = user.roles
+            new_roles = user_roles << role
+            user.update!(roles: new_roles)
+            STDOUT.puts("The user's roles are now #{user.roles}")
+        else 
+            STDOUT.puts("Aborting...")
         end
     end
 end

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -13,7 +13,6 @@ namespace :add_admins do
       OrganizationsUser.make_user_admin(user, org)
       if OrganizationsUser.find_by(organization_id: org.id, user_id: user.id).nil?
         STDOUT.puts("User #{user.full_name} with ID #{user.id} not added to #{org.name}.")
-
       else
         STDOUT.puts("User #{user.full_name} with ID #{user.id} successfully added to #{org.name}!")
       end
@@ -60,12 +59,10 @@ namespace :add_admins do
   task :batch_assign_roles do
     STDOUT.puts("Enter the role to assign to the users. (example: Case Details, Reader, etc.)")
     role = STDIN.gets.chomp
-
     STDOUT.puts("Enter the user ids to be assigned the role #{role} separated by commas (ex: 1, 2, 3...)")
     input = STDIN.gets.chomp
     user_array = input.split(",")
     user_array.each(&:strip)
-
     user_array.each do |id|
       Rake.application.invoke_task("add_admins:assign_role_to_user[#{id},#{role}]")
       Rake::Task["add_admins:assign_role_to_user"].reenable

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+namespace :add_admins do
+    desc "given the org and a user id, add the users as an admin to the organization"
+    task :add_single_admin, [:org_id, :user_id] => :environment do |t, args| 
+        org = Organization.find(args[:org_id].to_i)
+        user = User.find(args[:user_id].to_i)
+
+        STDOUT.puts("Organization: #{org.name}")
+        STDOUT.puts("User to be admin: #{user.full_name}")
+        STDOUT.puts("Is this correct? (y/n)")
+        input = STDIN.gets.chomp
+        if input.downcase == 'y'
+            OrganizationsUser.make_user_admin(user, org)
+            if OrganizationsUser.find_by(organization_id: org.id, user_id: user.id).nil?
+                STDOUT.puts("User #{user.full_name} with ID #{user.id} not added to #{org.name}.")
+
+            else
+                STDOUT.puts("User #{user.full_name} with ID #{user.id} successfully added to #{org.name}!")
+            end
+        else 
+            STDOUT.puts("Aborting...")
+        end
+    end
+
+    desc "given the org id and an array of user ids, batch add users as admins"
+    task :batch_add_admin do 
+        STDOUT.puts("Enter the organization id")
+        org_id = STDIN.gets.chomp
+        if org_id.to_i.is_a? Integer 
+            STDOUT.puts("Enter the user ids to be assigned as admins separated by commas (ex: 1, 2, 3...)")
+            input = STDIN.gets.chomp
+            user_array = input.split(",")
+            user_array.each {|n| n.strip}
+            STDOUT.puts("array: #{user_array}")
+            user_array.each do |id| 
+                Rake::Task["add_admins:add_single_admin"].reenable
+                Rake.application.invoke_task("add_admins:add_single_admin[#{org_id}, #{id}]")
+            end
+        else
+            STDOUT.puts("Improper input... exiting")
+        end
+    end
+end

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -1,74 +1,74 @@
 # frozen_string_literal: true
 
 namespace :add_admins do
-    desc "given the org and a user id, add the users as an admin to the organization"
-    task :add_single_admin, [:org_id, :user_id] => :environment do |t, args| 
-        org = Organization.find(args[:org_id].to_i)
-        user = User.find(args[:user_id].to_i)
-        STDOUT.puts("Organization: #{org.name}")
-        STDOUT.puts("User to be admin: #{user.full_name}")
-        STDOUT.puts("Is this correct? (y/n)")
-        input = STDIN.gets.chomp
-        if input.downcase == 'y'
-            OrganizationsUser.make_user_admin(user, org)
-            if OrganizationsUser.find_by(organization_id: org.id, user_id: user.id).nil?
-                STDOUT.puts("User #{user.full_name} with ID #{user.id} not added to #{org.name}.")
+  desc "given the org and a user id, add the users as an admin to the organization"
+  task :add_single_admin, [:org_id, :user_id] => :environment do |_t, args|
+    org = Organization.find(args[:org_id].to_i)
+    user = User.find(args[:user_id].to_i)
+    STDOUT.puts("Organization: #{org.name}")
+    STDOUT.puts("User to be admin: #{user.full_name}")
+    STDOUT.puts("Is this correct? (y/n)")
+    input = STDIN.gets.chomp
+    if input.casecmp("y").zero?
+      OrganizationsUser.make_user_admin(user, org)
+      if OrganizationsUser.find_by(organization_id: org.id, user_id: user.id).nil?
+        STDOUT.puts("User #{user.full_name} with ID #{user.id} not added to #{org.name}.")
 
-            else
-                STDOUT.puts("User #{user.full_name} with ID #{user.id} successfully added to #{org.name}!")
-            end
-        else 
-            STDOUT.puts("Aborting...")
-        end
+      else
+        STDOUT.puts("User #{user.full_name} with ID #{user.id} successfully added to #{org.name}!")
+      end
+    else
+      STDOUT.puts("Aborting...")
     end
+  end
 
-    desc "given the org id and an array of user ids, batch add users as admins"
-    task :batch_add_admin do 
-        STDOUT.puts("Enter the organization id")
-        org_id = STDIN.gets.chomp
-        if org_id.to_i.is_a? Integer 
-            STDOUT.puts("Enter the user ids to be assigned as admins separated by commas (ex: 1, 2, 3...)")
-            input = STDIN.gets.chomp
-            user_array = input.split(",")
-            user_array.each {|n| n.strip}
-            user_array.each do |id| 
-                Rake.application.invoke_task("add_admins:add_single_admin[#{org_id}, #{id}]")
-                Rake::Task["add_admins:add_single_admin"].reenable
-            end
-        else
-            STDOUT.puts("Improper input... exiting")
-        end
+  desc "given the org id and an array of user ids, batch add users as admins"
+  task :batch_add_admin do
+    STDOUT.puts("Enter the organization id")
+    org_id = STDIN.gets.chomp
+    if org_id.to_i.is_a? Integer
+      STDOUT.puts("Enter the user ids to be assigned as admins separated by commas (ex: 1, 2, 3...)")
+      input = STDIN.gets.chomp
+      user_array = input.split(",")
+      user_array.each(&:strip)
+      user_array.each do |id|
+        Rake.application.invoke_task("add_admins:add_single_admin[#{org_id}, #{id}]")
+        Rake::Task["add_admins:add_single_admin"].reenable
+      end
+    else
+      STDOUT.puts("Improper input... exiting")
     end
+  end
 
-    desc "given a user id and a role, assign the role to the user"
-    task :assign_role_to_user, [:user_id, :role] => :environment do |t, args| 
-        user = User.find(args[:user_id].to_i)
-        STDOUT.puts("Do you want to assign #{user.full_name} the role of #{args[:role]}?")
-        STDOUT.puts("y/n?")
-        input = STDIN.gets.chomp
-        if input.downcase == 'y'
-            user_roles = user.roles
-            new_roles = user_roles << args[:role]
-            user.update!(roles: new_roles)
-            STDOUT.puts("The user's roles are now #{user.roles}")
-        else 
-            STDOUT.puts("Aborting...")
-        end
+  desc "given a user id and a role, assign the role to the user"
+  task :assign_role_to_user, [:user_id, :role] => :environment do |_t, args|
+    user = User.find(args[:user_id].to_i)
+    STDOUT.puts("Do you want to assign #{user.full_name} the role of #{args[:role]}?")
+    STDOUT.puts("y/n?")
+    input = STDIN.gets.chomp
+    if input.casecmp("y").zero?
+      user_roles = user.roles
+      new_roles = user_roles << args[:role]
+      user.update!(roles: new_roles)
+      STDOUT.puts("The user's roles are now #{user.roles}")
+    else
+      STDOUT.puts("Aborting...")
     end
+  end
 
-    desc "given a list of user ids, batch assign roles to the users"
-    task :batch_assign_roles do
-        STDOUT.puts("Enter the role to assign to the users.")
-        role = STDIN.gets.chomp
+  desc "given a list of user ids, batch assign roles to the users"
+  task :batch_assign_roles do
+    STDOUT.puts("Enter the role to assign to the users.")
+    role = STDIN.gets.chomp
 
-        STDOUT.puts("Enter the user ids to be assigned the role #{role} separated by commas (ex: 1, 2, 3...)")
-        input = STDIN.gets.chomp
-        user_array = input.split(",")
-        user_array.each {|n| n.strip}
+    STDOUT.puts("Enter the user ids to be assigned the role #{role} separated by commas (ex: 1, 2, 3...)")
+    input = STDIN.gets.chomp
+    user_array = input.split(",")
+    user_array.each(&:strip)
 
-        user_array.each do |id|
-            Rake.application.invoke_task("add_admins:assign_role_to_user[#{id},#{role}]")
-            Rake::Task["add_admins:assign_role_to_user"].reenable
-        end
+    user_array.each do |id|
+      Rake.application.invoke_task("add_admins:assign_role_to_user[#{id},#{role}]")
+      Rake::Task["add_admins:assign_role_to_user"].reenable
     end
+  end
 end

--- a/lib/tasks/add_admins.rake
+++ b/lib/tasks/add_admins.rake
@@ -32,8 +32,8 @@ namespace :add_admins do
             user_array = input.split(",")
             user_array.each {|n| n.strip}
             user_array.each do |id| 
-                Rake::Task["add_admins:add_single_admin"].reenable
                 Rake.application.invoke_task("add_admins:add_single_admin[#{org_id}, #{id}]")
+                Rake::Task["add_admins:add_single_admin"].reenable
             end
         else
             STDOUT.puts("Improper input... exiting")
@@ -67,8 +67,8 @@ namespace :add_admins do
         user_array.each {|n| n.strip}
 
         user_array.each do |id|
-            Rake::Task["add_admins:assign_role_to_user"].reenable
             Rake.application.invoke_task("add_admins:assign_role_to_user[#{id},#{role}]")
+            Rake::Task["add_admins:assign_role_to_user"].reenable
         end
     end
 end

--- a/spec/models/organizations/supervisory_senior_council_spec.rb
+++ b/spec/models/organizations/supervisory_senior_council_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+describe SupervisorySeniorCouncil do
+  describe ".singleton" do
+    it "is named correctly" do
+      expect(SupervisorySeniorCouncil.singleton).to have_attributes(name: "Supervisory Senior Council")
+    end
+
+    it "will only have one SupervisorySeniorCouncil no matter how many times it is run" do
+      SupervisorySeniorCouncil.singleton
+      SupervisorySeniorCouncil.singleton
+      expect(Organization.where(name: "Supervisory Senior Council").count).to eq(1)
+    end
+
+    it "will have the correct url name" do
+      expect(SupervisorySeniorCouncil.singleton).to have_attributes(url: "supervisory-senior-council")
+    end
+  end
+
+  describe ".users_can_create_mail_task?" do
+    it "should always be true" do
+      expect(SupervisorySeniorCouncil.singleton.users_can_create_mail_task?).to eq(true)
+    end
+  end
+
+  describe ".can_receive_task?" do
+    it "returns false because the COB hasn't started using Queue yet" do
+      expect(SupervisorySeniorCouncil.singleton.can_receive_task?(nil)).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
Resolves [APPEAL-4295](https://vajira.max.gov/browse/APPEALS-4295)

### Description
Created a new model for the Supervisory Senior Council that will be responsible for splitting appeals. Also, the creation a rake task that will allow Production to easily assign admins to the new Supervisory Senior Council and add new roles to those new users. 

### Acceptance Criteria
- [x] A Supervisory Senior Council (SSC) organization is created in Caseflow
- [x] Users from the attached SSC Members.xlsx are added as Admins to the SSC organization
- [x] The Supervisory Senior Council has the following capabilities in Caseflow
- [x] Ability to search for cases
- [x] Ability to access the Case Details screen

### Testing Plan
#### Testing the Supervisory Senior Council (SSC) Model
1. Navigate to the Rails Console
2. Run `SupervisorySeniorCouncil.singleton` to create the Supervisory Senior Council.
3. Make sure the Supervisory Senior Council now appears in the local database. You can do this by querying the database or by using `Organization.find(SSC_ID_HERE)` in the Rails console. 

#### Testing the Add_Admins Rake Script
1. Navigate to the Rails Console
2. Run `Rake::Task['add_admins:batch_add_admins'].invoke` to run the batch add admins task. If the task doesn't run, you might need to load the task by running `require 'rake'` followed by `Rails.application.load_tasks` followed by `Rake::Task['add_admins:batch_add_admins'].invoke`.
3. Input the id for the **Supervisory Senior Council** from the database. 
4. Input the ids of a few test users separated by a comma.
5. At the prompt, confirm that the user's name is correct and the organization is the Supervisory Senior Council. Select **y** to create the user as an admin or **n** to skip them. 
6. At the end of the task, confirm the users were created in the **OrganizationsUser** table by running `OrganizationsUser.where(organization_id: SSC_ORG_ID_HERE)` and finding the ids of the users that were added. 
7. Next, run `Rake:Task['add_admins:batch_assign_roles'].invoke`. 
8. Enter **Case Details** into the prompt for the role.
9. Enter the ids of the users that were assigned as admins to the Supervisory Senior Council separated by a comma.
10. At the prompt, again confirm that the user's name is correct and the role is accurate. Select **y** to assign the role to the user or **n** to skip them.
11. At the end of the task, confirm the users have the new role added to them in the **User** table by running `User.find([user_1_id, user_2_id, user_3_id, etc...])`
