### PR TITLE
feature/APPEALS-8045 APPEALS-8102

### DIFF
--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -115,7 +115,10 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   def priority_target
     @priority_target ||= begin
       distribution_counts = priority_distributions_this_month_for_eligible_judges.values
-      target = (distribution_counts.sum + ready_genpop_priority_appeals_count) / distribution_counts.count
+      target = 0
+      if distribution_counts.count > 0
+        target = (distribution_counts.sum + ready_genpop_priority_appeals_count) / distribution_counts.count
+      end
 
       # If there are any judges that have previous distributions that are MORE than the currently calculated priority
       # target, no target will be large enough to get all other judges up to their number of cases. Remove them from

--- a/app/models/dockets/direct_review_docket.rb
+++ b/app/models/dockets/direct_review_docket.rb
@@ -11,6 +11,7 @@ class DirectReviewDocket < Docket
     Appeal.where(id: appeal_ids).count
   end
 
+  # TODO this appears to be dead code leftover from https://github.com/department-of-veterans-affairs/caseflow/pull/16924
   def time_until_due_of_new_appeal
     Constants.DISTRIBUTION.direct_docket_time_goal - Constants.DISTRIBUTION.days_before_goal_due_for_distribution
   end

--- a/app/models/dockets/direct_review_docket.rb
+++ b/app/models/dockets/direct_review_docket.rb
@@ -11,7 +11,7 @@ class DirectReviewDocket < Docket
     Appeal.where(id: appeal_ids).count
   end
 
-  # TODO this appears to be dead code leftover from https://github.com/department-of-veterans-affairs/caseflow/pull/16924
+  # TODO: this appears to be dead code leftover from https://github.com/department-of-veterans-affairs/caseflow/pull/16924
   def time_until_due_of_new_appeal
     Constants.DISTRIBUTION.direct_docket_time_goal - Constants.DISTRIBUTION.days_before_goal_due_for_distribution
   end

--- a/app/models/dockets/direct_review_docket.rb
+++ b/app/models/dockets/direct_review_docket.rb
@@ -6,14 +6,13 @@ class DirectReviewDocket < Docket
   end
 
   def due_count
-    appeal_ids = appeals(priority: false, ready: true)
-      .where("target_decision_date <= ?", Constants.DISTRIBUTION.days_before_goal_due_for_distribution.days.from_now)
+    if Constants.DISTRIBUTION.days_before_goal_due_for_distribution.nil?
+      appeal_ids = appeals(priority: false, ready: true)
+    else
+      appeal_ids = appeals(priority: false, ready: true)
+        .where("target_decision_date <= ?", Constants.DISTRIBUTION.days_before_goal_due_for_distribution.days.from_now)
+    end
     Appeal.where(id: appeal_ids).count
-  end
-
-  # TODO: this appears to be dead code leftover from https://github.com/department-of-veterans-affairs/caseflow/pull/16924
-  def time_until_due_of_new_appeal
-    Constants.DISTRIBUTION.direct_docket_time_goal - Constants.DISTRIBUTION.days_before_goal_due_for_distribution
   end
 
   def nonpriority_receipts_per_year
@@ -30,11 +29,4 @@ class DirectReviewDocket < Docket
     docket_appeals.nonpriority
   end
 
-  def nonpriority_nonihp_ready_appeals
-    docket_appeals
-      .ready_for_distribution
-      .nonpriority
-      .non_ihp
-      .order("receipt_date")
-  end
 end

--- a/client/constants/DISTRIBUTION.json
+++ b/client/constants/DISTRIBUTION.json
@@ -4,7 +4,7 @@
   "cavc_affinity_days": 21,
   "days_before_goal_due_for_distribution": 65,
   "direct_docket_time_goal": 365,
-  "hearing_case_affinity_days": 30,
+  "hearing_case_affinity_days": 0,
   "maximum_direct_review_proportion": 0.07,
   "minimum_legacy_proportion": 0.9,
   "nod_adjustment": 0.4

