### PR TITLE
Enable all SCHEDULED Jobs

### DIFF
--- a/app/controllers/api/v1/jobs_controller.rb
+++ b/app/controllers/api/v1/jobs_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::JobsController < Api::ApplicationController
   def create
     # start job asynchronously as given by the job_type post param
-    job = SUPPORTED_JOBS[params.require(:job_type)]
+    job = SCHEDULED_JOBS[params.require(:job_type)]
     return unrecognized_job unless job
 
     job = job.perform_later

--- a/app/controllers/asyncable_jobs_controller.rb
+++ b/app/controllers/asyncable_jobs_controller.rb
@@ -47,7 +47,7 @@ class AsyncableJobsController < ApplicationController
 
   def start_job
     # start job asynchronously as given by the job_type post param
-    job = SUPPORTED_JOBS[allowed_params[:job_type]]
+    job = SCHEDULED_JOBS[allowed_params[:job_type]]
     return unrecognized_job unless job
 
     success = true
@@ -149,6 +149,6 @@ class AsyncableJobsController < ApplicationController
   end
 
   def supported_jobs
-    SUPPORTED_JOBS.keys if FeatureToggle.enabled?(:async_manual_start, user: current_user) && current_user.admin?
+    SCHEDULED_JOBS.keys if FeatureToggle.enabled?(:async_manual_start, user: current_user) && current_user.admin?
   end
 end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -35,12 +35,3 @@ SCHEDULED_JOBS = {
     "warm_bgs_caches_job" => WarmBgsCachesJob,
     "va_notify_status_update_job" => VANotifyStatusUpdateJob
 }.freeze
-
-DISABLED_JOBS = {
-    "dependencies_check" => DependenciesCheckJob,
-    "dependencies_report_service_log" => DependenciesReportServiceLogJob,
-    "hearing_email_status_job" => Hearings::HearingEmailStatusJob,
-    "heartbeat" => HeartbeatTasksJob,
-}.freeze
-
-SUPPORTED_JOBS = SCHEDULED_JOBS.freeze

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -43,4 +43,4 @@ DISABLED_JOBS = {
     "heartbeat" => HeartbeatTasksJob,
 }.freeze
 
-SUPPORTED_JOBS = SCHEDULED_JOBS.reject {|k, v| DISABLED_JOBS.key?(k)}.freeze
+SUPPORTED_JOBS = SCHEDULED_JOBS.freeze

--- a/spec/config/initializers/scheduled_jobs_spec.rb
+++ b/spec/config/initializers/scheduled_jobs_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe "SCHEDULED_JOBS" do
   describe "for all jobs" do
-    SUPPORTED_JOBS.each_value do |job_class|
+    SCHEDULED_JOBS.each_value do |job_class|
       it "#{job_class.name} is not queued in default queue" do
         expect(job_class.queue_name).not_to eq("default")
       end


### PR DESCRIPTION
Resolves #{github issue number}

### Description
Removed DISABLED_JOBS

After deploying earlier on Friday 10/7 we found errors for two of the jobs in the async-job-trigger lambda logs for two jobs:
- dependencies_report_service_log
- dependencies_check

heartbeat job and hearing_email_status_job were also affected, but both have their EventBridge cron triggers disabled which is configured in this file: https://github.com/department-of-veterans-affairs/appeals-lambdas/blob/master/async-jobs-trigger/serverless.yml

#### Example for dependencies_report_service_log
![image](https://user-images.githubusercontent.com/47667333/194678499-a629048f-81ba-44fa-b19e-4d5b4701ddaf.png)


### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to ...

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
