### PR TITLE
setting hearing_case_affinity_days to 0

### DIFF
--- a/client/constants/DISTRIBUTION.json
+++ b/client/constants/DISTRIBUTION.json
@@ -4,7 +4,7 @@
   "cavc_affinity_days": 21,
   "days_before_goal_due_for_distribution": 65,
   "direct_docket_time_goal": 365,
-  "hearing_case_affinity_days": 30,
+  "hearing_case_affinity_days": 0,
   "maximum_direct_review_proportion": 0.07,
   "minimum_legacy_proportion": 0.9,
   "nod_adjustment": 0.4


### PR DESCRIPTION
Resolves [APPEALS-8285](https://vajira.max.gov/browse/APPEALS-8285)

### Description
Set hearing_case_affinity_days to 0

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] After priority push distribution and request for case distribution. 
- [ ] Cases with the evidence window closed are distributed immediately
- [ ] Any judge can receive these cases.
