### PR TITLE
msteele/APPEALS-8614 Removed BGS call and related rspec

### DIFF
--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -29,7 +29,7 @@ module AppellantNotification
       info = {}
       appeal_id = appeal.id
       claimant = appeal.claimant
-      info[:participant_id] = appeal.claimant_participant_id || AppellantNotification.legacy_non_vet_claimant_id(appeal)
+      info[:participant_id] = appeal.claimant_participant_id
       if claimant.nil?
         begin
           fail NoClaimantError, appeal_id
@@ -51,14 +51,6 @@ module AppellantNotification
       fail NoAppealError
     end
     info
-  end
-
-  def self.legacy_non_vet_claimant_id(appeal)
-    # find non veteran claimant participant id for legacy appeals
-    if !appeal&.veteran&.participant_id.nil?
-      bgs_poa = BgsPowerOfAttorney.fetch_bgs_poa_by_participant_id(appeal&.veteran&.participant_id)
-      bgs_poa.is_a?(Hash) ? bgs_poa[:claimant_participant_id] : nil
-    end
   end
 
   def self.notify_appellant(

--- a/db/seeds/notification_events.rb
+++ b/db/seeds/notification_events.rb
@@ -22,6 +22,9 @@ module Seeds
       NotificationEvent.create(event_type: "Privacy Act request complete", email_template_id: "5b7a4450-2d9d-44ad-8691-cc195e3aa5e4", sms_template_id: "48ec08e3-bf86-4329-af2c-943415396699")
       NotificationEvent.create(event_type: "VSO IHP pending", email_template_id: "33f1f441-325e-4825-adb3-3bde3393d79d", sms_template_id: "3adcbf09-827d-4d02-af28-864ab2e56b6f")
       NotificationEvent.create(event_type: "VSO IHP complete", email_template_id: "33496907-3292-48cb-8543-949023941b4a", sms_template_id: "02bc8052-1a8c-4e55-bb33-66bb2b50ad67")
+      # Following lines are fake uuids with no template
+      NotificationEvent.create(event_type: "No Participant Id Found", email_template_id: "f54a9779-24b0-46a3-b2c1-494d42db0614", sms_template_id: "663c2b42-3381-46e4-9d48-f336d79901bc")
+      NotificationEvent.create(event_type: "No Claimant Found", email_template_id: "ff871007-1f40-455d-beb3-5f2c71d065fc", sms_template_id: "364dd348-d577-44e8-82de-9fa000d6cd74")
     end
   end
 end

--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -36,14 +36,6 @@ describe AppellantNotification do
         end
       end
 
-      context "can catch some missing participant_id using BGS" do
-        let(:legacy_appeal) { create(:legacy_appeal, :with_veteran, vbms_id: 123_456) }
-        it "returns success after finding participant_id from BGS" do
-          allow(legacy_appeal).to receive(:claimant_participant_id).and_return(nil)
-          expect(AppellantNotification.handle_errors(legacy_appeal)[:status]).to eq "Success"
-        end
-      end
-
       context "with no errors" do
         it "doesn't raise" do
           expect(AppellantNotification.handle_errors(appeal)[:status]).to eq "Success"

--- a/spec/seeds/notification_events_spec.rb
+++ b/spec/seeds/notification_events_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 describe Seeds::NotificationEvents do
-    describe "#seed!" do
-      subject { described_class.new.seed! }
-  
-      it "creates the Notification Events" do
-        expect { subject }.to_not raise_error
-        expect(NotificationEvent.count).to eq(11)
-      end
+  describe "#seed!" do
+    subject { described_class.new.seed! }
+
+    it "creates the Notification Events" do
+      expect { subject }.to_not raise_error
+      expect(NotificationEvent.count).to eq(13)
     end
+  end
 end


### PR DESCRIPTION
Resolves APPEALS-8614

**Description**
Removed call to BGS to check for participant_id in the case that the veteran is not the claimant for legacy appeals.
Removed rspec associated with BGS call.
Added two new seeds to the notification_events table: 
"No Participant Id Found" and "No Claimant Found" (both of these have uuids that do not link to actual email/sms templates)
Adjusted rspec test to account for 2 additional events.

**Code Documentation Updates**

- [x]  Add or update code comments at the top of the class, module, and/or component.