### PR TITLE
Jruuuu/appeals 8207

### DIFF
--- a/app/jobs/dependencies_report_service_log_job.rb
+++ b/app/jobs/dependencies_report_service_log_job.rb
@@ -6,10 +6,7 @@ class DependenciesReportServiceLogJob < ApplicationJob
   def perform
     outage = DependenciesReportService.dependencies_report
     if outage.present?
-      Rails.logger.error "Caseflow Monitor shows possible outages with " \
-                         "#{outage}"
+      Rails.logger.error "Caseflow Monitor shows possible outages" \
     end
-  rescue StandardError
-    Rails.logger.error "Invalid report from Caseflow Monitor"
   end
 end

--- a/app/jobs/dependencies_report_service_log_job.rb
+++ b/app/jobs/dependencies_report_service_log_job.rb
@@ -4,11 +4,10 @@ class DependenciesReportServiceLogJob < ApplicationJob
   queue_with_priority :low_priority
 
   def perform
-    outage = DependenciesReportService.degraded_dependencies
+    outage = DependenciesReportService.dependencies_report
     if outage.present?
-      Rails.logger.error "Caseflow Monitor shows possible " \
-                         "#{outage.to_sentence(two_words_connector: ' and ', last_word_connector: ' and ')}" \
-                         " outage".pluralize(outage.size)
+      Rails.logger.error "Caseflow Monitor shows possible outages with " \
+                         "#{outage}"
     end
   rescue StandardError
     Rails.logger.error "Invalid report from Caseflow Monitor"

--- a/app/services/dependencies_report_service.rb
+++ b/app/services/dependencies_report_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class DependenciesReportService
-  class << self
 
+  class << self
     ALL_DEPENDENCIES_MAP = {
       degraded_service_banner_bgs: "BGS",
       degraded_service_banner_vbms: "VBMS",
@@ -9,22 +9,21 @@ class DependenciesReportService
       degraded_service_banner_vacols: "VACOLS",
       degraded_service_banner_gov_delivery: "GOV DELIVERY",
       degraded_service_banner_va_dot_gov: "VA.GOV"
-    }
+    }.freeze
 
     def dependencies_report
-      #Read All Dependencies written to the cache
-      cache_degraded_services = Rails.cache.read_multi(*ALL_DEPENDENCIES_MAP.keys())
-      #Create New Array, with key and value
+       #Read All Dependencies written to the cache
+      cache_degraded_services = Rails.cache.read_multi(*ALL_DEPENDENCIES_MAP.keys)
+       #Create New Array, with key and value
       cache_degraded_services.reduce([]) do |array, (key, value)|
-        #Return Array with only the value :display
+         #Return Array with only the value :display
         array.push(ALL_DEPENDENCIES_MAP[key]) if value == :display
-        array 
+        array
       end
-
-      rescue StandardError => error
+    rescue StandardError => error
         Rails.logger.warn "Exception thrown while checking dependency "\
           "status: #{error}"
         false
-      end
+    end
   end
 end

--- a/app/services/dependencies_report_service.rb
+++ b/app/services/dependencies_report_service.rb
@@ -21,9 +21,9 @@ class DependenciesReportService
         array
       end
     rescue StandardError => error
-    Rails.logger.warn "Exception thrown while checking dependency "\
-          "status: #{error}"
-        false
+      Rails.logger.warn "Exception thrown while checking dependency "\
+        "status: #{error}"
+      false
     end
   end
 end

--- a/app/services/dependencies_report_service.rb
+++ b/app/services/dependencies_report_service.rb
@@ -1,45 +1,30 @@
 # frozen_string_literal: true
-
 class DependenciesReportService
   class << self
-    ALL_DEPENDENCIES =
-      ["BGS.FilenumberService",
-       "BGS.PoaService",
-       "BGS.AddressService",
-       "BGS.OrganizationPoaService",
-       "BGS.VeteranService",
-       "BGS.AddressService",
-       "BGS.BenefitsService",
-       "BGS.ClaimantFlashesService",
-       "BGS.PersonFilenumberService",
-       "VACOLS",
-       "VBMS",
-       "VBMS.FindDocumentVersionReference",
-       "VVA"].freeze
 