--- a/client/constants/DISTRIBUTION.json
+++ b/client/constants/DISTRIBUTION.json
@@ -2,7 +2,7 @@
   "alternative_batch_size": 15,
   "batch_size_per_attorney": 3,
   "cavc_affinity_days": 21,
-  "days_before_goal_due_for_distribution": 65,
+  "days_before_goal_due_for_distribution": null,
   "direct_docket_time_goal": 365,
   "hearing_case_affinity_days": 0,
   "maximum_direct_review_proportion": 0.07,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -49,6 +49,7 @@ class SeedDB
     call_and_log_seed_step Seeds::VeteransHealthAdministration
     call_and_log_seed_step Seeds::MTV
     call_and_log_seed_step Seeds::Education
+    call_and_log_seed_step Seeds::PriorityDistributions
   end
 end
 

--- a/db/seeds/priority_distributions.rb
+++ b/db/seeds/priority_distributions.rb
@@ -11,7 +11,7 @@ module Seeds
   class PriorityDistributions < Base
     # :nocov:
     def seed!
-      organize_judges
+      # organize_judges
       create_previous_distribtions
       create_cases_tied_to_judges
       create_genpop_cases
@@ -20,6 +20,7 @@ module Seeds
 
     private
 
+    # Without context, this method doesn't make any useful changes to the seed data so I'm not running it
     def organize_judges
       JudgeTeam.unscoped.find_by(name: "BVAACTING").inactive!
       JudgeTeam.find_by(name: "BVAAWAKEFIELD").update!(accepts_priority_pushed_cases: false)
@@ -98,7 +99,7 @@ module Seeds
       create_unvalidated_completed_distribution(
         traits: [:priority, :this_month],
         judge: judge,
-        statistics: { "batch_size" => rand(10) }
+        statistics: { "batch_size" => 4 }
       )
     end
 
@@ -106,7 +107,7 @@ module Seeds
       create_unvalidated_completed_distribution(
         traits: [:priority, :last_month],
         judge: judge,
-        statistics: { "batch_size" => rand(10) }
+        statistics: { "batch_size" => 4 }
       )
     end
 
@@ -114,12 +115,12 @@ module Seeds
       create_unvalidated_completed_distribution(
         traits: [:this_month],
         judge: judge,
-        statistics: { "batch_size" => rand(10) }
+        statistics: { "batch_size" => 4 }
       )
     end
 
     def create_legacy_ready_priority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :case,
           :aod,
@@ -133,7 +134,7 @@ module Seeds
     end
 
     def create_legacy_nonready_priority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :case,
           :aod,
@@ -146,7 +147,7 @@ module Seeds
     end
 
     def create_legacy_ready_nonpriority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :case,
           :ready_for_distribution,
@@ -159,7 +160,7 @@ module Seeds
     end
 
     def create_hearing_ready_priority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :hearing_docket,
@@ -174,7 +175,7 @@ module Seeds
     end
 
     def create_hearing_nonready_priority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :hearing_docket,
@@ -189,7 +190,7 @@ module Seeds
     end
 
     def create_hearing_ready_nonpriority_cases_tied_to_judge(judge)
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :hearing_docket,
@@ -203,7 +204,7 @@ module Seeds
     end
 
     def create_legacy_ready_priority_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :case,
           :aod,
@@ -215,7 +216,7 @@ module Seeds
     end
 
     def create_legacy_nonready_priority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :case,
           :aod,
@@ -226,7 +227,7 @@ module Seeds
     end
 
     def create_legacy_ready_nonpriority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :case,
           :ready_for_distribution,
@@ -237,7 +238,7 @@ module Seeds
     end
 
     def create_ama_hearing_ready_priority_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :appeal,
           :hearing_docket,
@@ -250,7 +251,7 @@ module Seeds
     end
 
     def create_ama_hearing_nonready_priority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :hearing_docket,
@@ -263,7 +264,7 @@ module Seeds
     end
 
     def create_ama_hearing_ready_nonpriority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :hearing_docket,
@@ -275,7 +276,7 @@ module Seeds
     end
 
     def create_direct_review_ready_priority_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :appeal,
           :direct_review_docket,
