### PR TITLE
hotfix/APPEALS-9429 VA Notify - Privacy Act Hotfix

### DIFF
--- a/app/models/prepend/va_notify/privacy_act_complete.rb
+++ b/app/models/prepend/va_notify/privacy_act_complete.rb
@@ -10,7 +10,8 @@ module PrivacyActComplete
   def update_status_if_children_tasks_are_closed(child_task)
     # original method defined in app/models/task.rb
     super_return_value = super
-    if (type.to_s.include?("Foia") && !type.to_s.include?("FoiaTask")) || type.to_s.include?("PrivacyAct")
+    if ((type.to_s.include?("Foia") && !type.to_s.include?("FoiaTask")) || type.to_s.include?("PrivacyAct")) &&
+       status == Constants.TASK_STATUSES.completed
       AppellantNotification.notify_appellant(appeal, @@template_name)
     end
     super_return_value

--- a/app/models/prepend/va_notify/privacy_act_complete.rb
+++ b/app/models/prepend/va_notify/privacy_act_complete.rb
@@ -10,7 +10,7 @@ module PrivacyActComplete
   def update_status_if_children_tasks_are_closed(child_task)
     # original method defined in app/models/task.rb
     super_return_value = super
-    if type.to_s.include?("Foia") || type.to_s.include?("PrivacyAct")
+    if (type.to_s.include?("Foia") && !type.to_s.include?("FoiaTask")) || type.to_s.include?("PrivacyAct")
       AppellantNotification.notify_appellant(appeal, @@template_name)
     end
     super_return_value

--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -419,8 +419,7 @@ describe AppellantNotification do
         OrganizationsUser.make_user_admin(user, Colocated.singleton)
         user
       end
-      # let!(:foia_parent) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: attorney_task.id) }
-      # let!(:foia_child) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: foia_parent.id) }
+
       let(:foia_colocated_task) do
         {
           instructions: "kjkjk",

--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -419,8 +419,8 @@ describe AppellantNotification do
         OrganizationsUser.make_user_admin(user, Colocated.singleton)
         user
       end
-      let!(:foia_parent) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: attorney_task.id) }
-      let!(:foia_child) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: foia_parent.id) }
+      # let!(:foia_parent) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: attorney_task.id) }
+      # let!(:foia_child) { create(:foia_task, appeal: appeal, assigned_to: vlj_admin, parent_id: foia_parent.id) }
       let(:foia_colocated_task) do
         {
           instructions: "kjkjk",
@@ -436,10 +436,9 @@ describe AppellantNotification do
         ColocatedTask.create_from_params(foia_colocated_task, attorney)
       end
       it "sends notification when completing a FoiaColocatedTask" do
+        foia_c_task = ColocatedTask.create_from_params(foia_colocated_task, attorney)
         expect(AppellantNotification).to receive(:notify_appellant).with(appeal, template_closed)
-        foiactask = ColocatedTask.create_from_params(foia_colocated_task, attorney)
-        byebug
-        foia_child.update!(status: "completed")
+        foia_c_task.children.first.update!(status: "completed")
       end
     end
 

--- a/spec/models/appellant_notification_spec.rb
+++ b/spec/models/appellant_notification_spec.rb
@@ -437,6 +437,8 @@ describe AppellantNotification do
       end
       it "sends notification when completing a FoiaColocatedTask" do
         expect(AppellantNotification).to receive(:notify_appellant).with(appeal, template_closed)
+        foiactask = ColocatedTask.create_from_params(foia_colocated_task, attorney)
+        byebug
         foia_child.update!(status: "completed")
       end
     end


### PR DESCRIPTION
Resolves [APPEALS-9429](https://vajira.max.gov/browse/APPEALS-9429)

### Description
Privacy act request complete was sending out two notifications instead of one for completing a FoiaColocatedTask. This is because a FoiaTask(organization) is a child of FoiaColocatedTask and when it is closed, the parent FoiaColocatedTask is also immediately closed. Before, the code was sending out a notification for each closed task when it should've just sent out one. 

The code was changed to only check if FoiaColocatedTask is closed in this scenario, since checking the parent task is the priority. Before, the code was checking FoiaColocatedTask and FoiaTask(org). This works because FoiaTask(org) is only a child of FoiaColocatedTask and FoiaColocatedTask can only have a child that is a FoiaTask(org).

### Acceptance Criteria
- [x] Only one notification is sent out when FoiaTask (organization) and FoiaColocatedTask are closed.

### Testing Plan
Go to https://vajira.max.gov/browse/APPEALS-9439

