### PR TITLE
MattT/APPEALS-9781: Creation of HealthcareProviderClaimant Type (Based on development)

### DIFF
--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -63,6 +63,10 @@ class Claimant < CaseflowRecord
     claimant
   end
 
+  def self.unrecognized_claimant?
+    self <= OtherClaimant
+  end
+
   def power_of_attorney
     @power_of_attorney ||= find_power_of_attorney
   end

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -64,7 +64,7 @@ class Claimant < CaseflowRecord
   end
 
   def self.unrecognized_claimant?
-    self <= OtherClaimant
+    self <= OtherClaimant || false
   end
 
   def power_of_attorney

--- a/app/models/claimant.rb
+++ b/app/models/claimant.rb
@@ -63,8 +63,8 @@ class Claimant < CaseflowRecord
     claimant
   end
 
-  def self.unrecognized_claimant?
-    self <= OtherClaimant || false
+  def unrecognized_claimant?
+    self.class <= OtherClaimant || false
   end
 
   def power_of_attorney

--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -67,7 +67,7 @@ class DecisionDocument < CaseflowRecord
 
     if appeal.is_a?(Appeal)
       create_board_grant_effectuations!
-      fail NotImplementedError if appeal.claimant.is_a?(OtherClaimant)
+      fail NotImplementedError if appeal.claimant.unrecognized_claimant?
 
       # We do not want to process Board Grant Effectuations or create remand supplemental claims
       # for appeals with unrecognized appellants because claim establishment

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -125,17 +125,17 @@ class DecisionReviewIntake < Intake
   end
 
   def veteran_is_not_claimant
-    claimant_class_name != "VeteranClaimant"
+    claimant_class_name != VeteranClaimant.name
   end
 
   # If user has specified a different claimant, use that
   def participant_id
     case claimant_class_name
-    when "VeteranClaimant"
+    when VeteranClaimant.name
       veteran.participant_id
-    when "OtherClaimant"
+    when OtherClaimant.name
       ""
-    when "HealthcareProviderClaimant"
+    when HealthcareProviderClaimant.name
       ""
     else
       request_params[:claimant]

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -49,7 +49,7 @@ class DecisionReviewIntake < Intake
       payee_code: (need_payee_code? ? request_params[:payee_code] : nil)
     )
 
-    if claimant.is_a?(OtherClaimant)
+    if claimant.unrecognized_claimant?
       claimant.save_unrecognized_details!(
         request_params[:unlisted_claimant],
         request_params[:poa]
@@ -134,6 +134,8 @@ class DecisionReviewIntake < Intake
     when "VeteranClaimant"
       veteran.participant_id
     when "OtherClaimant"
+      ""
+    when "HealthcareProviderClaimant"
       ""
     else
       request_params[:claimant]

--- a/app/models/healthcare_provider_claimant.rb
+++ b/app/models/healthcare_provider_claimant.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+class HealthcareProviderClaimant < OtherClaimant; end

--- a/app/models/healthcare_provider_claimant.rb
+++ b/app/models/healthcare_provider_claimant.rb
@@ -2,6 +2,6 @@
 
 # HealthcareProviderClaimant is used whenever a HCP (Healthcare Provider)
 # is not listed in CorpDB, allowing a claim to be processed through Intake
-# despite this absence.
+# despite its absence.
 
 class HealthcareProviderClaimant < OtherClaimant; end

--- a/app/models/healthcare_provider_claimant.rb
+++ b/app/models/healthcare_provider_claimant.rb
@@ -1,3 +1,7 @@
 # frozen_string_literal: true
 
+# HealthcareProviderClaimant is used whenever a HCP (Healthcare Provider)
+# is not listed in CorpDB, allowing a claim to be processed through Intake
+# despite this absence.
+
 class HealthcareProviderClaimant < OtherClaimant; end

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -133,7 +133,7 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :appellant_phone_number do |object|
-    object.claimant.is_a?(OtherClaimant) ? object.claimant&.phone_number : nil
+    object.claimant.unrecognized_claimant? ? object.claimant&.phone_number : nil
   end
 
   attribute :appellant_email_address do |object|
@@ -149,11 +149,11 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :appellant_party_type do |appeal|
-    appeal.claimant.is_a?(OtherClaimant) ? appeal.claimant&.party_type : nil
+    appeal.claimant.unrecognized_claimant? ? appeal.claimant&.party_type : nil
   end
 
   attribute :unrecognized_appellant_id do |appeal|
-    appeal.claimant.is_a?(OtherClaimant) ? appeal.claimant&.unrecognized_appellant&.id : nil
+    appeal.claimant.unrecognized_claimant? ? appeal.claimant&.unrecognized_appellant&.id : nil
   end
 
   attribute :has_poa do |appeal|

--- a/client/.storybook/middleware.js
+++ b/client/.storybook/middleware.js
@@ -16,6 +16,27 @@ const expressMiddleWare = router => {
         }
 
         response.status(404).send(`"${userRole}" role does not have have a sample response yet.`);
-    })
+    });
+
+    router.get('/appeals/:appealId/power_of_attorney', (request, response) => {
+
+        response.send(
+            {
+                representative_type: 'Attorney',
+                representative_name: 'Clarence Darrow',
+                representative_address: {
+                    address_line_1: '9999 MISSION ST',
+                    address_line_2: 'UBER',
+                    address_line_3: 'APT 2',
+                    city: 'SAN FRANCISCO',
+                    zip: '94103',
+                    country: 'USA',
+                    state: 'CA'
+                },
+                representative_email_address: 'tom.brady@caseflow.gov',
+                poa_last_synced_at: '2022-10-03T09: 10: 51.266-04: 00'
+            }
+        );
+    });
 };
 module.exports = expressMiddleWare;

