### PR TITLE
fixed issue with missing end in split_appeal_controller

### DIFF
--- a/app/controllers/split_appeal_controller.rb
+++ b/app/controllers/split_appeal_controller.rb
@@ -26,7 +26,27 @@ class SplitAppealController < ApplicationController
           dup_appeal.save!
 
           # Setting the user_css_id
-          user_css_id = params[:user]
+          user_css_id = params[:user_css_id]
+          split_user = User.find_by_css_id user_css_id
+
+          if split_other_reason.strip.empty?
+            instructions = split_reason
+          else
+            instructions = split_other_reason
+          end
+
+          Task.transaction do
+            spt = SplitAppealTask.create!(
+              appeal: appeal,
+              parent: appeal.root_task,
+              assigned_to: split_user,
+              assigned_by: split_user,
+              assigned_at: Time.zone.now
+            )
+
+            spt.instructions.push(instructions)
+            spt.update!(status: Constants.TASK_STATUSES.completed)
+          end
 
           # run extra duplicate methods to finish split
           dup_appeal.finalize_split_appeal(appeal, user_css_id)
@@ -34,28 +54,12 @@ class SplitAppealController < ApplicationController
           # set the appeal split process to false
           appeal.appeal_split_process = false
 
-          if split_other_reason.strip.empty?
-            instructions = split_reason
-          else
-            instructions= split_other_reason
-          end
-        
-          Task.transaction do
-            spt = SplitAppealTask.create!(appeal: appeal,
-                parent: appeal.root_task,
-                assigned_to: user_css_id,
-                assigned_by: user_css_id,
-                assigned_at: Time.zone.now)
-
-            spt.instructions.push(instructions)
-            spt.update!(status: Constants.TASK_STATUSES.completed)
-          end
           # send success response
           dup_appeal.reload
           appeal.reload
           render json: { split_appeal: dup_appeal, original_appeal: appeal }, status: :created
         else
-          raise ActiveRecord::Rollback
+          fail ActiveRecord::Rollback
         end
       end
     end

--- a/app/controllers/split_appeal_controller.rb
+++ b/app/controllers/split_appeal_controller.rb
@@ -54,8 +54,9 @@ class SplitAppealController < ApplicationController
           dup_appeal.reload
           appeal.reload
           render json: { split_appeal: dup_appeal, original_appeal: appeal }, status: :created
-      else
-        raise ActiveRecord::Rollback
+        else
+          raise ActiveRecord::Rollback
+        end
       end
     end
   end

--- a/client/app/intake/actions/intake.js
+++ b/client/app/intake/actions/intake.js
@@ -16,7 +16,7 @@ export const setFileNumberSearch = (fileNumber) => ({
   }
 });
 
