### PR TITLE
MattT/APPEALS-9201: Ensure All Pre-Docket Participant Organizations Have the "Badges" Column in Queue Tabs

### DIFF
--- a/app/models/organizations/bva_intake.rb
+++ b/app/models/organizations/bva_intake.rb
@@ -26,6 +26,7 @@ class BvaIntake < Organization
   end
 
   COLUMN_NAMES = [
+    Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
     Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_OWNER.name,

--- a/app/models/organizations/vha_program_office.rb
+++ b/app/models/organizations/vha_program_office.rb
@@ -36,10 +36,10 @@ class VhaProgramOffice < Organization
   end
 
   COLUMN_NAMES = [
+    Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
     Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_OWNER.name,
-    # Constants.QUEUE_CONFIG.COLUMNS.VAMC_OWNER.name,
     Constants.QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
     Constants.QUEUE_CONFIG.COLUMNS.LAST_ACTION.name,
     Constants.QUEUE_CONFIG.COLUMNS.BOARD_INTAKE.name

--- a/spec/models/queue_tabs/bva_intake_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/bva_intake_completed_tasks_tab_spec.rb
@@ -16,7 +16,7 @@ describe BvaIntakeCompletedTab, :postgres do
       let(:params) { { assignee: create(:bva) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
     end
   end

--- a/spec/models/queue_tabs/bva_intake_pending_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/bva_intake_pending_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe BvaIntakePendingTab, :postgres do
       let(:params) { { assignee: assignee } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_PENDING_TAB_TITLE
+      is_expected.to eq "Pending (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Appeals in Pre-Docket streams:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.PENDING_TASKS_TAB_NAME)
+      is_expected.to eq("pending")
     end
   end
 

--- a/spec/models/queue_tabs/bva_intake_ready_for_review_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/bva_intake_ready_for_review_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe BvaIntakeReadyForReviewTab, :postgres do
       let(:params) { { assignee: create(:bva) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_READY_FOR_REVIEW_TAB_TITLE
+      is_expected.to eq "Ready for Review (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases assigned to Board Intake:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.BVA_READY_FOR_REVIEW_TASKS_TAB_NAME)
+      is_expected.to eq("bvaReadyForReview")
     end
   end
 

--- a/spec/models/queue_tabs/vha_program_office_assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_program_office_assigned_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe VhaProgramOfficeAssignedTasksTab, :postgres do
       let(:params) { { assignee: create(:vha_program_office) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TAB_TITLE
+      is_expected.to eq "Assigned (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases assigned to a member of the #{assignee.name} team:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_ASSIGNED_TASKS_TAB_NAME)
+      is_expected.to eq("po_assigned")
     end
   end
 

--- a/spec/models/queue_tabs/vha_program_office_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_program_office_completed_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe VhaProgramOfficeCompletedTasksTab, :postgres do
       let(:params) { { assignee: create(:vha_program_office) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::VHA_ORGANIZATIONAL_QUEUE_PAGE_COMPLETED_TAB_TITLE
+      is_expected.to eq "Completed"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases completed:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_COMPLETED_TASKS_TAB_NAME)
+      is_expected.to eq("po_completed")
     end
   end
 

--- a/spec/models/queue_tabs/vha_program_office_in_progress_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_program_office_in_progress_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe VhaProgramOfficeInProgressTasksTab, :postgres do
       let(:params) { { assignee: create(:vha_program_office) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_IN_PROGRESS_TAB_TITLE
+      is_expected.to eq "In Progress (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases in progress in a #{assignee.name} team member's queue."
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_IN_PROGRESS_TASKS_TAB_NAME)
+      is_expected.to eq("po_inProgressTab")
     end
   end
 

--- a/spec/models/queue_tabs/vha_program_office_on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_program_office_on_hold_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe VhaProgramOfficeOnHoldTasksTab, :postgres do
       let(:params) { { assignee: create(:vha_program_office) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::VHA_ORGANIZATIONAL_QUEUE_PAGE_ON_HOLD_TAB_TITLE
+      is_expected.to eq "On Hold"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases on hold in a #{assignee.name} team member's queue."
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_ON_HOLD_TASKS_TAB_NAME)
+      is_expected.to eq("po_on_hold")
     end
   end
 

--- a/spec/models/queue_tabs/vha_program_office_ready_for_review_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_program_office_ready_for_review_tasks_tab_spec.rb
@@ -16,8 +16,34 @@ describe VhaProgramOfficeReadyForReviewTasksTab, :postgres do
       let(:params) { { assignee: create(:vha_program_office) } }
 
       it "returns the correct number of columns" do
-        expect(subject.length).to eq(6)
+        expect(subject.length).to eq 7
       end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::VHA_ORGANIZATIONAL_QUEUE_PAGE_READY_FOR_REVIEW_TAB_TITLE
+      is_expected.to eq "Ready for Review"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases ready for review in a #{assignee.name} team member's queue."
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.READY_FOR_REVIEW_TASKS_TAB_NAME)
+      is_expected.to eq("readyForReviewTab")
     end
   end
 


### PR DESCRIPTION
Resolves [APPEALS-9201](https://vajira.max.gov/browse/9201)

### Description
We would like for all organizations that participate in pre-docket workflows, in all of their queue tabs, to have the Badges column so that they have access to various status/identity badges for appeals in their queues.

### Acceptance Criteria
- [ ] All pre-docket participant organizations, and their queue tabs, have the BADGES column.

### Testing Plan

1. I would recommend opening two browser windows, with one in incognito mode, and navigating both to Caseflow. Log into Caseflow as a BVA Intake user in one window, and a VHA PO user in the other.

2. In the Rails console, stage an appeal that will be in a VHA PO's queue:
```ruby
appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
parent_task = appeal.tasks.last
camo_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCamo.singleton )
po_task = AssessDocumentationTask.create!( parent: camo_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaProgramOffice.first )
```

3. Report the death of the veteran. This will cause the FNOD badge to appear in the queues:
```ruby
appeal.veteran.update(date_of_death: 2.days.before)
```

4. In the VHA PO window, go to the VHA PO queue's Assigned tab. It should have the FNOD badge beside it. [Local link](http://localhost:3000/organizations/community-care-payment-operations-management?tab=po_assigned&page=1)

5. In the BVA Intake window, go to BVA Intake's Pending tab. The appeal should have the FNOD Badge there as well. [Local link](http://localhost:3000/organizations/bva-intake?tab=pending)

6. Set the `po_task` as `in_progress`. Make sure that FNOD banner appears next to the appeal after it is moved into the VHA PO's In Progress tab. [Local link](http://localhost:3000/organizations/community-care-payment-operations-management?tab=po_inProgressTab)

```ruby
po_task.in_progress!
```

7. Send the appeal to a VISN. It should have the FNOD banner in the On Hold tab now. [Local Link](http://localhost:3000/organizations/community-care-payment-operations-management?tab=po_on_hold)

```ruby
visn_task = AssessDocumentationTask.create!( parent: po_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaRegionalOffice.first )
```

8. Mimic sending the appeal at the VISN back to the VHA PO as "Ready for review". Check that the appeal has the FNOD badge in the VHA PO's Ready for Review tab. [Local link]()
```ruby
visn_task.completed!
```
9. Mimic sending the appeal from the VHA PO to BVA Intake as "Ready for review". Now check that the appeal has the FNOD badge in the VHA PO's Completed tab. [Local link](http://localhost:3000/organizations/community-care-payment-operations-management?tab=po_completed)
```ruby
po_task.completed!
```

10. In the BVA Intake window, check for the badge next to the appeal in BVA Intake's Ready for Review Tab. [Local link](http://localhost:3000/organizations/bva-intake?tab=bvaReadyForReview)

11. "Docket" the appeal. Finally, check that the FNOD badge is beside the appeal in BVA Intake's Completed tab. [Local link](http://localhost:3000/organizations/bva-intake?tab=bvaIntakeCompletedTab)
```ruby
# This is the PreDocketTask on this appeal
parent_task.completed!
```

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
<img width="833" alt="badges-actually-before" src="https://user-images.githubusercontent.com/99351305/191113243-21c146d6-a688-4bf4-992d-8839af741f7c.PNG">|<img width="822" alt="badges-before" src="https://user-images.githubusercontent.com/99351305/191113272-0ef34162-1cf1-4c63-83cc-9f92c7d1b790.PNG">

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Code Coverage

Bva Intake:

BVA Intake's Completed Tab's coverage was updated in a previous story.

<img width="331" alt="bva_intake_pending_coverage" src="https://user-images.githubusercontent.com/99351305/191111139-d90af5ba-c303-4545-8367-ec20a84835cc.PNG">
<img width="390" alt="bva_intake_r4r_coverage" src="https://user-images.githubusercontent.com/99351305/191111141-223b8f4a-4ede-4076-bd8c-4d386740d497.PNG">

VHA PO:
<img width="359" alt="vha_po_r4r_coverage" src="https://user-images.githubusercontent.com/99351305/191111272-92483c53-cb9e-4501-9dee-21f9ef432e94.PNG">
<img width="352" alt="vha_po_assigned_coverage" src="https://user-images.githubusercontent.com/99351305/191111276-e991e811-4d4f-4567-a75b-1be26eb91de3.PNG">
<img width="368" alt="vha_po_completed_coverage" src="https://user-images.githubusercontent.com/99351305/191111278-e4995515-2375-4b88-95b7-717b1150b2d6.PNG">
<img width="360" alt="vha_po_in_progress_coverage" src="https://user-images.githubusercontent.com/99351305/191111281-5c778424-25c8-438c-8790-56b4ec168407.PNG">
<img width="413" alt="vha_po_on_hold_coverage" src="https://user-images.githubusercontent.com/99351305/191111285-2d7a9955-0cbd-47d4-ac64-3ae6f92bf99e.PNG">

