### PR TITLE
MattT/APPEALS-7453: Appeals With Caregiver Labels are Correctly Routed to CSP Organization's Queue

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -343,7 +343,7 @@ class Appeal < DecisionReview
     request_issues.active.any?(&:education_predocket?)
   end
 
-  def caregiver_issue?
+  def caregiver_has_issues?
     request_issues.active.any? { |ri| ri.nonrating_issue_category =~ /Caregiver/ }
   end
 

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -343,6 +343,10 @@ class Appeal < DecisionReview
     request_issues.active.any?(&:education_predocket?)
   end
 
+  def caregiver_issue?
+    request_issues.active.any? { |ri| ri.nonrating_issue_category =~ /Caregiver/ }
+  end
+
   alias cavc? cavc
 
   def cavc_remand

--- a/app/workflows/pre_docket_tasks_factory.rb
+++ b/app/workflows/pre_docket_tasks_factory.rb
@@ -37,8 +37,8 @@ class PreDocketTasksFactory
   private
 
   def determine_vha_assignee
-    return VhaCamo.singleton unless @appeal.caregiver_has_issues?
+    return VhaCaregiverSupport.singleton if @appeal.caregiver_has_issues?
 
-    VhaCaregiverSupport.singleton
+    VhaCamo.singleton
   end
 end

--- a/app/workflows/pre_docket_tasks_factory.rb
+++ b/app/workflows/pre_docket_tasks_factory.rb
@@ -37,7 +37,7 @@ class PreDocketTasksFactory
   private
 
   def determine_vha_assignee
-    return VhaCamo.singleton unless @appeal.caregiver_issue?
+    return VhaCamo.singleton unless @appeal.caregiver_has_issues?
 
     VhaCaregiverSupport.singleton
   end

--- a/app/workflows/pre_docket_tasks_factory.rb
+++ b/app/workflows/pre_docket_tasks_factory.rb
@@ -15,7 +15,7 @@ class PreDocketTasksFactory
     VhaDocumentSearchTask.create!(
       appeal: @appeal,
       assigned_by: @appeal.intake.user,
-      assigned_to: VhaCamo.singleton,
+      assigned_to: determine_vha_assignee,
       parent: pre_docket_task
     )
   end
@@ -32,5 +32,13 @@ class PreDocketTasksFactory
       assigned_to: EducationEmo.singleton,
       parent: pre_docket_task
     )
+  end
+
+  private
+
+  def determine_vha_assignee
+    return VhaCamo.singleton unless @appeal.caregiver_issue?
+
+    VhaCaregiverSupport.singleton
   end
 end

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -8,8 +8,10 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
     FeatureToggle.enable!(:vha_predocket_appeals)
     FeatureToggle.enable!(:visn_predocket_workflow)
     FeatureToggle.enable!(:docket_vha_appeals)
+
     bva_intake.add_user(bva_intake_user)
     camo.add_user(camo_user)
+    vha_caregiver.add_user(vha_caregiver_user)
     emo.add_user(emo_user)
     program_office.add_user(program_office_user)
     regional_office.add_user(regional_office_user)
@@ -23,18 +25,23 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
     FeatureToggle.disable!(:docket_vha_appeals)
   end
 
+  # Organizations
   let(:bva_intake) { BvaIntake.singleton }
-  let!(:bva_intake_user) { create(:intake_user) }
   let(:camo) { VhaCamo.singleton }
-  let(:camo_user) { create(:user) }
+  let(:vha_caregiver) { VhaCaregiverSupport.singleton }
   let(:emo) { EducationEmo.singleton }
-  let(:emo_user) { create(:user) }
+  let(:education_rpo) { create(:education_rpo) }
   let(:program_office) { create(:vha_program_office) }
-  let(:program_office_user) { create(:user) }
   let(:regional_office) { create(:vha_regional_office) }
   let(:regional_office_user) { create(:user) }
-  let(:education_rpo) { create(:education_rpo) }
+
+  # Users
+  let!(:bva_intake_user) { create(:intake_user) }
+  let(:camo_user) { create(:user) }
+  let(:vha_caregiver_user) { create(:user) }
+  let(:emo_user) { create(:user) }
   let(:education_rpo_user) { create(:user) }
+  let(:program_office_user) { create(:user) }
 
   let(:veteran) { create(:veteran) }
   let(:po_instructions) { "Please look for this veteran's documents." }
@@ -49,7 +56,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
 
       it "intaking VHA issues creates pre-docket tasks instead of regular docketing tasks" do
         step "BVA Intake user intakes a VHA case" do
-          categories.each do |c|
+          categories.each do |category|
             User.authenticate!(user: bva_intake_user)
             start_appeal(veteran, intake_user: bva_intake_user)
             visit "/intake"
