### PR TITLE
TYLERB/APPEALS-9413: Update pre-docketing confirmation screen messaging for each business line

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -934,6 +934,11 @@
   "UNTIMELY_EXEMPTION_COPY_VHA": " OR is this issue related to a VHA Caregiver appeal",
   "VHA_PRE_DOCKET_ADD_ISSUES_NOTICE": "You have added VHA issues. Once you click \"Submit Appeal\", this appeal will be marked for pre-docketing.",
   "VHA_PRE_DOCKET_ISSUE_BANNER": "Based on the issue selected, this will go to pre-docket queue.",
+  "VHA_CAMO_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to VHA CAMO for document assessment",
+  "VHA_CAREGIVER_SUPPORT_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to VHA Caregiver for document assessment",
+  "EDUCATION_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to Education for document assessment",
+  "PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded in pre-docket queue",
+  "INTAKE_SUCCESS_TITLE": "Intake completed",
 
   "VACOLS_OPTIN_ISSUE_NEW": "Adding this issue will automatically close VACOLS issue",
   "VACOLS_OPTIN_ISSUE_CLOSED_EDIT": "This issue has automatically closed the VACOLS issue",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -936,7 +936,7 @@
   "VHA_PRE_DOCKET_ISSUE_BANNER": "Based on the issue selected, this will go to pre-docket queue.",
   "VHA_CAMO_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to VHA CAMO for document assessment",
   "VHA_CAREGIVER_SUPPORT_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to VHA Caregiver for document assessment",
