### PR TITLE
hotfix/APPEALS-9419 Reactivate IHP pending Prepend

### DIFF
--- a/app/models/tasks/colocated_task.rb
+++ b/app/models/tasks/colocated_task.rb
@@ -16,7 +16,7 @@ class ColocatedTask < Task
   after_update :update_location_in_vacols
 
   class << self
-    # prepend IhpTaskPending
+    prepend IhpTaskPending
     def create_from_params(params, user)
       parent_task = params[:parent_id] ? Task.find(params[:parent_id]) : nil
       verify_user_can_create!(user, parent_task)

--- a/app/workflows/ihp_tasks_factory.rb
+++ b/app/workflows/ihp_tasks_factory.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class IhpTasksFactory
-  # prepend IhpTaskPending
+  prepend IhpTaskPending
 
   def initialize(parent)
     @parent = parent


### PR DESCRIPTION
Resolves APPEALS-9419

### Description
Re enabled IHP events for VA Notify

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-9425

### Testing Execution

https://vajira.max.gov/browse/APPEALS-9487 