-    # this method is in case we need list of dependencies/services that are degraded
-    def degraded_dependencies
-      str_report = Rails.cache.read(:dependencies_report)
-      return [] if !str_report
-
-      report = JSON.parse str_report
-      report.values.each_with_object([]) do |element, result|
-        result << element["name"] if element["up_rate_5"].to_i < 50
-      end
-    end
+    ALL_DEPENDENCIES_MAP = {
+      degraded_service_banner_bgs: "BGS",
+      degraded_service_banner_vbms: "VBMS",
+      degraded_service_banner_vva: "VVA",
+      degraded_service_banner_vacols: "VACOLS",
+      degraded_service_banner_gov_delivery: "GOV DELIVERY",
+      degraded_service_banner_va_dot_gov: "VA.GOV"
+    }
 
     def dependencies_report
-      case Rails.cache.read(:degraded_service_banner)
-      when :always_show
-        return ALL_DEPENDENCIES
-      when :never_show
-        return []
+      #Read All Dependencies written to the cache
+      cache_degraded_services = Rails.cache.read_multi(*ALL_DEPENDENCIES_MAP.keys())
+      #Create New Array, with key and value
+      cache_degraded_services.reduce([]) do |array, (key, value)|
+        #Return Array with only the value :display
+        array.push(ALL_DEPENDENCIES_MAP[key]) if value == :display
+        array 
       end
-      degraded_dependencies
-    rescue StandardError => error
-      Rails.logger.warn "Exception thrown while checking dependency "\
-        "status: #{error}"
-      false
-    end
+
+      rescue StandardError => error
+        Rails.logger.warn "Exception thrown while checking dependency "\
+          "status: #{error}"
+        false
+      end
   end
 end

--- a/app/services/dependencies_report_service.rb
+++ b/app/services/dependencies_report_service.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-class DependenciesReportService
 
+class DependenciesReportService
   class << self
     ALL_DEPENDENCIES_MAP = {
       degraded_service_banner_bgs: "BGS",
@@ -12,16 +12,16 @@ class DependenciesReportService
     }.freeze
 
     def dependencies_report
-       #Read All Dependencies written to the cache
+      # Read All Dependencies written to the cache
       cache_degraded_services = Rails.cache.read_multi(*ALL_DEPENDENCIES_MAP.keys)
-       #Create New Array, with key and value
+      # Create New Array, with key and value
       cache_degraded_services.reduce([]) do |array, (key, value)|
-         #Return Array with only the value :display
+        # Return Array with only the value :display
         array.push(ALL_DEPENDENCIES_MAP[key]) if value == :display
         array
       end
     rescue StandardError => error
-        Rails.logger.warn "Exception thrown while checking dependency "\
+    Rails.logger.warn "Exception thrown while checking dependency "\
           "status: #{error}"
         false
     end

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1276,5 +1276,8 @@
   "EMO_ASSIGN_TO_RPO_MODAL_BODY": "Regional Processing Office",
   "EDUCATION_RPO_SELECTOR_PLACEHOLDER": "Select RPO",
   "EDUCATION_RPO_RETURN_TO_EMO_MODAL_TITLE": "Return to Executive Management Office",
-  "EDUCATION_RPO_RETURN_TO_EMO_CONFIRMATION": "You have successfully returned %s's case to the Executive Management Office"
+  "EDUCATION_RPO_RETURN_TO_EMO_CONFIRMATION": "You have successfully returned %s's case to the Executive Management Office",
+
+  "DEGRADED_SYSTEM_SINGULAR": "is experiencing issues. Caseflow performance and availability may be impacted.",
+  "DEGRADED_SYSTEM_PLURAL": "are experiencing issues. Caseflow performance and availability may be impacted."
 }

--- a/client/app/2.0/utils/banner/format.js
+++ b/client/app/2.0/utils/banner/format.js
@@ -1,0 +1,4 @@
+export const listWithOxfordComma = (list) => {
+  return new Intl.ListFormat('en', { style: 'long' }).format(list);
+
+};

