### PR TITLE
Craig/appeals 8616

### DIFF
--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -13,8 +13,7 @@ class Distribution < CaseflowRecord
 
   validates :judge, presence: true
   validate :validate_user_is_judge, on: :create
-  validate :validate_number_of_unassigned_cases, on: :create, unless: :is_num_of_cases_exceeded?
-  validate :validate_has_not_exceeded_batch_size, on: :create, unless: !FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
+  validate :validate_number_of_unassigned_cases, on: :create, unless: :num_of_cases_exceeded?
   validate :validate_days_waiting_of_unassigned_cases, on: :create, unless: :priority_push?
   validate :validate_judge_has_no_pending_distributions, on: :create
 
@@ -30,19 +29,15 @@ class Distribution < CaseflowRecord
     end
   end
 
-  def is_num_of_cases_exceeded?
-    return false if FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
-
-    priority_push?
-  end
-
-  def validate_has_not_exceeded_batch_size
-    errors.add(:judge, :too_many_unassigned_cases) unless judge_has_less_than_batch_size
+  def num_of_cases_exceeded?
+    if FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
+      errors.add(:judge, :too_many_unassigned_cases) unless judge_has_less_than_batch_size
+    else
+      priority_push?
+    end
   end
 
   def judge_has_less_than_batch_size
-    return true if judge_tasks.length < batch_size
-
     judge_tasks.length + judge_legacy_tasks.length < batch_size
   end
 

--- a/app/models/distribution.rb
+++ b/app/models/distribution.rb
@@ -14,6 +14,9 @@ class Distribution < CaseflowRecord
   validates :judge, presence: true
   validate :validate_user_is_judge, on: :create
   validate :validate_number_of_unassigned_cases, on: :create, unless: :num_of_cases_exceeded?
+  validate :validate_has_not_exceeded_batch_size, on: :create, unless: proc {
+    !FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
+  }
   validate :validate_days_waiting_of_unassigned_cases, on: :create, unless: :priority_push?
   validate :validate_judge_has_no_pending_distributions, on: :create
 
@@ -30,14 +33,18 @@ class Distribution < CaseflowRecord
   end
 
   def num_of_cases_exceeded?
-    if FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
-      errors.add(:judge, :too_many_unassigned_cases) unless judge_has_less_than_batch_size
-    else
-      priority_push?
-    end
+    return false if FeatureToggle.enabled?(:acd_distribute_all, user: RequestStore.store[:current_user])
+
+    priority_push?
+  end
+
+  def validate_has_not_exceeded_batch_size
+    errors.add(:judge, :too_many_unassigned_cases) unless judge_has_less_than_batch_size
   end
 
   def judge_has_less_than_batch_size
+    return true if judge_tasks.length < batch_size
+
     judge_tasks.length + judge_legacy_tasks.length < batch_size
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ class SeedDB
   def seed
     call_and_log_seed_step :clean_db
 
-    #call_and_log_seed_step Seeds::Annotations
+    call_and_log_seed_step Seeds::Annotations
     call_and_log_seed_step Seeds::Tags
     call_and_log_seed_step Seeds::Users # TODO: must run this before others
     call_and_log_seed_step Seeds::Tasks
@@ -45,7 +45,7 @@ class SeedDB
     call_and_log_seed_step Seeds::Substitutions
     call_and_log_seed_step Seeds::DecisionIssues
     call_and_log_seed_step Seeds::CavcAmaAppeals
-    #call_and_log_seed_step Seeds::SanitizedJsonSeeds
+    call_and_log_seed_step Seeds::SanitizedJsonSeeds
     call_and_log_seed_step Seeds::VeteransHealthAdministration
     call_and_log_seed_step Seeds::MTV
     call_and_log_seed_step Seeds::Education

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -34,7 +34,7 @@ class SeedDB
   def seed
     call_and_log_seed_step :clean_db
 
-    call_and_log_seed_step Seeds::Annotations
+    #call_and_log_seed_step Seeds::Annotations
     call_and_log_seed_step Seeds::Tags
     call_and_log_seed_step Seeds::Users # TODO: must run this before others
     call_and_log_seed_step Seeds::Tasks

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -45,7 +45,7 @@ class SeedDB
     call_and_log_seed_step Seeds::Substitutions
     call_and_log_seed_step Seeds::DecisionIssues
     call_and_log_seed_step Seeds::CavcAmaAppeals
-    call_and_log_seed_step Seeds::SanitizedJsonSeeds
+    #call_and_log_seed_step Seeds::SanitizedJsonSeeds
     call_and_log_seed_step Seeds::VeteransHealthAdministration
     call_and_log_seed_step Seeds::MTV
     call_and_log_seed_step Seeds::Education

--- a/db/seeds/decision_issues.rb
+++ b/db/seeds/decision_issues.rb
@@ -13,8 +13,8 @@ module Seeds
     def build_veteran
       create(
         :veteran,
-        first_name: "Joe",
-        last_name: "Doe"
+        first_name: "Veteran",
+        last_name: "DecisionIssueSeed"
       )
     end
 

--- a/db/seeds/decision_issues.rb
+++ b/db/seeds/decision_issues.rb
@@ -14,7 +14,7 @@ module Seeds
       create(
         :veteran,
         first_name: "Joe",
-        last_name: "Doe",
+        last_name: "Doe"
       )
     end
 

--- a/db/seeds/decision_issues.rb
+++ b/db/seeds/decision_issues.rb
@@ -13,10 +13,8 @@ module Seeds
     def build_veteran
       create(
         :veteran,
-        file_number: 42_424_242,
         first_name: "Joe",
         last_name: "Doe",
-        participant_id: "330000000"
       )
     end
 

--- a/db/seeds/intake.rb
+++ b/db/seeds/intake.rb
@@ -20,7 +20,7 @@ module Seeds
     def create_intake_users
       ["Mail Intake", "Admin Intake"].each do |role|
         # do not try to recreate when running seed file after inital seed
-        next if User.find_by(css_id: "#{role.tr(' ', '')}_LOCAL".upcase)
+        next if User.find_by_css_id("#{role.tr(' ', '')}_LOCAL".upcase)
 
         create(:user,
                css_id: "#{role.tr(' ', '')}_LOCAL",

--- a/db/seeds/intake.rb
+++ b/db/seeds/intake.rb
@@ -29,30 +29,20 @@ module Seeds
     end
 
     def create_deceased_veteran
-      veteran_file_number = "45454545"
       create(:veteran,
-             file_number: veteran_file_number,
              first_name: "Ed",
              last_name: "Deceased",
              date_of_death: Time.zone.yesterday)
     end
 
     def create_veteran_with_no_dependents
-      veteran_file_number = "44444444"
-      participant_id = "444444444"
       create(:veteran,
-             file_number: veteran_file_number,
-             participant_id: participant_id,
              first_name: "Robert",
              last_name: "Lonely")
     end
 
     def create_deceased_veteran_with_no_dependents
-      veteran_file_number = "55555555"
-      participant_id = "555555555"
       create(:veteran,
-             file_number: veteran_file_number,
-             participant_id: participant_id,
              first_name: "Karen",
              last_name: "Lonely",
              date_of_death: Time.zone.yesterday)
@@ -84,8 +74,7 @@ module Seeds
     # rubocop:disable Metrics/AbcSize
     # rubocop:disable Metrics/MethodLength
     def create_higher_level_reviews_and_supplemental_claims
-      veteran_file_number = "682007349"
-      veteran = Veteran.find_or_create_by_file_number(veteran_file_number)
+      veteran = create(:veteran)
 
       ep_rating_code = "030HLRR"
       ep_nonrating_code = "030HLRNR"
@@ -95,14 +84,14 @@ module Seeds
       thirty_days_in_seconds = 30 * one_day_in_seconds
 
       higher_level_review = HigherLevelReview.create!(
-        veteran_file_number: veteran_file_number,
+        veteran_file_number: veteran.file_number,
         receipt_date: Time.zone.now - thirty_days_in_seconds,
         informal_conference: false,
         same_office: false,
         benefit_type: "compensation"
       )
       higher_level_review.create_claimant!(
-        participant_id: "5382910292",
+        participant_id: rand(600_000_000..999_999_999),
         payee_code: "10",
         type: "DependentClaimant"
       )

--- a/db/seeds/intake.rb
+++ b/db/seeds/intake.rb
@@ -19,12 +19,14 @@ module Seeds
 
     def create_intake_users
       ["Mail Intake", "Admin Intake"].each do |role|
-        User.create(
-          css_id: "#{role.tr(' ', '')}_LOCAL",
-          roles: [role],
-          station_id: "101",
-          full_name: "Jame Local #{role} Smith"
-        )
+        # do not try to recreate when running seed file after inital seed
+        next if User.find_by(css_id: "#{role.tr(' ', '')}_LOCAL".upcase)
+
+        create(:user,
+               css_id: "#{role.tr(' ', '')}_LOCAL",
+               roles: [role],
+               station_id: "101",
+               full_name: "Jame Local #{role} Smith")
       end
     end
 
@@ -83,112 +85,103 @@ module Seeds
       two_days_in_seconds = 2 * one_day_in_seconds
       thirty_days_in_seconds = 30 * one_day_in_seconds
 
-      higher_level_review = HigherLevelReview.create!(
-        veteran_file_number: veteran.file_number,
-        receipt_date: Time.zone.now - thirty_days_in_seconds,
-        informal_conference: false,
-        same_office: false,
-        benefit_type: "compensation"
-      )
+      higher_level_review = create(:higher_level_review,
+                                   veteran_file_number: veteran.file_number,
+                                   receipt_date: Time.zone.now - thirty_days_in_seconds,
+                                   informal_conference: false,
+                                   same_office: false,
+                                   benefit_type: "compensation")
       higher_level_review.create_claimant!(
         participant_id: rand(600_000_000..999_999_999),
         payee_code: "10",
         type: "DependentClaimant"
       )
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_rating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: "CAN",
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_rating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: "CAN",
+             claimant_participant_id: veteran.participant_id)
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_rating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: nil,
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_rating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: nil,
+             claimant_participant_id: veteran.participant_id)
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_rating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: "PEND",
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_rating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: "PEND",
+             claimant_participant_id: veteran.participant_id)
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_rating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: "CLR",
-        last_synced_at: Time.zone.now - one_day_in_seconds,
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_rating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: "CLR",
+             last_synced_at: Time.zone.now - one_day_in_seconds,
+             claimant_participant_id: veteran.participant_id)
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_nonrating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: "CLR",
-        last_synced_at: Time.zone.now - two_days_in_seconds,
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_nonrating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: "CLR",
+             last_synced_at: Time.zone.now - two_days_in_seconds,
+             claimant_participant_id: veteran.participant_id)
 