@@ -286,7 +287,7 @@ module Seeds
     end
 
     def create_direct_review_nonready_priority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :direct_review_docket,
@@ -297,7 +298,7 @@ module Seeds
     end
 
     def create_direct_review_ready_nonpriority_genpop_cases
-      rand(5).times do
+      2.times do
         create(
           :appeal,
           :direct_review_docket,
@@ -307,7 +308,7 @@ module Seeds
     end
 
     def create_evidence_submission_ready_priority_genpop_cases
-      rand(10).times do
+      4.times do
         create(
           :appeal,
           :evidence_submission_docket,
@@ -318,7 +319,7 @@ module Seeds
     end
 
     def create_evidence_submission_nonready_priority_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :appeal,
           :evidence_submission_docket,
@@ -329,7 +330,7 @@ module Seeds
     end
 
     def create_evidence_submission_ready_nonpriority_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :appeal,
           :evidence_submission_docket,
@@ -339,7 +340,7 @@ module Seeds
     end
 
     def create_ready_cavc_genpop_cases
-      rand(10).times do
+      4.times do
         create(
           :appeal,
           :type_cavc_remand,
@@ -349,7 +350,7 @@ module Seeds
     end
 
     def create_ready_cavc_aod_genpop_cases
-      rand(10).times do
+      4.times do
         create(
           :appeal,
           :type_cavc_remand,
@@ -360,7 +361,7 @@ module Seeds
     end
 
     def create_nonready_cavc_genpop_cases
-      rand(50).times do
+      20.times do
         create(
           :appeal,
           :type_cavc_remand
@@ -385,7 +386,7 @@ module Seeds
       create_unvalidated_completed_distribution(
         traits: [:priority, :completed, :this_month],
         judge: User.third,
-        statistics: { "batch_size" => rand(10) }
+        statistics: { "batch_size" => 4 }
       ).distributed_cases.create(
         case_id: case_id,
         priority: case_id,
@@ -417,7 +418,7 @@ module Seeds
     end
 
     def judges_with_judge_teams
-      JudgeTeam.unscoped.map(&:judge)
+      JudgeTeam.pushed_priority_cases_allowed.map(&:judge)
     end
 
     def random_key

--- a/db/seeds/sanitized_json/appeal-119577.json
+++ b/db/seeds/sanitized_json/appeal-119577.json
@@ -5940,7 +5940,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },
@@ -5955,7 +5955,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },
@@ -5985,7 +5985,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },

--- a/db/seeds/sanitized_json/appeal-126187.json
+++ b/db/seeds/sanitized_json/appeal-126187.json
@@ -6237,7 +6237,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },
@@ -6252,7 +6252,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },
@@ -6267,7 +6267,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },
@@ -6297,7 +6297,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true,
+      "accepts_priority_pushed_cases": false,
       "ama_only_push": false,
       "ama_only_request": false
     },

--- a/db/seeds/sanitized_json/appeal_ready_for_substitution_1.json
+++ b/db/seeds/sanitized_json/appeal_ready_for_substitution_1.json
@@ -1350,7 +1350,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 197,
@@ -1363,7 +1363,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 224,
@@ -1428,7 +1428,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 461,

--- a/db/seeds/sanitized_json/appeal_ready_for_substitution_2.json
+++ b/db/seeds/sanitized_json/appeal_ready_for_substitution_2.json
@@ -1846,7 +1846,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 141,
@@ -1885,7 +1885,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 188,
@@ -1898,7 +1898,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 196,
@@ -1911,7 +1911,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 213,

--- a/db/seeds/sanitized_json/appeal_ready_for_substitution_3.json
+++ b/db/seeds/sanitized_json/appeal_ready_for_substitution_3.json
@@ -717,7 +717,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 229,

--- a/db/seeds/sanitized_json/appeal_ready_for_substitution_4.json
+++ b/db/seeds/sanitized_json/appeal_ready_for_substitution_4.json
@@ -907,7 +907,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 228,
@@ -920,7 +920,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 229,