--- a/client/app/components/PerformanceDegradationBanner.jsx
+++ b/client/app/components/PerformanceDegradationBanner.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import WrenchIcon from './WrenchIcon';
 import ApiUtil from '../util/ApiUtil';
 import { listWithOxfordComma } from '../2.0/utils/banner/format';
-import COPY from '../../COPY.json';
+import COPY from '../../COPY';
 import * as AppConstants from '../constants/AppConstants';
 
 /*

--- a/client/app/components/PerformanceDegradationBanner.jsx
+++ b/client/app/components/PerformanceDegradationBanner.jsx
@@ -1,32 +1,53 @@
 import React from 'react';
 import WrenchIcon from './WrenchIcon';
 import ApiUtil from '../util/ApiUtil';
+import { listWithOxfordComma } from '../2.0/utils/banner/format';
+import COPY from '../../COPY.json';
 import * as AppConstants from '../constants/AppConstants';
 
 /*
  * Caseflow Performance Degradation Banner.
  * Shared between all Certification pages.
  * Notifies users if dependencies may be experiencing an outage .
- *
+ * Updated to display one ore more systems when experiencing outages.
  */
 export default class PerformanceDegradationBanner extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      showBanner: false,
-      isRequesting: false
+      isRequesting: false,
+      services: [],
     };
+  }
 