@@ -60,7 +67,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
             click_intake_add_issue
             fill_in "Benefit type", with: "Veterans Health Administration"
             find("#issue-benefit-type").send_keys :enter
-            fill_in "Issue category", with: c
+            fill_in "Issue category", with: category
             find("#issue-category").send_keys :enter
             fill_in "Issue description", with: "I am a VHA issue"
             fill_in "Decision date", with: 1.month.ago.mdY
@@ -72,10 +79,15 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
             click_intake_finish
             expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
 
-            appeal = Appeal.last
+            vha_document_search_task = VhaDocumentSearchTask.last
+            appeal = vha_document_search_task.appeal
+            expect(vha_document_search_task.assigned_to).to eq vha_caregiver
+
             visit "/queue/appeals/#{appeal.external_id}"
             expect(page).to have_content("Pre-Docket")
-            expect(page).to have_content(c)
+            expect(page).to have_content(category)
+
+            expect(page).to have_content(vha_caregiver.name)
           end
         end
       end

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -118,9 +118,14 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           click_intake_finish
           expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
 
-          appeal = Appeal.last
+          vha_document_search_task = VhaDocumentSearchTask.last
+          appeal = vha_document_search_task.appeal
+          expect(vha_document_search_task.assigned_to).to eq camo
+
           visit "/queue/appeals/#{appeal.external_id}"
           expect(page).to have_content("Pre-Docket")
+
+          expect(page).to have_content(camo.name)
         end
 
         step "Use can search the case and see the Pre Docketed status" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1201,6 +1201,22 @@ describe Appeal, :all_dbs do
     end
   end
 
+  describe "#caregiver_issue?" do
+    subject { appeal.caregiver_issue? }
+
+    context "appeal has no caregiver tasks" do
+      let(:appeal) { create(:appeal, request_issues: [create(:request_issue, :nonrating)]) }
+
+      it { expect(subject).to eq false }
+    end
+
+    context "appeal has caregiver tasks" do
+      let(:appeal) { create(:appeal, :with_vha_issue) }
+
+      it { expect(subject).to eq true }
+    end
+  end
+
   describe "#contested_claim?" do
     subject { appeal.contested_claim? }
 

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1201,8 +1201,8 @@ describe Appeal, :all_dbs do
     end
   end
 
-  describe "#caregiver_issue?" do
-    subject { appeal.caregiver_issue? }
+  describe "#caregiver_has_issues?" do
+    subject { appeal.caregiver_has_issues? }
 
     context "appeal has no caregiver tasks" do
       let(:appeal) { create(:appeal, request_issues: [create(:request_issue, :nonrating)]) }

--- a/spec/workflows/pre_docket_tasks_factory_spec.rb
+++ b/spec/workflows/pre_docket_tasks_factory_spec.rb
@@ -5,71 +5,84 @@ describe PreDocketTasksFactory, :postgres do
     before { bva_intake.add_user(bva_intake_user) }
 
     let(:bva_intake) { BvaIntake.singleton }
-    let(:camo) { VhaCamo.singleton }
     let(:bva_intake_user) { create(:intake_user) }
-
-    let(:appeal) { create(:appeal, intake: create(:intake, user: bva_intake_user)) }
 
     subject { PreDocketTasksFactory.new(appeal).call_vha }
 
-    it "creates a PreDocket task and child CAMO task" do
-      expect(appeal.tasks.count).to eq 0
+    shared_examples "VhaDocumentSearchTask is assigned to assignee" do
+      it "creates a PreDocket task and child VhaDocumentSearchTask" do
+        expect(appeal.tasks.count).to eq 0
 
-      subject
+        subject
 
-      pre_docket_task = Task.find_by(
-        appeal: appeal,
-        type: "PreDocketTask",
-        status: Constants.TASK_STATUSES.on_hold,
-        assigned_to: bva_intake
-      )
-      camo_task = pre_docket_task.children.first
+        pre_docket_task = Task.find_by(
+          appeal: appeal,
+          type: "PreDocketTask",
+          status: Constants.TASK_STATUSES.on_hold,
+          assigned_to: bva_intake
+        )
+        camo_task = pre_docket_task.children.first
 