-      EndProductEstablishment.create!(
-        source: higher_level_review,
-        veteran_file_number: veteran.file_number,
-        claim_date: Time.zone.now - thirty_days_in_seconds,
-        code: ep_rating_code,
-        station: "397",
-        benefit_type_code: "1",
-        payee_code: "00",
-        synced_status: "LOL",
-        claimant_participant_id: veteran.participant_id
-      )
+      create(:end_product_establishment,
+             source: higher_level_review,
+             veteran_file_number: veteran.file_number,
+             claim_date: Time.zone.now - thirty_days_in_seconds,
+             code: ep_rating_code,
+             station: "397",
+             benefit_type_code: "1",
+             payee_code: "00",
+             synced_status: "LOL",
+             claimant_participant_id: veteran.participant_id)
 
-      eligible_request_issue = RequestIssue.create!(
-        decision_review: higher_level_review,
-        nonrating_issue_category: "Military Retired Pay",
-        nonrating_issue_description: "nonrating description",
-        contention_reference_id: "1234",
-        ineligible_reason: nil,
-        benefit_type: "compensation",
-        decision_date: Date.new(2018, 5, 1)
-      )
+      eligible_request_issue =
+        create(:request_issue,
+               decision_review: higher_level_review,
+               nonrating_issue_category: "Military Retired Pay",
+               nonrating_issue_description: "nonrating description",
+               ineligible_reason: nil,
+               benefit_type: "compensation",
+               decision_date: Date.new(2018, 5, 1))
 
-      untimely_request_issue = RequestIssue.create!(
-        decision_review: higher_level_review,
-        nonrating_issue_category: "Active Duty Adjustments",
-        nonrating_issue_description: "nonrating description",
-        contention_reference_id: "12345",
-        decision_date: Date.new(2018, 5, 1),
-        benefit_type: "compensation",
-        ineligible_reason: :untimely
-      )
+      untimely_request_issue =
+        create(:request_issue,
+               decision_review: higher_level_review,
+               nonrating_issue_category: "Active Duty Adjustments",
+               nonrating_issue_description: "nonrating description",
+               decision_date: Date.new(2018, 5, 1),
+               benefit_type: "compensation",
+               ineligible_reason: :untimely)
 
       higher_level_review.create_issues!([
                                            eligible_request_issue,
@@ -196,11 +189,10 @@ module Seeds
                                          ])
       higher_level_review.establish!
 
-      SupplementalClaim.create(
-        veteran_file_number: veteran.file_number,
-        receipt_date: Time.zone.now,
-        benefit_type: "compensation"
-      )
+      create(:supplemental_claim,
+             veteran_file_number: veteran.file_number,
+             receipt_date: Time.zone.now,
+             benefit_type: "compensation")
     end
     # rubocop:enable Metrics/AbcSize
     # rubocop:enable Metrics/MethodLength
@@ -237,7 +229,7 @@ module Seeds
     # rubocop:enable Metrics/MethodLength
 
     def create_bgs_attorneys
-      5000.times { create(:bgs_attorney) }
+      5000.times { create(:bgs_attorney) } if BgsAttorney.count < 5000
     end
   end
 end

--- a/db/seeds/mtv.rb
+++ b/db/seeds/mtv.rb
@@ -10,8 +10,8 @@ module Seeds
 
     private
 
-    def create_decided_appeal(file_number, mtv_judge, drafting_attorney)
-      veteran = create(:veteran, file_number: file_number)
+    def create_decided_appeal(mtv_judge, drafting_attorney)
+      veteran = create(:veteran)
       appeal = create(
         :appeal,
         :dispatched,
@@ -91,13 +91,13 @@ module Seeds
     def original_fully_dispatched(mtv_judge, drafting_attorney)
       # MTV file numbers with a decided appeal
       # From here a MailTeam user or LitigationSupport team member would create a motion to vacate task
-      ("000100000".."000100009").each { |file_number| create_decided_appeal(file_number, mtv_judge, drafting_attorney) }
+      10.times { create_decided_appeal(mtv_judge, drafting_attorney) }
     end
 
     def original_at_lit_support(mtv_judge, drafting_attorney)
       # These are ready for the Lit Support user to send_to_judge
-      ("000100010".."000100012").each do |file_number|
-        create_decided_appeal(file_number, mtv_judge, drafting_attorney).tap do |appeal|
+      3.times do
+        create_decided_appeal(mtv_judge, drafting_attorney).tap do |appeal|
           create_motion_to_vacate_mail_task(appeal)
         end
       end
@@ -105,22 +105,22 @@ module Seeds
 
     def original_at_judge_to_address_motion(mtv_judge, drafting_attorney, lit_support_user)
       # These are ready to be addressed by the Judge
-      ("000100013".."000100015").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "denied")
       end
 
-      ("000100016".."000100018").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "dismissed")
       end
 
-      ("000100019".."000100021").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "granted")
@@ -131,40 +131,40 @@ module Seeds
     # rubocop:disable Metrics/AbcSize
     def vacate_at_attorney_review(mtv_judge, drafting_attorney, lit_support_user)
       # These are ready to be reviewed by the decision drafting attorney on the vacate stream
-      ("000100022".."000100024").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "denied")
         judge_addresses_mtv(jam_task, "denied", nil, lit_support_user)
       end
 
-      ("000100025".."000100027").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "dismissed")
         judge_addresses_mtv(jam_task, "dismissed", nil, lit_support_user)
       end
 
-      ("000100028".."000100030").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "granted")
         judge_addresses_mtv(jam_task, "granted", "straight_vacate", drafting_attorney)
       end
 
-      ("000100031".."000100033").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "granted")
         judge_addresses_mtv(jam_task, "granted", "vacate_and_readjudication", drafting_attorney)
       end
 
-      ("000100034".."000100036").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "granted")
@@ -176,8 +176,8 @@ module Seeds
 
     # rubocop:disable Metrics/MethodLength
     def fully_processed_vacate_appeal(mtv_judge, drafting_attorney, lit_support_user)
-      ("000100037".."000100039").each do |file_number|
-        original_stream = create_decided_appeal(file_number, mtv_judge, drafting_attorney)
+      3.times do
+        original_stream = create_decided_appeal(mtv_judge, drafting_attorney)
         mtv_task = create_motion_to_vacate_mail_task(original_stream)
         mtv_task.update!(status: "on_hold")
         jam_task = send_mtv_to_judge(original_stream, mtv_judge, lit_support_user, mtv_task, "granted")
