### PR TITLE
Switching UAT or PreProd to RAILS_ENV=staging for New Relic

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -74,7 +74,7 @@ module CaseflowCertification
     end
 
     # :nocov:
-    if %w[development ssh_forwarding staging].include?(Rails.env)
+    if %w[development ssh_forwarding].include?(Rails.env)
       # configure pry
       silence_warnings do
         begin

--- a/config/database.yml
+++ b/config/database.yml
@@ -33,6 +33,7 @@ development:
 staging:
   <<: *default
   database: caseflow_certification_staging
+  url: <%= ENV["POSTGRES_URL"] %>
 
 production:
   <<: *default

--- a/config/database.yml
+++ b/config/database.yml
@@ -60,6 +60,10 @@ etl_test:
   <<: *etl_default
   database: caseflow_etl_test<%= ENV["TEST_SUBCATEGORY"] %>
 
+etl_staging:
+  <<: *etl_default
+  url: <%= ENV["ETL_DB_URL"] %>
+
 etl_production:
   <<: *etl_default
   url: <%= ENV["ETL_DB_URL"] %>
@@ -92,9 +96,10 @@ staging_vacols:
   adapter: oracle_enhanced
   username: <%= ENV["VACOLS_USERNAME"] %>
   password: <%= ENV["VACOLS_PASSWORD"] %>
-  host: vacols.dev.vaco.va.gov
-  port: 1526
-  database: BVAP.VACO.VA.GOV
+  host: <%= ENV["VACOLS_HOST"] %>
+  port: <%= ENV["VACOLS_PORT"] %>
+  database: <%= ENV["VACOLS_DATABASE"] %>
+  pool: <%= ENV["DB_CONN_POOL_MAX_SIZE"] || 5 %>
 
 production_vacols:
   adapter: oracle_enhanced

--- a/config/database.yml
+++ b/config/database.yml
@@ -32,7 +32,6 @@ development:
 
 staging:
   <<: *default
-  database: caseflow_certification_staging
   url: <%= ENV["POSTGRES_URL"] %>
 
 production:

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -1,53 +1,106 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  # In the development environment your application's code is reloaded on
-  # every request. This slows down response time but is perfect for development
-  # since you don't have to restart the web server when you make code changes.
-  config.cache_classes = false
+  # Code is not reloaded between requests.
+  config.cache_classes = true
 
-  # Do not eager load code on boot.
-  config.eager_load = false
+  # Eager load code on boot. This eager loads most of Rails and
+  # your application in memory, allowing both threaded web servers
+  # and those relying on copy on write to perform better.
+  # Rake tasks automatically ignore this option for performance.
+  config.eager_load = true
 
-  # Show full error reports and disable caching.
-  config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  # Full error reports are disabled and caching is turned on.
+  config.consider_all_requests_local       = false
+  config.action_controller.perform_caching = true
+
+  # Attempt to read encrypted secrets from `config/secrets.yml.enc`.
+  # Requires an encryption key in `ENV["RAILS_MASTER_KEY"]` or
+  # `config/secrets.yml.key`.
+  # config.read_encrypted_secrets = true
+
+  # Disable serving static files from the `/public` folder by default since
+  # Apache or NGINX already handles this.
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+
+  # Compress JavaScripts and CSS.
+  # config.assets.css_compressor = :sass
+
+  # Do not fallback to assets pipeline if a precompiled asset is missed.
+  config.assets.compile = false
+
+  # Enable serving of images, stylesheets, and JavaScripts from an asset server.
+  # config.action_controller.asset_host = 'http://assets.example.com'
+
+  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+
+  # Specifies the header that your server uses for sending files.
+  # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
+  # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
+
+  # Mount Action Cable outside main process or domain
+  # config.action_cable.mount_path = nil
+  # config.action_cable.url = 'wss://example.com/cable'
+  # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
+
+  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # config.force_ssl = true
+
+  # Use the lowest log level to ensure availability of diagnostic information
+  # when problems arise.
+  config.log_level = :debug
+
+  # Prepend all log lines with the following tags.
+  config.log_tags = [ :request_id ]
+
+  # Use a different logger for distributed setups.
+  # require 'syslog/logger'
+  # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
+
+  if ENV["RAILS_LOG_TO_STDOUT"].present?
+    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger.formatter = config.log_formatter
+    config.logger = ActiveSupport::TaggedLogging.new(logger)
+  end
+
+  # Use a different cache store in production.
+  # config.cache_store = :mem_cache_store
+
+  # Use a real queuing backend for Active Job (and separate queues per environment)
+  # config.active_job.queue_adapter     = :resque
+  # config.active_job.queue_name_prefix = "caseflow_certification_#{Rails.env}"
+  config.action_mailer.perform_caching = false
 
   config.action_mailer.delivery_method = :govdelivery_tms
   config.action_mailer.govdelivery_tms_settings = {
     auth_token: ENV["GOVDELIVERY_TOKEN"],
-    api_root: "https://#{ENV["GOVDELIVERY_SERVER"]}"
+    api_root: "https://#{ENV["GOVDELIVERY_SERVER"]}",
+    return_response: true
   }
 