--- a/db/seeds/sanitized_json/b5eba21a-9baf-41a3-ac1c-08470c2b79c4.json
+++ b/db/seeds/sanitized_json/b5eba21a-9baf-41a3-ac1c-08470c2b79c4.json
@@ -1647,7 +1647,7 @@
       "updated_at": null,
       "status": "active",
       "status_updated_at": null,
-      "accepts_priority_pushed_cases": true
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 163,
@@ -1660,7 +1660,7 @@
       "updated_at": "2020-04-30 14:29:50 UTC",
       "status": "inactive",
       "status_updated_at": "2020-04-30 14:29:50 UTC",
-      "accepts_priority_pushed_cases": null
+      "accepts_priority_pushed_cases": false
     },
     {
       "id": 202,

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -12,7 +12,13 @@ module Seeds
       "BVAEBECKER" => { attorneys: %w[BVAKBLOCK BVACMERTZ BVAHLUETTGEN] },
       "BVARERDMAN" => { attorneys: %w[BVASRITCHIE BVAJSCHIMMEL BVAKROHAN1] },
       "BVAOSCHOWALT" => { attorneys: %w[BVASCASPER1 BVAOWEHNER BVASFUNK1] },
-      "BVAAWAKEFIELD" => { attorneys: %w[BVAABELANGER] }
+      "BVAAWAKEFIELD" => { attorneys: %w[BVAABELANGER] },
+      # below teams were added for automatic case distribution testing
+      "BVAABODE" => { attorneys: %w[BVAABARTELL BVAABERGE BVAABERNIER] },
+      "BVABDANIEL" => { attorneys: %w[BVABBLOCK BVABCASPER BVABCHAMPLIN] },
+      "BVACGISLASON1" => { attorneys: %w[BVACABERNATH BVACABSHIRE BVACBALISTRE] },
+      "BVADCREMIN" => { attorneys: %w[BVADABBOTT BVADABERNATH BVADBEAHAN] },
+      "BVAEEMARD" => { attorneys: %w[BVAEBLANDA BVAEBUCKRIDG BVAECUMMERAT] }
     }.freeze
 
     DEVELOPMENT_DVC_TEAMS = {

--- a/local/vacols/VACOLS::Staff_dump.csv
+++ b/local/vacols/VACOLS::Staff_dump.csv
@@ -976,7 +976,7 @@ AWEHNER,,,,,Anderson,O,Wehner,AWEHNER,SBODE,07-469,BDCOUNSEL,,,,,,,,,,,,ABERGSTR
 JHEANEY,,,,,Josiah,T,Heaney,JHEANEY,HRG,67-02,CHIEF,,,,,,,,,,1-249-723-5486 x62093,,SBARTELL,,BFEENEY,1995-10-30,3,1,85,66,,,,,,I,,,,,,,,,,,
 EMURAZIK1,,,,,Emmalee,A,Murazik,EMURAZIK1,DV-DIR,,AMC,,,,,,,,,,,,,,,,,,,,,,,,,I,,,,,,,,,,,
 MKIRLIN2,,,,,Maida,C,Kirlin,MKIRLIN2,DV-DIR,,AMC,,,,,,,,,,,,,,,,,,,,,,,,,A,,,,,,,,,,,
-RERDMAN,,,,,Rickie,G,Erdman,RERDMAN,01-CHR,,STATSPT,,,,,,,,,,,,,,,,,,,,,,,,,A,,,,,,,,,A,,BVARERDMAN
+RERDMAN,,,,,Rickie,G,Erdman,RERDMAN,01-CHR,,STATSPT,,,,,,,,,,,,,,,,,,,,,,,,,A,,,,,,,,9000,A,,BVARERDMAN
 CMAYER1,,,,,Candida,V,Mayer,CMAYER1,DV-DIR,,AMC,,,,,,,,,,,,,,,,,,,,,,,,,I,,,,,,,,,,,
 PHYATT,,,,,Paris,E,Hyatt,PHYATT,VFW,,VFW,,,,,,,,,,,,,,,,,,,,,,,,,I,,,,,,,,,,,
 DRODRIGUE1,,,,,Dane,P,Rodriguez,DRODRIGUE1,DV-DIR,,AMC,,,,,,,,,,,,,,,,,,,,,,,,,A,,,,,,,,,,,BVADRODRIGUE1

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -166,15 +166,15 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
 
     it "should only distribute the ready priority cases tied to a judge" do
       expect(subject.count).to eq eligible_judges.count
-      expect(subject.map { |dist| dist.statistics["batch_size"] }).to match_array [2, 2, 0, 0]
+      expect(subject.map { |dist| dist.statistics["batch_size"] }).to match_array [1, 1, 0, 0]
 
       # Ensure we only distributed the 2 ready legacy and hearing priority cases that are tied to a judge
       distributed_cases = DistributedCase.where(distribution: subject)
-      expect(distributed_cases.count).to eq 4
-      expected_array = [ready_priority_bfkey, ready_priority_uuid, ready_priority_bfkey2, ready_priority_uuid2]
+      expect(distributed_cases.count).to eq 2
+      expected_array = [ready_priority_bfkey, ready_priority_bfkey2]
       expect(distributed_cases.map(&:case_id)).to match_array expected_array
       # Ensure all docket types cases are distributed, including the 5 cavc evidence submission cases
-      expected_array2 = ["legacy", Constants.AMA_DOCKETS.hearing, "legacy", Constants.AMA_DOCKETS.hearing]
+      expected_array2 = %w[legacy legacy]
       expect(distributed_cases.map(&:docket)).to match_array expected_array2
       expect(distributed_cases.map(&:priority).uniq).to match_array [true]
       expect(distributed_cases.map(&:genpop).uniq).to match_array [false]

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -221,10 +221,10 @@ describe DocketCoordinator do
     let(:genpop_evidence_case_count) { 2 }
 
     let(:genpop_priority_cases_count) do
-      genpop_legacy_case_count + genpop_ama_hearing_case_count + genpop_direct_case_count + genpop_evidence_case_count
+      genpop_legacy_case_count + genpop_ama_hearing_case_count + genpop_direct_case_count + genpop_evidence_case_count + tied_ama_hearing_case_count
     end
     let(:all_priority_cases_count) do
-      genpop_priority_cases_count + tied_legacy_case_count + tied_ama_hearing_case_count
+      genpop_priority_cases_count + tied_legacy_case_count
     end
 
     before do

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -79,7 +79,7 @@ describe DocketCoordinator do
       end
     end
 
-    let(:days_before_goal_due) { Constants.DISTRIBUTION.days_before_goal_due_for_distribution }
+    let(:days_before_goal_due) { Constants.DISTRIBUTION.days_before_goal_due_for_distribution.to_i }
     let(:days_to_decision_goal) { Constants.DISTRIBUTION.direct_docket_time_goal }
 
     let!(:other_direct_review_cases) do
@@ -126,9 +126,9 @@ describe DocketCoordinator do
     context "when there are due direct reviews" do
       it "uses the number of due direct reviews as a proportion of the docket margin net of priority" do
         expect(docket_coordinator.docket_proportions).to include(
-          direct_review: docket_coordinator.due_direct_review_proportion
+          direct_review: Constants.DISTRIBUTION.maximum_direct_review_proportion
         )
-        expect(docket_coordinator.target_number_of_ama_hearings(2.years)).to eq(64)
+        expect(docket_coordinator.target_number_of_ama_hearings(2.years)).to eq(30)
       end
 
       it "sets valid proportions that sum to 1" do
@@ -204,7 +204,7 @@ describe DocketCoordinator do
 
       it "doesn't distribute direct reviews" do
         expect(docket_coordinator.docket_proportions).to include(
-          direct_review: 0.0
+          direct_review: 0.07
         )
       end
     end

--- a/spec/models/dockets/direct_review_docket_spec.rb
+++ b/spec/models/dockets/direct_review_docket_spec.rb
@@ -8,18 +8,6 @@ describe DirectReviewDocket, :postgres do
     end
   end
 
-  context "#time_until_due_of_new_appeal" do
-    subject { DirectReviewDocket.new.time_until_due_of_new_appeal }
-
-    it "returns a positive value" do
-      expect(subject).to be > 0
-    end
-
-    it "returns the correct value" do
-      expect(subject).to eq(300)
-    end
-  end
-
   context "#due_count" do
     subject { DirectReviewDocket.new.due_count }
 
@@ -36,7 +24,7 @@ describe DirectReviewDocket, :postgres do
     end
 
     it "returns the expected count" do
-      expect(subject).to eq(5)
+      expect(subject).to eq(10)
     end
   end
 

--- a/spec/models/dockets/hearing_request_docket_spec.rb
+++ b/spec/models/dockets/hearing_request_docket_spec.rb
@@ -18,11 +18,11 @@ describe HearingRequestDocket, :all_dbs do
       first_appeal = matching_all_base_conditions_with_no_hearings
       second_appeal = matching_all_base_conditions_with_no_held_hearings
       third_appeal = matching_all_base_conditions_with_most_recent_hearing_tied_to_other_judge_but_not_held
-
-      # This one below should never happen, but is included for completeness
       fourth_appeal = matching_all_base_conditions_with_most_recent_held_hearing_not_tied_to_any_judge
+      fifth_appeal = matching_all_conditions_except_not_tied_to_judge
+      recent_hearing_tied_to_judge = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_judge
 
-      result = [first_appeal, second_appeal, third_appeal, fourth_appeal]
+      result = [first_appeal, second_appeal, third_appeal, fourth_appeal, fifth_appeal, recent_hearing_tied_to_judge]
         .map(&:ready_for_distribution_at).map(&:to_s)
 
       # For some reason, in Circle CI, the datetimes are not matching exactly to the millisecond
@@ -45,6 +45,10 @@ describe HearingRequestDocket, :all_dbs do
       it "only distributes nonpriority, distributable, hearing docket cases
           where the most recent held hearing is tied to the distribution judge
           but doesn't exceed affinity threshold" do
+        # commenting out parts of the test because setting hearing_case_affinity_days to 0 means cases can no longer be
+        # tied to judges
+        # When completing work under https://vajira.max.gov/browse/APPEALS-8311 this should be cleaned up or removed
+
         create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
         matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
 
@@ -58,12 +62,12 @@ describe HearingRequestDocket, :all_dbs do
 
         distributed_appeals = distribution_judge.reload.tasks.map(&:appeal)
 
-        expect(tasks.length).to eq(1)
-        expect(tasks.first.class).to eq(DistributedCase)
-        expect(tasks.first.genpop).to eq false
-        expect(tasks.first.genpop_query).to eq "not_genpop"
-        expect(distribution.distributed_cases.length).to eq(1)
-        expect(distribution_judge.reload.tasks.map(&:appeal)).to eq([appeal])
+        expect(tasks.length).to eq(0)
+        # expect(tasks.first.class).to eq(DistributedCase)
+        # expect(tasks.first.genpop).to eq false
+        # expect(tasks.first.genpop_query).to eq "not_genpop"
+        # expect(distribution.distributed_cases.length).to eq(1)
+        # expect(distribution_judge.reload.tasks.map(&:appeal)).to eq([appeal])
 
         # If hearing date exceeds specified days for affinity, appeal no longer tied to judge
         expect(distributed_appeals).not_to include(outside_affinity)
@@ -79,6 +83,10 @@ describe HearingRequestDocket, :all_dbs do
 
       it "only distributes priority, distributable, hearing docket cases
           where the most recent held hearing is tied to the distribution judge" do
+        # commenting out parts of the test because setting hearing_case_affinity_days to 0 means cases can no longer be
+        # tied to judges
+        # When completing work under https://vajira.max.gov/browse/APPEALS-8311 this should be cleaned up or removed
+
         # appeals that should not be returned
         create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
         create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
@@ -93,12 +101,13 @@ describe HearingRequestDocket, :all_dbs do
 
         tasks = subject
 
-        expect(tasks.length).to eq(2)
-        expect(tasks.first.class).to eq(DistributedCase)
-        expect(tasks.first.genpop).to eq false
-        expect(tasks.first.genpop_query).to eq "not_genpop"
-        expect(distribution.distributed_cases.length).to eq(2)
-        expect(distribution_judge.reload.tasks.map(&:appeal)).to match_array([appeal, another])
+        expect(tasks.length).to eq(0)
+        # expect(tasks.first.class).to eq(DistributedCase)
+        # expect(tasks.first.genpop).to eq false
+        # expect(tasks.first.genpop_query).to eq "not_genpop"
+        # expect(distribution.distributed_cases.length).to eq(2)
+        # expect(distribution_judge.reload.tasks.map(&:appeal)).to match_array([appeal, another])
+        expect(distribution_judge.reload.tasks.map(&:appeal).length).to eq(0)
       end
     end
 
@@ -117,18 +126,18 @@ describe HearingRequestDocket, :all_dbs do
         not_tied = create_priority_distributable_hearing_appeal_not_tied_to_any_judge
         tied = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
         outside_affinity = matching_all_base_conditions_with_most_recent_held_hearing_outside_affinity
-        expected_result = [tied, not_tied, outside_affinity]
+        inside_affinity = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_judge
+        expected_result = [tied, not_tied, outside_affinity, inside_affinity]
 
         # won't be included
         create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
         create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
-        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_judge
 
         tasks = subject
 
         expect(tasks.map(&:case_id)).to match_array(expected_result.map(&:uuid))
         expect(tasks.first.class).to eq(DistributedCase)
-        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop).to eq true
         expect(tasks.first.genpop_query).to eq "any"
         expect(tasks.second.genpop).to eq true
         expect(tasks.second.genpop_query).to eq "any"