@@ -190,7 +190,7 @@ module Seeds
         BvaDispatchTask.create_from_root_task(root_task)
         dispatch_user = vacate_stream.tasks
           .reload.assigned_to_any_user.find_by(type: "BvaDispatchTask").assigned_to
-        last_six = file_number[-6..-1]
+        last_six = original_stream.veteran.file_number[-6..-1]
         citation_number = "A19#{last_six}"
         outcode_params = {
           citation_number: citation_number,

--- a/db/seeds/priority_distributions.rb
+++ b/db/seeds/priority_distributions.rb
@@ -251,7 +251,7 @@ module Seeds
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
+          :with_post_intake_tasks,
           :advanced_on_docket_due_to_age,
           :held_hearing,
           receipt_date: num.days.ago,

--- a/db/seeds/priority_distributions.rb
+++ b/db/seeds/priority_distributions.rb
@@ -167,9 +167,9 @@ module Seeds
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
+          :with_post_intake_tasks,
           :advanced_on_docket_due_to_age,
-          :held_hearing,
+          :held_hearing_and_ready_to_distribute,
           :tied_to_judge,
           receipt_date: num.days.ago,
           tied_judge: judge,
@@ -199,8 +199,8 @@ module Seeds
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
-          :held_hearing,
+          :with_post_intake_tasks,
+          :held_hearing_and_ready_to_distribute,
           :tied_to_judge,
           receipt_date: num.days.ago,
           tied_judge: judge,
@@ -253,7 +253,7 @@ module Seeds
           :hearing_docket,
           :with_post_intake_tasks,
           :advanced_on_docket_due_to_age,
-          :held_hearing,
+          :held_hearing_and_ready_to_distribute,
           receipt_date: num.days.ago,
           adding_user: User.first
         )
@@ -279,8 +279,8 @@ module Seeds
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
-          :held_hearing,
+          :with_post_intake_tasks,
+          :held_hearing_and_ready_to_distribute,
           receipt_date: num.days.ago,
           adding_user: User.first
         )

--- a/db/seeds/substitutions.rb
+++ b/db/seeds/substitutions.rb
@@ -14,8 +14,8 @@ module Seeds
     def deceased_vet
       @deceased_vet ||= create(
         :veteran,
-        first_name: "Jane",
-        last_name: "Deceased"
+        first_name: "JaneDeceased",
+        last_name: "SubstitutionsSeed"
       )
     end
 

--- a/db/seeds/substitutions.rb
+++ b/db/seeds/substitutions.rb
@@ -14,7 +14,6 @@ module Seeds
     def deceased_vet
       @deceased_vet ||= create(
         :veteran,
-        file_number: 54_545_454,
         first_name: "Jane",
         last_name: "Deceased"
       )

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -33,7 +33,6 @@ module Seeds
           build(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO"),
           build(:claimant, participant_id: "OTHER_CLAIMANT")
         ],
-        veteran_file_number: "701305078",
         docket_type: Constants.AMA_DOCKETS.direct_review,
         request_issues: create_list(:request_issue, 3, :nonrating, notes: notes)
       )