-    this.dependencies = {
-      certification: ['BGS.AddressService', 'BGS.OrganizationPoaService', 'BGS.PersonFilenumberService',
-        'BGS.VeteranService', 'VACOLS', 'VBMS', 'VBMS.FindDocumentVersionReference'],
-      reader: ['VBMS', 'VACOLS'],
-      hearing: ['VACOLS'],
-      dispatch: ['BGS.BenefitsService', 'VBMS', 'VACOLS'],
-      other: ['BGS.AddressService', 'BGS.BenefitsService', 'BGS.ClaimantFlashesService', 'BGS.OrganizationPoaService',
-        'BGS.PersonFilenumberService', 'BGS.VeteranService', 'VACOLS', 'VBMS', 'VBMS.FindDocumentVersionReference',
-        'VVA']
-    };
+  // generates banner text prefix by formatting the services list for proper grammar
+  getBannerTextPrefix() {
+    const { services } = this.state;
+
+    // formats a list following oxford comma grammar
+    return listWithOxfordComma(services);
+  }
+
+  // formats banner text suffix with proper grammer
+  formatBannerTextSuffix(services) {
+    return this.suffix = (services.length > 1 ? COPY.DEGRADED_SYSTEM_PLURAL : COPY.DEGRADED_SYSTEM_SINGULAR);
+
+  }
+
+  // generates banner text suffix with proper grammar
+  getBannerTextSuffix() {
+    const { services } = this.state;
+
+    return this.formatBannerTextSuffix(services);
+  }
+
+  // generates banner text
+  getBannerText() {
+    return (
+      <span className="banner-text">
+        <b>{this.getBannerTextPrefix()}</b> {this.getBannerTextSuffix()}
+      </span>
+    );
   }
 
   checkDependencies() {
@@ -36,26 +57,18 @@ export default class PerformanceDegradationBanner extends React.Component {
       return;
     }
 
-    this.appName = Object.keys(this.dependencies).filter((key) => {
-      return window.location.pathname.includes(key);
-    })[0] || 'other';
-
     this.setState({ isRequesting: true });
     ApiUtil.get('/dependencies-check').
       then((data) => {
         let report = data.body.dependencies_report;
-        // Each app has a relevant report
-        let outageAffectingCurrentApp = report.filter((key) => {
-          return this.dependencies[this.appName].includes(key);
-        });
 
         this.setState({
-          showBanner: Boolean(outageAffectingCurrentApp.length > 0),
-          isRequesting: false
+          services: report,
+          isRequesting: false,
         });
       }, () => {
         this.setState({
-          showBanner: false,
+          services: [],
           isRequesting: false
         });
       });
@@ -75,18 +88,14 @@ export default class PerformanceDegradationBanner extends React.Component {
   }
 
   render() {
-
     return <div>
-      { this.state.showBanner &&
+      {this.state.services.length > 0 &&
         <div className="usa-banner">
           <div className="usa-grid usa-banner-inner">
             <div className="banner-icon">
               <WrenchIcon />
             </div>
-            <span className="banner-text">
-              We've detected technical issues in our system.
-              You can continue working, though some users may experience delays.
-            </span>
+            {this.getBannerText()}
           </div>
         </div>
       }

--- a/client/app/components/WrenchIcon.jsx
+++ b/client/app/components/WrenchIcon.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const WrenchIcon = () => {
   return <span>
-    <svg width="27px" height="26px" className="cf-wrench-icon"
+    <svg width="27px" height="22px" className="cf-wrench-icon"
       xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27 26">
       <title>wrench icon</title>
       {/* eslint-disable max-len */}

--- a/client/app/styles/react/_performance_degradation_banner.scss
+++ b/client/app/styles/react/_performance_degradation_banner.scss
@@ -4,15 +4,15 @@
 }
 
 .usa-banner-inner {
-  padding: .5em;
+  padding: .8em;
 }
 
 .banner-icon {
   display: inline-block;
   vertical-align: text-top;
-  height: 25px;
+  // height: 25px;
 }
 
 .banner-text {
-  padding-left: 10px;
+  padding-left: 6px;
 }

--- a/spec/feature/certification/start_certification_spec.rb
+++ b/spec/feature/certification/start_certification_spec.rb
@@ -221,9 +221,9 @@ RSpec.feature "Start Certification", :all_dbs do
       visit "certifications/new/#{appeal_ready.vacols_id}"
       expect(page).to have_content "Caseflow performance and availability may be impacted."
       # Banner is not showing when degraded dependency is irrelevant
-      allow(DependenciesReportService).to receive(:dependencies_report).and_return(["VVA"])
+      allow(DependenciesReportService).to receive(:dependencies_report).and_return([])
       visit "certifications/new/#{appeal_ready.vacols_id}"
-      expect(page).to_not have_content "Caseflow performance and availability may be impacted."
+      expect(page).to_not have_content "We've detected technical issues in our system"
       User.unauthenticate!
       visit "certifications/new/#{appeal_ready.vacols_id}"
       expect(page.has_no_content?("Caseflow performance and availability may be impacted.")).to eq(true)

--- a/spec/feature/certification/start_certification_spec.rb
+++ b/spec/feature/certification/start_certification_spec.rb
@@ -219,14 +219,14 @@ RSpec.feature "Start Certification", :all_dbs do
       # Banner is showing when degraded dependency is relevant
       allow(DependenciesReportService).to receive(:dependencies_report).and_return(["VACOLS"])
       visit "certifications/new/#{appeal_ready.vacols_id}"
-      expect(page).to have_content "We've detected technical issues in our system"
+      expect(page).to have_content "Caseflow performance and availability may be impacted."
       # Banner is not showing when degraded dependency is irrelevant
       allow(DependenciesReportService).to receive(:dependencies_report).and_return(["VVA"])
       visit "certifications/new/#{appeal_ready.vacols_id}"
-      expect(page).to_not have_content "We've detected technical issues in our system"
+      expect(page).to_not have_content "Caseflow performance and availability may be impacted."
       User.unauthenticate!
       visit "certifications/new/#{appeal_ready.vacols_id}"
-      expect(page.has_no_content?("We've detected technical issues in our system")).to eq(true)
+      expect(page.has_no_content?("Caseflow performance and availability may be impacted.")).to eq(true)
     end
   end
 end

--- a/spec/jobs/dependencies_report_service_log_job_spec.rb
+++ b/spec/jobs/dependencies_report_service_log_job_spec.rb
@@ -18,21 +18,11 @@ describe DependenciesReportServiceLogJob do
 
   context "when outage is present" do
     before do
-      Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITH_OUTAGES)
+      Rails.cache.write(:degraded_service_banner_bgs, :display)
     end
 
     it "should log the correct error message" do
-      expect(Rails.logger).to receive(:error).with("Caseflow Monitor shows possible VACOLS and VBMS outages")
-      DependenciesReportServiceLogJob.perform_now
-    end
-  end
-
-  context "when report is invalid" do
-    before do
-      Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITH_INVALID_DATA)
-    end
-    it "should log the correct error message" do
-      expect(Rails.logger).to receive(:error).with("Invalid report from Caseflow Monitor")
+      expect(Rails.logger).to receive(:error).with("Caseflow Monitor shows possible outages")
       DependenciesReportServiceLogJob.perform_now
     end
   end

--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -2,105 +2,62 @@
 
 describe DependenciesReportService do
   DEPENDENCIES_REPORT_WITH_OUTAGES = <<-'EOF'.strip_heredoc.freeze
-    {
-      "BGS":{"name":"BGS","up_rate_5":100.0},
-      "VACOLS":{"name":"VACOLS","up_rate_5":10.0},
-      "VBMS":{"name":"VBMS","up_rate_5":49.0},
-      "VBMS.FindDocumentVersionReference":{"name":"VBMS.FindDocumentVersionReference",
-        "up_rate_5":100.0}
-    }
+    [
+      "BGS",
+      "VACOLS"
+    ]
   EOF
   DEPENDENCIES_REPORT_WITHOUT_OUTAGES = <<-'EOF'.strip_heredoc.freeze
-    {
-      "BGS":{"name":"BGS","up_rate_5":100.0},
-      "VACOLS":{"name":"VACOLS","up_rate_5":100.0},
-      "VBMS":{"name":"VBMS","up_rate_5":51.0},
-      "VBMS.FindDocumentVersionReference":{"name":"VBMS.FindDocumentVersionReference",
-        "up_rate_5":100.0}
-    }
+    []
   EOF
-  context "when there is an outage" do
+
+  before(:each) do
+    Rails.cache.clear
+  end
+
+  context "when there is an outage for only one system" do
     before do
-      Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITH_OUTAGES)
+      Rails.cache.write(:degraded_service_banner_bgs, :display)
     end
 
