### PR TITLE
APPEALS-9713 Foia tasks can not be completed on legacy appeals

### DIFF
--- a/app/models/prepend/va_notify/privacy_act_complete.rb
+++ b/app/models/prepend/va_notify/privacy_act_complete.rb
@@ -10,7 +10,7 @@ module PrivacyActComplete
   def update_status_if_children_tasks_are_closed(child_task)
     # original method defined in app/models/task.rb
     super_return_value = super
-    if ((type.to_s.include?("Foia") && !parent.type.to_s.include?("Foia")) ||
+    if ((type.to_s.include?("Foia") && !parent&.type.to_s.include?("Foia")) ||
        (type.to_s.include?("PrivacyAct") && !parent.type.to_s.include?("PrivacyAct"))) &&
        status == Constants.TASK_STATUSES.completed
       # appellant notification call


### PR DESCRIPTION
Resolves [APPEALS-9713](https://vajira.max.gov/browse/APPEALS-9713)

### Description
The issue is that some Legacy appeals had FoiaColocatedTasks with no parent, so the Appellant Notification module would error out and the privacy team wouldn't be able to complete the privacy task.

A ruby safeguard was added to [line 13 of privacy_act_complete.rb](https://github.com/department-of-veterans-affairs/caseflow/blob/master/app/models/prepend/va_notify/privacy_act_complete.rb#L13) so the module won't error out when FoiaColocatedTask has no parent.

### Acceptance Criteria
- [ ] User can successfully complete FoiaColocatedTask with no parent for legacy appeals

### Testing Plan
1. Go to [APPEALS-9749](https://vajira.max.gov/browse/APPEALS-9749)