### PR TITLE
Matt g/appeals 4378 split appeals user seed data

### DIFF
--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -375,18 +375,22 @@ module Seeds
     end
 
     def create_split_appeals_test_users
-      ussc = User.create!(station_id: 101, css_id: "SPLTAPPLSNOW",
-      full_name: "Jon SupervisorySeniorCouncilUser Snow")
+      ussc = User.create!(station_id: 101,
+                          css_id: "SPLTAPPLSNOW",
+                          full_name: "Jon SupervisorySeniorCouncilUser Snow")
       SupervisorySeniorCouncil.singleton.add_user(ussc)
-      ussc2 = User.create!(station_id: 101, css_id: "SPLTAPPLTARGARYEN", 
-      full_name: "Daenerys SupervisorySeniorCouncilUser Targaryen")
+      ussc2 = User.create!(station_id: 101,
+                           css_id: "SPLTAPPLTARGARYEN",
+                           full_name: "Daenerys SupervisorySeniorCouncilUser Targaryen")
       SupervisorySeniorCouncil.singleton.add_user(ussc2)
-      ussccr = User.create!(station_id: 101, css_id: "SPLTAPPLLANNISTER", 
-      full_name: "Jaime SupervisorySeniorCouncilCaseReviewUser Lannister")
+      ussccr = User.create!(station_id: 101,
+                            css_id: "SPLTAPPLLANNISTER",
+                            full_name: "Jaime SupervisorySeniorCouncilCaseReviewUser Lannister")
       SupervisorySeniorCouncil.singleton.add_user(ussccr)
       CaseReview.singleton.add_user(ussccr)
-      ussccr2 = User.create!(station_id: 101, css_id: "SPLTAPPLSTARK", 
-      full_name: "Ned SupervisorySeniorCouncilCaseReviewUser Stark")
+      ussccr2 = User.create!(station_id: 101,
+                             css_id: "SPLTAPPLSTARK",
+                             full_name: "Ned SupervisorySeniorCouncilCaseReviewUser Stark")
       SupervisorySeniorCouncil.singleton.add_user(ussccr2)
       CaseReview.singleton.add_user(ussccr2)
     end

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -79,6 +79,7 @@ module Seeds
       create_mail_team_user
       create_clerk_of_the_board_users
       create_case_search_only_user
+      create_split_appeals_test_users
       create_judge_teams
       create_dvc_teams
       create_hearings_user
@@ -371,6 +372,19 @@ module Seeds
 
     def create_case_search_only_user
       User.create!(station_id: 101, css_id: "CASE_SEARCHER_ONLY", full_name: "Blair CaseSearchAccessNoQueueAccess Lyon")
+    end
+
+    def create_split_appeals_test_users
+      uSSCOnly = User.create!(station_id: 101, css_id: "SPLTAPPLSNOW", full_name: "Jon SupervisorySeniorCouncilUser Snow")
+      SupervisorySeniorCouncil.singleton.add_user(uSSCOnly)
+      uSSCOnly2 = User.create!(station_id: 101, css_id: "SPLTAPPLTARGARYEN", full_name: "Daenerys SupervisorySeniorCouncilUser Targaryen")
+      SupervisorySeniorCouncil.singleton.add_user(uSSCOnly2)
+      uSSCCR = User.create!(station_id: 101, css_id: "SPLTAPPLLANNISTER", full_name: "Jaime SupervisorySeniorCouncilCaseReviewUser Lannister")
+      SupervisorySeniorCouncil.singleton.add_user(uSSCCR)
+      CaseReview.singleton.add_user(uSSCCR)
+      uSSCCR2 = User.create!(station_id: 101, css_id: "SPLTAPPLSTARK", full_name: "Ned SupervisorySeniorCouncilCaseReviewUser Stark")
+      SupervisorySeniorCouncil.singleton.add_user(uSSCCR)
+      CaseReview.singleton.add_user(uSSCCR)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -375,16 +375,20 @@ module Seeds
     end
 
     def create_split_appeals_test_users
-      uSSCOnly = User.create!(station_id: 101, css_id: "SPLTAPPLSNOW", full_name: "Jon SupervisorySeniorCouncilUser Snow")
-      SupervisorySeniorCouncil.singleton.add_user(uSSCOnly)
-      uSSCOnly2 = User.create!(station_id: 101, css_id: "SPLTAPPLTARGARYEN", full_name: "Daenerys SupervisorySeniorCouncilUser Targaryen")
-      SupervisorySeniorCouncil.singleton.add_user(uSSCOnly2)
-      uSSCCR = User.create!(station_id: 101, css_id: "SPLTAPPLLANNISTER", full_name: "Jaime SupervisorySeniorCouncilCaseReviewUser Lannister")
-      SupervisorySeniorCouncil.singleton.add_user(uSSCCR)
-      CaseReview.singleton.add_user(uSSCCR)
-      uSSCCR2 = User.create!(station_id: 101, css_id: "SPLTAPPLSTARK", full_name: "Ned SupervisorySeniorCouncilCaseReviewUser Stark")
-      SupervisorySeniorCouncil.singleton.add_user(uSSCCR)
-      CaseReview.singleton.add_user(uSSCCR)
+      ussc = User.create!(station_id: 101, css_id: "SPLTAPPLSNOW",
+      full_name: "Jon SupervisorySeniorCouncilUser Snow")
+      SupervisorySeniorCouncil.singleton.add_user(ussc)
+      ussc2 = User.create!(station_id: 101, css_id: "SPLTAPPLTARGARYEN", 
+      full_name: "Daenerys SupervisorySeniorCouncilUser Targaryen")
+      SupervisorySeniorCouncil.singleton.add_user(ussc2)
+      ussccr = User.create!(station_id: 101, css_id: "SPLTAPPLLANNISTER", 
+      full_name: "Jaime SupervisorySeniorCouncilCaseReviewUser Lannister")
+      SupervisorySeniorCouncil.singleton.add_user(ussccr)
+      CaseReview.singleton.add_user(ussccr)
+      ussccr2 = User.create!(station_id: 101, css_id: "SPLTAPPLSTARK", 
+      full_name: "Ned SupervisorySeniorCouncilCaseReviewUser Stark")
+      SupervisorySeniorCouncil.singleton.add_user(ussccr2)
+      CaseReview.singleton.add_user(ussccr2)
     end
   end
   # rubocop:enable Metrics/AbcSize

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -7,7 +7,7 @@ describe Seeds::Users do
     it "creates all kinds of users and organizations" do
       expect { subject }.to_not raise_error
       expect(User.count).to eq(103)
-      expect(Organization.count).to eq(29)
+      expect(Organization.count).to eq(30)
     end
   end
 end

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -6,7 +6,7 @@ describe Seeds::Users do
 
     it "creates all kinds of users and organizations" do
       expect { subject }.to_not raise_error
-      expect(User.count).to eq(99)
+      expect(User.count).to eq(103)
       expect(Organization.count).to eq(29)
     end
   end


### PR DESCRIPTION
Resolves APPEALS-4378

### Description
Create Test User data for Split appeals create set of users in Supervisory Senior Council as well as Case Review and separately create set of users in Supervisory Senior Council only.

### Acceptance Criteria
4 new users have been added:
Jon SupervisorySeniorCouncilUser Snow
Daenerys SupervisorySeniorCouncilUser Targaryen
Jaime SupervisorySeniorCouncilCaseReviewUser Lannister
Ned SupervisorySeniorCouncilCaseReviewUser Stark

### Testing Plan
1. Launch the application
2. In upper right click the "switch user" button in the drop down
3. Search the user box for the above names

### Database Changes
*No schema changes were made
