### PR TITLE
craig/docker-compose-m1.yml

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -60,13 +60,25 @@ ready:  ## Helper command that watches the docker containers to finish start up
 up:  ## Start the docker containers
 	docker-compose up -d
 
+up-m1:  ## Start the docker containers on a M1 Mac
+	docker-compose -f docker-compose-m1.yml up -d
+
 down:	## Stop the docker containers
 	docker-compose down
+
+down-m1:  ## Stop the docker containers on a M1 Mac
+	docker-compose -f docker-compose-m1.yml down
 
 run: up ready  ## Start rails server and frontend server
 	foreman start
 
+run-m1: up-m1 ready  ## Start rails server and frontend server on a M1 Mac
+	foreman start
+
 run-backend: up ready  ## Start rails server without the frontend
+	REACT_ON_RAILS_ENV=HOT bundle exec rails s -p 3000
+
+run-backend-m1: up-m1 ready  ## Start the rails server without the frontend on a M1 Mac
 	REACT_ON_RAILS_ENV=HOT bundle exec rails s -p 3000
 
 run-frontend: ## Start just the frontend server
@@ -103,6 +115,8 @@ sqs-conf-dir:	## Create local required dir
 	mkdir -p local/sqs/conf
 
 build: clean sqs-conf-dir download-facols up ready reset	## First time local dev setup
+
+build-m1: clean sqs-conf-dir download-facols up-m1 ready reset	## First time local dev setup on a M1 Mac
 
 destroy: clean
 	bundle exec rake local:destroy

--- a/docker-compose-m1.yml
+++ b/docker-compose-m1.yml
@@ -1,0 +1,32 @@
+version: '3'
+services:
+  appeals-redis:
+    container_name: appeals-redis
+    image: redis:3.2.10
+    ports:
+      - "6379:6379"
+
+  appeals-postgres:
+    image: postgres:11.7
+    container_name: appeals-db
+    ports:
+      - "5432:5432"
+    volumes:
+      - "postgresdata:/var/lib/postgresql/data"
+    environment:
+     - POSTGRES_PASSWORD=postgres
+
+  appeals-localstack-aws:
+    platform: linux/amd64
+    container_name: localstack
+    image: localstack/localstack:0.11.4
+    ports:
+      - "4567-4583:4567-4583"
+      - "8082:${PORT_WEB_UI-8080}"
+    environment:
+      - SERVICES=sqs
+    volumes:
+      - ./local/sqs/conf:/conf
+
+volumes:
+  postgresdata:


### PR DESCRIPTION
### Description
Added docker-compose-m1.yml from Grant and edited the makefile scripts to allow running docker-compose with the new file instead of the default docker-compose.yml

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Verify modified makefile commands work using the intended docker-compose file
- up-m1, down-m1, run-m1, run-backend-m1, build-m1 use the docker-compose-m1.yml file
- up, down, run, run-backend, build use the docker-compose.yml file