-      expect(pre_docket_task).to_not be nil
-      expect(pre_docket_task.parent.is_a?(RootTask)).to be true
-      expect(camo_task).to have_attributes(
-        type: "VhaDocumentSearchTask",
-        status: Constants.TASK_STATUSES.assigned,
-        assigned_by: bva_intake_user,
-        assigned_to: camo,
-        parent: pre_docket_task
-      )
+        expect(pre_docket_task).to_not be nil
+        expect(pre_docket_task.parent.is_a?(RootTask)).to be true
+        expect(camo_task).to have_attributes(
+          type: "VhaDocumentSearchTask",
+          status: Constants.TASK_STATUSES.assigned,
+          assigned_by: bva_intake_user,
+          assigned_to: assignee,
+          parent: pre_docket_task
+        )
+      end
+    end
+
+    context "with an appeal without a caregiver issue" do
+      let(:appeal) { create(:appeal, intake: create(:intake, user: bva_intake_user)) }
+      let(:assignee) { VhaCamo.singleton }
+
+      it_behaves_like "VhaDocumentSearchTask is assigned to assignee"
+    end
+
+    context "with an appeal with a caregiver issue" do
+      let(:appeal) { create(:appeal, :with_vha_issue, intake: create(:intake, user: bva_intake_user)) }
+      let(:assignee) { VhaCaregiverSupport.singleton }
+
+      it_behaves_like "VhaDocumentSearchTask is assigned to assignee"
     end
   end
+end
 
-  context "PreDocket Appeals for Education" do
-    before { bva_intake.add_user(bva_intake_user) }
+context "PreDocket Appeals for Education" do
+  before { bva_intake.add_user(bva_intake_user) }
 
-    let(:bva_intake) { BvaIntake.singleton }
-    let(:emo) { EducationEmo.singleton }
-    let(:bva_intake_user) { create(:intake_user) }
+  let(:bva_intake) { BvaIntake.singleton }
+  let(:emo) { EducationEmo.singleton }
+  let(:bva_intake_user) { create(:intake_user) }
 
-    let(:appeal) { create(:appeal, intake: create(:intake, user: bva_intake_user)) }
+  let(:appeal) { create(:appeal, intake: create(:intake, user: bva_intake_user)) }
 
-    subject { PreDocketTasksFactory.new(appeal).call_edu }
+  subject { PreDocketTasksFactory.new(appeal).call_edu }
 
-    it "creates a PreDocket task and child Education task" do
-      expect(appeal.tasks.count).to eq 0
+  it "creates a PreDocket task and child Education task" do
+    expect(appeal.tasks.count).to eq 0
 
-      subject
+    subject
 
-      pre_docket_task = Task.find_by(
-        appeal: appeal,
-        type: "PreDocketTask",
-        status: Constants.TASK_STATUSES.on_hold,
-        assigned_to: bva_intake
-      )
-      emo_task = pre_docket_task.children.first
+    pre_docket_task = Task.find_by(
+      appeal: appeal,
+      type: "PreDocketTask",
+      status: Constants.TASK_STATUSES.on_hold,
+      assigned_to: bva_intake
+    )
+    emo_task = pre_docket_task.children.first
 
-      expect(pre_docket_task).to_not be nil
-      expect(pre_docket_task.parent.is_a?(RootTask)).to be true
-      expect(emo_task).to have_attributes(
-        type: "EducationDocumentSearchTask",
-        status: Constants.TASK_STATUSES.assigned,
-        assigned_by: bva_intake_user,
-        assigned_to: emo,
-        parent: pre_docket_task
-      )
-    end
+    expect(pre_docket_task).to_not be nil
+    expect(pre_docket_task.parent.is_a?(RootTask)).to be true
+    expect(emo_task).to have_attributes(
+      type: "EducationDocumentSearchTask",
+      status: Constants.TASK_STATUSES.assigned,
+      assigned_by: bva_intake_user,
+      assigned_to: emo,
+      parent: pre_docket_task
+    )
   end
 end