-export const splitAppeal = (appealId, selectedIssues, reason, otherReason, user) => (dispatch) => {
+export const splitAppeal = (appealId, selectedIssues, reason, otherReason, userCssId) => (dispatch) => {
   dispatch({
     type: ACTIONS.SET_SPLIT_APPEAL,
     meta: { analytics }
@@ -27,7 +27,7 @@ export const splitAppeal = (appealId, selectedIssues, reason, otherReason, user)
     appeal_split_issues: selectedIssues,
     split_reason: reason,
     split_other_reason: otherReason,
-    user_css_id: user
+    user_css_id: userCssId
   };
 
   return ApiUtil.post(`/appeals/${data.appeal_id}/${ENDPOINT_NAMES.SPLIT_APPEAL}`, { data }).

--- a/client/app/intakeEdit/IntakeEditFrame.jsx
+++ b/client/app/intakeEdit/IntakeEditFrame.jsx
@@ -238,7 +238,7 @@ export const IntakeEditFrame = (props) => {
               <AppSegment styling={textAlignRightStyling}>
                 <Route exact path={PAGE_PATHS.BEGIN} component={EditButtons} />
                 <Route exact path={PAGE_PATHS.CREATE_SPLIT} component={SplitButtons} />
-                <IntakeAppealContext.Provider value={props.appeal}>
+                <IntakeAppealContext.Provider value={[props.appeal, props.user]}>
                   <Route exact path={PAGE_PATHS.REVIEW_SPLIT} component={CreateButtons} />
                 </IntakeAppealContext.Provider>
               </AppSegment>
@@ -271,6 +271,7 @@ IntakeEditFrame.propTypes = {
   userDisplayName: PropTypes.string,
   appeal: PropTypes.object,
   claimId: PropTypes.string,
+  user: PropTypes.string,
   routerTestProps: PropTypes.object,
   router: PropTypes.object
 };

--- a/client/app/intakeEdit/components/CreateButtons.jsx
+++ b/client/app/intakeEdit/components/CreateButtons.jsx
@@ -84,10 +84,10 @@ const BackButton = connect(
 
 class SplitButtonUnconnected extends React.PureComponent {
 
-  handleSplitSubmit = (appeal, payloadInfo) => {
+  handleSplitSubmit = (appeal, payloadInfo, userCssId) => {
 
     const response = this.props.splitAppeal(appeal.id, payloadInfo.selectedIssues,
-      payloadInfo.reason, payloadInfo.otherReason, this.props.user);
+      payloadInfo.reason, payloadInfo.otherReason, userCssId);
 
     response.then(() => {
       window.location.href = `/queue/appeals/${this.props.claimId}`;
@@ -97,14 +97,14 @@ class SplitButtonUnconnected extends React.PureComponent {
 
     return (
       <IntakeAppealContext.Consumer>
-        {(appeal) => (
+        {(appealInfoUserArray) => (
           <StateContext.Consumer>
             {(payloadInfo) => (
               <Button
                 id="button-submit-update"
                 classNames={['cf-submit usa-button']}
                 // on click button sends claim id for dummy data
-                onClick={() => this.handleSplitSubmit(appeal, payloadInfo)}>
+                onClick={() => this.handleSplitSubmit(appealInfoUserArray[0], payloadInfo, appealInfoUserArray[1])}>
                 { COPY.CORRECT_REQUEST_ISSUES_SPLIT_APPEAL }
               </Button>
 

--- a/spec/controllers/split_appeal_controller_spec.rb
+++ b/spec/controllers/split_appeal_controller_spec.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe SplitAppealController, type: :controller do
-
   describe "POST split_appeal" do
-    let(:ssc_user) { create(:user, roles: '{Hearing Prep,Reader,SPLTAPPLLANNISTER}')}
+    let(:ssc_user) { create(:user, roles: "{Hearing Prep,Reader,SPLTAPPLLANNISTER}")}
 
     before do
       User.authenticate!(user: ssc_user)
@@ -13,23 +12,42 @@ RSpec.describe SplitAppealController, type: :controller do
     context "with valid parameters" do
       let(:benefit_type1) { "compensation" }
       let(:request_issue) { create(:request_issue, benefit_type: benefit_type1) }
-      let(:appeal) { create(:appeal)}
-      # let(:request_issue_params, {request_issue.id => true})
+      let(:root_task) { RootTask.find(create(:root_task).id) }
+      let(:appeal) { create(:appeal, tasks: [root_task]) }
       let(:valid_params) do
-          {
-            appeal_id: appeal.id,
-            appeal_split_issues: {request_issue.id => true},
-            split_reason: "Include a motion for CUE with respect to a prior Board decision",
-            split_other_reason: ""
-          }
+        {
+          appeal_id: appeal.id,
+          appeal_split_issues: { request_issue.id => true },
+          split_reason: "Include a motion for CUE with respect to a prior Board decision",
+          split_other_reason: "",
+          user_css_id: ssc_user.css_id
+        }
       end
 
-      it "creates a new split appeal" do 
-          post :split_appeal, params: valid_params
-          expect(response.status).to eq 201
-          dup_appeal = Appeal.last
-          expect(appeal.stream_docket_number).to eq(dup_appeal.stream_docket_number)
-          expect(appeal.veteran_file_number).to eq(dup_appeal.veteran_file_number)
+      it "creates a new split appeal" do
+        post :split_appeal, params: valid_params
+        expect(response.status).to eq 201
+        dup_appeal = Appeal.last
+        expect(appeal.stream_docket_number).to eq(dup_appeal.stream_docket_number)
+        expect(appeal.veteran_file_number).to eq(dup_appeal.veteran_file_number)
+      end
+
+      it "creates a split appeal task on the original and duplicate appeal" do
+        post :split_appeal, params: valid_params
+        expect(response.status).to eq 201
+        appeal.reload
+        dup_appeal = Appeal.last
+        appeal_split_task = appeal.tasks.where(type: "SplitAppealTask").first
+        dup_split_task = dup_appeal.tasks.where(type: "SplitAppealTask").first
+
+        expect(appeal.tasks.where(type: "SplitAppealTask").count).to eq(1)
+        expect(appeal_split_task.parent_id).to eq(appeal.root_task.id)
+        expect(appeal_split_task.instructions).to eq([valid_params[:split_reason]])
+        expect(appeal_split_task.status).to eq("completed")
+
+        expect(dup_appeal.tasks.where(type: "SplitAppealTask").count).to eq(1)
+        expect(dup_split_task.parent_id).to eq(dup_appeal.root_task.id)
+        expect(dup_split_task.appeal_id).to eq(dup_appeal.id)
       end
     end
 
@@ -37,37 +55,39 @@ RSpec.describe SplitAppealController, type: :controller do
       let(:benefit_type1) { "compensation" }
       let(:request_issue) { create(:request_issue, benefit_type: benefit_type1) }
       let(:invalid_params) do
-          {
-            appeal_id: "fail",
-            appeal_split_issues: {request_issue.id.to_s => true},
-            split_reason: "Include a motion for CUE with respect to a prior Board decision",
-            split_other_reason: ""
-          }
+        {
+          appeal_id: "fail",
+          appeal_split_issues: { request_issue.id.to_s => true },
+          split_reason: "Include a motion for CUE with respect to a prior Board decision",
+          split_other_reason: ""
+        }
       end
 
       it "doesn't create the new split appeal" do
-          post :split_appeal, params: invalid_params 
-          expect Appeal.count == 0
-          expect(response).to have_http_status 404
+        post :split_appeal, params: invalid_params
+        expect Appeal.count == 0
+        expect(response).to have_http_status 404
       end
     end
 
     context "the appeal is split" do
       let(:benefit_type1) { "compensation" }
       let(:request_issue) { create(:request_issue, benefit_type: benefit_type1) }
-      let(:original_appeal) { create(:appeal) }
+      let(:root_task) { RootTask.find(create(:root_task).id) }
+      let(:appeal) { create(:appeal, tasks: [root_task]) }
       let(:valid_params) do
         {
-          appeal_id: original_appeal.id,
-          appeal_split_issues: {request_issue.id.to_s => true},
+          appeal_id: appeal.id,
+          appeal_split_issues: { request_issue.id => true },
           split_reason: "Include a motion for CUE with respect to a prior Board decision",
-          split_other_reason: ""
+          split_other_reason: "",
+          user_css_id: ssc_user.css_id
         }
       end
       it "maintains the same relations as the original appeal" do
         post :split_appeal, params: valid_params
         dup_appeal = Appeal.last
-        expect(original_appeal.stream_docket_number).equal? dup_appeal.stream_docket_number
+        expect(appeal.stream_docket_number).equal? dup_appeal.stream_docket_number
       end
     end
     context "with an appeal that has a full hearing day" do
@@ -81,7 +101,8 @@ RSpec.describe SplitAppealController, type: :controller do
           scheduled_for: Time.zone.today + 1.week
         )
       end
-      let(:appeal) { create(:appeal, request_issues: [request_issue] ) }
+      let(:root_task) { RootTask.find(create(:root_task).id) }
+      let(:appeal) { create(:appeal, tasks: [root_task]) }
       let!(:hearing) do
         create(
           :hearing,
@@ -96,18 +117,18 @@ RSpec.describe SplitAppealController, type: :controller do
         end
       end
       let(:valid_params) do
-          {
-            appeal_id: appeal.id,
-            appeal_split_issues: {request_issue.id.to_s => true},
-            split_reason: "Include a motion for CUE with respect to a prior Board decision",
-            split_other_reason: ""
-          }
+        {
+          appeal_id: appeal.id,
+          appeal_split_issues: { request_issue.id.to_s => true },
+          split_reason: "Include a motion for CUE with respect to a prior Board decision",
+          split_other_reason: "",
+          user_css_id: ssc_user.css_id
+        }
       end
       it "creates the split appeal despite the hearing_day being full" do
         hearing_day.reload
-        appeal_count = Appeal.count
         post :split_appeal, params: valid_params
-        expect(Appeal.count).to be(appeal_count + 1)
+        expect(appeal.stream_docket_number).to eq(Appeal.last.stream_docket_number)
         expect(response).to have_http_status :success
       end
 

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -480,7 +480,6 @@ feature "Appeal Edit issues", :all_dbs do
 
     scenario "on the review_split page, testing appellant and vetera" do
       skill_form(appeal2)
-      # binding.pry
       if expect(appeal2.veteran_is_not_claimant).to be(false)
         row2_1 = page.find(:xpath, ".//table/tr[2]/td[1]/em").text
         row3_1 = page.find(:xpath, ".//table/tr[3]/td[1]/em").text


### PR DESCRIPTION
Patch to [APPEALS-3419](https://vajira.max.gov/browse/APPEALS-3419) Split Appeal Controller work

### Description
Patch to split_appeal_controller work for APPEALS-3419.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to the split_appeal_controller.rb file and make sure there are no errors. 