@@ -176,8 +185,7 @@ describe HearingRequestDocket, :all_dbs do
           that are either genpop or not genpop" do
         # won't be included
         create_priority_distributable_hearing_appeal_not_tied_to_any_judge
-        matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
-        non_distributable = create_nonpriority_unblocked_hearing_appeal_within_affinity
+        non_distributable = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
 
         # will be included
         tied = create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
@@ -185,8 +193,9 @@ describe HearingRequestDocket, :all_dbs do
         no_held_hearings = non_priority_with_no_held_hearings
         no_hearings = non_priority_with_no_hearings
         outside_affinity = create_nonpriority_distributable_hearing_appeal_tied_to_other_judge_outside_affinity
+        inside_affinity = create_nonpriority_unblocked_hearing_appeal_within_affinity
 
-        expected_result = [tied, not_tied, no_held_hearings, no_hearings, outside_affinity]
+        expected_result = [tied, not_tied, no_held_hearings, no_hearings, outside_affinity, inside_affinity]
 
         tasks = subject
 
@@ -194,7 +203,7 @@ describe HearingRequestDocket, :all_dbs do
         expect(appeal_ids).to match_array(expected_result.map(&:uuid))
         expect(appeal_ids).to_not include(non_distributable.uuid)
         expect(tasks.first.class).to eq(DistributedCase)
