### PR TITLE
Hun jer bah/appeals 4290 edit

### DIFF
--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -288,7 +288,7 @@ class AddIssuesPage extends React.Component {
             + Add issue
             </Button>,
             (' '),
-            <Link to="/create_split">
+            <Link to="/create_split" disabled={issuesChanged}>
               <Button
                 name="split-appeal"
                 label="split-appeal"

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -456,6 +456,9 @@ feature "Appeal Edit issues", :all_dbs do
     end
 
     scenario "when navigating from split_appeal to queue, the success banner displays" do
+      # set success and fail message
+      success_message = "You have successfully split"
+      fail_message = "This new appeal stream has the same docket number and tasks as the original appeal."
       # add issues to the appeal
       appeal2.request_issues << request_issue_1
       appeal2.request_issues << request_issue_2
@@ -465,15 +468,13 @@ feature "Appeal Edit issues", :all_dbs do
 
       click_button("Split appeal")
       expect(page).to have_current_path("/queue/appeals/#{appeal2.uuid}")
-      expect(page).to have_content("You have successfully split")
-      expect(page).to
-      have_content("This new appeal stream has the same docket number and tasks as the original appeal.")
+      expect(page).to have_content(success_message)
+      expect(page).to have_content(fail_message)
 
       # resetting the page removes the banner on load.
       page.reset!
-      expect(page).to_not have_content("You have successfully split")
-      expect(page).to_not
-      have_content("This new appeal stream has the same docket number and tasks as the original appeal.")
+      expect(page).to_not have_content(success_message)
+      expect(page).to_not have_content(fail_message)
     end
   end
 


### PR DESCRIPTION
Edit to [APPEALS-4290](https://vajira.max.gov/browse/APPEALS-4290)

### Description
Quick fix to resolve the Split Appeal button still being able to link to the Create Split page even though the button was disabled. 

### Acceptance Criteria
- [x] Code compiles correctly
- [ ] If the user has added or removed an issue and still needs to save the Split Appeal button is disabled

### Testing Plan
1. Log in as a SSC user. 
![image](https://user-images.githubusercontent.com/99915461/187274021-f7d796c0-74a8-461b-a511-f5c1d93b1461.png)

2. Click **Your Queue** and **Search Cases** to pull up the search.
![image](https://user-images.githubusercontent.com/99915461/187274185-67723543-10c9-46f7-b2e3-6736b80bf4f5.png)

3. Enter a veteran ID number and click the **docket number** to navigate to the docket. 
![image](https://user-images.githubusercontent.com/99915461/187274364-e41d2b99-ea9a-4620-88f4-386fd74e0805.png)

4. Click the **Correct issues** link to go to the edit issues page.
![image](https://user-images.githubusercontent.com/99915461/187274426-f938cbbc-933b-438c-af98-00c86018bf09.png)

5. If the appeal has no issues, add 2 issues to the appeal using the **Add Issues** button. 
![image](https://user-images.githubusercontent.com/99915461/187274533-1704efa1-6890-462a-b9a7-eb13e0fd301b.png)
![image](https://user-images.githubusercontent.com/99915461/187274563-3fd185ba-de36-4229-ae28-cdd8abaa3627.png)
![image](https://user-images.githubusercontent.com/99915461/187274623-07c5160c-9432-4256-b0b3-dc66b79478cb.png)

6. The **Split Appeal** button should now show. Click the button and make sure that it does not go to any other page.
7. After confirming that the button doesn't navigate when greyed out, click **Save**. On the popup, click **Yes, save**.
![image](https://user-images.githubusercontent.com/99915461/187274819-aceca41e-3844-49fc-b705-0b46b092c315.png)

8. Navigate back to the edit page by clicking **Correct issues**. The **Split Appeal** button should now be blue and working. Confirm the button works by clicking **Split Appeal** to navigate to the Create Split page.
![image](https://user-images.githubusercontent.com/99915461/187275054-d337125c-87d3-4446-9df4-069349d55b2c.png)
![image](https://user-images.githubusercontent.com/99915461/187275087-44a227f0-97a9-43e1-a5d7-5e328b87e4f9.png)