-  # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # Ignore bad email addresses and do not raise email delivery errors.
+  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
+  # config.action_mailer.raise_delivery_errors = true
 
-  # Print deprecation notices to the Rails logger.
-  config.active_support.deprecation = :log
+  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
+  # the I18n.default_locale when a translation cannot be found).
+  config.i18n.fallbacks = true
 
-  # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
+  # Send deprecation notices to registered listeners.
+  config.active_support.deprecation = :notify
 
-  # Debug mode disables concatenation and preprocessing of assets.
-  # This option may cause significant delays in view rendering with a large
-  # number of complex assets.
-  config.assets.debug = true
+  # Use default logging formatter so that PID and timestamp are not suppressed.
+  config.log_formatter = ::Logger::Formatter.new
 
-  # Asset digests allow you to set far-future HTTP expiration dates on all assets,
-  # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  # Don't colorize logging in production (for easier to read log files).
+  config.colorize_logging = false
 
-  # Adds additional error checking when serving assets at runtime.
-  # Checks for improperly declared sprockets dependencies.
-  # Raises helpful error messages.
-  config.assets.raise_runtime_errors = true
+  # Do not dump schema after migrations.
+  config.active_record.dump_schema_after_migration = false
 
   # Setup S3
-  config.s3_enabled = ENV["AWS_ACCESS_KEY_ID"].present?
+  config.s3_enabled = ENV["AWS_BUCKET_NAME"].present?
   config.s3_bucket_name = ENV["AWS_BUCKET_NAME"]
 
-  config.google_analytics_account = "UA-74789258-5"
-
-  # Raises error for missing translations
-  # config.action_view.raise_on_missing_translations = true
+  config.google_analytics_account = ENV["GA_TRACKING_ID"]
 end

--- a/config/initializers/warmup_vacols.rb
+++ b/config/initializers/warmup_vacols.rb
@@ -15,7 +15,7 @@ ActiveSupport.on_load(:active_record_vacols) do
 
   # skip if accessing via 'rails c'
   next if defined? Rails::Console
-  next if Rails.env.staging? || Rails.env.ssh_forwarding?
+  next if Rails.env.ssh_forwarding?
 
   db_config =  Rails.application.config.database_configuration[Rails.env]
 

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -32,8 +32,8 @@ test:
   redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
 
 staging:
-  secret_key_base: <%= ENV["SECRET_KEY_BASE"] || "8c6b64e47fa8d523a9ea3d7e7658dbd5ee916003785039b14ffdd076fae644afaedc04eb683fc705c47f6f07020184c8cf3a30e79f2258521a45b861ab8e7862" %>
-  redis_url_cache: <%= ENV["REDIS_URL_CACHE"] || "redis://localhost:6379/0/cache/" %>
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+  redis_url_cache: <%= ENV["REDIS_URL_CACHE"] %>
   user_ip_address: <%= ENV["USER_IP_ADDRESS"] %>
 
 # Do not keep production secrets in the unencrypted secrets file.

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -9,11 +9,11 @@ namespace :data do
 
   desc "Prepare test data needed to run a smoke test"
   task prepare: [:environment] do
-    fail staging_only_error unless Rails.env.staging?
+    #{}fail staging_only_error unless Rails.env.staging?
 
-    test_appeal_vacols_id = "2765748"
+    #{}test_appeal_vacols_id = "2765748"
 
-    test_appeal = LegacyAppeal.find_or_create_by_vacols_id(test_appeal_vacols_id)
-    AppealRepository.uncertify(test_appeal)
+    #{}test_appeal = LegacyAppeal.find_or_create_by_vacols_id(test_appeal_vacols_id)
+    #{}AppealRepository.uncertify(test_appeal)
   end
 end


### PR DESCRIPTION
### Description
These changes are to make `RAILS_ENV=staging` work in either UAT or PreProd for deploying New Relic to UAT/PreProd. Currently UAT, PreProd, and Prod are all `RAILS_ENV=production` which will cause issues for turning on New Relic in either UAT or PreProd.

This work will be coordinated with an appeals-deployment repo change as well.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. [Deploy the custom branch to UAT/PreProd to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
2. Once verified working add in New Relic Variables (Cert, License Key, etc) to turn on New Relic in UAT/PreProd


### Relations
- https://github.com/department-of-veterans-affairs/appeals-deployment/pull/3727