-    it "returns degraded services" do
-      expect(DependenciesReportService.degraded_dependencies).to eq %w[VACOLS VBMS]
-      expect(DependenciesReportService.dependencies_report.present?).to be_truthy
+    it "returns one degraded systems" do
+      expect(DependenciesReportService.dependencies_report).to eq %w[BGS]
     end
   end
 
-  context "when there is no outage" do
+  context "when there is an outage for multiple systems" do
     before do
-      Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITHOUT_OUTAGES)
+      Rails.cache.write(:degraded_service_banner_bgs, :display)
+      Rails.cache.write(:degraded_service_banner_vacols, :display)
     end
 
-    it "returns no outage" do
-      expect(DependenciesReportService.degraded_dependencies).to be_empty
-      expect(DependenciesReportService.dependencies_report.present?).to be_falsey
+    it "returns muliple systems" do
+      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITH_OUTAGES
     end
   end
 
-  # needed to reach 90% test coverage
-  context "when dependencies report is invalid" do
+  context "when there is no system outages" do
     before do
-      Rails.cache.write(:dependencies_report,
-                        "This isn't JSON")
+      Rails.cache.write(:degraded_service_banner_bgs, :hide)
+      Rails.cache.write(:degraded_service_banner_vbms, :hide)
+      Rails.cache.write(:degraded_service_banner_vva, :hide)
+      Rails.cache.write(:degraded_service_banner_vacols, :hide)
+      Rails.cache.write(:degraded_service_banner_gov_delivery, :hide)
+      Rails.cache.write(:degraded_service_banner_va_dot_gov, :hide)
     end
 
-    it "returns no outage" do
-      expect(DependenciesReportService.dependencies_report.present?).to be_falsey
+    it "returns an empty array" do
+      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
     end
   end
 
-  context "when the degraded service banner has been enabled manually" do
+  context "when there is an invalid value written to cache"
     before do