-        expect(tasks.first.genpop).to eq false
+        expect(tasks.first.genpop).to eq true
         expect(tasks.first.genpop_query).to eq "any"
         expect(tasks.second.genpop).to eq true
         expect(tasks.second.genpop_query).to eq "any"
@@ -216,8 +225,10 @@ describe HearingRequestDocket, :all_dbs do
         outside_affinity = matching_all_base_conditions_with_most_recent_held_hearing_outside_affinity
         no_held_hearings = matching_all_base_conditions_with_no_held_hearings
         no_hearings = matching_all_base_conditions_with_no_hearings
+        recent_hearing_tied_to_judge = matching_all_base_conditions_with_most_recent_held_hearing_tied_to_judge
+        another = matching_all_conditions_except_not_tied_to_judge
 
-        expected_result = [outside_affinity, no_held_hearings, no_hearings]
+        expected_result = [outside_affinity, no_held_hearings, no_hearings, recent_hearing_tied_to_judge, another]
 
         # won't be included
         create_appeals_that_should_not_be_returned_by_query
@@ -247,15 +258,15 @@ describe HearingRequestDocket, :all_dbs do
         # won't be included
         create_priority_distributable_hearing_appeal_not_tied_to_any_judge
         matching_all_base_conditions_with_most_recent_held_hearing_tied_to_distribution_judge
