### PR TITLE
MattT/Increase Test Coverage on services/dependencies_report_service_spec.rb

### DIFF
--- a/spec/services/dependencies_report_service_spec.rb
+++ b/spec/services/dependencies_report_service_spec.rb
@@ -8,13 +8,15 @@ describe DependenciesReportService do
     Rails.cache.clear
   end
 
+  subject { DependenciesReportService.dependencies_report }
+
   context "when there is an outage for only one system" do
     before do
       Rails.cache.write(:degraded_service_banner_bgs, :display)
     end
 
     it "returns one degraded systems" do
-      expect(DependenciesReportService.dependencies_report).to eq %w[BGS]
+      is_expected.to eq %w[BGS]
     end
   end
 
@@ -25,7 +27,7 @@ describe DependenciesReportService do
     end
 
     it "returns muliple systems" do
-      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITH_OUTAGES
+      is_expected.to eq DEPENDENCIES_REPORT_WITH_OUTAGES
     end
   end
 
@@ -40,7 +42,7 @@ describe DependenciesReportService do
     end
 
     it "returns an empty array" do
-      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
+      is_expected.to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
     end
   end
 
@@ -50,7 +52,22 @@ describe DependenciesReportService do
     end
 
     it "returns and empty array" do
-      expect(DependenciesReportService.dependencies_report).to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
+      is_expected.to eq DEPENDENCIES_REPORT_WITHOUT_OUTAGES
+    end
+  end
+
+  context "whenever there is an error raised when accessing the Rails cache" do
+    before { allow(Rails.cache).to receive(:read_multi).and_raise(StandardError, error_status) }
+
+    let(:error_status) { "Could not retrieve statuses" }
+
+    it "logs the error and returns false" do
+      expect(Rails.logger).to receive(:warn).with(
+        "Exception thrown while checking dependency "\
+        "status: #{error_status}"
+      )
+
+      is_expected.to eq false
     end
   end
 end


### PR DESCRIPTION
### Description
This PR increases the test coverage on services/dependencies_report_service_spec.rb to be above the 90% threshold in order to resolve a recurring error on CircleCI.

<img width="721" alt="code-cov-error" src="https://user-images.githubusercontent.com/99351305/189241742-6427e0ea-c153-4a37-bec0-c40a81b70634.PNG">


 BEFORE|AFTER
 ---|---
<img width="925" alt="simplecov" src="https://user-images.githubusercontent.com/99351305/189241614-c1406193-31b6-4ebc-b425-a2336b603626.PNG">|<img width="917" alt="simplecov2" src="https://user-images.githubusercontent.com/99351305/189241638-378de0e2-e4d4-4491-8cf7-894af19217d4.PNG">