@@ -42,21 +41,20 @@ module Seeds
       dr = Constants.AMA_DOCKETS.direct_review
       # Older style, tasks to be created later
       [
-        { number_of_claimants: nil, veteran_file_number: "783740847", docket_type: es, request_issue_count: 3 },
-        { number_of_claimants: 1, veteran_file_number: "228081153", docket_type: es, request_issue_count: 1 },
-        { number_of_claimants: 1, veteran_file_number: "152003980", docket_type: dr, request_issue_count: 3 },
-        { number_of_claimants: 1, veteran_file_number: "375273128", docket_type: dr, request_issue_count: 1 },
-        { number_of_claimants: 1, veteran_file_number: "682007349", docket_type: dr, request_issue_count: 5 },
-        { number_of_claimants: 1, veteran_file_number: "231439628", docket_type: dr, request_issue_count: 1 },
-        { number_of_claimants: 1, veteran_file_number: "975191063", docket_type: dr, request_issue_count: 8 },
-        { number_of_claimants: 1, veteran_file_number: "662643660", docket_type: dr, request_issue_count: 8 },
-        { number_of_claimants: 1, veteran_file_number: "162726229", docket_type: dr, request_issue_count: 8 },
-        { number_of_claimants: 1, veteran_file_number: "760362568", docket_type: dr, request_issue_count: 8 }
+        { number_of_claimants: nil, docket_type: es, request_issue_count: 3 },
+        { number_of_claimants: 1, docket_type: es, request_issue_count: 1 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 3 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 1 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 5 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 1 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 8 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 8 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 8 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 8 }
       ].each do |params|
         @ama_appeals << create(
           :appeal,
           number_of_claimants: params[:number_of_claimants],
-          veteran_file_number: params[:veteran_file_number],
           docket_type: params[:docket_type],
           request_issues: create_list(
             :request_issue, params[:request_issue_count], :nonrating, notes: notes
@@ -66,15 +64,14 @@ module Seeds
 
       # Newer style, tasks created through the Factory trait
       [
-        { number_of_claimants: nil, veteran_file_number: "963360019", docket_type: dr, request_issue_count: 2 },
-        { number_of_claimants: 1, veteran_file_number: "604969679", docket_type: dr, request_issue_count: 1 }
+        { number_of_claimants: nil, docket_type: dr, request_issue_count: 2 },
+        { number_of_claimants: 1, docket_type: dr, request_issue_count: 1 }
       ].each do |params|
         create(
           :appeal,
           :assigned_to_judge,
           number_of_claimants: params[:number_of_claimants],
           active_task_assigned_at: Time.zone.now,
-          veteran_file_number: params[:veteran_file_number],
           docket_type: params[:docket_type],
           closest_regional_office: "RO17",
           request_issues: create_list(
@@ -85,13 +82,11 @@ module Seeds
 
       # Create AMA appeals ready for distribution
       (1..30).each do |num|
-        vet_file_number = format("3213213%<num>02d", num: num)
         create(
           :appeal,
           :ready_for_distribution,
           number_of_claimants: 1,
           active_task_assigned_at: Time.zone.now,
-          veteran_file_number: vet_file_number,
           docket_type: Constants.AMA_DOCKETS.direct_review,
           closest_regional_office: "RO17",
           receipt_date: num.days.ago,
@@ -103,13 +98,11 @@ module Seeds
 
       # Create AMA appeals blocked for distribution due to Evidence Window
       (1..30).each do |num|
-        vet_file_number = format("4324324%<num>02d", num: num)
         create(
           :appeal,
           :with_post_intake_tasks,
           number_of_claimants: 1,
           active_task_assigned_at: Time.zone.now,
-          veteran_file_number: vet_file_number,
           docket_type: Constants.AMA_DOCKETS.evidence_submission,
           closest_regional_office: "RO17",
           receipt_date: num.days.ago,
@@ -121,13 +114,11 @@ module Seeds
 
       # Create AMA appeals blocked for distribution due to blocking mail
       (1..30).each do |num|
-        vet_file_number = format("4324334%<num>02d", num: num)
         create(
           :appeal,
           :mail_blocking_distribution,
           number_of_claimants: 1,
           active_task_assigned_at: Time.zone.now,
-          veteran_file_number: vet_file_number,
           docket_type: Constants.AMA_DOCKETS.direct_review,
           closest_regional_office: "RO17",
           receipt_date: num.days.ago,
@@ -136,11 +127,11 @@ module Seeds
           )
         )
       end
-      LegacyAppeal.create(vacols_id: "2096907", vbms_id: "228081153S")
-      LegacyAppeal.create(vacols_id: "2226048", vbms_id: "213912991S")
-      LegacyAppeal.create(vacols_id: "2249056", vbms_id: "608428712S")
-      LegacyAppeal.create(vacols_id: "2306397", vbms_id: "779309925S")
-      LegacyAppeal.create(vacols_id: "2657227", vbms_id: "169397130S")
+      LegacyAppeal.find_or_create_by(vacols_id: "2096907", vbms_id: "228081153S")
+      LegacyAppeal.find_or_create_by(vacols_id: "2226048", vbms_id: "213912991S")
+      LegacyAppeal.find_or_create_by(vacols_id: "2249056", vbms_id: "608428712S")
+      LegacyAppeal.find_or_create_by(vacols_id: "2306397", vbms_id: "779309925S")
+      LegacyAppeal.find_or_create_by(vacols_id: "2657227", vbms_id: "169397130S")
     end
 
     def create_tasks
@@ -196,7 +187,6 @@ module Seeds
       Faker::Config.random = Random.new(seed)
       vet = create(
         :veteran,
-        file_number: Faker::Number.number(digits: 9).to_s,
         first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name
       )
@@ -259,7 +249,6 @@ module Seeds
 
         vet = create(
           :veteran,
-          file_number: Faker::Number.number(digits: 9).to_s,
           first_name: Faker::Name.first_name,
           last_name: Faker::Name.last_name
         )
@@ -301,7 +290,6 @@ module Seeds
 
         vet = create(
           :veteran,
-          file_number: Faker::Number.number(digits: 9).to_s,
           first_name: Faker::Name.first_name,
           last_name: Faker::Name.last_name
         )
@@ -342,7 +330,6 @@ module Seeds
     )
       vet = create(
         :veteran,
-        file_number: Faker::Number.number(digits: 9).to_s,
         first_name: Faker::Name.first_name,
         last_name: Faker::Name.last_name
       )
@@ -455,7 +442,7 @@ module Seeds
     def create_change_hearing_disposition_task
       hearings_member = User.find_or_create_by(css_id: "BVATWARNER", station_id: 101)
       hearing_day = create(:hearing_day, created_by: hearings_member, updated_by: hearings_member)
-      veteran = create(:veteran, first_name: "Abellona", last_name: "Valtas", file_number: 123_456_789)
+      veteran = create(:veteran, first_name: "Abellona", last_name: "Valtas")
       appeal = create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number)
       root_task = create(:root_task, appeal: appeal)
       distribution_task = create(:distribution_task, parent: root_task)
@@ -636,10 +623,12 @@ module Seeds
       attorney = User.find_by_css_id("BVASCASPER1")
       judge = User.find_by_css_id("BVAAABSHIRE")
 
-      acting_judge = create(:user, css_id: "BVAACTING", station_id: 101, full_name: "Kris ActingVLJ_AVLJ Merle")
-      create(:staff, :attorney_judge_role, user: acting_judge)
+      if !User.find_by(css_id: "BVAACTING")
+        acting_judge = create(:user, css_id: "BVAACTING", station_id: 101, full_name: "Kris ActingVLJ_AVLJ Merle")
+        create(:staff, :attorney_judge_role, user: acting_judge)
+      end
 
-      JudgeTeam.create_for_judge(acting_judge)
+      JudgeTeam.create_for_judge(acting_judge) unless JudgeTeam.for_judge(acting_judge)
       JudgeTeam.for_judge(judge).add_user(acting_judge)
 
       create_appeal_at_judge_assignment(judge: acting_judge)
@@ -733,7 +722,6 @@ module Seeds
         number_of_claimants: 1,
         associated_judge: judge,
         active_task_assigned_at: assigned_at,
-        veteran_file_number: Generators::Random.unique_ssn,
         docket_type: Constants.AMA_DOCKETS.direct_review,
         closest_regional_office: "RO17",
         request_issues: create_list(

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -624,7 +624,7 @@ module Seeds
     def create_tasks_at_acting_judge
       attorney = User.find_by_css_id("BVASCASPER1")
       judge = User.find_by_css_id("BVAAABSHIRE")
-      acting_judge = User.find_by(css_id: "BVAACTING")
+      acting_judge = User.find_by_css_id("BVAACTING")
 
       if !acting_judge
         acting_judge = create(:user, css_id: "BVAACTING", station_id: 101, full_name: "Kris ActingVLJ_AVLJ Merle")

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -348,13 +348,11 @@ module Seeds
       )
       root_task = appeal.root_task
 
-      judge = create(:user, station_id: 101)
-      judge.update!(full_name: judge_name) if judge_name
+      judge = User.find_by(full_name: judge_name) || create(:user, station_id: 101, full_name: judge_name)
       create(:staff, :judge_role, user: judge)
       judge_task = JudgeAssignTask.create!(appeal: appeal, parent: root_task, assigned_to: judge)
 
-      atty = create(:user, station_id: 101)
-      atty.update!(full_name: attorney_name) if attorney_name
+      atty = User.find_by(full_name: attorney_name) || create(:user, station_id: 101, full_name: attorney_name)
       create(:staff, :attorney_role, user: atty)
       atty_task_params = { appeal: appeal, parent_id: judge_task.id, assigned_to: atty, assigned_by: judge }
       atty_task = AttorneyTask.create!(atty_task_params)

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -541,7 +541,7 @@ module Seeds
         org_task_args = { appeal: LegacyAppeal.find_by(vacols_id: attrs[:vacols_id]),
                           assigned_by: attorney }
         # do not attempt to create a new colocated task if one already exists for the this LegacyAppeal
-        next if org_task_args[:appeal].tasks.map { |t| t.is_a?(ColocatedTask) }.any? { |bool| bool }
+        next if org_task_args[:appeal].tasks.map { |task| task.is_a?(ColocatedTask) }.any? { |bool| bool }
 
         create(:colocated_task, attrs[:trait], org_task_args)
       end

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -893,9 +893,6 @@ module Seeds
         # Create the veteran for this legacy appeal
         veteran = create(:veteran)
 
-        # Embed the ro here so that the titrnums are unique across the
-        # different ros, otherwise collisions cause errors
-        # vacols_titrnum = "1#{regional_office}#{offset}"
         vacols_titrnum = veteran.file_number
 
         # Create some video and some travel hearings

--- a/lib/generators/random.rb
+++ b/lib/generators/random.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Generators::Random
-  @unique_ssns = {}
+  @unique_ssns = Veteran.all.map(&:ssn).map { |ssn| [ssn, 0] }.to_h
 
   class << self
     def whitespace(len = 16)

--- a/lib/generators/random.rb
+++ b/lib/generators/random.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Generators::Random
+  # gets all veteran SSNs that exist in the DB to ensure no data collisions
   @unique_ssns = Veteran.all.map(&:ssn).map { |ssn| [ssn, 0] }.to_h
 
   class << self

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -109,7 +109,7 @@ FactoryBot.define do
 
     transient do
       veteran do
-        Veteran.find_by(file_number: (generate :veteran_file_number)) ||
+        Veteran.find_by(file_number: veteran_file_number) ||
           create(:veteran, file_number: (generate :veteran_file_number))
       end
     end

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -109,7 +109,8 @@ FactoryBot.define do
 
     transient do
       veteran do
-        Veteran.find_by(file_number: (generate :veteran_file_number)) || create(:veteran, file_number: (generate :veteran_file_number))
+        Veteran.find_by(file_number: (generate :veteran_file_number)) ||
+          create(:veteran, file_number: (generate :veteran_file_number))
       end
     end
 

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     established_at { Time.zone.now }
     receipt_date { Time.zone.yesterday }
     filed_by_va_gov { false }
+    veteran_file_number { generate :veteran_file_number }
     uuid { SecureRandom.uuid }
 
     after(:build) do |appeal, evaluator|
@@ -153,6 +154,16 @@ FactoryBot.define do
 
       after(:create) do |appeal, evaluator|
         create(:hearing, :held, judge: nil, appeal: appeal, adding_user: evaluator.adding_user)
+      end
+    end
+
+    trait :held_hearing_no_tasks do
+      transient do
+        adding_user { nil }
+      end
+
+      after(:create) do |appeal, evaluator|
+        create(:hearing, disposition: "held", judge: nil, appeal: appeal, adding_user: evaluator.adding_user)
       end
     end
 

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# When using this factory, passing in a created Veteran object is the preferred way of creating an appeal.
+# The required veteran can be created in-line or before the appeal and passed in as the veteran: arg
+# This ensures that the appeal is created with the correct veteran_file_number association
+
 FactoryBot.define do
   factory :appeal do
     docket_type { Constants.AMA_DOCKETS.evidence_submission }
@@ -157,6 +161,7 @@ FactoryBot.define do
       end
     end
 
+    # this method should not be used for seeding data but is required for some tests
     trait :held_hearing_no_tasks do
       transient do
         adding_user { nil }
@@ -167,6 +172,7 @@ FactoryBot.define do
       end
     end
 
+    # this trait should be run with :with_post_intake_tasks so that it creates a correct task tree
     trait :held_hearing_and_ready_to_distribute do
       transient do
         adding_user { nil }

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -152,7 +152,7 @@ FactoryBot.define do
       end
 
       after(:create) do |appeal, evaluator|
-        create(:hearing, judge: nil, disposition: "held", appeal: appeal, adding_user: evaluator.adding_user)
+        create(:hearing, :held, judge: nil, appeal: appeal, adding_user: evaluator.adding_user)
       end
     end
 

--- a/spec/factories/end_product_establishment.rb
+++ b/spec/factories/end_product_establishment.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :end_product_establishment do
-    sequence(:veteran_file_number, &:to_s)
+    veteran_file_number { generate :veteran_file_number }
     sequence(:reference_id, &:to_s)
     source { create(:ramp_election, veteran_file_number: veteran_file_number) }
     code { "030HLRR" }

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -36,6 +36,10 @@ FactoryBot.define do
       after(:create) do |hearing, _evaluator|
         appeal = hearing.appeal
         hearing_task = appeal.tasks.find_by(type: :HearingTask)
+        if hearing_task.nil?
+          appeal.create_tasks_on_intake_success!
+          hearing_task = appeal.tasks.find_by(type: :HearingTask)
+        end
         create(:hearing_task_association,
                hearing: hearing,
                hearing_task: hearing_task)

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -32,14 +32,35 @@ FactoryBot.define do
 
     trait :held do
       disposition { Constants.HEARING_DISPOSITION_TYPES.held }
+      # TODO: add child tasks from assign_hearing_disposition_task here
+      after(:create) do |hearing, _evaluator|
+        appeal = hearing.appeal
+        hearing_task = appeal.tasks.find_by(type: :HearingTask)
+        create(:hearing_task_association,
+               hearing: hearing,
+               hearing_task: hearing_task)
+        appeal.tasks.find_by(type: :ScheduleHearingTask).completed!
+        assign_hearing_disposition_task = create(:assign_hearing_disposition_task,
+                                                 :completed,
+                                                 parent: hearing_task,
+                                                 appeal: appeal)
+        #create(:transcription_task,
+        #       parent: assign_hearing_disposition_task)
+        #create(:evidence_submission_window_task,
+        #       parent: assign_hearing_disposition_task)
+        appeal.tasks.find_by(type: :DistributionTask).update!(status: :on_hold)
+        assign_hearing_disposition_task.hold!
+      end
     end
 
     trait :postponed do
       disposition { Constants.HEARING_DISPOSITION_TYPES.postponed }
+      # TODO: check if child tasks for these are being created
     end
 
     trait :no_show do
       disposition { Constants.HEARING_DISPOSITION_TYPES.no_show }
+      # TODO: check if child tasks for these are being created
     end
 
     trait :scheduled_in_error do
@@ -48,6 +69,8 @@ FactoryBot.define do
 
     trait :cancelled do
       disposition { Constants.HEARING_DISPOSITION_TYPES.cancelled }
+      # TODO: check if child tasks for these are being created
+      # TODO: check if vacols needs to be updated here
     end
 
     trait :with_tasks do
@@ -96,6 +119,7 @@ FactoryBot.define do
                :completed,
                parent: hearing.hearing_task_association.hearing_task,
                appeal: hearing.appeal)
+        # TODO: add child tasks of assign_hearing_disposition_task here
       end
     end
   end

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -30,6 +30,9 @@ FactoryBot.define do
     updated_by { adding_user }
     virtual_hearing { nil }
 
+    # this trait creates a realistic hearing task tree from a completed hearing, but if it needs to
+    # be ready for distribution then the referring class must mark the transcription/evidence
+    # tasks complete and set the distribution task to assigned
     trait :held do
       disposition { Constants.HEARING_DISPOSITION_TYPES.held }
       # TODO: add child tasks from assign_hearing_disposition_task here

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -44,10 +44,6 @@ FactoryBot.define do
                                                  :completed,
                                                  parent: hearing_task,
                                                  appeal: appeal)
-        #create(:transcription_task,
-        #       parent: assign_hearing_disposition_task)
-        #create(:evidence_submission_window_task,
-        #       parent: assign_hearing_disposition_task)
         appeal.tasks.find_by(type: :DistributionTask).update!(status: :on_hold)
         assign_hearing_disposition_task.hold!
       end

--- a/spec/factories/higher_level_review.rb
+++ b/spec/factories/higher_level_review.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :higher_level_review do
-    sequence(:veteran_file_number, &:to_s)
+    veteran_file_number { generate :veteran_file_number }
     receipt_date { 1.month.ago }
     benefit_type { "compensation" }
     uuid { SecureRandom.uuid }

--- a/spec/factories/legacy_appeal.rb
+++ b/spec/factories/legacy_appeal.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# When using this factory, passing in a VACOLS::Case object as vacols_case is the preferred method. The
+# :case factory in the factories/vacols is used to generate VACOLS cases. This ensures that the correct
+# associations exist between VACOLS and Caseflow, and that the BFKEY of the case is unique.
+
 FactoryBot.define do
   factory :legacy_appeal do
     transient do

--- a/spec/factories/ramp_election.rb
+++ b/spec/factories/ramp_election.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :ramp_election do
-    sequence(:veteran_file_number, &:to_s)
+    veteran_file_number { generate :veteran_file_number }
     receipt_date { 1.month.ago }
 
     trait :established do

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -5,6 +5,8 @@ FactoryBot.define do
     association(:decision_review, factory: [:appeal, :with_post_intake_tasks])
     benefit_type { "compensation" }
     contested_rating_issue_diagnostic_code { "5008" }
+    # initial value provides 100000 values which allows hundreds of seed runs
+    sequence :contention_reference_id, RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100000 }.max + 1
 
     factory :request_issue_with_epe do
       end_product_establishment { create(:end_product_establishment, source: decision_review) }

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -5,7 +5,6 @@ FactoryBot.define do
     association(:decision_review, factory: [:appeal, :with_post_intake_tasks])
     benefit_type { "compensation" }
     contested_rating_issue_diagnostic_code { "5008" }
