### PR TITLE
janet/APPEALS-8610 enqueue send notification job in appellant notification module

### DIFF
--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -67,6 +67,7 @@ module AppellantNotification
     # queue = Shoryuken::Client.queues(ActiveJob::Base.queue_name_prefix + "_send_notifications.fifo")
   )
     msg_bdy = create_payload(appeal, template_name)
+    SendNotificationJob.perform_later(msg_bdy)
     # queue.send_message(msg_bdy)
   end
 

--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -67,6 +67,10 @@ module AppellantNotification
   )
     msg_bdy = create_payload(appeal, template_name)
     SendNotificationJob.perform_later(msg_bdy)
+<<<<<<< HEAD
+=======
+    # queue.send_message(msg_bdy)
+>>>>>>> 810ef919d2fedf21203a9dc2ae5bb736aee6e632
   end
 
   def self.create_payload(appeal, template_name)

--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -64,11 +64,9 @@ module AppellantNotification
   def self.notify_appellant(
     appeal,
     template_name
-    # queue = Shoryuken::Client.queues(ActiveJob::Base.queue_name_prefix + "_send_notifications.fifo")
   )
     msg_bdy = create_payload(appeal, template_name)
     SendNotificationJob.perform_later(msg_bdy)
-    # queue.send_message(msg_bdy)
   end
 
   def self.create_payload(appeal, template_name)

--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -67,13 +67,6 @@ module AppellantNotification
   )
     msg_bdy = create_payload(appeal, template_name)
     SendNotificationJob.perform_later(msg_bdy)
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 810ef919d2fedf21203a9dc2ae5bb736aee6e632
-    # queue.send_message(msg_bdy)
->>>>>>> 810ef919d2fedf21203a9dc2ae5bb736aee6e632
   end
 
   def self.create_payload(appeal, template_name)

--- a/config/initializers/shoryuken.rb
+++ b/config/initializers/shoryuken.rb
@@ -15,6 +15,8 @@ if Rails.application.config.sqs_create_queues
   # create the development queues
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_low_priority' })
   Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_high_priority' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_send_notifications' })
+  Shoryuken::Client.sqs.create_queue({ queue_name: ActiveJob::Base.queue_name_prefix + '_receive_notifications' })
 end
 
 Shoryuken.configure_server do |config|

--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -443,4 +443,17 @@ describe AppellantNotification do
       end
     end
   end
+
+  describe SendNotificationJob do
+    let(:appeal) { create(:appeal, :active) }
+    let(:template) { "Hearing scheduled" }
+    let(:payload) { AppellantNotification.create_payload(appeal, template_name) }
+    describe '#perform' do
+      it 'pushes a new message' do
+        ActiveJob::Base.queue_adapter = :test
+        AppellantNotification.notify_appellant(appeal, template)
+        expect(SendNotificationJob).to have_been_enqueued.exactly(:once)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-8610](https://vajira.max.gov/browse/APPEALS-8610)

### Description
The notification module has logic that will enqueue the send notification method.

### Acceptance Criteria
- [x] AppellantNotification module calls SendNotificationJob to queue payload
- [x] Rspec tests are updated and passing

### Testing Plan
1. Open two terminals
2. Run `bundle exec shoryuken -q caseflow_development_send_notifications -R` in one terminal
3. Run `appeal=Appeal.first` in other terminal
4. Run `AppellantNotification.notify_appellant(appeal, "Hearing scheduled")` 
5. Monitor the output in the terminal where shoryuken is running. It should look like this:
![sjfieojdlk](https://user-images.githubusercontent.com/93942793/187572649-8770182c-10ce-4172-a70b-c23663982b4c.PNG)



