### PR TITLE
TYLERB/APPEALS-8974: Mark task in progress modal updates

### DIFF
--- a/client/app/queue/components/InProgressTaskModal.jsx
+++ b/client/app/queue/components/InProgressTaskModal.jsx
@@ -44,7 +44,7 @@ const InProgressTaskModal = (props) => {
       pathAfterSubmit={taskData?.redirect_after ?? '/queue'}
       submit={submit}
       button={taskData.modal_button_text || 'Submit'}
-      buttonClasses={['usa-button']}
+      submitButtonClassNames={['usa-button']}
     >
       {taskData?.modal_body &&
           <div> { StringUtil.nl2br(taskData.modal_body) } </div>


### PR DESCRIPTION
Resolves [APPEALS-8974](https://vajira.max.gov/browse/APPEALS-8974)

### Description
Fixed a property naming issue in the in progress task modal so it properly uses the blue primary button coloring for its submit button

### Acceptance Criteria
- [ ] Mark in progress modal should utilize the primary (blue) coloring for the "Mark in progress" submit/confirmation button
- [ ] No other modals should be altered by the change

### Testing Plan
1. Create an appeal assigned to the VHA Caregiver Support either with the rails console or through standard intake that does not have a task status of in progress.

Example rails console commands:
```ruby
# task instructions for mark task as in progress

appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
parent_task = appeal.tasks.last
caregiver_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCaregiverSupport.singleton )

# Lastly update the veteran case number so it's easier to see in the queue
appeal.update( veteran_file_number: "500000999" )
```

2. Navigate to the new appeal in the unassigned tab in the caregiver support queue and select the case details

3. Select the mark task in progress task action

4. Verify that the modal submission button is the correct color and style

![image](https://user-images.githubusercontent.com/109369527/189161764-6f781741-ce0c-4754-bf5b-2199230d7c35.png)