-    # contention_reference_id { generate :contention_reference_id }
 
     factory :request_issue_with_epe do
       end_product_establishment { create(:end_product_establishment, source: decision_review) }

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -6,7 +6,8 @@ FactoryBot.define do
     benefit_type { "compensation" }
     contested_rating_issue_diagnostic_code { "5008" }
     # initial value provides 100000 values which allows hundreds of seed runs
-    sequence :contention_reference_id, RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100000 }.max + 1
+    sequence :contention_reference_id, (RequestIssue.all.map(&:contention_reference_id).map(&:to_i)
+                                                        .filter { |id| id < 100_000 }.max.to_i + 1)
 
     factory :request_issue_with_epe do
       end_product_establishment { create(:end_product_establishment, source: decision_review) }

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -5,9 +5,7 @@ FactoryBot.define do
     association(:decision_review, factory: [:appeal, :with_post_intake_tasks])
     benefit_type { "compensation" }
     contested_rating_issue_diagnostic_code { "5008" }
-    # initial value provides 100000 values which allows hundreds of seed runs
-    sequence :contention_reference_id, (RequestIssue.all.map(&:contention_reference_id).map(&:to_i)
-                                                        .filter { |id| id < 100_000 }.max.to_i + 1)
+    contention_reference_id { generate :contention_reference_id }
 
     factory :request_issue_with_epe do
       end_product_establishment { create(:end_product_establishment, source: decision_review) }

--- a/spec/factories/request_issue.rb
+++ b/spec/factories/request_issue.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     association(:decision_review, factory: [:appeal, :with_post_intake_tasks])
     benefit_type { "compensation" }
     contested_rating_issue_diagnostic_code { "5008" }
-    contention_reference_id { generate :contention_reference_id }
+    # contention_reference_id { generate :contention_reference_id }
 
     factory :request_issue_with_epe do
       end_product_establishment { create(:end_product_establishment, source: decision_review) }

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -1,19 +1,34 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+  # initialize these values at 1 in case the DB relations are not created yet which could error
+  # during the build process
+  correspondent_key_initial_value = 1
+  case_key_initial_value = 1
+  veteran_initial_value = 1
+  contention_reference_initial_value = 1
+
   # these get the highest existing value within the filter and uses that + 1 as the
   # initial value; filter values gives sufficient margin to allow seeds to be run hundreds
   # of times before a data collision occurs
-  correspondent_key_initial_value =
-    VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max.to_i + 1
+  if VACOLS::Correspondent.exists?
+    correspondent_key_initial_value =
+      VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max.to_i + 1
+  end
 
-  case_key_initial_value =
-    VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max.to_i + 1
+  if VACOLS::Case.exists?
+    case_key_initial_value =
+      VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max.to_i + 1
+  end
 
-  veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
+  if Veteran.exists?
+    veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
+  end
 