-        create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
 
         # will be included
         appeal = create_nonpriority_distributable_hearing_appeal_not_tied_to_any_judge
         no_held_hearings = non_priority_with_no_held_hearings
         no_hearings = non_priority_with_no_hearings
         outside_affinity = create_nonpriority_distributable_hearing_appeal_tied_to_other_judge_outside_affinity
+        inside_affinity = create_nonpriority_distributable_hearing_appeal_tied_to_distribution_judge
 
-        expected_result = [appeal, no_held_hearings, no_hearings, outside_affinity]
+        expected_result = [appeal, no_held_hearings, no_hearings, outside_affinity, inside_affinity]
 
         tasks = subject
 
@@ -333,12 +344,11 @@ describe HearingRequestDocket, :all_dbs do
   private
 
   def create_appeals_that_should_not_be_returned_by_query
-    matching_all_conditions_except_not_tied_to_judge
+    # matching_all_conditions_except_not_tied_to_judge
     matching_all_conditions_except_priority
     matching_all_conditions_except_ready_for_distribution
     matching_all_conditions_except_priority_and_ready_for_distribution
     matching_only_priority_and_ready_for_distribution
-    matching_all_base_conditions_with_most_recent_held_hearing_tied_to_judge
   end
 
   def matching_all_base_conditions_with_no_hearings
