### PR TITLE
MattT/APPEALS-8973: Return to Board Intake Modal Updates

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1312,8 +1312,8 @@
       "VALUE": "SC Pending"
     },
     "VHA_CAREGIVER_SUPPORT_RETURN_TO_BOARD_INTAKE_MODAL_NOT_PCAFC": {
-      "LABEL": "Not PCAFC Related",
-      "VALUE": "Not PCAFC Related"
+      "LABEL": "Not PCAFC related",
+      "VALUE": "Not PCAFC related"
     },
     "VHA_CAREGIVER_SUPPORT_RETURN_TO_BOARD_INTAKE_MODAL_NO_PCAFC_DECISIONS": {
       "LABEL": "No PCAFC decisions for this individual",

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -325,6 +325,7 @@ const VhaCaregiverSupportReturnToBoardIntakeModal = ({ props, state, setState })
             onChange={(value) => setState({ instructions: value })}
             value={state.instructions}
             styling={marginTop(2)}
+            maxlength={ATTORNEY_COMMENTS_MAX_LENGTH}
             optional
           />
         </div>

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -325,7 +325,6 @@ const VhaCaregiverSupportReturnToBoardIntakeModal = ({ props, state, setState })
             onChange={(value) => setState({ instructions: value })}
             value={state.instructions}
             styling={marginTop(2)}
-            maxlength={ATTORNEY_COMMENTS_MAX_LENGTH}
             optional
           />
         </div>

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -429,13 +429,13 @@ const MODAL_TYPE_ATTRS = {
       let formattedInstructions = '';
 
       if (state.dropdown === 'other') {
-        formattedInstructions += `\nReason for return: Other - ${state.otherInstructions}`;
+        formattedInstructions += `\n**Reason for return:**\nOther - ${state.otherInstructions}`;
       } else {
-        formattedInstructions += `\nReason for return: ${state.dropdown}`;
+        formattedInstructions += `\n**Reason for return:**${state.dropdown}`;
       }
 
       if (state.instructions) {
-        formattedInstructions += `\nDetails:\n${state.instructions}`;
+        formattedInstructions += `\n**Detail:**\n${state.instructions}`;
       }
 
       return formattedInstructions;

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -430,11 +430,11 @@ const MODAL_TYPE_ATTRS = {
       if (state.dropdown === 'other') {
         formattedInstructions += `\n**Reason for return:**\nOther - ${state.otherInstructions}`;
       } else {
-        formattedInstructions += `\n**Reason for return:**${state.dropdown}`;
+        formattedInstructions += `\n**Reason for return:** ${state.dropdown}`;
       }
 
       if (state.instructions) {
-        formattedInstructions += `\n**Detail:**\n${state.instructions}`;
+        formattedInstructions += `\n\n**Detail:**\n${state.instructions}`;
       }
 
       return formattedInstructions;

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -430,7 +430,7 @@ const MODAL_TYPE_ATTRS = {
       if (state.dropdown === 'other') {
         formattedInstructions += `\n**Reason for return:**\nOther - ${state.otherInstructions}`;
       } else {
-        formattedInstructions += `\n**Reason for return:** ${state.dropdown}`;
+        formattedInstructions += `\n**Reason for return:**\n${state.dropdown}`;
       }
 
       if (state.instructions) {

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -164,7 +164,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'VBMS',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'CAREGIVER -> BVA Intake',
         buttonText
       );
@@ -179,7 +179,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'Other',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'CAREGIVER -> BVA Intake',
         buttonText,
         'Other Source'
@@ -206,7 +206,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'Centralized Mail Portal',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'EMO -> BVA Intake',
         buttonText
       );
@@ -221,7 +221,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'Other',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'EMO -> BVA Intake',
         buttonText,
         'Other Source'
@@ -248,7 +248,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'Centralized Mail Portal',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'RPO -> BVA Intake',
         buttonText
       );
@@ -263,7 +263,7 @@ describe('CompleteTaskModal', () => {
 
       enterModalRadioOptions(
         'Other',
-        'Provide details such as file structure or file path',
+        'Provide details such as file structure or file path Optional',
         'RPO -> BVA Intake',
         buttonText,
         'Other Source'
@@ -280,12 +280,12 @@ describe('CompleteTaskModal', () => {
     const buttonText = COPY.MODAL_RETURN_BUTTON;
     const modalType = 'vha_caregiver_support_return_to_board_intake';
 
-    test('Modal title to be something', () => {
+    test('Modal title to be "Return to Board Intake"', () => {
       renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
       expect(screen.getByText('Return to Board Intake')).toBeTruthy();
     });
 
-    test('Instructions are formatted properly whenever a non-other reason is selected for return', () => {
+    test('Instructions are formatted properly whenever a non-other reason is selected for return', async () => {
       renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
 
       selectFromDropdown(
@@ -293,10 +293,36 @@ describe('CompleteTaskModal', () => {
         'Not PCAFC related'
       );
 
-      expect(true).toBe(true);
+      userEvent.click(await screen.findByRole('button', { name: buttonText, disabled: false }));
+
+      expect(getReceivedInstructions()).toBe(
+        '\n**Reason for return:**\nNot PCAFC related'
+      );
     });
 
-    test('Instructions are formatted properly whenever "Other" reason is selected for return', () => {
+    test('Instructions are formatted properly whenever a non-other reason and context is provided', async () => {
+      renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
+
+      selectFromDropdown(
+        'Why is this appeal being returned?',
+        'Not PCAFC related'
+      );
+
+      const optionalTextArea = screen.getByRole(
+        'textbox', { name: 'Provide additional context for this action Optional' }
+      );
+
+      userEvent.type(optionalTextArea, 'Additional context');
+
+      userEvent.click(await screen.findByRole('button', { name: buttonText, disabled: false }));
+
+      expect(getReceivedInstructions()).toBe(
+        '\n**Reason for return:**\nNot PCAFC related' +
+        '\n\n**Detail:**\nAdditional context'
+      );
+    });
+
+    test('Instructions are formatted properly whenever "Other" reason is selected for return', async () => {
       renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
 
       selectFromDropdown(
@@ -304,7 +330,45 @@ describe('CompleteTaskModal', () => {
         'Other'
       );
 
-      expect(true).toBe(true);
+      const otherTextArea = screen.getByRole(
+        'textbox', { name: 'Please provide the reason for return' }
+      );
+
+      userEvent.type(otherTextArea, 'Reasoning for the return');
+
+      userEvent.click(await screen.findByRole('button', { name: buttonText, disabled: false }));
+
+      expect(getReceivedInstructions()).toBe(
+        '\n**Reason for return:**\nOther - Reasoning for the return'
+      );
+    });
+
+    test('Instructions are formatted properly when "Other" reason is selected for return plus context', async () => {
+      renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
+
+      selectFromDropdown(
+        'Why is this appeal being returned?',
+        'Other'
+      );
+
+      const otherTextArea = screen.getByRole(
+        'textbox', { name: 'Please provide the reason for return' }
+      );
+
+      userEvent.type(otherTextArea, 'Reasoning for the return');
+
+      const optionalTextArea = screen.getByRole(
+        'textbox', { name: 'Provide additional context for this action Optional' }
+      );
+
+      userEvent.type(optionalTextArea, 'Additional context');
+
+      userEvent.click(await screen.findByRole('button', { name: buttonText, disabled: false }));
+
+      expect(getReceivedInstructions()).toBe(
+        '\n**Reason for return:**\nOther - Reasoning for the return' +
+        '\n\n**Detail:**\nAdditional context'
+      );
     });
   });
 });

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -96,15 +96,16 @@ describe('CompleteTaskModal', () => {
   describe('vha_send_to_board_intake', () => {
     const taskType = 'VhaDocumentSearchTask';
     const buttonText = COPY.MODAL_SUBMIT_BUTTON;
+    const modalType = 'vha_send_to_board_intake';
 
     test('modal title is Send to Board Intake', () => {
-      renderCompleteTaskModal('vha_send_to_board_intake', camoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, camoToBvaIntakeData, taskType);
 
       expect(screen.getByText('Send to Board Intake')).toBeTruthy();
     });
 
     test('CAMO Notes section only appears once whenever CAMO sends appeal back to BVA Intake', () => {
-      renderCompleteTaskModal('vha_send_to_board_intake', camoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, camoToBvaIntakeData, taskType);
 
       enterModalOptions(
         'Correct documents have been successfully added',
@@ -120,7 +121,7 @@ describe('CompleteTaskModal', () => {
     });
 
     test('PO Details appear next to Program Office Notes section', () => {
-      renderCompleteTaskModal('vha_send_to_board_intake', camoToProgramOfficeToCamoData, taskType);
+      renderCompleteTaskModal(modalType, camoToProgramOfficeToCamoData, taskType);
 
       enterModalOptions(
         'Correct documents have been successfully added',
@@ -140,15 +141,16 @@ describe('CompleteTaskModal', () => {
 
   describe('vha_caregiver_support_send_to_board_intake_for_review', () => {
     const taskType = 'VhaDocumentSearchTask';
-    const buttonText = COPY.MODAL_SEND_BUTTON
+    const buttonText = COPY.MODAL_SEND_BUTTON;
+    const modalType = 'vha_caregiver_support_send_to_board_intake_for_review';
 
     test('modal title is Ready for Review', () => {
-      renderCompleteTaskModal('vha_caregiver_support_send_to_board_intake_for_review', caregiverToIntakeData, taskType);
+      renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
       expect(screen.getByText('Ready for Review')).toBeTruthy();
     });
 
     test('When VBMS is chosen in Modal', () => {
-      renderCompleteTaskModal('vha_caregiver_support_send_to_board_intake_for_review', caregiverToIntakeData, taskType);
+      renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
 
       enterModalOptions(
         'VBMS',
@@ -163,7 +165,7 @@ describe('CompleteTaskModal', () => {
     });
 
     test('When Other is Chosen in Modal', () => {
-      renderCompleteTaskModal('vha_caregiver_support_send_to_board_intake_for_review', caregiverToIntakeData, taskType);
+      renderCompleteTaskModal(modalType, caregiverToIntakeData, taskType);
 
       enterModalOptions(
         'Other',
@@ -182,14 +184,15 @@ describe('CompleteTaskModal', () => {
   describe('emo_send_to_board_intake_for_review', () => {
     const taskType = 'EducationDocumentSearchTask';
     const buttonText = COPY.MODAL_SUBMIT_BUTTON;
+    const modalType = 'emo_send_to_board_intake_for_review';
 
     test('modal title is Ready for Review', () => {
-      renderCompleteTaskModal('emo_send_to_board_intake_for_review', emoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, emoToBvaIntakeData, taskType);
       expect(screen.getByText('Ready for Review')).toBeTruthy();
     });
 
     test('When Centralized Mail Portal is chosen in Modal', () => {
-      renderCompleteTaskModal('emo_send_to_board_intake_for_review', emoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, emoToBvaIntakeData, taskType);
 
       enterModalOptions(
         'Centralized Mail Portal',
@@ -204,7 +207,7 @@ describe('CompleteTaskModal', () => {
     });
 
     test('When Other is Chosen in Modal', () => {
-      renderCompleteTaskModal('emo_send_to_board_intake_for_review', emoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, emoToBvaIntakeData, taskType);
 
       enterModalOptions(
         'Other',
@@ -223,14 +226,15 @@ describe('CompleteTaskModal', () => {
   describe('rpo_send_to_board_intake_for_review', () => {
     const taskType = 'EducationAssessDocumentationTask';
     const buttonText = COPY.MODAL_SUBMIT_BUTTON;
+    const modalType = 'rpo_send_to_board_intake_for_review';
 
     test('modal title is Ready for Review', () => {
-      renderCompleteTaskModal('emo_send_to_board_intake_for_review', rpoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, rpoToBvaIntakeData, taskType);
       expect(screen.getByText('Ready for Review')).toBeTruthy();
     });
 
     test('When Centralized Mail Portal is chosen in Modal', () => {
-      renderCompleteTaskModal('rpo_send_to_board_intake_for_review', rpoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, rpoToBvaIntakeData, taskType);
 
       enterModalOptions(
         'Centralized Mail Portal',
@@ -245,7 +249,7 @@ describe('CompleteTaskModal', () => {
     });
 
     test('When Other is Chosen in Modal', () => {
-      renderCompleteTaskModal('rpo_send_to_board_intake_for_review', rpoToBvaIntakeData, taskType);
+      renderCompleteTaskModal(modalType, rpoToBvaIntakeData, taskType);
 
       enterModalOptions(
         'Other',
@@ -259,5 +263,9 @@ describe('CompleteTaskModal', () => {
         '\n\n**Detail:**\n\nRPO -> BVA Intake\n'
       );
     });
+  });
+
+  describe('vha_caregiver_support_return_to_board_intake', () => {
+
   });
 });

--- a/client/test/data/queue/taskActionModals/completeTaskActionModalData.js
+++ b/client/test/data/queue/taskActionModals/completeTaskActionModalData.js
@@ -13,6 +13,7 @@ const uiData = {
   }
 };
 
+/* eslint-disable max-len */
 const caregiverActions = [
   {
     func: 'vha_caregiver_support_mark_task_in_progress',
@@ -22,9 +23,9 @@ const caregiverActions = [
       modal_title: 'Mark task as in progress',
       modal_body: 'By marking task as in progress, you are confirming that you are actively working on collecting documents for this appeal.\n\nOnce marked, other members of your organization will no longer be able to mark this task as in progress.',
       modal_button_text: 'Mark in progress',
-      message_title: 'You have successfully marked Bob Smithbeer\'s case as in progress',
+      message_title: 'You have successfully marked Bob Smithswift\'s case as in progress',
       type: 'VhaDocumentSearchTask',
-      redirect_after: '/organizations/vha-csp'
+      redirect_after: '/organizations/vha-csp?tab=caregiver_support_in_progress'
     }
   },
   {
@@ -34,13 +35,59 @@ const caregiverActions = [
     data: {
       modal_title: 'Ready for Review',
       modal_button_text: 'Send',
-      message_title: 'You have successfully sent Bob Smithbeer\'s case to Board Intake for Review',
+      message_title: 'You have successfully sent Bob Smithswift\'s case to Board Intake for Review',
       type: 'VhaDocumentSearchTask',
-      redirect_after: '/organizations/vha-csp',
+      redirect_after: '/organizations/vha-csp?tab=caregiver_support_completed',
       body_optional: true
+    }
+  },
+  {
+    func: 'vha_caregiver_support_return_to_board_intake',
+    label: 'Return to Board Intake',
+    value: 'modal/vha_caregiver_support_return_to_board_intake',
+    data: {
+      modal_title: 'Return to Board Intake',
+      modal_body: 'This appeal will be returned to Board intake.',
+      type: 'VhaDocumentSearchTask',
+      options: [
+        {
+          label: 'Duplicate',
+          value: 'Duplicate'
+        },
+        {
+          label: 'HLR Pending',
+          value: 'HLR Pending'
+        },
+        {
+          label: 'SC Pending',
+          value: 'SC Pending'
+        },
+        {
+          label: 'Not PCAFC related',
+          value: 'Not PCAFC related'
+        },
+        {
+          label: 'No PCAFC decisions for this individual',
+          value: 'no PCAFC decisions for this individual'
+        },
+        {
+          label: 'No PCAFC decision for identified time period',
+          value: 'No PCAFC decision for identified time period'
+        },
+        {
+          label: 'Multiple PCAFC decisions could apply',
+          value: 'Multiple PCAFC decisions could apply'
+        },
+        {
+          label: 'Other',
+          value: 'other'
+        }
+      ],
+      redirect_after: '/organizations/vha-csp?tab=caregiver_support_completed'
     }
   }
 ];
+/* eslint-enable max-len */
 
 const vhaDocumentSearchTaskData = {
   7119: {

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -126,7 +126,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(vha_document_search_task.reload.status).to eq Constants.TASK_STATUSES.in_progress
         end
 
-        step "enacting the 'Return to board intake' task action returns the task to BVA intake" do
+        step "enacting the 'Return to Board Intake' task action returns the task to BVA intake" do
           User.authenticate!(user: vha_caregiver_user)
 
           vha_document_search_task = VhaDocumentSearchTask.last


### PR DESCRIPTION
Resolves [APPEALS-8973](https://vajira.max.gov/browse/APPEALS-8973)

### Description
Adjustments for the Return to Board Intake modal and input displayed on the case timeline surfacing from the dogfooding session.

### Acceptance Criteria
- [ ] "Not PCAFC related" dropdown option should use a lowercase "r" for related
- [ ] Formatting of modal input reflects designs identified by design team
- [ ] Case timeline is updated to match designs provided by the design team

### Testing Plan
1. Open your Rails console and create a couple of appeals assigned to CSP:
```ruby
appeals = (1..2).map do
  appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
  parent_task = appeal.tasks.last
  caregiver_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCaregiverSupport.singleton )
  appeal
end
```

2. Sign into Caseflow as a Caregiver user (ex: `CAREGIVERUSER`).
3. Navigate to the VHA CSP queue: [/organizations/vha-csp](http://localhost:3000/organizations/vha-csp)
4. Go to the Case Details page for the first appeal. Open the "Actions" dropdown. Select "Return to Board Intake".
5. Click on the "Why is this appeal being returned?" dropdown. Make sure the option "Not PCAFC related" exists with a lowercase "r".
6. Click on any option except for "Other". Add some text to the text area, and then hit "Return".
7. You will be redirected to the VHA CSP completed tab. Click on the appeal link in the tab to go back to the Case Details page. Scroll down to the Case Timeline and ensure it appears as prescribed by the design team (with your own text, of course):
<img width="575" alt="Screen Shot 2022-09-08 at 7 46 50 AM" src="https://user-images.githubusercontent.com/99351305/189206153-5272b0ca-3479-4d9b-ae47-98a0232c2a2b.png">
8. Go back to VHA CSP's Unassigned tab and go to the Case Details page for the second appeal.
9. Open the "Return to Board Intake" modal once more. This time, select "Other" as the reason for returning the appeal. Enter text into the top textarea.
10. Go to the Case Details page for this appeal and scroll down to the case timeline. Make sure this one matches the designs as well:

<img width="575" alt="Screen Shot 2022-09-08 at 7 46 50 AM" src="https://user-images.githubusercontent.com/99351305/189206624-2d099fcf-f5d9-4332-beaf-fa846a657139.png">


- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 SCENARIO|BEFORE MODAL|BEFORE TIMELINE|AFTER MODAL|AFTER TIMELINE
 ---|---|---|--|--
 Non-other|![Screenshot from 2022-09-08 11-18-53](https://user-images.githubusercontent.com/99351305/189172975-f2664764-2600-4e87-bee5-fc433ddfc240.png)|![Screenshot from 2022-09-08 11-19-13](https://user-images.githubusercontent.com/99351305/189172926-1ef13027-805b-4c57-a81a-be84f27a1ec0.png)|<img width="209" alt="8973-non-other-modal" src="https://user-images.githubusercontent.com/99351305/189171954-d9b0843f-2c88-4d58-9d1f-3fd7c02b7937.PNG">|<img width="271" alt="8973-non-other-timeline" src="https://user-images.githubusercontent.com/99351305/189171953-4911a46a-c719-4c13-8989-b2a020cf2606.PNG">
 Other|![Screenshot from 2022-09-08 11-17-08](https://user-images.githubusercontent.com/99351305/189172968-fba5e2e3-ed95-4d05-b58c-acb872e0ca03.png)|![Screenshot from 2022-09-08 11-17-51](https://user-images.githubusercontent.com/99351305/189172971-87807047-0cd3-4d32-bb15-3107816d3e09.png)|<img width="208" alt="8973-other-modal" src="https://user-images.githubusercontent.com/99351305/189171952-25567b22-ab49-4154-a28c-6e1371a2fe04.PNG">|<img width="229" alt="8973-other-timeline" src="https://user-images.githubusercontent.com/99351305/189171951-7b184113-25c4-4568-b992-2b19b99cf9df.PNG">

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.