### PR TITLE
janet/APPEALS-9 Update appellant_notification_spec.rb because it was missing a parenthesis

### DIFF
--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -324,7 +324,7 @@ describe AppellantNotification do
           }
         end
         it "will notify appellant when a hearing is withdrawn/cancelled" do
-          expect(AppellantNotification).to receive(:notify_appellant).with(hearing.appeal, template_name
+          expect(AppellantNotification).to receive(:notify_appellant).with(hearing.appeal, template_name)
           hearing.update_caseflow_and_vacols(hearing_info)
         end
       end


### PR DESCRIPTION
I added an end parenthesis on line 372 in appellant_notification_spec.rb