@@ -383,6 +393,7 @@ describe HearingRequestDocket, :all_dbs do
                      disposition: "held",
                      appeal: appeal)
     hearing.update(judge: judge_with_team)
+    appeal
   end
 
   def matching_all_conditions_except_priority

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -6,8 +6,8 @@ describe Seeds::Users do
 
     it "creates all kinds of users and organizations" do
       expect { subject }.to_not raise_error
-      expect(User.count).to eq(99)
-      expect(Organization.count).to eq(29)
+      expect(User.count).to eq(119)
+      expect(Organization.count).to eq(34)
     end
   end
 end

--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -53,4 +53,11 @@ describe DependenciesReportService do
       expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
     end
   end
+
+  context "throws error" do
+    it "when Rails.cache fails" do
+      allow(Rails.cache).to receive(:read_multi).and_raise("boom")
+      expect(DependenciesReportService.dependencies_report).to eq false
+    end
+  end
 end


### PR DESCRIPTION
Resolves
- https://vajira.max.gov/browse/APPEALS-8045
- https://vajira.max.gov/browse/APPEALS-8102

### Description
Requires Database to be reseeded for local or demo
- Change distribution lever `days_before_goal_due_for_distribution` to null. Code will now include all AMA Direct Review docket cases regardless of `target_decision_date`
- Change distribution lever `hearing_case_affinity_days` to 0 which causes AMA Hearing Docket cases to be assigned to genpop immediately instead of waiting 30 days from when the DistributionTask was assigned for AMA Hearing cases that are ready to be distributed. This is for AMA Hearings cases held by a VLJ.
- Update seed data to allow `PushPriorityAppealsToJudgesJob` to work in local and demo after seeding data

### Acceptance Criteria
- Direct review cases that have a target decision date less than 300 days away are distributed to eligible VLJs.
- Direct review cases that have a target decision date more than 300 days away are distributed to eligible VLJs.
- Hearing Docket cases that were held by a VLJ more than 30 days ago are distributed to any VLJ
- Hearing Docket cases that were held by a VLJ less than 30 days ago are distributed to any VLJ

### Testing Plan
1. Go to ...
[ACD Test Guide (Updates 1 and 3).docx](https://github.com/department-of-veterans-affairs/caseflow/files/9527232/ACD.Test.Guide.Updates.1.and.3.docx)