-  contention_reference_initial_value =
-    RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100_000 }.max.to_i + 1
+  if RequestIssue.exists?
+    contention_reference_initial_value =
+      RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100_000 }.max.to_i + 1
+  end
 
   # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow
   sequence :veteran_file_number, veteran_initial_value do |n|

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  initial_value = Veteran.all.map(&:file_number).max
+  initial_value = Veteran.all.map(&:file_number).max.to_i
 
   sequence :veteran_file_number, initial_value do |n|
     format("%<n>09d", n: n)

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -41,5 +41,4 @@ FactoryBot.define do
 
   # BRIEFF.BFKEY
   sequence :vacols_case_key, case_key_initial_value
-
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -1,33 +1,43 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  # initialize these values at 1 in case the DB relations are not created yet which could error
-  # during the build process
-  correspondent_key_initial_value = 1
-  case_key_initial_value = 1
-  veteran_initial_value = 1
-  contention_reference_initial_value = 1
-
-  # these get the highest existing value within the filter and uses that + 1 as the
+  # get the highest existing value within the filter for each table and use that + 1 as the
   # initial value; filter values gives sufficient margin to allow seeds to be run hundreds
   # of times before a data collision occurs
-  if VACOLS::Correspondent.exists?
+  # if a table doesn't yet exist the rescued error will occur, in that case set the value to 1
+  begin
     correspondent_key_initial_value =
       VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max.to_i + 1
+  rescue ActiveRecord::StatementInvalid => error
+    raise if !error.message.include?("PG::UndefinedTable")
+
+    correspondent_key_initial_value = 1
   end
 
-  if VACOLS::Case.exists?
+  begin
     case_key_initial_value =
       VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max.to_i + 1
+  rescue ActiveRecord::StatementInvalid => error
+    raise if !error.message.include?("PG::UndefinedTable")
+
+    case_key_initial_value = 1
   end
 
-  if Veteran.exists?
-    veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
-  end
-
-  if RequestIssue.exists?
+  begin
     contention_reference_initial_value =
       RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100_000 }.max.to_i + 1
+  rescue ActiveRecord::StatementInvalid => error
+    raise if !error.message.include?("PG::UndefinedTable")
+
+    contention_reference_initial_value = 1
+  end
+
+  begin
+    veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
+  rescue ActiveRecord::StatementInvalid => error
+    raise if !error.message.include?("PG::UndefinedTable")
+
+    veteran_initial_value = 1
   end
 
   # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -24,15 +24,6 @@ FactoryBot.define do
   end
 
   begin
-    contention_reference_initial_value =
-      RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100_000 }.max.to_i + 1
-  rescue ActiveRecord::StatementInvalid => error
-    raise if !error.message.include?("PG::UndefinedTable")
-
-    contention_reference_initial_value = 1
-  end
-
-  begin
     veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
   rescue ActiveRecord::StatementInvalid => error
     raise if !error.message.include?("PG::UndefinedTable")
@@ -51,6 +42,4 @@ FactoryBot.define do
   # BRIEFF.BFKEY
   sequence :vacols_case_key, case_key_initial_value
 
-  # used in request_issues factory
-  # sequence :contention_reference_id, contention_reference_initial_value
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -4,10 +4,10 @@ FactoryBot.define do
   # these get the highest existing value within the filter and uses that + 1 as the
   # initial value; filter values gives sufficient margin to allow seeds to be run hundreds
   # of times before a data collision occurs
-  correspondend_key_initial_value = 
-    VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max + 1
+  correspondend_key_initial_value =
+    VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max.to_i + 1
   case_key_initial_value =
-    VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max + 1
+    VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max.to_i + 1
   veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
 
   # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -51,6 +51,6 @@ FactoryBot.define do
   # BRIEFF.BFKEY
   sequence :vacols_case_key, case_key_initial_value
 
-  # used in decision_issues factory
-  sequence :contention_reference_id, contention_reference_initial_value
+  # used in request_issues factory
+  # sequence :contention_reference_id, contention_reference_initial_value
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -4,11 +4,16 @@ FactoryBot.define do
   # these get the highest existing value within the filter and uses that + 1 as the
   # initial value; filter values gives sufficient margin to allow seeds to be run hundreds
   # of times before a data collision occurs
-  correspondend_key_initial_value =
+  correspondent_key_initial_value =
     VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max.to_i + 1
+
   case_key_initial_value =
     VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max.to_i + 1
+
   veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
+
+  contention_reference_initial_value =
+    RequestIssue.all.map(&:contention_reference_id).map(&:to_i).filter { |id| id < 100_000 }.max.to_i + 1
 
   # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow
   sequence :veteran_file_number, veteran_initial_value do |n|
@@ -16,8 +21,11 @@ FactoryBot.define do
   end
 
   # CORRES.STAFKEY, BRIEFF.BFCORKEY, FOLDER.TICKNUM
-  sequence :vacols_correspondent_key, correspondend_key_initial_value
+  sequence :vacols_correspondent_key, correspondent_key_initial_value
 
   # BRIEFF.BFKEY
   sequence :vacols_case_key, case_key_initial_value
+
+  # used in decision_issues factory
+  sequence :contention_reference_id, contention_reference_initial_value
 end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max + 1
   veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
 
+  # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow
   sequence :veteran_file_number, veteran_initial_value do |n|
     format("%<n>09d", n: n)
   end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  initial_value = Veteran.all.map(&:file_number).max
+
+  sequence :veteran_file_number, initial_value do |n|
+    format("%<n>09d", n: n)
+  end
+end

--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -1,9 +1,22 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  initial_value = Veteran.all.map(&:file_number).max.to_i
+  # these get the highest existing value within the filter and uses that + 1 as the
+  # initial value; filter values gives sufficient margin to allow seeds to be run hundreds
+  # of times before a data collision occurs
+  correspondend_key_initial_value = 
+    VACOLS::Correspondent.all.map(&:stafkey).map(&:to_i).filter { |key| key < 49_999 }.max + 1
+  case_key_initial_value =
+    VACOLS::Case.all.map(&:bfkey).map(&:to_i).filter { |key| key < 99_999 }.max + 1
+  veteran_initial_value = Veteran.all.map(&:file_number).max.to_i + 1
 
-  sequence :veteran_file_number, initial_value do |n|
+  sequence :veteran_file_number, veteran_initial_value do |n|
     format("%<n>09d", n: n)
   end
+
+  # CORRES.STAFKEY, BRIEFF.BFCORKEY, FOLDER.TICKNUM
+  sequence :vacols_correspondent_key, correspondend_key_initial_value
+
+  # BRIEFF.BFKEY
+  sequence :vacols_case_key, case_key_initial_value
 end

--- a/spec/factories/supplemental_claim.rb
+++ b/spec/factories/supplemental_claim.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :supplemental_claim do
-    sequence(:veteran_file_number, &:to_s)
+    veteran_file_number { generate :veteran_file_number }
     receipt_date { 1.month.ago }
     benefit_type { "compensation" }
     uuid { SecureRandom.uuid }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,15 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:css_id, User.count + 1) { |n| "CSS_ID#{n}" }
+    # attempt to set initial sequence value; if table doesn't exist, rescue error and set it to 1
+    begin
+      sequence_initial_value = User.count + 1
+    rescue ActiveRecord::StatementInvalid => error
+      raise if !error.message.include?("PG::UndefinedTable")
+
+      sequence_initial_value = 1
+    end
+    sequence(:css_id, sequence_initial_value) { |n| "CSS_ID#{n}" }
 
     station_id { User::BOARD_STATION_ID }
     full_name { "Lauren Roth" }

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :user do
-    sequence(:css_id) { |n| "CSS_ID#{n}" }
+    sequence(:css_id, User.count + 1) { |n| "CSS_ID#{n}" }
 
     station_id { User::BOARD_STATION_ID }
     full_name { "Lauren Roth" }

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :case, class: VACOLS::Case do
     sequence(:bfkey) # a.k.a. VACOLS_ID
     sequence(:bfcorkey)
-    sequence(:bfcorlid, 300_000_000) { |n| "#{n}S" }
+    bfcorlid { generate :veteran_file_number }
 
     association :correspondent, factory: :correspondent
 

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -1,5 +1,14 @@
 # frozen_string_literal: true
 
