### PR TITLE
MattT/APPEALS-7867-and-APPEALS-7873

### DIFF
--- a/app/models/hearings/forms/hearing_update_form.rb
+++ b/app/models/hearings/forms/hearing_update_form.rb
@@ -29,14 +29,14 @@ class HearingUpdateForm < BaseHearingUpdateForm
 
   def after_update_hearing
     if virtual_hearing_created?
-      updated_hearing_type = Constants.HEARING_REQUEST_TYPES.virtual
+      hearing.appeal.update!(
+        changed_hearing_request_type: Constants.HEARING_REQUEST_TYPES.virtual
+      )
     elsif virtual_hearing_cancelled?
-      updated_hearing_type = hearing.original_request_type
+      hearing.appeal.update!(
+        changed_hearing_request_type: hearing.original_request_type
+      )
     end
-
-    hearing.appeal.update!(
-      changed_hearing_request_type: updated_hearing_type
-    )
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/app/models/hearings/forms/hearing_update_form.rb
+++ b/app/models/hearings/forms/hearing_update_form.rb
@@ -27,6 +27,18 @@ class HearingUpdateForm < BaseHearingUpdateForm
     )
   end
 
+  def after_update_hearing
+    if virtual_hearing_created?
+      updated_hearing_type = Constants.HEARING_REQUEST_TYPES.virtual
+    elsif virtual_hearing_cancelled?
+      updated_hearing_type = hearing.original_request_type
+    end
+
+    hearing.appeal.update!(
+      changed_hearing_request_type: updated_hearing_type
+    )
+  end
+
   # rubocop:disable Metrics/MethodLength
   def hearing_updates
     {

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -206,7 +206,8 @@ const HearingDetails = (props) => {
       const { virtualHearing, transcription, ...hearingChanges } = convertingToVirtual ?
         getConvertToVirtualChanges(
           initialHearing,
-          hearing
+          hearing,
+          userVsoEmployee
         ) :
         getChanges(
           initialHearing,

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -143,6 +143,14 @@ const HearingDetails = (props) => {
     };
   };
 
+  const filterEmailAttribute = (email) => {
+    if (convertingToVirtual) {
+      return Object.keys(email).includes('email_address') && email.email_address;
+    }
+
+    return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');
+  };
+
   const handleCancelButton = () => {
     if (userVsoEmployee) {
       goBack();
@@ -224,7 +232,7 @@ const HearingDetails = (props) => {
             type: 'RepresentativeHearingEmailRecipient'
           }, isNil
         )
-      ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
+      ].filter((email) => filterEmailAttribute(email));
 
       // Put the UI into a loading state
       setLoading(true);

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -210,22 +210,22 @@ const HearingDetails = (props) => {
       // Due to the pre-population of the email fields, we want to make sure that
       // we always send up all email and timezone info during a conversion to a virtual hearing,
       // especially whenever the default values are not changed.
-      const hearingInfoForRecipients = convertingToVirtual ? hearing : hearingChanges;
+      const hearingInfo = convertingToVirtual ? hearing : hearingChanges;
 
       const emailRecipientAttributes = [
         omitBy(
           {
             id: hearing?.appellantEmailId,
-            timezone: hearingInfoForRecipients?.appellantTz,
-            email_address: hearingInfoForRecipients?.appellantEmailAddress,
+            timezone: hearingInfo?.appellantTz,
+            email_address: hearingInfo?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
           }, isUndefined
         ),
         omitBy(
           {
             id: hearing?.representativeEmailId,
-            timezone: hearingInfoForRecipients?.representativeTz,
-            email_address: hearingInfoForRecipients?.representativeEmailAddress,
+            timezone: hearingInfo?.representativeTz,
+            email_address: hearingInfo?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )
@@ -237,7 +237,7 @@ const HearingDetails = (props) => {
       // Save the hearing
       const response = await saveHearing({
         hearing: {
-          ...(hearingInfoForRecipients || {}),
+          ...(hearingInfo || {}),
           // Always send full transcription details because a new record is created each update
           transcription_attributes: transcription ? hearing.transcription : {},
           virtual_hearing_attributes: virtualHearing || {},

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -1,7 +1,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { css } from 'glamor';
-import { isUndefined, get, omitBy, isNil } from 'lodash';
+import { isUndefined, get, omitBy } from 'lodash';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import PropTypes from 'prop-types';
 import React, { useState, useContext, useEffect } from 'react';
@@ -144,14 +144,6 @@ const HearingDetails = (props) => {
     };
   };
 
-  const filterEmailAttribute = (email) => {
-    if (convertingToVirtual) {
-      return Object.keys(email).includes('email_address') && email.email_address;
-    }
-
-    return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');
-  };
-
   const handleCancelButton = () => {
     if (userVsoEmployee) {
       goBack();
@@ -228,7 +220,7 @@ const HearingDetails = (props) => {
             timezone: hearingInfo?.appellantTz,
             email_address: hearingInfo?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
-          }, isNil
+          }, isUndefined
         ),
         omitBy(
           {
@@ -236,9 +228,9 @@ const HearingDetails = (props) => {
             timezone: hearingInfo?.representativeTz,
             email_address: hearingInfo?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
-          }, isNil
+          }, isUndefined
         )
-      ].filter((email) => filterEmailAttribute(email));
+      ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
 
       // Put the UI into a loading state
       setLoading(true);

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -18,6 +18,7 @@ import { HearingsUserContext } from '../contexts/HearingsUserContext';
 import {
   deepDiff,
   getChanges,
+  getConvertToVirtualChanges,
   getAppellantTitle,
   processAlerts,
   startPolling,
@@ -143,6 +144,14 @@ const HearingDetails = (props) => {
     };
   };
 
+  const filterEmailAttribute = (email) => {
+    if (convertingToVirtual) {
+      return Object.keys(email).includes('email_address') && email.email_address;
+    }
+
+    return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');
+  };
+
   const handleCancelButton = () => {
     if (userVsoEmployee) {
       goBack();
@@ -203,7 +212,10 @@ const HearingDetails = (props) => {
 
       // Only send updated properties unless converting to virtual, then send everything.
       const { virtualHearing, transcription, ...hearingInfo } = convertingToVirtual ?
-        omitBy(hearing, isNil) :
+        getConvertToVirtualChanges(
+          initialHearing,
+          hearing
+        ) :
         getChanges(
           initialHearing,
           hearing
@@ -226,7 +238,7 @@ const HearingDetails = (props) => {
             type: 'RepresentativeHearingEmailRecipient'
           }, isNil
         )
-      ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
+      ].filter((email) => filterEmailAttribute(email));
 
       // Put the UI into a loading state
       setLoading(true);

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -214,8 +214,7 @@ const HearingDetails = (props) => {
       const { virtualHearing, transcription, ...hearingChanges } = convertingToVirtual ?
         getConvertToVirtualChanges(
           initialHearing,
-          hearing,
-          userVsoEmployee
+          hearing
         ) :
         getChanges(
           initialHearing,

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -145,7 +145,11 @@ const HearingDetails = (props) => {
 
   const filterEmailAttribute = (email) => {
     if (convertingToVirtual) {
-      return Object.keys(email).includes('email_address') && email.email_address;
+      return Object.keys(email).includes('email_address') && (
+        // Only send up a blank email if a recipient already exists in hearing_email_recipients
+        // Otherwise, the backend will throw a validation error.
+        email.email_address || initialHearing.representativeEmailAddress
+      );
     }
 
     return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -1,7 +1,7 @@
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import { css } from 'glamor';
-import { isUndefined, get, omitBy } from 'lodash';
+import { isUndefined, get, omitBy, isNil } from 'lodash';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import PropTypes from 'prop-types';
 import React, { useState, useContext, useEffect } from 'react';
@@ -201,16 +201,11 @@ const HearingDetails = (props) => {
         return openEmailConfirmationModal({ type: 'change_email_or_timezone' });
       }
 
-      // Only send updated properties
-      const { virtualHearing, transcription, ...hearingChanges } = getChanges(
+      // Only send updated properties unless converting to virtual, then send everything.
+      const { virtualHearing, transcription, ...hearingInfo } = convertingToVirtual ? hearing : getChanges(
         initialHearing,
         hearing
       );
-
-      // Due to the pre-population of the email fields, we want to make sure that
-      // we always send up all email and timezone info during a conversion to a virtual hearing,
-      // especially whenever the default values are not changed.
-      const hearingInfo = convertingToVirtual ? hearing : hearingChanges;
 
       const emailRecipientAttributes = [
         omitBy(
@@ -219,7 +214,7 @@ const HearingDetails = (props) => {
             timezone: hearingInfo?.appellantTz,
             email_address: hearingInfo?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
-          }, isUndefined
+          }, isNil
         ),
         omitBy(
           {
@@ -227,7 +222,7 @@ const HearingDetails = (props) => {
             timezone: hearingInfo?.representativeTz,
             email_address: hearingInfo?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
-          }, isUndefined
+          }, isNil
         )
       ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
 

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -207,20 +207,25 @@ const HearingDetails = (props) => {
         hearing
       );
 
+      // Due to the pre-population of the email fields, we want to make sure that
+      // we always send up all email and timezone info during a conversion to a virtual hearing,
+      // especially whenever the default values are not changed.
+      const hearingInfoForRecipients = convertingToVirtual ? hearing : hearingChanges;
+
       const emailRecipientAttributes = [
         omitBy(
           {
-            id: hearingChanges?.appellantEmailId,
-            timezone: hearingChanges?.appellantTz,
-            email_address: hearingChanges?.appellantEmailAddress,
+            id: hearing?.appellantEmailId,
+            timezone: hearingInfoForRecipients?.appellantTz,
+            email_address: hearingInfoForRecipients?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
           }, isUndefined
         ),
         omitBy(
           {
-            id: hearingChanges?.representativeEmailId,
-            timezone: hearingChanges?.representativeTz,
-            email_address: hearingChanges?.representativeEmailAddress,
+            id: hearing?.representativeEmailId,
+            timezone: hearingInfoForRecipients?.representativeTz,
+            email_address: hearingInfoForRecipients?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )
@@ -232,7 +237,7 @@ const HearingDetails = (props) => {
       // Save the hearing
       const response = await saveHearing({
         hearing: {
-          ...(hearingChanges || {}),
+          ...(hearingInfoForRecipients || {}),
           // Always send full transcription details because a new record is created each update
           transcription_attributes: transcription ? hearing.transcription : {},
           virtual_hearing_attributes: virtualHearing || {},

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -207,25 +207,20 @@ const HearingDetails = (props) => {
         hearing
       );
 
-      // Due to the pre-population of the email fields, we want to make sure that
-      // we always send up all email and timezone info during a conversion to a virtual hearing,
-      // especially whenever the default values are not changed.
-      const hearingInfoForRecipients = convertingToVirtual ? hearing : hearingChanges;
-
       const emailRecipientAttributes = [
         omitBy(
           {
-            id: hearingInfoForRecipients?.appellantEmailId,
-            timezone: hearingInfoForRecipients?.appellantTz,
-            email_address: hearingInfoForRecipients?.appellantEmailAddress,
+            id: hearingChanges?.appellantEmailId,
+            timezone: hearingChanges?.appellantTz,
+            email_address: hearingChanges?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
           }, isUndefined
         ),
         omitBy(
           {
-            id: hearingInfoForRecipients?.representativeEmailId,
-            timezone: hearingInfoForRecipients?.representativeTz,
-            email_address: hearingInfoForRecipients?.representativeEmailAddress,
+            id: hearingChanges?.representativeEmailId,
+            timezone: hearingChanges?.representativeTz,
+            email_address: hearingChanges?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -203,7 +203,7 @@ const HearingDetails = (props) => {
       }
 
       // Only send updated properties unless converting to virtual, then send everything.
-      const { virtualHearing, transcription, ...hearingInfo } = convertingToVirtual ?
+      const { virtualHearing, transcription, ...hearingChanges } = convertingToVirtual ?
         getConvertToVirtualChanges(
           initialHearing,
           hearing
@@ -217,16 +217,16 @@ const HearingDetails = (props) => {
         omitBy(
           {
             id: hearing?.appellantEmailId,
-            timezone: hearingInfo?.appellantTz,
-            email_address: hearingInfo?.appellantEmailAddress,
+            timezone: hearingChanges?.appellantTz,
+            email_address: hearingChanges?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
           }, isUndefined
         ),
         omitBy(
           {
             id: hearing?.representativeEmailId,
-            timezone: hearingInfo?.representativeTz,
-            email_address: hearingInfo?.representativeEmailAddress,
+            timezone: hearingChanges?.representativeTz,
+            email_address: hearingChanges?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )
@@ -238,7 +238,7 @@ const HearingDetails = (props) => {
       // Save the hearing
       const response = await saveHearing({
         hearing: {
-          ...(hearingInfo || {}),
+          ...(hearingChanges || {}),
           // Always send full transcription details because a new record is created each update
           transcription_attributes: transcription ? hearing.transcription : {},
           virtual_hearing_attributes: virtualHearing || {},

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -214,10 +214,12 @@ const HearingDetails = (props) => {
       }
 
       // Only send updated properties unless converting to virtual, then send everything.
-      const { virtualHearing, transcription, ...hearingInfo } = convertingToVirtual ? hearing : getChanges(
-        initialHearing,
-        hearing
-      );
+      const { virtualHearing, transcription, ...hearingInfo } = convertingToVirtual ?
+        omitBy(hearing, isNil) :
+        getChanges(
+          initialHearing,
+          hearing
+        );
 
       const emailRecipientAttributes = [
         omitBy(

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -144,6 +144,14 @@ const HearingDetails = (props) => {
     };
   };
 
+  const filterEmailAttribute = (email) => {
+    if (convertingToVirtual) {
+      return Object.keys(email).includes('email_address') && email.email_address;
+    }
+
+    return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');
+  };
+
   const handleCancelButton = () => {
     if (userVsoEmployee) {
       goBack();
@@ -231,7 +239,7 @@ const HearingDetails = (props) => {
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )
-      ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
+      ].filter((email) => filterEmailAttribute(email));
 
       // Put the UI into a loading state
       setLoading(true);

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -207,20 +207,25 @@ const HearingDetails = (props) => {
         hearing
       );
 
+      // Due to the pre-population of the email fields, we want to make sure that
+      // we always send up all email and timezone info during a conversion to a virtual hearing,
+      // especially whenever the default values are not changed.
+      const hearingInfoForRecipients = convertingToVirtual ? hearing : hearingChanges;
+
       const emailRecipientAttributes = [
         omitBy(
           {
-            id: hearing?.appellantEmailId,
-            timezone: hearingChanges?.appellantTz,
-            email_address: hearingChanges?.appellantEmailAddress,
+            id: hearingInfoForRecipients?.appellantEmailId,
+            timezone: hearingInfoForRecipients?.appellantTz,
+            email_address: hearingInfoForRecipients?.appellantEmailAddress,
             type: 'AppellantHearingEmailRecipient'
           }, isUndefined
         ),
         omitBy(
           {
-            id: hearing?.representativeEmailId,
-            timezone: hearingChanges?.representativeTz,
-            email_address: hearingChanges?.representativeEmailAddress,
+            id: hearingInfoForRecipients?.representativeEmailId,
+            timezone: hearingInfoForRecipients?.representativeTz,
+            email_address: hearingInfoForRecipients?.representativeEmailAddress,
             type: 'RepresentativeHearingEmailRecipient'
           }, isUndefined
         )

--- a/client/app/hearings/components/Details.jsx
+++ b/client/app/hearings/components/Details.jsx
@@ -143,18 +143,6 @@ const HearingDetails = (props) => {
     };
   };
 
-  const filterEmailAttribute = (email) => {
-    if (convertingToVirtual) {
-      return Object.keys(email).includes('email_address') && (
-        // Only send up a blank email if a recipient already exists in hearing_email_recipients
-        // Otherwise, the backend will throw a validation error.
-        email.email_address || initialHearing.representativeEmailAddress
-      );
-    }
-
-    return Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone');
-  };
-
   const handleCancelButton = () => {
     if (userVsoEmployee) {
       goBack();
@@ -238,7 +226,7 @@ const HearingDetails = (props) => {
             type: 'RepresentativeHearingEmailRecipient'
           }, isNil
         )
-      ].filter((email) => filterEmailAttribute(email));
+      ].filter((email) => Object.keys(email).includes('email_address') || Object.keys(email).includes('timezone'));
 
       // Put the UI into a loading state
       setLoading(true);

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -14,14 +14,14 @@ import {
   reduce,
   isObject,
   isEqual,
-  isNil,
   concat,
   uniq,
   times,
   compact,
   sortBy,
   get,
-  map
+  map,
+  isUndefined
 } from 'lodash';
 
 import HEARING_ROOMS_LIST from 'constants/HEARING_ROOMS_LIST';
@@ -291,7 +291,7 @@ export const getConvertToVirtualChanges = (first, second) => {
     appellantEmailAddress: second.appellantEmailAddress,
     representativeTz: second.representativeTz,
     representativeEmailAddress: second.representativeEmailAddress
-  }, isNil);
+  }, isUndefined);
 };
 
 /**

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -14,6 +14,7 @@ import {
   reduce,
   isObject,
   isEqual,
+  isNil,
   concat,
   uniq,
   times,
@@ -272,6 +273,25 @@ export const getChanges = (first, second) => {
   const { init, current } = toggleCancelled(first, second, 'virtualHearing');
 
   return deepDiff(init, current);
+};
+
+/**
+ * Method to calculate hearing details changes accounting for hearings being converted to virtual
+ * @param {Object} init -- The initial form details
+ * @param {Object} current -- The current form details
+ */
+export const getConvertToVirtualChanges = (first, second) => {
+  const diff = getChanges(first, second);
+
+  // Always return emails and timezones whenever converting to virtual due to
+  // field pre-population unless they're blank.
+  return omitBy({
+    ...diff,
+    appellantTz: second.appellantTz,
+    appellantEmailAddress: second.appellantEmailAddress,
+    representativeTz: second.representativeTz,
+    representativeEmailAddress: second.representativeEmailAddress
+  }, isNil);
 };
 
 /**

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -284,16 +284,13 @@ export const getConvertToVirtualChanges = (first, second) => {
   const diff = getChanges(first, second);
 
   // Always return emails and timezones whenever converting to virtual due to
-  // field pre-population unless they're blank.
+  // field pre-population. Leave out emails if they're blank to prevent validation issues.
   return omitBy({
     ...diff,
     appellantTz: second.appellantTz,
-    ...((second.appellantEmailAddress || (!second.appellantEmailAddress && first.appellantEmailAddress)) &&
-        { appellantEmailAddress: second.appellantEmailAddress }),
+    ...(second.appellantEmailAddress && { appellantEmailAddress: second.appellantEmailAddress }),
     representativeTz: second.representativeTz,
-    ...((second.representativeEmailAddress ||
-          (!second.representativeEmailAddress && first.representativeEmailAddress)) &&
-        { representativeEmailAddress: second.representativeEmailAddress })
+    ...(second.representativeEmailAddress && { representativeEmailAddress: second.representativeEmailAddress })
   }, isUndefined);
 };
 

--- a/client/app/hearings/utils.js
+++ b/client/app/hearings/utils.js
@@ -288,9 +288,12 @@ export const getConvertToVirtualChanges = (first, second) => {
   return omitBy({
     ...diff,
     appellantTz: second.appellantTz,
-    appellantEmailAddress: second.appellantEmailAddress,
+    ...((second.appellantEmailAddress || (!second.appellantEmailAddress && first.appellantEmailAddress)) &&
+        { appellantEmailAddress: second.appellantEmailAddress }),
     representativeTz: second.representativeTz,
-    representativeEmailAddress: second.representativeEmailAddress
+    ...((second.representativeEmailAddress ||
+          (!second.representativeEmailAddress && first.representativeEmailAddress)) &&
+        { representativeEmailAddress: second.representativeEmailAddress })
   }, isUndefined);
 };
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -37,11 +37,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
-
-  config.action_mailer.perform_caching = false
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
@@ -92,7 +87,19 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 
-  config.action_mailer.delivery_method = :test
+  if ENV["WITH_TEST_EMAIL_SERVER"]
+    config.action_mailer.delivery_method = :smtp
+    config.action_mailer.smtp_settings = {
+      port: ENV["TEST_MAIL_SERVER_PORT"] || 1025,
+      address: 'localhost'
+    }
+  else
+    # Don't care if the mailer can't send.
+    config.action_mailer.raise_delivery_errors = false
+
+    config.action_mailer.perform_caching = false
+    config.action_mailer.delivery_method = :test
+  end
 
   # eFolder API URL to retrieve appeal documents
   config.efolder_url = "http://localhost:4000"

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -383,8 +383,6 @@ RSpec.feature "Convert hearing request type" do
         step "representative recives email notification" do
           sleep 5
 
-          byebug
-
           hearing = video_appeal.reload.hearings.first
 
           expect(hearing.email_events.count).to eq 2

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -328,7 +328,7 @@ RSpec.feature "Convert hearing request type" do
       end
     end
 
-    context "When not providing hearing participant emails and then later converting hearing to virtual" do
+    context "When not initially providing hearing participant emails and then later converting hearing to virtual" do
       before do
         FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
       end
@@ -348,7 +348,7 @@ RSpec.feature "Convert hearing request type" do
           click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN_V2_PAGE.label)
 
           click_dropdown(name: "appealHearingLocation", index: 0)
-          find(".cf-form-radio-option", text: "8:30 am").click
+          find(".cf-form-radio-option", text: /8:30 am/i).click
           click_button("Submit")
         end
 
@@ -356,6 +356,8 @@ RSpec.feature "Convert hearing request type" do
           hearing = video_appeal.hearings.first
 
           visit "hearings/#{hearing.external_id}/details"
+
+          click_dropdown(name: "hearingType", index: 0)
         end
 
         step "update hearing to have a representative email address" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -329,16 +329,16 @@ RSpec.feature "Convert hearing request type" do
     end
 
     context "When not initially providing hearing participant emails and then later converting hearing to virtual" do
+      let!(:hearing_day) do
+        create(:hearing_day, :video, scheduled_for: Time.zone.today + 10.days, regional_office: "RO39")
+      end
+
       before do
         FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
       end
 
       after do
         FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
-      end
-
-      let!(:hearing_day) do
-        create(:hearing_day, :video, scheduled_for: Time.zone.today + 10.days, regional_office: "RO39")
       end
 
       scenario do
@@ -353,7 +353,7 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "convert the scheduled hearing to virtual without a representative email address" do
-          hearing = video_appeal.hearings.first
+          hearing = video_appeal.reload.hearings.first
 
           visit "hearings/#{hearing.external_id}/details"
 

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -361,7 +361,7 @@ RSpec.feature "Convert hearing request type" do
 
           click_dropdown(name: "hearingType", index: 0)
 
-          click_button("Convert Hearing To Virtual")
+          click_button("Save")
         end
 
         step "appellant receives email notification" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -365,6 +365,8 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "appellant receives email notification" do
+          sleep 5
+
           hearing = video_appeal.reload.hearings.first
 
           expect(hearing.email_events.count).to eq 1
@@ -374,9 +376,15 @@ RSpec.feature "Convert hearing request type" do
           fill_in "POA/Representative Email", with: "representative@example.com"
 
           click_button("Save")
+
+          click_button("button-submit-virtual-hearing")
         end
 
         step "representative recives email notification" do
+          sleep 5
+
+          byebug
+
           hearing = video_appeal.reload.hearings.first
 
           expect(hearing.email_events.count).to eq 2

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -353,6 +353,8 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "convert the scheduled hearing to virtual without a representative email address" do
+          find("p", text: "APPEAL STREAM TYPE")
+
           hearing = video_appeal.reload.hearings.first
 
           visit "hearings/#{hearing.external_id}/details"
@@ -363,6 +365,8 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "appellant receives email notification" do
+          hearing = video_appeal.reload.hearings.first
+
           expect(hearing.email_events.count).to eq 1
         end
 
@@ -373,6 +377,8 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "representative recives email notification" do
+          hearing = video_appeal.reload.hearings.first
+
           expect(hearing.email_events.count).to eq 2
         end
       end

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -362,7 +362,18 @@ RSpec.feature "Convert hearing request type" do
           click_button("Save")
         end
 
+        step "appellant receives email notification" do
+          expect(hearing.email_events.count).to eq 1
+        end
+
         step "update hearing to have a representative email address" do
+          fill_in "POA/Representative Email", with: "representative@example.com"
+
+          click_button("Save")
+        end
+
+        step "representative recives email notification" do
+          expect(hearing.email_events.count).to eq 2
         end
       end
     end

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -361,7 +361,7 @@ RSpec.feature "Convert hearing request type" do
 
           click_dropdown(name: "hearingType", index: 0)
 
-          click_button("Save")
+          click_button("Convert Hearing To Virtual")
         end
 
         step "appellant receives email notification" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -349,7 +349,7 @@ RSpec.feature "Convert hearing request type" do
 
           click_dropdown(name: "appealHearingLocation", index: 0)
           find(".cf-form-radio-option", text: /8:30 am/i).click
-          click_button("Submit")
+          click_button("Schedule")
         end
 
         step "convert the scheduled hearing to virtual without a representative email address" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -327,6 +327,41 @@ RSpec.feature "Convert hearing request type" do
         expect(page).to have_content(central_office_appeal.docket_number)
       end
     end
+
+    context "When not providing hearing participant emails and then later converting hearing to virtual" do
+      before do
+        FeatureToggle.enable!(:schedule_veteran_virtual_hearing)
+      end
+
+      after do
+        FeatureToggle.disable!(:schedule_veteran_virtual_hearing)
+      end
+
+      let!(:hearing_day) do
+        create(:hearing_day, :video, scheduled_for: Time.zone.today + 10.days, regional_office: "RO39")
+      end
+
+      scenario do
+        visit "/queue/appeals/#{video_appeal.external_id}"
+
+        step "schedule hearing as a video hearing without providing participant email addresses" do
+          click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN_V2_PAGE.label)
+
+          click_dropdown(name: "appealHearingLocation", index: 0)
+          find(".cf-form-radio-option", text: "8:30 am").click
+          click_button("Submit")
+        end
+
+        step "convert the scheduled hearing to virtual without a representative email address" do
+          hearing = video_appeal.hearings.first
+
+          visit "hearings/#{hearing.external_id}/details"
+        end
+
+        step "update hearing to have a representative email address" do
+        end
+      end
+    end
   end
 
   context "for all other users" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -358,6 +358,8 @@ RSpec.feature "Convert hearing request type" do
           visit "hearings/#{hearing.external_id}/details"
 
           click_dropdown(name: "hearingType", index: 0)
+
+          click_button("Save")
         end
 
         step "update hearing to have a representative email address" do

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
@@ -222,9 +222,12 @@ RSpec.feature "Convert hearing request type" do
         )
         expect(page).to have_content(COPY::VSO_CONVERT_HEARING_TYPE_SUCCESS_DETAIL)
 
-        expect(hearing.reload.appeal.changed_hearing_request_type).to eq(
-          Constants.HEARING_REQUEST_TYPES.virtual
-        )
+        # We only display hearing types for AMA hearings
+        if hearing.is_a?(Hearing)
+          expect(hearing.reload.appeal.changed_hearing_request_type).to eq(
+            Constants.HEARING_REQUEST_TYPES.virtual
+          )
+        end
       end
     end
   end

--- a/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/vso_change_hearing_request_type_spec.rb
@@ -148,6 +148,10 @@ RSpec.feature "Convert hearing request type" do
         hearing_id = hearing.is_a?(Hearing) ? hearing.uuid : hearing.vacols_id
         visit "hearings/#{hearing_id}/details"
         expect(page).to have_content format(COPY::CONVERT_HEARING_TITLE, "Virtual")
+
+        expect(hearing.appeal.changed_hearing_request_type).to_not eq(
+          Constants.HEARING_REQUEST_TYPES.virtual
+        )
       end
 
       step "verify pre-population of Hearings form fields" do
@@ -217,6 +221,10 @@ RSpec.feature "Convert hearing request type" do
           "You have successfully converted #{appellant_name}'s hearing to virtual"
         )
         expect(page).to have_content(COPY::VSO_CONVERT_HEARING_TYPE_SUCCESS_DETAIL)
+
+        expect(hearing.reload.appeal.changed_hearing_request_type).to eq(
+          Constants.HEARING_REQUEST_TYPES.virtual
+        )
       end
     end
   end

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -28,7 +28,7 @@ RSpec.feature "Hearing Details", :all_dbs do
 
   let(:pre_loaded_veteran_email) { hearing.appeal.veteran.email_address }
   let(:pre_loaded_rep_email) { hearing.appeal.representative_email_address }
-  let(:fill_in_veteran_email) { "new@email.com" }
+  let(:fill_in_veteran_email) { "veteran@example.com" }
   let(:fill_in_veteran_tz) { "Eastern Time (US & Canada) (12:00 AM)" }
   let(:fill_in_rep_email) { "rep@testingEmail.com" }
   let(:fill_in_rep_tz) { "Mountain Time (US & Canada) (10:00 PM)" }
@@ -482,8 +482,8 @@ RSpec.feature "Hearing Details", :all_dbs do
             hearing: hearing
           )
         end
-        let(:fill_in_veteran_email) { "new@email.com" }
-        let(:fill_in_rep_email) { "rep@testingEmail.com" }
+        let(:fill_in_veteran_email) { "veteran@example.com" }
+        let(:fill_in_rep_email) { "rep@example.com" }
 
         scenario "user can update emails" do
           visit "hearings/" + hearing.external_id.to_s + "/details"

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -970,9 +970,9 @@ RSpec.feature "Hearing Details", :all_dbs do
 
       step "hearing email recipients have been recorded and emails notifications have been sent" do
         expect(hearing.appellant_recipient.email_address).to eq expected_veteran_email
-        expect(hearing.representative_recipient.email_address).to eq fill_in_rep_email
+        expect(hearing.representative_recipient.email_address).to eq current_user.email
 
-        expect(hearing.sent_email_events.count).to eq 2
+        expect(hearing.email_events.count).to eq 2
       end
     end
 


### PR DESCRIPTION
Resolves the issues detailed in [APPEALS-7867](https://vajira.max.gov/browse/APPEALS-7867) and [APPEALS-7873](https://vajira.max.gov/browse/APPEALS-7873)

### Description
Whenever converting a scheduled hearing to virtual, as a hearings coordinator, hearings scheduler, or VSO employee (if representing the hearing's claimant), send all email and timezone values to the backend to be persisted (including pre-populated values).

### Acceptance Criteria
- [ ] Whenever converting a hearing to virtual as any type of user, if pre-populated values placed within the hearing conversion form are not removed, all remaining values are sent to the backend to be persisted.
- [ ] Whenever converting a hearing to a type other than hearing, the pre-existing behavior where only altered values are sent to the backend is left intact.
- [ ] Email notifications are sent to all parties registered to a hearing upon converting to/from virtual.

### Testing Plan

**Note**: I highly recommend that you read [this comment](https://github.com/department-of-veterans-affairs/caseflow/pull/17371#discussion_r944053872) prior to working through the testing plan as it details how to set up a local email server for observing whether or not email notifications are being sent properly. 

1. Locate appeals with `assigned` `ScheduleHearingTasks`:
```ruby
uhs = Appeal.all.filter { |a| a.tasks.any? { |t| t.type == ScheduleHearingTask.name && t.status == "assigned" } }
```

Be sure that the hearing request type is not `virtual`.

```ruby
non_virtual_uhs = uhs.reject { |h| h.changed_hearing_request_type == "R" || (!h.changed_hearing_request_type && h.original_hearing_request_type == "R") }
```

2. Log into Caseflow as a hearings coordinator (ex: `BVASYELLOW`)

3. Navigate to the case details page for one of the appeals you've located:
`/queue/appeals/<non_virtual_uhs[n].external_id>`

4. Select the "Schedule Veteran" option from the actions dropdown.

5. Schedule the hearing **without** entering email addresses for the appellant and representative. Also be sure to keep the hearing set to be non-virtual..

6. Refresh the Case Details page, and then scroll down to the Hearings section. Click on the "View Hearing Details" link.

7. Select "Virtual" from the "Hearing Type" dropdown.

8. Leave any pre-populated values intact. You can choose to leave the representative email address field blank.

9. If you'd like, open the Developer Tools panel (CTRL+SHIFT+I in Chrome), and open the Network tab. Submit the conversion for. You should have sent a payload similar to this:

**Note**: Represenative's email address was left blank.
```json
{
    "appellant_tz": "America/Los_Angeles",
    "appellant_email_address": "prepopulated@email.com",
    "representative_tz": "America/Los_Angeles",
    "transcription_attributes": {},
    "virtual_hearing_attributes": {
        "request_cancelled": false,
        "job_completed": false
    },
    "email_recipients_attributes": {
        "0": {
            "id": "",
            "timezone": "America/Los_Angeles",
            "email_address": "prepopulated@email.com",
            "type": "AppellantHearingEmailRecipient"
        }
    }
}
```

10. If you've elected to run a local mail server, now's the time to check your inbox! You should have received an email message addressed to the appellant and/or representative confirming that their virtual hearing has been scheduled:
<img width="942" alt="maildev-test" src="https://user-images.githubusercontent.com/99351305/184781443-9786bb87-4a3b-4218-a8cb-b02d1bb33cc0.PNG">


11. You are also able to check that any email messages have successfully been sent at the bottom of the "Email Notifications" section of the Hearing Details page:

<img width="379" alt="emails_sent" src="https://user-images.githubusercontent.com/99351305/184781354-a78d6f61-922c-44ed-8606-9b9aa00816b7.PNG">

12. Repeat these steps for another unscheduled hearing. However, once you've scheduled the hearing, switch to a VSO user (ex: `BILLIE_VSO`) and perform the conversion as that user instead.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.
