### PR TITLE
hotfix for APPEALS-2320

### DIFF
--- a/app/services/hearing_schedule/validate_judge_spreadsheet.rb
+++ b/app/services/hearing_schedule/validate_judge_spreadsheet.rb
@@ -29,7 +29,11 @@ class HearingSchedule::ValidateJudgeSpreadsheet
 
     # we get the name in the format "Last, First"
     split_name = name.split(", ")
-    full_name = "#{split_name.last} #{split_name.first}"
+    # below is full_name before hotfix
+    # full_name = "#{split_name.last} #{split_name.first}"
+
+    # hotfix for APPEALS-2320 below
+    full_name = FullName.new(split_name.last, nil, split_name.first).formatted(:readable_short)
 
     user.full_name.casecmp?(full_name)
   end


### PR DESCRIPTION
Resolves APPEALS-2320

### Description
Changes full_name in validate_judge_spreadsheet.rb to bypass running names through Titleize. Titleize has been shown to incorrectly modify names.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Deploy to UAT to test

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)