--- a/client/app/queue/AppellantDetail.jsx
+++ b/client/app/queue/AppellantDetail.jsx
@@ -49,10 +49,9 @@ export const AppellantDetail = ({ appeal, substitutionDate }) => {
   }
 
   const editNotice = () => {
-    if ([
-      APPELLANT_TYPES.OTHER_CLAIMANT,
-      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
-    ].includes(appellantType)) {
+    if ([APPELLANT_TYPES.OTHER_CLAIMANT, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT].includes(
+      appellantType
+    )) {
       return CASE_DETAILS_UNRECOGNIZED_APPELLANT;
     } else if (appellantType === APPELLANT_TYPES.ATTORNEY_CLAIMANT) {
       return CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT;

--- a/client/app/queue/AppellantDetail.jsx
+++ b/client/app/queue/AppellantDetail.jsx
@@ -49,7 +49,10 @@ export const AppellantDetail = ({ appeal, substitutionDate }) => {
   }
 
   const editNotice = () => {
-    if (appellantType === APPELLANT_TYPES.OTHER_CLAIMANT) {
+    if ([
+      APPELLANT_TYPES.OTHER_CLAIMANT,
+      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
+    ].includes(appellantType)) {
       return CASE_DETAILS_UNRECOGNIZED_APPELLANT;
     } else if (appellantType === APPELLANT_TYPES.ATTORNEY_CLAIMANT) {
       return CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT;

--- a/client/app/queue/AppellantDetail.jsx
+++ b/client/app/queue/AppellantDetail.jsx
@@ -49,9 +49,7 @@ export const AppellantDetail = ({ appeal, substitutionDate }) => {
   }
 
   const editNotice = () => {
-    if ([APPELLANT_TYPES.OTHER_CLAIMANT, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT].includes(
-      appellantType
-    )) {
+    if ([APPELLANT_TYPES.OTHER_CLAIMANT, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT].includes(appellantType)) {
       return CASE_DETAILS_UNRECOGNIZED_APPELLANT;
     } else if (appellantType === APPELLANT_TYPES.ATTORNEY_CLAIMANT) {
       return CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT;

--- a/client/app/queue/AppellantDetail.stories.js
+++ b/client/app/queue/AppellantDetail.stories.js
@@ -3,9 +3,10 @@ import React from 'react';
 import { AppellantDetail } from './AppellantDetail';
 
 import { appealData as appeal } from '../../test/data/appeals';
+import { APPELLANT_TYPES } from './constants';
 
-const selectAppellantDetails = ({ appellantFullName, appellantAddress, appellantRelationship }) =>
-  ({ appellantFullName, appellantAddress, appellantRelationship });
+const selectAppellantDetails = ({ appellantFullName, appellantAddress, appellantRelationship, appellantType }) =>
+  ({ appellantFullName, appellantAddress, appellantRelationship, appellantType });
 
 export default {
   title: 'Queue/AppellantDetail',
@@ -17,3 +18,12 @@ const Template = (args) => <AppellantDetail appeal={{ ...args }} />;
 
 export const Default = Template.bind({});
 Default.args = selectAppellantDetails(appeal);
+
+export const WithHealthcareProviderClaimant = Template.bind({});
+WithHealthcareProviderClaimant.args = selectAppellantDetails(
+  {
+    ...appeal,
+    appellantRelationship: 'Healthcare Provider',
+    appellantType: APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
+  }
+);

--- a/client/app/queue/AppellantDetail.stories.js
+++ b/client/app/queue/AppellantDetail.stories.js
@@ -9,7 +9,7 @@ const selectAppellantDetails = ({ appellantFullName, appellantAddress, appellant
   ({ appellantFullName, appellantAddress, appellantRelationship, appellantType });
 
 export default {
-  title: 'Queue/AppellantDetail',
+  title: 'Queue/Case Details/AppellantDetail',
   component: AppellantDetail,
   parameters: { controls: { expanded: true } },
 };

--- a/client/app/queue/AppellantDetail.stories.js
+++ b/client/app/queue/AppellantDetail.stories.js
@@ -27,3 +27,21 @@ WithHealthcareProviderClaimant.args = selectAppellantDetails(
     appellantType: APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
   }
 );
+
+export const WithOtherClaimant = Template.bind({});
+WithOtherClaimant.args = selectAppellantDetails(
+  {
+    ...appeal,
+    appellantRelationship: 'Other',
+    appellantType: APPELLANT_TYPES.OTHER_CLAIMANT
+  }
+);
+
+export const WithAttorneyClaimant = Template.bind({});
+WithAttorneyClaimant.args = selectAppellantDetails(
+  {
+    ...appeal,
+    appellantRelationship: 'Attorney',
+    appellantType: APPELLANT_TYPES.ATTORNEY_CLAIMANT
+  }
+);

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -169,17 +169,16 @@ export const CaseDetailsView = (props) => {
   const appealIsDispatched = isAppealDispatched(appeal);
 
   const editAppellantInformation = (
-    [APPELLANT_TYPES.OTHER_CLAIMANT,
-      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
-    ].includes(appeal.appellantType) && props.featureToggles.edit_unrecognized_appellant
+    [APPELLANT_TYPES.OTHER_CLAIMANT, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT].includes(
+      appeal.appellantType
+    ) && props.featureToggles.edit_unrecognized_appellant
   );
 
   const editPOAInformation =
     props.userCanEditUnrecognizedPOA &&
-    [APPELLANT_TYPES.OTHER_CLAIMANT,
-      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
-    ].includes(appeal.appellantType) &&
-    !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
+    [APPELLANT_TYPES.OTHER_CLAIMANT, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT].includes(
+      appeal.appellantType
+    ) && !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =
     currentUserIsOnCavcLitSupport && !appeal.isLegacyAppeal;

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -168,11 +168,16 @@ export const CaseDetailsView = (props) => {
 
   const appealIsDispatched = isAppealDispatched(appeal);
 
-  const editAppellantInformation =
-    appeal.appellantType === APPELLANT_TYPES.OTHER_CLAIMANT && props.featureToggles.edit_unrecognized_appellant;
+  const editAppellantInformation = (
+    [
+      APPELLANT_TYPES.OTHER_CLAIMANT,
+      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
+    ].includes(appeal.appellantType) && props.featureToggles.edit_unrecognized_appellant
+  );
 
   const editPOAInformation =
-    props.userCanEditUnrecognizedPOA && appeal.appellantType === 'OtherClaimant' &&
+    props.userCanEditUnrecognizedPOA &&
+    ['OtherClaimant', 'HealthcareProviderClaimant'].includes(appeal.appellantType) &&
     !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -169,15 +169,16 @@ export const CaseDetailsView = (props) => {
   const appealIsDispatched = isAppealDispatched(appeal);
 
   const editAppellantInformation = (
-    [
-      APPELLANT_TYPES.OTHER_CLAIMANT,
+    [APPELLANT_TYPES.OTHER_CLAIMANT,
       APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
     ].includes(appeal.appellantType) && props.featureToggles.edit_unrecognized_appellant
   );
 
   const editPOAInformation =
     props.userCanEditUnrecognizedPOA &&
-    ['OtherClaimant', 'HealthcareProviderClaimant'].includes(appeal.appellantType) &&
+    [APPELLANT_TYPES.OTHER_CLAIMANT,
+      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
+    ].includes(appeal.appellantType) &&
     !appeal.hasPOA && props.featureToggles.edit_unrecognized_appellant_poa;
 
   const supportCavcRemand =

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { bindActionCreators } from 'redux';
 import { connect, useSelector } from 'react-redux';
 import { css } from 'glamor';
@@ -454,3 +455,4 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(CaseDetailsView);
+/* eslint-enable max-lines */

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -11,6 +11,7 @@ import Address from './components/Address';
 import BareList from '../components/BareList';
 import { PoaRefresh } from './components/PoaRefresh';
 import COPY from '../../COPY';
+import { APPELLANT_TYPES } from './constants';
 import Alert from '../components/Alert';
 
 /**
@@ -128,9 +129,9 @@ export const PowerOfAttorneyDetailUnconnected = ({ powerOfAttorney, appealId, po
 
   const renderPoaLogic = () => {
     const isRecognizedAppellant = ![
-      'OtherClaimant',
-      'AttorneyClaimant',
-      'HealthcareProviderClaimant'
+      APPELLANT_TYPES.OTHER_CLAIMANT,
+      APPELLANT_TYPES.ATTORNEY_CLAIMANT,
+      APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
     ].includes(appellantType);
 
     if (isRecognizedAppellant && isRecognizedPoa) {

--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -127,7 +127,11 @@ export const PowerOfAttorneyDetailUnconnected = ({ powerOfAttorney, appealId, po
   const isRecognizedPoa = poa.representative_type !== 'Unrecognized representative';
 
   const renderPoaLogic = () => {
-    const isRecognizedAppellant = !['OtherClaimant', 'AttorneyClaimant'].includes(appellantType);
+    const isRecognizedAppellant = ![
+      'OtherClaimant',
+      'AttorneyClaimant',
+      'HealthcareProviderClaimant'
+    ].includes(appellantType);
 
     if (isRecognizedAppellant && isRecognizedPoa) {
       return <PoaRefresh powerOfAttorney={poa} appealId={appealId} {...detailListStyling} />;

--- a/client/app/queue/PowerOfAttorneyDetail.stories.mdx
+++ b/client/app/queue/PowerOfAttorneyDetail.stories.mdx
@@ -1,5 +1,10 @@
 import { Meta, Story, Preview } from '@storybook/addon-docs/blocks';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { applyMiddleware, createStore, compose } from 'redux';
 
+import { APPELLANT_TYPES } from 'app/queue/constants';
+import { amaAppeal as appeal } from 'test/data/appeals';
 import { PowerOfAttorneyNameUnconnected, PowerOfAttorneyDetailUnconnected } from './PowerOfAttorneyDetail';
 
 <Meta
@@ -22,15 +27,49 @@ export const powerOfAttorney = {
   representative_email_address: "tom.brady@caseflow.gov"
 };
 
+export const defaultValues = {
+    ui: {
+      poaAlert: {
+        powerOfAttorney
+      },
+      featureToggles: {
+        poa_button_refresh: true
+      }
+    },
+    queue: {
+      appeals: {
+        ...appeal,
+        ...powerOfAttorney,
+        hasPOA: true,
+        appellantType: APPELLANT_TYPES.VETERAN_CLAIMANT,
+      }
+    },
+    editPOAInformation: true
+  };
+
+export const reducer = function(state = defaultValues) {
+  return state;
+};
+
+export const generateStore = () => {
+  return createStore(
+    reducer,
+    compose(applyMiddleware(thunk))
+  );
+};
+
 # Power Of Attorney Detail
 
 ### Full Detail
 
 <Preview>
   <Story name="Normal">
-    <PowerOfAttorneyDetailUnconnected
-      powerOfAttorney={powerOfAttorney}
-    />
+    <Provider store={generateStore()}>
+      <PowerOfAttorneyDetailUnconnected
+        powerOfAttorney={powerOfAttorney}
+        poaAlert={powerOfAttorney}
+      />
+    </Provider>
   </Story>
 </Preview>
 
@@ -38,8 +77,11 @@ export const powerOfAttorney = {
 
 <Preview>
   <Story name="Just Name">
-    <PowerOfAttorneyNameUnconnected
-      powerOfAttorney={powerOfAttorney}
-    />
+    <Provider store={generateStore()}>
+      <PowerOfAttorneyNameUnconnected
+        powerOfAttorney={powerOfAttorney}
+        poaAlert={powerOfAttorney}
+      />
+    </Provider>
   </Story>
 </Preview>

--- a/client/app/queue/PowerOfAttorneyDetail.stories.mdx
+++ b/client/app/queue/PowerOfAttorneyDetail.stories.mdx
@@ -8,7 +8,7 @@ import { amaAppeal as appeal } from 'test/data/appeals';
 import { PowerOfAttorneyNameUnconnected, PowerOfAttorneyDetailUnconnected } from './PowerOfAttorneyDetail';
 
 <Meta
-  title="Queue/Components/PowerOfAttorneyDetail"
+  title="Queue/Case Details/PowerOfAttorneyDetail/PowerOfAttorneyDetail"
   component={PowerOfAttorneyDetailUnconnected}
 />
 

--- a/client/app/queue/PowerOfAttorneyDetailUnconnected.stories.js
+++ b/client/app/queue/PowerOfAttorneyDetailUnconnected.stories.js
@@ -1,0 +1,77 @@
+import React from 'react';
+
+import { MemoryRouter } from 'react-router';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { applyMiddleware, createStore, compose } from 'redux';
+
+import { PowerOfAttorneyDetailUnconnected } from 'app/queue/PowerOfAttorneyDetail';
+
+import { amaAppeal as appeal, powerOfAttorney } from 'test/data/appeals';
+import { APPELLANT_TYPES } from 'app/queue/constants';
+
+export default {
+  title: 'Queue/Case Details/PowerOfAttorneyDetail/PowerOfAttorneyDetailUnconnected',
+  component: PowerOfAttorneyDetailUnconnected,
+  parameters: { controls: { expanded: true } },
+};
+
+const createReducer = (storeValues) => {
+  return function(state = storeValues) {
+
+    return state;
+  };
+};
+
+const Template = (args) => {
+  const store = createStore(
+    createReducer({ ...args }),
+    compose(applyMiddleware(thunk))
+  );
+
+  const appealId = Object.keys(args.queue.appeals)[0];
+
+  return (
+    <Provider store={store}>
+      <MemoryRouter>
+        <PowerOfAttorneyDetailUnconnected
+          appellantType={args.queue.appeals.appellantType}
+          poaAlert={args.ui.poaAlert}
+          powerOfAttorney={powerOfAttorney}
+          appealId={appealId}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+};
+
+const generateStore = (hasPOA, appellantType) => {
+  return {
+    queue: {
+      appeals: {
+        ...appeal,
+        hasPOA,
+        appellantType,
+        ...powerOfAttorney,
+      }
+    },
+    ui: {
+      poaAlert: {
+        powerOfAttorney
+      },
+      featureToggles: {
+        poa_button_refresh: true
+      }
+    },
+    editPOAInformation: true
+  };
+};
+
+export const VeteranClaimantWithPOA = Template.bind({});
+VeteranClaimantWithPOA.args = generateStore(true, APPELLANT_TYPES.VETERAN_CLAIMANT);
+
+export const HealthcareProviderClaimantWithPOA = Template.bind({});
+HealthcareProviderClaimantWithPOA.args = generateStore(true, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT);
+
+export const OtherClaimantWithPOA = Template.bind({});
+OtherClaimantWithPOA.args = generateStore(true, APPELLANT_TYPES.OTHER_CLAIMANT);

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -124,6 +124,7 @@ export const APPELLANT_TYPES = {
   OTHER_CLAIMANT: 'OtherClaimant',
   ATTORNEY_CLAIMANT: 'AttorneyClaimant',
   VETERAN_CLAIMANT: 'VeteranClaimant',
+  HEALTHCARE_PROVIDER_CLAIMANT: 'HealthcareProviderClaimant'
 };
 
 export const SEARCH_ERROR_FOR = {

--- a/client/test/app/queue/AppellantDetail.test.js
+++ b/client/test/app/queue/AppellantDetail.test.js
@@ -1,0 +1,66 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { AppellantDetail } from 'app/queue/AppellantDetail';
+
+import { appealData as appeal } from 'test/data/appeals';
+import { APPELLANT_TYPES } from 'app/queue/constants';
+import COPY from '../../../COPY';
+
+const renderAppellantDetail = (appealData) => {
+
+  return render(
+    <AppellantDetail appeal={{ ...appealData }} />
+  );
+};
+
+describe('editNotice', () => {
+  test('editNotice is displayed whenever appellantType is "OtherClaimant"', () => {
+    renderAppellantDetail(
+      {
+        ...appeal,
+        appellantType: APPELLANT_TYPES.OTHER_CLAIMANT
+      }
+    );
+
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_APPELLANT)).toBeTruthy();
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT)).not.toBeTruthy();
+  });
+
+  test('editNotice is displayed whenever appellantType is "HealthcareProviderClaimant"', () => {
+    renderAppellantDetail(
+      {
+        ...appeal,
+        appellantType: APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT
+      }
+    );
+
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_APPELLANT)).toBeTruthy();
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT)).not.toBeTruthy();
+  });
+
+  test('Attorney editNotice is displayed whenever appellantType is "AttorneyClaimant"', () => {
+    renderAppellantDetail(
+      {
+        ...appeal,
+        appellantType: APPELLANT_TYPES.ATTORNEY_CLAIMANT
+
+      }
+    );
+
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_APPELLANT)).not.toBeTruthy();
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT)).toBeTruthy();
+  });
+
+  test('editNotice is not displayed whenever appellantType is "VeteranClaimant"', () => {
+    renderAppellantDetail(
+      {
+        ...appeal,
+        appellantType: APPELLANT_TYPES.VETERAN_CLAIMANT
+      }
+    );
+
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_APPELLANT)).not.toBeTruthy();
+    expect(screen.queryByText(COPY.CASE_DETAILS_UNRECOGNIZED_ATTORNEY_APPELLANT)).not.toBeTruthy();
+  });
+});

--- a/client/test/app/queue/PowerOfAttorneyDetail.test.js
+++ b/client/test/app/queue/PowerOfAttorneyDetail.test.js
@@ -41,23 +41,9 @@ const renderPowerOfAttorneyDetailUnconnected = (storeValues, appellantType) => {
   );
 };
 
-const queueStoreValues = {
-  loadingAppealDetail: {
-    [appeal.externalId]: {
-      powerOfAttorney: {
-        loading: false
-      },
-      veteranInfo: {
-        loading: false
-      }
-    }
-  }
-};
-
 const createStoreValues = (hasPOA, appellantType, editPOAInformation) => {
   return {
     queue: {
-      ...queueStoreValues,
       appeals: {
         ...appeal,
         hasPOA,
@@ -67,8 +53,8 @@ const createStoreValues = (hasPOA, appellantType, editPOAInformation) => {
     },
     ui: {
       poaAlert: {
-        message: 'Test message',
-        alertType: 'success',
+        message: 'Info banner message',
+        alertType: 'info',
         powerOfAttorney
       },
       featureToggles: {

--- a/client/test/app/queue/PowerOfAttorneyDetail.test.js
+++ b/client/test/app/queue/PowerOfAttorneyDetail.test.js
@@ -1,0 +1,91 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import { applyMiddleware, createStore, compose } from 'redux';
+
+import PowerOfAttorneyDetail from 'app/queue/PowerOfAttorneyDetail';
+
+import { amaAppeal as appeal, powerOfAttorney } from 'test/data/appeals';
+import { APPELLANT_TYPES } from 'app/queue/constants';
+import COPY from '../../../COPY';
+
+const createQueueReducer = (storeValues) => {
+  return (state = storeValues) => {
+
+    return state;
+  };
+};
+
+const renderPowerOfAttorneyDetail = (storeValues, appellantType) => {
+
+  const queueReducer = createQueueReducer(storeValues);
+
+  const store = createStore(
+    queueReducer,
+    compose(applyMiddleware(thunk))
+  );
+
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <PowerOfAttorneyDetail
+          title={COPY.CASE_DETAILS_POA_SUBSTITUTE}
+          appealId={Object.keys(storeValues.queue.appeals)[0]}
+          appellantType={appellantType}
+        />
+      </MemoryRouter>
+    </Provider>
+  );
+};
+
+const queueStoreValues = {
+  loadingAppealDetail: {
+    [appeal.externalId]: {
+      powerOfAttorney: {
+        loading: false
+      },
+      veteranInfo: {
+        loading: false
+      }
+    }
+  }
+};
+
+const createStoreValues = (hasPOA, appellantType, poaAlert, editPOAInformation) => {
+  return {
+    queue: {
+      ...queueStoreValues,
+      appeals: {
+        ...appeal,
+        hasPOA,
+        appellantType,
+        ...powerOfAttorney,
+      }
+    },
+    ui: {
+      poaAlert
+    },
+    editPOAInformation
+  };
+};
+
+describe('POA Refresh button', () => {
+  test('Does not appear if claimant is an OtherClaimant', () => {
+    const storeValues = createStoreValues(false, APPELLANT_TYPES.OTHER_CLAIMANT, false, false);
+
+    renderPowerOfAttorneyDetail(storeValues, APPELLANT_TYPES.OTHER_CLAIMANT);
+
+    expect(screen.queryByText('POA Refresh')).not.toBeTruthy();
+  });
+
+  test('Does not appear if claimant is a HealthcareProviderClaimant', () => {
+    const storeValues = createStoreValues(false, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT, false, false);
+
+    renderPowerOfAttorneyDetail(storeValues, APPELLANT_TYPES.OTHER_CLAIMANT);
+
+    expect(screen.queryByText('POA Refresh')).not.toBeTruthy();
+  });
+});

--- a/client/test/app/queue/PowerOfAttorneyDetail.test.js
+++ b/client/test/app/queue/PowerOfAttorneyDetail.test.js
@@ -6,11 +6,10 @@ import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
 import { applyMiddleware, createStore, compose } from 'redux';
 
-import PowerOfAttorneyDetail from 'app/queue/PowerOfAttorneyDetail';
+import { PowerOfAttorneyDetailUnconnected } from 'app/queue/PowerOfAttorneyDetail';
 
 import { amaAppeal as appeal, powerOfAttorney } from 'test/data/appeals';
 import { APPELLANT_TYPES } from 'app/queue/constants';
-import COPY from '../../../COPY';
 
 const createQueueReducer = (storeValues) => {
   return (state = storeValues) => {
@@ -19,7 +18,7 @@ const createQueueReducer = (storeValues) => {
   };
 };
 
-const renderPowerOfAttorneyDetail = (storeValues, appellantType) => {
+const renderPowerOfAttorneyDetailUnconnected = (storeValues, appellantType) => {
 
   const queueReducer = createQueueReducer(storeValues);
 
@@ -31,10 +30,11 @@ const renderPowerOfAttorneyDetail = (storeValues, appellantType) => {
   return render(
     <Provider store={store}>
       <MemoryRouter>
-        <PowerOfAttorneyDetail
-          title={COPY.CASE_DETAILS_POA_SUBSTITUTE}
+        <PowerOfAttorneyDetailUnconnected
           appealId={Object.keys(storeValues.queue.appeals)[0]}
           appellantType={appellantType}
+          poaAlert={storeValues.ui.poaAlert}
+          powerOfAttorney={powerOfAttorney}
         />
       </MemoryRouter>
     </Provider>
@@ -54,7 +54,7 @@ const queueStoreValues = {
   }
 };
 
-const createStoreValues = (hasPOA, appellantType, poaAlert, editPOAInformation) => {
+const createStoreValues = (hasPOA, appellantType, editPOAInformation) => {
   return {
     queue: {
       ...queueStoreValues,
@@ -66,7 +66,14 @@ const createStoreValues = (hasPOA, appellantType, poaAlert, editPOAInformation) 
       }
     },
     ui: {
-      poaAlert
+      poaAlert: {
+        message: 'Test message',
+        alertType: 'success',
+        powerOfAttorney
+      },
+      featureToggles: {
+        poa_button_refresh: true
+      }
     },
     editPOAInformation
   };
@@ -74,18 +81,26 @@ const createStoreValues = (hasPOA, appellantType, poaAlert, editPOAInformation) 
 
 describe('POA Refresh button', () => {
   test('Does not appear if claimant is an OtherClaimant', () => {
-    const storeValues = createStoreValues(false, APPELLANT_TYPES.OTHER_CLAIMANT, false, false);
+    const storeValues = createStoreValues(true, APPELLANT_TYPES.OTHER_CLAIMANT, false);
 
-    renderPowerOfAttorneyDetail(storeValues, APPELLANT_TYPES.OTHER_CLAIMANT);
+    renderPowerOfAttorneyDetailUnconnected(storeValues, APPELLANT_TYPES.OTHER_CLAIMANT);
 
-    expect(screen.queryByText('POA Refresh')).not.toBeTruthy();
+    expect(screen.queryByText('Refresh POA')).not.toBeTruthy();
   });
 
   test('Does not appear if claimant is a HealthcareProviderClaimant', () => {
-    const storeValues = createStoreValues(false, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT, false, false);
+    const storeValues = createStoreValues(true, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT, false);
 
-    renderPowerOfAttorneyDetail(storeValues, APPELLANT_TYPES.OTHER_CLAIMANT);
+    renderPowerOfAttorneyDetailUnconnected(storeValues, APPELLANT_TYPES.HEALTHCARE_PROVIDER_CLAIMANT);
 
-    expect(screen.queryByText('POA Refresh')).not.toBeTruthy();
+    expect(screen.queryByText('Refresh POA')).not.toBeTruthy();
+  });
+
+  test('Appears if claimant is a VeteranClaimant', () => {
+    const storeValues = createStoreValues(true, APPELLANT_TYPES.VETERAN_CLAIMANT, false);
+
+    renderPowerOfAttorneyDetailUnconnected(storeValues, APPELLANT_TYPES.VETERAN_CLAIMANT);
+
+    expect(screen.queryByText('Refresh POA')).toBeTruthy();
   });
 });

--- a/db/migrate/20221008031628_add_healthcare_provider_claimant_to_column_comments.rb
+++ b/db/migrate/20221008031628_add_healthcare_provider_claimant_to_column_comments.rb
@@ -1,0 +1,6 @@
+class AddHealthcareProviderClaimantToColumnComments < ActiveRecord::Migration[5.2]
+  def change
+    change_column_comment :claimants, :type, "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, OtherClaimant, or HealthcareProviderClaimant."
+    change_column_comment :unrecognized_appellants, :claimant_id, "The OtherClaimant or HealthcareProviderClaimant record associating this appellant to a DecisionReview."
+  end
+end

--- a/db/migrate/20221014181613_adjust_comment_to_include_hcp.rb
+++ b/db/migrate/20221014181613_adjust_comment_to_include_hcp.rb
@@ -1,0 +1,5 @@
+class AdjustCommentToIncludeHcp < ActiveRecord::Migration[5.2]
+  def change
+    change_column_comment :unrecognized_appellants, :relationship, "Relationship to veteran. Allowed values: attorney, child, spouse, other, or healthcare_provider."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_09_20_122149) do
+ActiveRecord::Schema.define(version: 2022_10_08_031628) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -394,7 +394,7 @@ ActiveRecord::Schema.define(version: 2022_09_20_122149) do
     t.text "notes", comment: "This is a notes field for adding claimant not listed and any supplementary information outside of unlisted claimant."
     t.string "participant_id", null: false, comment: "The participant ID of the claimant."
     t.string "payee_code", comment: "The payee_code for the claimant, if applicable. payee_code is required when the claim is processed in VBMS."
-    t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, or OtherClaimant."
+    t.string "type", default: "Claimant", comment: "The class name for the single table inheritance type of Claimant, for example VeteranClaimant, DependentClaimant, AttorneyClaimant, OtherClaimant, or HealthcareProviderClaimant."
     t.datetime "updated_at"
     t.index ["decision_review_type", "decision_review_id"], name: "index_claimants_on_decision_review_type_and_decision_review_id"
     t.index ["participant_id"], name: "index_claimants_on_participant_id"
@@ -1536,7 +1536,7 @@ ActiveRecord::Schema.define(version: 2022_09_20_122149) do
   end
 
   create_table "unrecognized_appellants", comment: "Unrecognized non-veteran appellants", force: :cascade do |t|
-    t.bigint "claimant_id", null: false, comment: "The OtherClaimant record associating this appellant to a DecisionReview"
+    t.bigint "claimant_id", null: false, comment: "The OtherClaimant or HealthcareProviderClaimant record associating this appellant to a DecisionReview."
     t.datetime "created_at", null: false
     t.bigint "created_by_id", null: false, comment: "The user that created this version of the unrecognized appellant"
     t.bigint "current_version_id", comment: "The current version for this unrecognized appellant"

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -57,6 +57,14 @@ FactoryBot.define do
           decision_review: appeal,
           type: "OtherClaimant"
         )
+      elsif evaluator.has_healthcare_provider_claimant
+        create(
+          :claimant,
+          :with_unrecognized_appellant_detail,
+          participant_id: appeal.veteran.participant_id,
+          decision_review: appeal,
+          type: "HealthcareProviderClaimant"
+        )
       elsif !Claimant.exists?(participant_id: appeal.veteran.participant_id, decision_review: appeal)
         create(
           :claimant,
@@ -111,6 +119,10 @@ FactoryBot.define do
 
     transient do
       has_unrecognized_appellant { false }
+    end
+
+    transient do
+      has_healthcare_provider_claimant { false }
     end
 
     transient do

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -328,4 +328,32 @@ describe Claimant, :postgres do
       expect(attorney_claimant.name).to eq("William Jennings Bryan")
     end
   end
+
+  context "#unrecognized_claimant?" do
+    subject { claimant.unrecognized_claimant? }
+
+    context "Claimant" do
+      let(:claimant) { create(:claimant, type: "Claimant") }
+
+      it { is_expected.to be false }
+    end
+
+    context "AttorneyClaimant" do
+      let(:claimant) { create(:claimant, type: "AttorneyClaimant") }
+
+      it { is_expected.to be false }
+    end
+
+    context "DependentClaimant" do
+      let(:claimant) { create(:claimant, type: "DependentClaimant") }
+
+      it { is_expected.to be false }
+    end
+
+    context "VeteranClaimant" do
+      let(:claimant) { create(:claimant, type: "VeteranClaimant") }
+
+      it { is_expected.to be false }
+    end
+  end
 end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -346,6 +346,10 @@ describe Claimant, :postgres do
       expect(DependentClaimant.unrecognized_claimant?).to eq false
     end
 
+    it "AttorneyClaimant isn't considered an unrecognized claimant" do
+      expect(AttorneyClaimant.unrecognized_claimant?).to eq false
+    end
+
     it "OtherClaimant is considered an unrecognized claimant" do
       expect(OtherClaimant.unrecognized_claimant?).to eq true
     end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -328,4 +328,30 @@ describe Claimant, :postgres do
       expect(attorney_claimant.name).to eq("William Jennings Bryan")
     end
   end
+
+  context ".unrecognized_claimant?" do
+    it "Claimant isn't considered an unrecognized claimant" do
+      expect(Claimant.unrecognized_claimant?).to eq false
+    end
+
+    it "VeteranClaimant isn't considered an unrecognized claimant" do
+      expect(VeteranClaimant.unrecognized_claimant?).to eq false
+    end
+
+    it "BgsRelatedClaimant isn't considered an unrecognized claimant" do
+      expect(BgsRelatedClaimant.unrecognized_claimant?).to eq false
+    end
+
+    it "DependentClaimant isn't considered an unrecognized claimant" do
+      expect(DependentClaimant.unrecognized_claimant?).to eq false
+    end
+
+    it "OtherClaimant is considered an unrecognized claimant" do
+      expect(OtherClaimant.unrecognized_claimant?).to eq true
+    end
+
+    it "HealthcareProviderClaimant is considered an unrecognized claimant" do
+      expect(HealthcareProviderClaimant.unrecognized_claimant?).to eq true
+    end
+  end
 end

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -328,34 +328,4 @@ describe Claimant, :postgres do
       expect(attorney_claimant.name).to eq("William Jennings Bryan")
     end
   end
-
-  context ".unrecognized_claimant?" do
-    it "Claimant isn't considered an unrecognized claimant" do
-      expect(Claimant.unrecognized_claimant?).to eq false
-    end
-
-    it "VeteranClaimant isn't considered an unrecognized claimant" do
-      expect(VeteranClaimant.unrecognized_claimant?).to eq false
-    end
-
-    it "BgsRelatedClaimant isn't considered an unrecognized claimant" do
-      expect(BgsRelatedClaimant.unrecognized_claimant?).to eq false
-    end
-
-    it "DependentClaimant isn't considered an unrecognized claimant" do
-      expect(DependentClaimant.unrecognized_claimant?).to eq false
-    end
-
-    it "AttorneyClaimant isn't considered an unrecognized claimant" do
-      expect(AttorneyClaimant.unrecognized_claimant?).to eq false
-    end
-
-    it "OtherClaimant is considered an unrecognized claimant" do
-      expect(OtherClaimant.unrecognized_claimant?).to eq true
-    end
-
-    it "HealthcareProviderClaimant is considered an unrecognized claimant" do
-      expect(HealthcareProviderClaimant.unrecognized_claimant?).to eq true
-    end
-  end
 end

--- a/spec/models/healthcare_provider_claimant_spec.rb
+++ b/spec/models/healthcare_provider_claimant_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+describe HealthcareProviderClaimant do
+  let(:appeal_with_healthcare_provider_claimant) do
+    create(
+      :appeal,
+      has_healthcare_provider_claimant: true,
+      veteran_is_not_claimant: true
+    )
+  end
+
+  subject { appeal_with_healthcare_provider_claimant.claimant }
+
+  context "#unrecognized_claimant?" do
+    it "HealthcareProvider is considered an unrecognized appellant" do
+      expect(subject.unrecognized_claimant?).to eq false
+    end
+  end
+end

--- a/spec/models/healthcare_provider_claimant_spec.rb
+++ b/spec/models/healthcare_provider_claimant_spec.rb
@@ -12,7 +12,7 @@ describe HealthcareProviderClaimant do
   subject { appeal_with_healthcare_provider_claimant.claimant }
 
   context "#unrecognized_claimant?" do
-    it "HealthcareProvider is considered an unrecognized appellant" do
+    it "HealthcareProvider is considered an unrecognized claimant" do
       expect(subject.unrecognized_claimant?).to eq true
     end
   end

--- a/spec/models/healthcare_provider_claimant_spec.rb
+++ b/spec/models/healthcare_provider_claimant_spec.rb
@@ -1,19 +1,13 @@
 # frozen_string_literal: true
 
 describe HealthcareProviderClaimant do
-  let(:appeal_with_healthcare_provider_claimant) do
-    create(
-      :appeal,
-      has_healthcare_provider_claimant: true,
-      veteran_is_not_claimant: true
-    )
-  end
+  let(:claimant) { create(:claimant, type: "HealthcareProviderClaimant") }
 
-  subject { appeal_with_healthcare_provider_claimant.claimant }
+  describe "#unrecognized_claimant?" do
+    subject { claimant.unrecognized_claimant? }
 
-  context "#unrecognized_claimant?" do
-    it "HealthcareProvider is considered an unrecognized claimant" do
-      expect(subject.unrecognized_claimant?).to eq true
+    it "HealthcareProviderClaimant is considered an unrecognized claimant" do
+      is_expected.to eq true
     end
   end
 end

--- a/spec/models/healthcare_provider_claimant_spec.rb
+++ b/spec/models/healthcare_provider_claimant_spec.rb
@@ -13,7 +13,7 @@ describe HealthcareProviderClaimant do
 
   context "#unrecognized_claimant?" do
     it "HealthcareProvider is considered an unrecognized appellant" do
-      expect(subject.unrecognized_claimant?).to eq false
+      expect(subject.unrecognized_claimant?).to eq true
     end
   end
 end

--- a/spec/models/other_claimant_spec.rb
+++ b/spec/models/other_claimant_spec.rb
@@ -145,4 +145,12 @@ describe OtherClaimant, :postgres do
       expect(subject).to be_truthy
     end
   end
+
+  describe "#unrecognized_claimant?" do
+    subject { claimant.unrecognized_claimant? }
+
+    it "OtherClaimant is considered an unrecognized claimant" do
+      is_expected.to eq true
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-9781](https://vajira.max.gov/browse/APPEALS-9781)

### Description
> We need a new claimant type to capture the new Healthcare Provider option that has been requested by stakeholders. This type will be sharing essentially a one-to-one behavior with the already established OtherClaimant type, so we've decided the logical path forward at this time is for the new class to inherit directly from the already established OtherClaimant model.

This PR creates a HealthcareProviderClaimant class that is a subclass of OtherClaimant. It will be used in the HLR and SC intake workflows.

### Acceptance Criteria
- [ ] Create a new class of healthcare provider claimant that inherits from other claimant

### Testing Plan
0. Run `rails db:migrate RAILS_ENV=development`

1. Set a claimant to be a HealthcareProviderClaimant:
```ruby
appeal = Appeal.first

appeal.claimant.update!(type: HealthcareProviderClaimant.name)
```

2. Check that the claimant class is correct:
```ruby
appeal.reload.claimant.is_a?(HealthcareProviderClaimant)
=> true
```

3. Confirm that the `HealthcareProviderClaimant` is a seen as an object of a subclass of `OtherClaimant`:

```ruby
appeal.claimant.class <= OtherClaimant
=> true
```

4. Set the claimant type to a `VeteranClaimant` and check that this code correctly identifies the claimant as not an instance of `OtherClaimant`:

```ruby
appeal.claimant.update!(type: VeteranClaimant.name)

appeal.reload.claimant.is_a?(HealthcareProviderClaimant)
=> false

appeal.claimant.class <= OtherClaimant
=> false
```

5. Open up Storybook with `make storybook`.

6. Find the Queue -> Case Details section:
<img width="132" alt="9781-storybooks" src="https://user-images.githubusercontent.com/99351305/195190447-2595583a-8b95-4d7f-951b-8f91cdba31af.PNG">

7. In the PowerOfAttorneyUnconnected section, ensure that the "POA Refresh" link doesn't appear whenever the `appellantType`/claimant type is either `OtherClaimant` or `HealthcareProviderClaimant`.

8. In the AppellantDetail section, ensure the following text only appears if the the `appellantType`/claimant type is either `OtherClaimant` or `HealthcareProviderClaimant`:

"This appellant is not listed in VBMS. To update this information, please edit directly in Caseflow."

The `AttorneyClaimant` type has its own similar informational text.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

### Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)