+# When using this factory, passing in a created Veteran object is the preferred way of creating a case.
+# The required veteran can be created in-line or before the case and passed in as the bfcorlid: arg
+# This ensures that the case is created with the correct veteran_file_number association, and ensures that
+# no unique index constraints are violated between VACOLS and Caseflow.
+#
+# Additionally, this factory should be used in conjuction with the :legacy_appeal factory when a caseflow
+# legacy appeal object is needed. Pass a case created by this factory into :legacy_appeal as vacols_case:
+# to ensure the correct associations are made between a veteran, case, and legacy appeal.
+
 FactoryBot.define do
   factory :case, class: VACOLS::Case do
     bfkey { generate :vacols_case_key } # a.k.a. VACOLS_ID

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :case, class: VACOLS::Case do
-    sequence(:bfkey) # a.k.a. VACOLS_ID
-    sequence(:bfcorkey)
+    bfkey { generate :vacols_case_key } # a.k.a. VACOLS_ID
+    bfcorkey { generate :vacols_correspondent_key }
     bfcorlid { generate :veteran_file_number }
 
     association :correspondent, factory: :correspondent

--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
   factory :case, class: VACOLS::Case do
     bfkey { generate :vacols_case_key } # a.k.a. VACOLS_ID
     bfcorkey { generate :vacols_correspondent_key }
-    bfcorlid { generate :veteran_file_number }
+    bfcorlid { "#{generate :veteran_file_number}S" }
 
     association :correspondent, factory: :correspondent
 

--- a/spec/factories/vacols/correspondent.rb
+++ b/spec/factories/vacols/correspondent.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :correspondent, class: VACOLS::Correspondent do
-    sequence(:stafkey)
+    stafkey { generate :vacols_correspondent_key }
 
     snamef { "Joshua" }
     snamel { "Chamberlain" }

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# Whenever a veteran is needed for another factory, create a veteran via this factory and pass in either
+# the Veteran object or veteran.file_number, depending on which factory. The appeals factory should be passed
+# the Veteran object (either in-line or as a variable), while most other factories require the file_number
+
 FactoryBot.define do
   factory :veteran do
     first_name { "Bob" }

--- a/spec/factories/veteran.rb
+++ b/spec/factories/veteran.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
     last_name { "Smith#{Faker::Name.last_name.downcase.tr('\'', '')}" }
     name_suffix { (bob_smith_count == 1) ? "II" : bob_smith_count.to_s }
     ssn { Generators::Random.unique_ssn }
+    file_number { generate :veteran_file_number }
     email_address { "#{first_name}.#{last_name}@test.com" }
     date_of_death { nil }
 
@@ -29,7 +30,6 @@ FactoryBot.define do
       end
     end
 
-    sequence(:file_number, 100_000_000)
     sequence(:participant_id, 500_000_000)
 
     after(:build) do |veteran, evaluator|

--- a/spec/feature/api/v2/appeals_spec.rb
+++ b/spec/feature/api/v2/appeals_spec.rb
@@ -294,6 +294,7 @@ describe "Appeals API v2", :all_dbs, type: :request do
     let(:legacy_opt_in_approved) { false }
     let(:veteran_is_not_claimant) { false }
     let(:profile_date) { receipt_date - 1 }
+    let(:veteran) { create(:veteran, file_number: veteran_file_number)}
 
     let!(:hlr) do
       create(:higher_level_review,
@@ -359,7 +360,7 @@ describe "Appeals API v2", :all_dbs, type: :request do
 
     let!(:appeal) do
       create(:appeal,
-             veteran_file_number: veteran_file_number,
+             veteran: veteran,
              receipt_date: receipt_date,
              request_issues: [request_issue1, request_issue2],
              docket_type: Constants.AMA_DOCKETS.evidence_submission)

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -54,7 +54,11 @@ RSpec.shared_examples("fill substitution form") do
       appeal.reload
       visit "/queue/appeals/#{appeal.uuid}"
 
+      # refresh the page if the case hasn't finished processing yet
+      visit "/queue/appeals/#{appeal.uuid}" if page.has_text? "Unable to load this case"
+
       # Navigate to substitution page
+      expect(page).to have_content "+ Add Substitute"
       page.find("button", text: "+ Add Substitute").click
 
       expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}/substitute_appellant/basics")

--- a/spec/feature/queue/substitute_appellant/shared_setup.rb
+++ b/spec/feature/queue/substitute_appellant/shared_setup.rb
@@ -54,7 +54,7 @@ RSpec.shared_examples("fill substitution form") do
       appeal.reload
       visit "/queue/appeals/#{appeal.uuid}"
 
-      # refresh the page if the case hasn't finished processing yet
+      # refresh the page if the case hasn't finished processing the create/load yet
       visit "/queue/appeals/#{appeal.uuid}" if page.has_text? "Unable to load this case"
 
       # Navigate to substitution page

