### PR TITLE
jshields/APPEALS-8613 Task APPEALS-8826 Update the notification table to support decoupling of API and audit records

### DIFF
--- a/db/migrate/20220830124000_update_notification_content_column.rb
+++ b/db/migrate/20220830124000_update_notification_content_column.rb
@@ -1,0 +1,8 @@
+class UpdateNotificationContentColumn < Caseflow::Migration
+  def up
+    change_column_null :notifications, :notification_content, true
+  end
+  def down
+    change_column_null :notifications, :notification_content, false
+  end
+end

--- a/db/migrate/20220830124000_update_notification_content_column.rb
+++ b/db/migrate/20220830124000_update_notification_content_column.rb
@@ -1,7 +1,24 @@
+# Public: Active migration to handle the Migration and Rollback of making the
+# column noticiations.notification_content nullable
+
 class UpdateNotificationContentColumn < Caseflow::Migration
+  
+  # Purpose: Method update the notifications.notification_content column to be nullable
+  # when this migration is apllied
+  #
+  # Params: None
+  #
+  # Returns: None
   def up
     change_column_null :notifications, :notification_content, true
   end
+
+  # Purpose: Method update the notifications.notification_content column to not be nullable
+  # when this migration is rollbacked
+  #
+  # Params: None
+  #
+  # Returns: None
   def down
     change_column_null :notifications, :notification_content, false
   end

--- a/db/migrate/20220830143800_update_notification_index.rb
+++ b/db/migrate/20220830143800_update_notification_index.rb
@@ -1,0 +1,22 @@
+class UpdateNotificationIndex < Caseflow::Migration
+  def up
+    delete_duplicated_records
+    remove_index :notifications, name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
+    add_safe_index :notifications, [:appeals_id, :appeals_type], name: "index_appeals_notifications_on_appeals_id_and_appeals_type", unique: true
+  end
+
+  def down
+    remove_index :notifications, name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
+    add_safe_index :notifications, [:appeals_id, :appeals_type], name: "index_appeals_notifications_on_appeals_id_and_appeals_type", unique: false
+  end
+
+  private
+
+  def delete_duplicated_records
+    dup_notification_ids = Notification.group(:appeals_id, :appeals_type).having('COUNT(*) > 1').pluck(:appeals_id)
+    dup_notification_ids.each_slice(400) do |dupe_ids|
+      not_remove_order_ids = Notification.where(appeals_id: dupe_ids).group(:appeals_id, :appeals_type).having('COUNT(*) > 1').pluck('MIN(id)')
+      Notification.where(appeals_id: dupe_ids).where.not(id: not_remove_order_ids).destroy_all
+    end
+  end
+end

--- a/db/migrate/20220830143800_update_notification_index.rb
+++ b/db/migrate/20220830143800_update_notification_index.rb
@@ -1,10 +1,27 @@
+# Public: Active migration to handle the Migration and Rollback of making the
+# index_appeals_notifications_on_appeals_id_and_appeals_type index unique
 class UpdateNotificationIndex < Caseflow::Migration
+
+  # Purpose: Code and logic needed to re create the index_appeals_notifications_on_appeals_id_and_appeals_type index
+  # to now require the combination the columns [:appeals_id, :appeals_type] to be unique.
+  # Given the index use to not be unique this method also calls delete_duplicated_records to clean up the code
+  # before the new index can be applied
+  #
+  # Params: None
+  #
+  # Returns: None
   def up
     delete_duplicated_records
     remove_index :notifications, name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
     add_safe_index :notifications, [:appeals_id, :appeals_type], name: "index_appeals_notifications_on_appeals_id_and_appeals_type", unique: true
   end
 
+  # Purpose: Method to re create the index_appeals_notifications_on_appeals_id_and_appeals_type index to be not 
+  # unique in case of rollback from this migration
+  #
+  # Params: None
+  #
+  # Returns: None
   def down
     remove_index :notifications, name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
     add_safe_index :notifications, [:appeals_id, :appeals_type], name: "index_appeals_notifications_on_appeals_id_and_appeals_type", unique: false
@@ -12,6 +29,11 @@ class UpdateNotificationIndex < Caseflow::Migration
 
   private
 
+  # Purpose: Removing duplicate records that were allwoed by the index when it was not unique
+  #
+  # Params: None
+  #
+  # Returns: None
   def delete_duplicated_records
     dup_notification_ids = Notification.group(:appeals_id, :appeals_type).having('COUNT(*) > 1').pluck(:appeals_id)
     dup_notification_ids.each_slice(400) do |dupe_ids|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_30_124000) do
+ActiveRecord::Schema.define(version: 2022_08_30_143800) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1120,7 +1120,7 @@ ActiveRecord::Schema.define(version: 2022_08_30_124000) do
     t.string "recipient_phone_number", comment: "Participants Phone Number"
     t.string "sms_notification_status", comment: "Status of SMS/Text Notification"
     t.datetime "updated_at", comment: "TImestamp of when Notification was Updated"
-    t.index ["appeals_id", "appeals_type"], name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
+    t.index ["appeals_id", "appeals_type"], name: "index_appeals_notifications_on_appeals_id_and_appeals_type", unique: true
     t.index ["notification_events_id"], name: "index_notifications_on_notification_events_id"
     t.index ["participant_id"], name: "index_participant_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_04_135348) do
+ActiveRecord::Schema.define(version: 2022_08_30_124000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1111,7 +1111,7 @@ ActiveRecord::Schema.define(version: 2022_08_04_135348) do
     t.string "email_notification_status", comment: "Status of the Email Notification"
     t.date "event_date", null: false, comment: "Date of Event"
     t.string "event_type", null: false, comment: "Type of Event"
-    t.text "notification_content", null: false, comment: "Full Text Content of Notification"
+    t.text "notification_content", comment: "Full Text Content of Notification"
     t.bigint "notification_events_id"
     t.string "notification_type", null: false, comment: "Type of Notification that was created"
     t.datetime "notified_at", null: false, comment: "Time Notification was created"


### PR DESCRIPTION
Resolves APPEALS-8613 Task: APPEALS-8826

### Description
Created two migration to make the following changes to the Notification table:
1. Update the column notification_column to be nullable
1. Update the index_appeals_notifications_on_appeals_id_and_appeals_type index to be unique and added data clean up for any duplicate records in the index



### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

### Database Changes
*Only for Schema Changes*

* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [x] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)