-      Rails.cache.write(:degraded_service_banner, :always_show)
+      Rails.cache.write(:degraded_service_banner_bgs, :invalid_entry)
     end
 
-    it "returns degraded service" do
-      expect(DependenciesReportService.dependencies_report.present?).to be_truthy
-    end
-  end
-
-  context "when the degraded service banner has been disabled manually" do
-    before do
-      Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITH_OUTAGES)
-      Rails.cache.write(:degraded_service_banner, :never_show)
-    end
-
-    it "returns no outage" do
-      expect(DependenciesReportService.dependencies_report.present?).to be_falsey
-    end
-  end
-
-  context "when the degraded service banner has been set to auto" do
-    before do
-      Rails.cache.write(:degraded_service_banner, :auto)
-    end
-
-    context "when there is an outage" do
-      before do
-        Rails.cache.write(:dependencies_report, DEPENDENCIES_REPORT_WITH_OUTAGES)
-      end
-
-      it "returns degraded services" do
-        expect(DependenciesReportService.degraded_dependencies).to eq %w[VACOLS VBMS]
-        expect(DependenciesReportService.dependencies_report.present?).to be_truthy
-      end
-    end
-
-    context "when there is no outage" do
-      before do
-        Rails.cache.write(
-          :dependencies_report, DEPENDENCIES_REPORT_WITHOUT_OUTAGES
-        )
-      end
-
-      it "returns no outage" do
-        expect(DependenciesReportService.degraded_dependencies).to be_empty
-        expect(DependenciesReportService.dependencies_report.present?).to be_falsey
-      end
+    it "returns and empty array" do
+      expect(DependenciesReportService.dependencies_report).to eq  DEPENDENCIES_REPORT_WITHOUT_OUTAGES
     end
   end
 end

--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -1,16 +1,10 @@
 # frozen_string_literal: true
 
 describe DependenciesReportService do
-  DEPENDENCIES_REPORT_WITH_OUTAGES = <<-'EOF'.strip_heredoc.freeze
-    [
-      "BGS",
-      "VACOLS"
-    ]
-  EOF
-  DEPENDENCIES_REPORT_WITHOUT_OUTAGES = <<-'EOF'.strip_heredoc.freeze
-    []
-  EOF
 
+  DEPENDENCIES_REPORT_WITH_OUTAGES = %w[BGS VACOLS].freeze
+  DEPENDENCIES_REPORT_WITHOUT_OUTAGES = [].freeze
+  
   before(:each) do
     Rails.cache.clear
   end
@@ -57,7 +51,7 @@ describe DependenciesReportService do
     end
 
     it "returns and empty array" do
-      expect(DependenciesReportService.dependencies_report).to eq  DEPENDENCIES_REPORT_WITHOUT_OUTAGES
+      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
     end
   end
 end

--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -51,7 +51,7 @@ describe DependenciesReportService do
     end
   end
 
-  context "when there is an invalid value written to cache"
+  context "when there is an invalid value written to cache" do
     before do
       Rails.cache.write(:degraded_service_banner_bgs, :invalid_entry)
     end

--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -1,10 +1,9 @@
 # frozen_string_literal: true
 
 describe DependenciesReportService do
-
   DEPENDENCIES_REPORT_WITH_OUTAGES = %w[BGS VACOLS].freeze
   DEPENDENCIES_REPORT_WITHOUT_OUTAGES = [].freeze
-  
+
   before(:each) do
     Rails.cache.clear
   end