--- a/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
+++ b/spec/feature/queue/substitute_appellant/substitute_appellant_spec.rb
@@ -37,7 +37,7 @@ RSpec.feature "granting substitute appellant for appeals", :all_dbs do
         let(:docket_type) { Constants.AMA_DOCKETS.hearing }
         let(:appeal) do
           create(:appeal,
-                 :dispatched, :with_decision_issue, :held_hearing,
+                 :dispatched, :with_decision_issue, :held_hearing_no_tasks,
                  docket_type: docket_type,
                  disposition: "dismissed_death",
                  receipt_date: veteran.date_of_death + 5.days,
@@ -95,8 +95,8 @@ RSpec.feature "granting substitute appellant for appeals", :all_dbs do
           let(:docket_type) { Constants.AMA_DOCKETS.hearing }
           let(:appeal) do
             create(:appeal,
-                   :assigned_to_judge,
-                   :held_hearing,
+                   :assigned_to_judge, 
+                   :held_hearing_no_tasks,
                    associated_judge: judge,
                    docket_type: docket_type,
                    receipt_date: veteran.date_of_death + 5.days,

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -184,7 +184,7 @@ describe Claimant, :postgres do
       let(:claimant) do
         create(:claimant,
                participant_id: "no-such-pid",
-               decision_review: build(:appeal, veteran_file_number: "no-such-file-number"))
+               decision_review: build(:appeal, veteran: build(:veteran, file_number: "no-such-file-number")))
       end
 
       let!(:bgs_service) { BGSService.new }

--- a/spec/models/concerns/all_case_distribution_spec.rb
+++ b/spec/models/concerns/all_case_distribution_spec.rb
@@ -7,8 +7,8 @@ describe AllCaseDistribution, :all_dbs do
 
     attr_accessor :judge
 
-    # the value here doesn't matter but if a test is checking batch_size then its values need to add to this
-    def batch_size
+    # the value here doesn't matter but if a test is checking initial_capacity then its values need to add to this
+    def initial_capacity
       12
     end
   end
@@ -40,14 +40,14 @@ describe AllCaseDistribution, :all_dbs do
   end
 
   # hash is set up to only use direct_review/evidence_submission so that legacy/hearing can be mocked
-  # the total for each of these dockets needs to equal the batch_size above
+  # the total for each of these dockets needs to equal the initial_capacity above
   let(:priority_count_hash) { { legacy: 3, direct_review: 3, evidence_submission: 3, hearing: 3 } }
 
   context "#priority_push_distribution" do
     it "calls each method and returns the array of objects received from each method" do
       # distribute all priority appeals from all dockets
       expect(@new_acd).to receive(:num_oldest_priority_appeals_for_judge_by_docket)
-        .with(@new_acd, @new_acd.batch_size)
+        .with(@new_acd, @new_acd.initial_capacity)
         .and_return(priority_count_hash)
 
       expect_any_instance_of(LegacyDocket).to receive(:distribute_appeals)
@@ -75,10 +75,6 @@ describe AllCaseDistribution, :all_dbs do
 
   context "#requested_distribution" do
     it "calls each method and returns the array of objects received from each method" do
-      # method from distributing legacy appeals when :priority_acd enabled
-      expect_any_instance_of(LegacyDocket).to receive(:distribute_nonpriority_appeals)
-        .and_return([])
-
       # returning {} from num_oldest_priority_appeals_by_docket will bypass
       # distribute_limited_priority_appeals_from_all_dockets not iterate over anything
       expect(@new_acd).to receive(:num_oldest_priority_appeals_for_judge_by_docket)
@@ -86,7 +82,7 @@ describe AllCaseDistribution, :all_dbs do
 
       # distribute all nonpriority appeals from all dockets
       expect(@new_acd).to receive(:num_oldest_nonpriority_appeals_for_judge_by_docket)
-        .with(@new_acd, @new_acd.batch_size)
+        .with(@new_acd, @new_acd.initial_capacity)
         .and_return(nonpriority_count_hash)
 
       expect_any_instance_of(LegacyDocket).to receive(:distribute_appeals)
@@ -107,7 +103,7 @@ describe AllCaseDistribution, :all_dbs do
 
       # requested_distribution is private so .send is used to directly call it
       return_array = @new_acd.send :requested_distribution
-      expect(return_array.count).to eq(@new_acd.batch_size)
+      expect(return_array.count).to eq(@new_acd.initial_capacity)
     end
   end
 
@@ -119,25 +115,25 @@ describe AllCaseDistribution, :all_dbs do
 
     it "calls each docket and sorts the return values if num > 0" do
       expect_any_instance_of(LegacyDocket).to receive(:age_of_n_oldest_priority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(DirectReviewDocket).to receive(:age_of_n_oldest_priority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(EvidenceSubmissionDocket).to receive(:age_of_n_oldest_priority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(HearingRequestDocket).to receive(:age_of_n_oldest_priority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       return_array = @new_acd.send(
         :num_oldest_priority_appeals_for_judge_by_docket,
         @new_acd,
-        @new_acd.batch_size
+        @new_acd.initial_capacity
       )
       expect(return_array).to eq(priority_count_hash)
     end
@@ -151,25 +147,25 @@ describe AllCaseDistribution, :all_dbs do
 
     it "calls each docket and sorts the return values if num > 0" do
       expect_any_instance_of(LegacyDocket).to receive(:age_of_n_oldest_nonpriority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(DirectReviewDocket).to receive(:age_of_n_oldest_nonpriority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(EvidenceSubmissionDocket).to receive(:age_of_n_oldest_nonpriority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       expect_any_instance_of(HearingRequestDocket).to receive(:age_of_n_oldest_nonpriority_appeals_available_to_judge)
-        .with(@new_acd.judge, @new_acd.batch_size)
-        .and_return(add_dates_to_date_array(@new_acd.batch_size))
+        .with(@new_acd.judge, @new_acd.initial_capacity)
+        .and_return(add_dates_to_date_array(@new_acd.initial_capacity))
 
       return_array = @new_acd.send(
       :num_oldest_nonpriority_appeals_for_judge_by_docket,
         @new_acd,
-        @new_acd.batch_size
+        @new_acd.initial_capacity
       )
       expect(return_array).to eq(nonpriority_count_hash)
     end

--- a/spec/models/docket_coordinator_spec.rb
+++ b/spec/models/docket_coordinator_spec.rb
@@ -215,7 +215,7 @@ describe DocketCoordinator do
 
     let(:tied_legacy_case_count) { 5 }
     let(:genpop_legacy_case_count) { 4 }
-    let(:tied_ama_hearing_case_count) { 3 }
+    let(:tied_ama_hearing_case_count) { 3 } if !FeatureToggle.enabled?(:acd_distribute_all)
     let(:genpop_ama_hearing_case_count) { 2 }
     let(:genpop_direct_case_count) { 2 }
     let(:genpop_evidence_case_count) { 2 }
@@ -234,9 +234,8 @@ describe DocketCoordinator do
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
           :advanced_on_docket_due_to_age,
-          :held_hearing,
+          :held_hearing_and_ready_to_distribute,
           :tied_to_judge,
           tied_judge: judge,
           adding_user: judge
@@ -246,9 +245,8 @@ describe DocketCoordinator do
         create(
           :appeal,
           :hearing_docket,
-          :ready_for_distribution,
           :advanced_on_docket_due_to_age,
-          :held_hearing,
+          :held_hearing_and_ready_to_distribute,
           adding_user: judge
         )
       end

--- a/spec/models/request_issues_update_spec.rb
+++ b/spec/models/request_issues_update_spec.rb
@@ -22,7 +22,7 @@ describe RequestIssuesUpdate, :all_dbs do
   # and contention data stubbed out properly
   let(:review) { create(:higher_level_review, veteran_file_number: veteran.file_number) }
 
-  let!(:veteran) { Generators::Veteran.build(file_number: "789987789") }
+  let!(:veteran) { create(:veteran) }
 
   let!(:intake_user) { create(:user) }
   let(:edit_user) { create(:user) }

--- a/spec/models/tasks/hearing_task_spec.rb
+++ b/spec/models/tasks/hearing_task_spec.rb
@@ -126,7 +126,7 @@ describe HearingTask, :postgres do
     end
 
     context "ama appeal" do
-      let(:appeal) { create(:appeal, veteran_file_number: veteran.file_number) }
+      let(:appeal) { create(:appeal, veteran: veteran) }
       let!(:hearing) { create(:hearing, appeal: appeal, disposition: nil) }
       let!(:vso) do
         Vso.create(

--- a/spec/seeds/decision_issues_spec.rb
+++ b/spec/seeds/decision_issues_spec.rb
@@ -2,12 +2,12 @@
 
 describe Seeds::DecisionIssues do
   describe "#seed!" do
-    let(:veteran_file_number) { "42424242" }
     subject { described_class.new.seed! }
 
     it "creates a decision issue with a decision date in the future" do
       expect { subject }.to_not raise_error
-      appeal = Appeal.find_by(veteran_file_number: veteran_file_number)
+      veteran = Veteran.find_by(first_name: "Veteran", last_name: "DecisionIssueSeed")
+      appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
       decision_issue = appeal.decision_issues[0]
       expect(decision_issue.caseflow_decision_date).to be > Time.zone.now
     end

--- a/spec/seeds/substitutions_spec.rb
+++ b/spec/seeds/substitutions_spec.rb
@@ -15,7 +15,13 @@ describe Seeds::Substitutions do
     it "creates appeals ready for substitution" do
       expect { subject }.to_not raise_error
 
-      expect(Appeal.where(veteran_file_number: 54_545_454).count).to eq(6)
+      expect(
+        Appeal.where(
+          veteran_file_number: Veteran.where(
+            first_name: "JaneDeceased", last_name: "SubstitutionsSeed"
+          ).map(&:file_number)
+        ).count
+      ).to eq(6)
     end
   end
 end

--- a/spec/services/veteran_profile_spec.rb
+++ b/spec/services/veteran_profile_spec.rb
@@ -22,7 +22,9 @@ describe VeteranProfile, :postgres do
     }
   end
 
-  let!(:appeal) { create(:appeal, veteran_file_number: file_number) }
+  let(:veteran) { build(:veteran, file_number: file_number) }
+
+  let!(:appeal) { create(:appeal, veteran: veteran) }
   let!(:hlr) { create(:higher_level_review, veteran_file_number: file_number) }
 
   describe "#call" do

--- a/spec/services/virtual_hearing_user_alert_builder_spec.rb
+++ b/spec/services/virtual_hearing_user_alert_builder_spec.rb
@@ -2,7 +2,7 @@
 
 describe VirtualHearingUserAlertBuilder do
   let(:veteran) { create(:veteran, first_name: "Serrif", last_name: "Gnest") }
-  let(:appeal) { create(:appeal, :hearing_docket, veteran_file_number: veteran.file_number) }
+  let(:appeal) { create(:appeal, :hearing_docket, veteran: veteran) }
   let(:hearing) { create(:hearing, appeal: appeal) }
   let!(:virtual_hearing) do
     create(

--- a/spec/workflows/tasks_for_appeal_spec.rb
+++ b/spec/workflows/tasks_for_appeal_spec.rb
@@ -75,7 +75,7 @@ describe TasksForAppeal do
         end
 
         context "hearing has been held" do
-          let!(:hearing) { create(:hearing, :with_tasks, :held, appeal: appeal) }
+          let!(:hearing) { create(:hearing, :held, appeal: appeal) }
 
           it "includes the HearingTask" do
             expect(subject.find { |t| t.is_a?(HearingTask) }).to_not be_nil


### PR DESCRIPTION
Resolves [APPEALS-8616](https://vajira.max.gov/browse/APPEALS-8616) A/C 4

### Description
- Modified seed files to not use hard-coded values in as many places as possible
- Added global sequences to FactoryBot for veteran_file_number, vacols_correspondent_key, and vacols_case_key for use in any factory that creates an object requiring this parameter; this allows us to re-run seeds and not have data collisions on those parameters
- Modified hearings factory to generate the tasks that would normally be created for held hearings and complete them where appropriate
- Refactored creation of new objects from class methods to using FactoryBot where possible
- Added TODO comments where more work is necessary to complete this story

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] After running make reset,  the following seed files can be manually run without error:
> - [ ] Tasks
> - [ ] Hearings
> - [ ] Intake
> - [ ] Jobs
> - [ ] Substitutions
> - [ ] DecisionIssues
> - [ ] CavcAmaAppeals
> - [ ] MTV
> - [ ] PriorityDistributions

### Testing Plan
1. In rails console, run make reset and ensure it completes with no error
2. In rails console, run each of the above seeds manually and ensure they complete with no error

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.