### PR DESCRIPTION
Resolves [APPEALS-7453](https://vajira.max.gov/browse/APPEALS-7453)

### Description
Upon submitting an appeal through Caseflow Intake, the appeal will be listed in the CSP's queue as part of the pre-docket workflow given that the appeal has an issue with the following attributes:
   - Benefit Type: "Veterans Health Administration"
   - Non-rating Issue Category: "Caregiver | *"

Prior to these changes all appeals with an issue with the VHA benefit type would be directed towards VHA CAMO's queue.

### Acceptance Criteria
- [x] Selection of the following caregiver issue categories should be routed to the Caregiver Support Program predocket queue
   - [x] Caregiver | Eligibility
   - [x] Caregiver | Tier Level
   - [x] Caregiver | Revocation/Discharge
   - [x] Caregiver | Other
- [x] The following occurs when an appeal is routed to the VHA CSP predocket queue
   - [x] A predocket task is created
      - [ ] task is placed on hold until appeal is returned to BVA Intake
   - [ ] The appeal appears on the Pending tab for BVA Intake
      - [ ] Appeal will remain on the Pending tab the entire time case is assigned to VHA CSP
   - [x] A VHA CSP Review Documentation task is created and is active
   - [ ] The appeal appears on the Unassigned tab of the VHA CSP predocket queue
- [ ] Any other issue categories under the VHA benefit type not caregiver should still be routed to VHA CAMO (existing functionality)

### Testing Plan
1. Switch to a BVA Intake user (ex: `BVAISHAW`). Navigate to `/intake`. Begin to submit a 10182 - NOD form. None of the values you select have any consequence upon the ability to test this story until you get to the Add/Remove issues page. See step 2 for what you will need to do there.

2. Add an issue with a benefit type of "Veterans Health Administration" and a caregiver-related issue:

<img width="735" alt="caregiver-queue-test" src="https://user-images.githubusercontent.com/99351305/182421396-5823db99-c328-47e8-95c4-a591f3c3c960.PNG">

3. Submit the appeal. Navigate to the Case Details page for the appeal.

4. Ensure that the "Review Documentation" task is assigned to the "VHA Caregiver Support Program":
<img width="826" alt="csp-routed-appeal" src="https://user-images.githubusercontent.com/99351305/182421720-26dfa419-327e-4d2d-8e14-f202355bf7bb.PNG">

5. Feel free to repeat these steps for the other 3 caregiver-related issue categories.

6. If the VHA CSP Unassigned tab story is available in this branch ([APPEALS-7431](https://vajira.max.gov/browse/APPEALS-7431)) then switch to a VHA CSP user (ex: `CAREGIVERUSER`) and navigate to the VHA CSP queue (`/organizations/vha-csp`). All appeals submitted up to this point should be under the Unassigned tab.

7. If you'd like to validate the task tree in the Rails console:
```ruby
csp_appeal = Appeal.find_by_uuid("<appeal-uuid-from-case-details-url>")

csp_appeal.treee

                                      ┌────────────────────────────────────────────────────────────────────────────┐
Appeal 1632 (D 220731-1632 Original)  │ ID   │ STATUS   │ ASGN_BY  │ ASGN_TO             │ UPDATED_AT              │
└── RootTask                          │ 7117 │ on_hold  │          │ Bva                 │ 2022-08-02 16:03:32 UTC │
    └── PreDocketTask                 │ 7118 │ on_hold  │          │ BvaIntake           │ 2022-08-02 16:03:32 UTC │
        └── VhaDocumentSearchTask     │ 7119 │ assigned │ BVAISHAW │ VhaCaregiverSupport │ 2022-08-02 16:03:32 UTC │
                                      └────────────────────────────────────────────────────────────────────────────┘

```

8. Submit another appeal through Intake. This time, select a benefit type of "Veterans Health Administration" on an issue, but select a non-caregiver issue:

<img width="735" alt="caregiver-queue-test" src="https://user-images.githubusercontent.com/99351305/182423365-2b3b7506-057e-45e4-ad0f-f96d34462a8f.PNG">

9. Submit the appeal. Navigate to the Case Details page for the appeal.

10. Ensure that the "Review Documentation" task is assigned to the "VHA CAMO":
<img width="826" alt="vha-camo-routed-appeal" src="https://user-images.githubusercontent.com/99351305/182423546-7bf60645-75b0-45ce-9231-651f8e1753b6.PNG">

11. Likewise to before, here are the commands you can use to validate the appeal in the Rails console:

```ruby
camo_appeal = Appeal.find_by_uuid("<appeal-uuid-from-case-details-url>")

camo_appeal.treee

                                      ┌──────────────────────────────────────────────────────────────────┐
Appeal 1633 (D 220731-1633 Original)  │ ID   │ STATUS   │ ASGN_BY  │ ASGN_TO   │ UPDATED_AT              │
└── RootTask                          │ 7120 │ on_hold  │          │ Bva       │ 2022-08-02 16:12:50 UTC │
    └── PreDocketTask                 │ 7121 │ on_hold  │          │ BvaIntake │ 2022-08-02 16:12:50 UTC │
        └── VhaDocumentSearchTask     │ 7122 │ assigned │ BVAISHAW │ VhaCamo   │ 2022-08-02 16:12:50 UTC │
                                      └──────────────────────────────────────────────────────────────────┘
```

12. Switch to a VHA CAMO user (ex: `CAMOADMIN`). Navigate to the VHA CAMO queue (`/organizations/vha-camo`), and ensure this appeal appears under the Assigned tab.

13. Switch back to the BVA Intake user from before. Navigate to BVA Intake's organizational queue (`/organizations/bva-intake?tab=pending&page=1`).
You should see all of the appeals you have submitted here:

<img width="824" alt="bva-intake-pending-vha" src="https://user-images.githubusercontent.com/99351305/182435142-37326840-7211-47df-bbd0-56cd1833c50d.PNG">

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.