### PR DESCRIPTION
Resolves [APPEALS-8207](https://vajira.max.gov/browse/APPEALS-8207)

### Description
I made two major changes

**1.  I updated the dependencies_report_service.rb**
- updated and added ALL_DEPENDENCIES_MAP and added keys so when the end user runs a cache command for example: `Rails.cache.write(:degraded_service_banner_bgs, :display)` it updates the dependencies-check api
- Updated the dependencies_report method to find and create a new array with the map(s) that only have the `:display` value
- Then maps though the new array and grabs the keys to displays in the controller in json format

**2. I updated the PerformanceDegradationBanner.jsx** 
- updated states to show 3 different conditions to show banner.
- added an array state for the degradedServices 
- updated the render method to return when a specific condition is true to display
- also added condition statement when degradedServices is greater than 2 to map through and add commas 
- removed tech debt that was no longer being used 

### Acceptance Criteria
- [ ] Systems team member is able to run the rails command for a specific partnered system being down
Verify banner shows correct message for that system

- [ ] System team member is able to run the rails command to enable banner for multiple parentered systems being down
Verify banner shows correct messages for each system

- [ ] System team member is able to run the rails command to disable/enable banner for partnered system without impacting others

### Testing Plan
1. Assuming that APPEALS-8203 has been merged
2. Have front and backend is running
3. open caseflow app, make sure there is no banner showing
4. log into rails console and run `Rails.cache.write(:degraded_service_banner_bgs, :display)`
5. refresh casflow app
6. banner with BGS is displayed
7. repeat for the remaining systems
- `Rails.cache.write(:degraded_service_banner_vbms, :display)`
- `Rails.cache.write(:degraded_service_banner_vva, :display)`
- `Rails.cache.write(:degraded_service_banner_vacols, :display)`
- `Rails.cache.write(:degraded_service_banner_gov_delivery, :display)`
- `Rails.cache.write(:degraded_service_banner_va_dot_gov, :display)`
8. to hide a system in rails console run `Rails.cache.write(:degraded_service_banner_bgs, :hide)`
9. Refresh caseflow app, BGS should no longer be in the banner
10. repeat for remaining systems
- `Rails.cache.write(:degraded_service_banner_vbms, :hide)`
- `Rails.cache.write(:degraded_service_banner_vva, :hide)`
- `Rails.cache.write(:degraded_service_banner_vacols, :hide)`
- `Rails.cache.write(:degraded_service_banner_gov_delivery, :hide)`
- `Rails.cache.write(:degraded_service_banner_va_dot_gov, :hide)`
11. If there is no longer any systems down, banner should no longer appear.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)


### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![BEFORE: OLD BANNER](https://user-images.githubusercontent.com/71367882/186214000-489d7cc0-7d73-44d7-a5ba-b0dd2124273b.png)|![ZERO SYSTEMS DOWN](https://user-images.githubusercontent.com/71367882/186214257-e9418c00-8201-47e9-a27c-9ded1555ab10.png)![ONE SYSTEM DOWN](https://user-images.githubusercontent.com/71367882/186214294-1bd62cc1-ff94-42ab-be5a-671cafaf5df5.png)![TWO SYSTEMS DOWN](https://user-images.githubusercontent.com/71367882/186214334-b0acbdff-ceb0-4f58-8166-06b05b209b0c.png)![THREE SYSTEMS DOWN](https://user-images.githubusercontent.com/71367882/186214350-0f3edb87-04fe-4bae-95a5-64b25c756cbc.png)![3 or MORE SYSTEMS DOWN](https://user-images.githubusercontent.com/71367882/186214375-921f837a-da5f-46c8-b647-c1da654bf2dc.png)
![BEFORE: HIDE OLD BANNER](https://user-images.githubusercontent.com/71367882/186214040-a54964de-1e92-4d2d-8d17-71f3936e37f4.png)|![HIDE TWO SYSTEMS](https://user-images.githubusercontent.com/71367882/186218148-f429f214-fd8f-4cba-af3e-51af4c01ec5e.png)![HIDE 4 SYSTEMS](https://user-images.githubusercontent.com/71367882/186218212-3239689d-ab9a-4f2e-b4f1-3adb50815548.png)![HIDE 5 SYSTEMS ](https://user-images.githubusercontent.com/71367882/186218242-73430a21-cce2-4021-9237-b34aa96be4a7.png)![HIDE ALL SYSTEMS](https://user-images.githubusercontent.com/71367882/186218277-eed752db-76e4-41f7-91f2-71a8fa82facc.png)





### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

### Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

### Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
* [ ] Update Fakes
* [ ] Integrations impacting functionality are tested in Caseflow UAT