-  "EDUCATION_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to Education for document assessment",
+  "EDUCATION_PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded and sent to Education Service for document assessment",
   "PRE_DOCKET_INTAKE_SUCCESS_TITLE": "Appeal recorded in pre-docket queue",
   "INTAKE_SUCCESS_TITLE": "Intake completed",
 

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -82,7 +82,7 @@ const leadMessageList = ({ veteran, formName, requestIssues, asyncJobUrl, editIs
   return leadMessageArr;
 };
 
-const getChecklistItems = (featureToggles, formType, requestIssues, isInformalConferenceRequested) => {
+const getChecklistItems = (formType, requestIssues, isInformalConferenceRequested) => {
   const eligibleRequestIssues = requestIssues.filter((ri) => !ri.ineligibleReason);
 
   if (formType === 'appeal') {
@@ -158,7 +158,6 @@ class VacolsOptInList extends React.PureComponent {
 class DecisionReviewIntakeCompleted extends React.PureComponent {
   render() {
     const {
-      featureToggles,
       veteran,
       formType,
       intakeStatus,
@@ -230,7 +229,6 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       }
       checklist={
         getChecklistItems(
-          featureToggles,
           formType,
           requestIssues,
           informalConference
@@ -253,7 +251,6 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
 
 export default connect(
   (state) => ({
-    featureToggles: state.featureToggles,
     veteran: state.intake.veteran,
     formType: state.intake.formType,
     asyncJobUrl: state.intake.asyncJobUrl,

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -97,7 +97,7 @@ const getChecklistItems = (formType, requestIssues, isInformalConferenceRequeste
     }
 
     if (checkIssuesForEducation(requestIssues) && checkIfPreDocketed(requestIssues)) {
-      statusMessage = 'Appeal created and sent to Education for document assessment.';
+      statusMessage = 'Appeal created and sent to Education Service for document assessment.';
     }
 
     return [<Fragment>

--- a/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
+++ b/client/app/intake/pages/decisionReviewIntakeCompleted.jsx
@@ -198,7 +198,7 @@ class DecisionReviewIntakeCompleted extends React.PureComponent {
       return <SmallLoader message="Creating task..." spinnerColor={LOGO_COLORS.CERTIFICATION.ACCENT} />;
     }
 
-    let title = checkIfPreDocketed(requestIssues) ? preDocketTitle(requestIssues) : COPY.INTAKE_SUCESS_TITLE;
+    let title = checkIfPreDocketed(requestIssues) ? preDocketTitle(requestIssues) : COPY.INTAKE_SUCCESS_TITLE;
 
     const deceasedVeteranAlert = () => {
       return (

--- a/spec/feature/intake/confirmation_page_spec.rb
+++ b/spec/feature/intake/confirmation_page_spec.rb
@@ -62,7 +62,26 @@ feature "Intake Confirmation Page", :postgres do
   end
 
   describe "when completing an appeal" do
-    context "appeal has VHA issues" do
+    context "appeal has VHA CAMO issues" do
+      let(:claim_review_type) { :board_appeal }
+      it "displays the correct copy on confirmation page" do
+        start_claim_review(claim_review_type)
+        visit "/intake"
+        click_intake_continue
+        click_intake_add_issue
+
+        add_intake_vha_issue(date: 2.days.ago, category: "Beneficiary Travel | Mileage")
+        click_intake_finish
+
+        expect(page).to_not have_content("Intake completed")
+        expect(page).to have_content("Appeal recorded and sent to VHA CAMO for document assessment")
+        expect(page).to have_content("If needed, you may correct the issues")
+        expect(page).to_not have_content("Edit the notice letter to reflect the status of requested issues.")
+        expect(page).to have_content("Appeal created and sent to VHA CAMO for document assessment.")
+      end
+    end
+
+    context "appeal has VHA Caregiver Issues" do
       let(:claim_review_type) { :board_appeal }
       it "displays the correct copy on confirmation page" do
         start_claim_review(claim_review_type)
@@ -74,10 +93,10 @@ feature "Intake Confirmation Page", :postgres do
         click_intake_finish
 
         expect(page).to_not have_content("Intake completed")
-        expect(page).to have_content("Appeal recorded in pre-docket queue")
+        expect(page).to have_content("Appeal recorded and sent to VHA Caregiver for document assessment")
         expect(page).to have_content("If needed, you may correct the issues")
         expect(page).to_not have_content("Edit the notice letter to reflect the status of requested issues.")
-        expect(page).to have_content("Appeal created and sent to VHA for document assessment.")
+        expect(page).to have_content("Appeal created and sent to VHA Caregiver for document assessment.")
       end
     end
   end

--- a/spec/feature/queue/camo_cancellation_spec.rb
+++ b/spec/feature/queue/camo_cancellation_spec.rb
@@ -49,7 +49,7 @@ RSpec.feature "CAMO can recommend cancellation to BVA Intake", :all_dbs do
       end
       step "trigger error state" do
         submit_button = find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON)
-        expect(submit_button[:disabled]).to eq "true"       
+        expect(submit_button[:disabled]).to eq "true"
       end
       step "submit valid form" do
         find("label", text: COPY::VHA_SEND_TO_BOARD_INTAKE_MODAL_NOT_APPEALABLE).click

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -78,6 +78,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
             expect(page).to have_button("Submit appeal")
             click_intake_finish
             expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
+            expect(page).to have_content(COPY::VHA_CAREGIVER_SUPPORT_PRE_DOCKET_INTAKE_SUCCESS_TITLE)
 
             vha_document_search_task = VhaDocumentSearchTask.last
             appeal = vha_document_search_task.appeal
@@ -346,6 +347,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_button("Submit appeal")
           click_intake_finish
           expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
+          expect(page).to have_content(COPY::VHA_CAMO_PRE_DOCKET_INTAKE_SUCCESS_TITLE)
 
           vha_document_search_task = VhaDocumentSearchTask.last
           appeal = vha_document_search_task.appeal
@@ -700,6 +702,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         expect(page).to have_button("Submit appeal")
         click_intake_finish
         expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.appeal} has been submitted.")
+        expect(page).to have_content(COPY::EDUCATION_PRE_DOCKET_INTAKE_SUCCESS_TITLE)
       end
 
       step "User can search the case and see the Pre Docketed status" do


### PR DESCRIPTION
Resolves [APPEALS-9413](https://vajira.max.gov/browse/APPEALS-9413)

### Description
Updates the success title message for pre-docket intake to be more descriptive to the user about which organization the pre-docket appeal is being sent to.

### Acceptance Criteria
- [ ] VHA messaging reads "Appeal recorded and sent to VHA CAMO for document assessment"
- [ ] Education messaging reads "Appeal recorded and sent to Education for document assessment"
- [ ] VHA messaging reads "Appeal recorded and sent to VHA Caregiver for document assessment"

### Testing Plan
1. Setup testing data somehow
```ruby
#create 3 usable veterans somehow
```
2. Switch to a user that can perform mail intake. BVAISHAW is the cssid of a common user that can do this.
3. Click on the mail intake tab and click the start link or visit the url /intake path in whatever app you are using to test. E.g. http://localhost:3000/intake
4. Start an intake using the dropdown. 
5. Select Decision Review Request: Board Appeal (Notice of Disagreement) — VA Form 10182
6. Enter the a valid veteran ID or SSN and press enter.
7. Fill out all fields in the review and click go the next part of the intake
8. Click the add issue button
9. Select the benefit type Veterans Health Administration
10. Select an issue category that is a caregiver issue
11. Fill out the rest of the fields and add the issue
12. Submit the appeal
13. Verify that the success title is "Appeal recorded and sent to VHA Caregiver for document assessment"
14. Maybe verify the add issue message also states the correct message??
![image](https://user-images.githubusercontent.com/109369527/193136120-a0082fc6-dd9b-4ff5-ab4d-617594337ab4.png)

15. Repeat steps 2-9
16. Select an issue category that isn't a caregiver issue
17. Fill out the rest of the fields and add the issue
18. Submit the appeal
19. Verify that the success title is "Appeal recorded and sent to VHA CAMO for document assessment"
20. Maybe verify the add issue message also states the correct message??

21. Repeat steps 2-8
22. Select a benefit type Education
23. Select any education issue category
24. Fill out the rest of the fields and add the issue
25. Submit the appeal
26. Verify that the success title is "Appeal recorded and sent to Education for document assessment"
27. Maybe verify the add issue message also states the correct message??
![image](https://user-images.githubusercontent.com/109369527/193135981-a3b25129-513e-4a63-972b-b2244da0e3c7.png)

