### PR TITLE
Add additional stats to ACD

### DIFF
--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -72,8 +72,8 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   end
 
   def add_stuck_appeals_to_report(report, appeals)
-    report.unshift(COPY::PRIORITY_PUSH_WARNING_MESSAGE)
     report.unshift("[WARN]")
+    report << COPY::PRIORITY_PUSH_WARNING_MESSAGE
     report << "Legacy appeals not distributed: `LegacyAppeal.where(vacols_id: #{appeals[:legacy]})`"
     report << "AMA appeals not distributed: `Appeal.where(uuid: #{appeals.values.drop(1).flatten})`"
   end

--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -68,10 +68,10 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   end
 
   def add_stuck_appeals_to_report(report, appeals)
+    report.unshift(COPY::PRIORITY_PUSH_WARNING_MESSAGE)
     report.unshift("[WARN]")
     report << "Legacy appeals not distributed: `LegacyAppeal.where(vacols_id: #{appeals[:legacy]})`"
     report << "AMA appeals not distributed: `Appeal.where(uuid: #{appeals.values.drop(1).flatten})`"
-    report << COPY::PRIORITY_PUSH_WARNING_MESSAGE
   end
 
   # Distribute all priority cases tied to a judge without limit

--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -53,7 +53,11 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
       [docket_type, docket.ready_priority_appeal_ids]
     end.to_h
 
-    report << "*Number of appeals _not_ distributed*: #{appeals_not_distributed.values.flatten.count}"
+    report << "*Total Number of appeals _not_ distributed*: #{appeals_not_distributed.values.flatten.count}"
+    docket_coordinator.dockets.each_pair do |sym, docket|
+      report << "*Number of #{sym} appeals _not_ distributed*: #{docket.count(priority: true, ready: true)}"
+    end
+    report << "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: #{legacy_not_genpop_count}"
 
     report << ""
     report << "*Debugging information*"
@@ -173,5 +177,9 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
 
   def use_by_docket_date?
     FeatureToggle.enabled?(:acd_distribute_by_docket_date, user: RequestStore.store[:current_user])
+  end
+
+  def legacy_not_genpop_count
+    docket_coordinator.dockets[:legacy].not_genpop_priority_count
   end
 end

--- a/app/jobs/push_priority_appeals_to_judges_job.rb
+++ b/app/jobs/push_priority_appeals_to_judges_job.rb
@@ -74,8 +74,8 @@ class PushPriorityAppealsToJudgesJob < CaseflowJob
   def add_stuck_appeals_to_report(report, appeals)
     report.unshift("[WARN]")
     report << COPY::PRIORITY_PUSH_WARNING_MESSAGE
-    report << "Legacy appeals not distributed: `LegacyAppeal.where(vacols_id: #{appeals[:legacy]})`"
     report << "AMA appeals not distributed: `Appeal.where(uuid: #{appeals.values.drop(1).flatten})`"
+    report << "Legacy appeals not distributed: `LegacyAppeal.where(vacols_id: #{appeals[:legacy]})`"
   end
 
   # Distribute all priority cases tied to a judge without limit

--- a/app/models/concerns/by_docket_date_distribution.rb
+++ b/app/models/concerns/by_docket_date_distribution.rb
@@ -8,6 +8,7 @@ module ByDocketDateDistribution
   private
 
   def priority_push_distribution(limit)
+    @priority_target = limit
     @rem = 0
     @appeals = []
     # Distribute <limit> number of cases, regardless of docket type, oldest first.
@@ -50,10 +51,15 @@ module ByDocketDateDistribution
     {
       batch_size: @appeals.count,
       total_batch_size: total_batch_size,
-      priority_count: priority_count,
-      direct_review_due_count: direct_review_due_count,
-      legacy_hearing_backlog_count: VACOLS::CaseDocket.nonpriority_hearing_cases_for_judge_count(judge),
-      nonpriority_iterations: @nonpriority_iterations,
+      priority: {
+        count: priority_count,
+        target: @priority_target
+      },
+      nonpriority: {
+        direct_review_due_count: direct_review_due_count,
+        legacy_hearing_backlog_count: legacy_hearing_backlog_count(judge),
+        iterations: @nonpriority_iterations
+      },
       algorithm: "by_docket_date"
     }
   end

--- a/app/models/concerns/by_docket_date_distribution.rb
+++ b/app/models/concerns/by_docket_date_distribution.rb
@@ -51,14 +51,14 @@ module ByDocketDateDistribution
   def priority_stats
     {
       count: priority_count,
-      target: @push_priority_target
+      priority_target: @push_priority_target
     }
   end
 
   def nonpriority_stats
     {
       count: nonpriority_count,
-      target: @request_priority_count
+      priority_target: @request_priority_count
     }
   end
 

--- a/app/models/concerns/case_distribution.rb
+++ b/app/models/concerns/case_distribution.rb
@@ -6,8 +6,10 @@ module CaseDistribution
   delegate :dockets,
            :docket_proportions,
            :priority_count,
+           :nonpriority_count,
            :direct_review_due_count,
            :total_batch_size,
+           :legacy_hearing_backlog_count,
            to: :docket_coordinator
 
   private

--- a/app/models/concerns/case_distribution.rb
+++ b/app/models/concerns/case_distribution.rb
@@ -18,23 +18,11 @@ module CaseDistribution
     @docket_coordinator ||= DocketCoordinator.new
   end
 
-  def priority_push_distribution(limit = nil)
-    fail Caseflow::Error::MustImplementInSubclass
-  end
-
-  def requested_distribution
-    fail Caseflow::Error::MustImplementInSubclass
-  end
-
   def collect_appeals
     appeals = yield
     @rem -= appeals.count
     @appeals += appeals
     appeals
-  end
-
-  def ama_statistics
-    fail Caseflow::Error::MustImplementInSubclass
   end
 
   def priority_target

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -96,6 +96,13 @@ class DocketCoordinator
       .sum
   end
 
+  def nonpriority_count
+    @nonpriority_count ||= dockets
+      .values
+      .map { |docket| docket.count(priority: false, ready: true) }
+      .sum
+  end
+
   def genpop_priority_count
     @genpop_priority_count ||= dockets.values.map(&:genpop_priority_count).sum
   end

--- a/app/models/docket_coordinator.rb
+++ b/app/models/docket_coordinator.rb
@@ -113,6 +113,10 @@ class DocketCoordinator
     direct_review_due_count.to_f / docket_margin_net_of_priority
   end
 
+  def legacy_hearing_backlog_count(judge)
+    VACOLS::CaseDocket.nonpriority_hearing_cases_for_judge_count(judge)
+  end
+
   private
 
   def docket_margin_net_of_priority

--- a/app/models/dockets/legacy_docket.rb
+++ b/app/models/dockets/legacy_docket.rb
@@ -20,6 +20,10 @@ class LegacyDocket < Docket
     LegacyAppeal.repository.genpop_priority_count
   end
 
+  def not_genpop_priority_count
+    LegacyAppeal.repository.not_genpop_priority_count
+  end
+
   def weight
     count(priority: false) + nod_count * Constants.DISTRIBUTION.nod_adjustment
   end

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -192,6 +192,15 @@ class VACOLS::CaseDocket < VACOLS::Record
     connection.exec_query(query).to_hash.count
   end
 
+  def self.not_genpop_priority_count
+    query = <<-SQL
+      #{SELECT_PRIORITY_APPEALS}
+      where VLJ is not null
+    SQL
+
+    connection.exec_query(query).to_hash.count
+  end
+
   def self.nod_count
     where("BFMPRO = 'ADV' and BFD19 is null").count
   end

--- a/app/repositories/appeal_repository.rb
+++ b/app/repositories/appeal_repository.rb
@@ -724,6 +724,14 @@ class AppealRepository
       end
     end
 
+    def not_genpop_priority_count
+      MetricsService.record("VACOLS: not_genpop_priority_count",
+                            name: "not_genpop_priority_count",
+                            service: :vacols) do
+        VACOLS::CaseDocket.not_genpop_priority_count
+      end
+    end
+
     def priority_ready_appeal_vacols_ids
       MetricsService.record("VACOLS: priority_ready_appeal_vacols_ids",
                             name: "priority_ready_appeal_vacols_ids",

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -699,14 +699,13 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[11]).to eq "*Number of hearing appeals _not_ distributed*: 1"
       expect(subject[12]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[13]).to eq "Priority Target: 6"
-      expect(subject[14]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[15].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[16].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[16].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[16].include?(ready_priority_direct_case.uuid)).to be true
-
-      expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[15]).to eq "Priority Target: 6"
+      expect(subject[16]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[17]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[18].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[19].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[19].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[19].include?(ready_priority_direct_case.uuid)).to be true
     end
 
     it "returns the Slack Message associated with By Docket Date Distribution" do
@@ -730,14 +729,13 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[10]).to eq "*Number of hearing appeals _not_ distributed*: 1"
       expect(subject[11]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[12]).to eq "Priority Target: 6"
-      expect(subject[13]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[14].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[15].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[15].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[15].include?(ready_priority_direct_case.uuid)).to be true
-
-      expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[14]).to eq "Priority Target: 6"
+      expect(subject[15]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[16]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[17].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[18].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_direct_case.uuid)).to be true
     end
 
     after do
@@ -843,14 +841,13 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[11]).to eq "*Number of hearing appeals _not_ distributed*: 1"
       expect(subject[12]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[13]).to eq "Priority Target: 6"
-      expect(subject[14]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[15].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[16].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[16].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[16].include?(ready_priority_direct_case.uuid)).to be true
-
-      expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[15]).to eq "Priority Target: 6"
+      expect(subject[16]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[17]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
+      expect(subject[18].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[19].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[19].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[19].include?(ready_priority_direct_case.uuid)).to be true
     end
   end
 

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -702,10 +702,10 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[15]).to eq "Priority Target: 6"
       expect(subject[16]).to eq "Previous monthly distributions: #{previous_distributions}"
       expect(subject[17]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
-      expect(subject[18].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[19].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[19].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[19].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[19].include?(legacy_priority_case.bfkey)).to be true
     end
 
     it "returns the Slack Message associated with By Docket Date Distribution" do
@@ -732,10 +732,10 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[14]).to eq "Priority Target: 6"
       expect(subject[15]).to eq "Previous monthly distributions: #{previous_distributions}"
       expect(subject[16]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
-      expect(subject[17].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[18].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[18].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[18].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[17].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[17].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[17].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[18].include?(legacy_priority_case.bfkey)).to be true
     end
 
     after do
@@ -844,10 +844,10 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       expect(subject[15]).to eq "Priority Target: 6"
       expect(subject[16]).to eq "Previous monthly distributions: #{previous_distributions}"
       expect(subject[17]).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
-      expect(subject[18].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[19].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[19].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[19].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[18].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[19].include?(legacy_priority_case.bfkey)).to be true
     end
   end
 

--- a/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
+++ b/spec/jobs/push_priority_appeals_to_judges_job_spec.rb
@@ -692,14 +692,19 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       hearing_days_waiting = (today - ready_priority_hearing_case.ready_for_distribution_at.to_date).to_i
       expect(subject[6]).to eq "*Age of oldest hearing case*: #{hearing_days_waiting} days"
 
-      expect(subject[7]).to eq "*Number of appeals _not_ distributed*: 4"
+      expect(subject[7]).to eq "*Total Number of appeals _not_ distributed*: 4"
+      expect(subject[8]).to eq "*Number of legacy appeals _not_ distributed*: 1"
+      expect(subject[9]).to eq "*Number of direct_review appeals _not_ distributed*: 1"
+      expect(subject[10]).to eq "*Number of evidence_submission appeals _not_ distributed*: 1"
+      expect(subject[11]).to eq "*Number of hearing appeals _not_ distributed*: 1"
+      expect(subject[12]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[10]).to eq "Priority Target: 6"
-      expect(subject[11]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[12].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[13].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[13].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[13].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[13]).to eq "Priority Target: 6"
+      expect(subject[14]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[15].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[16].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[16].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[16].include?(ready_priority_direct_case.uuid)).to be true
 
       expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
     end
@@ -718,14 +723,19 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       hearing_days_waiting = (today - ready_priority_hearing_case.receipt_date).to_i
       expect(subject[5]).to eq "*Age of oldest hearing case*: #{hearing_days_waiting} days"
 
-      expect(subject[6]).to eq "*Number of appeals _not_ distributed*: 4"
+      expect(subject[6]).to eq "*Total Number of appeals _not_ distributed*: 4"
+      expect(subject[7]).to eq "*Number of legacy appeals _not_ distributed*: 1"
+      expect(subject[8]).to eq "*Number of direct_review appeals _not_ distributed*: 1"
+      expect(subject[9]).to eq "*Number of evidence_submission appeals _not_ distributed*: 1"
+      expect(subject[10]).to eq "*Number of hearing appeals _not_ distributed*: 1"
+      expect(subject[11]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[9]).to eq "Priority Target: 6"
-      expect(subject[10]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[11].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[12].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[12].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[12].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[12]).to eq "Priority Target: 6"
+      expect(subject[13]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[14].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[15].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[15].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[15].include?(ready_priority_direct_case.uuid)).to be true
 
       expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
     end
@@ -826,14 +836,19 @@ describe PushPriorityAppealsToJudgesJob, :all_dbs do
       hearing_days_waiting = (today - ready_priority_hearing_case.ready_for_distribution_at.to_date).to_i
       expect(subject[6]).to eq "*Age of oldest hearing case*: #{hearing_days_waiting} days"
 
-      expect(subject[7]).to eq "*Number of appeals _not_ distributed*: 4"
+      expect(subject[7]).to eq "*Total Number of appeals _not_ distributed*: 4"
+      expect(subject[8]).to eq "*Number of legacy appeals _not_ distributed*: 1"
+      expect(subject[9]).to eq "*Number of direct_review appeals _not_ distributed*: 1"
+      expect(subject[10]).to eq "*Number of evidence_submission appeals _not_ distributed*: 1"
+      expect(subject[11]).to eq "*Number of hearing appeals _not_ distributed*: 1"
+      expect(subject[12]).to eq "*Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 1"
 
-      expect(subject[10]).to eq "Priority Target: 6"
-      expect(subject[11]).to eq "Previous monthly distributions: #{previous_distributions}"
-      expect(subject[12].include?(legacy_priority_case.bfkey)).to be true
-      expect(subject[13].include?(ready_priority_hearing_case.uuid)).to be true
-      expect(subject[13].include?(ready_priority_evidence_case.uuid)).to be true
-      expect(subject[13].include?(ready_priority_direct_case.uuid)).to be true
+      expect(subject[13]).to eq "Priority Target: 6"
+      expect(subject[14]).to eq "Previous monthly distributions: #{previous_distributions}"
+      expect(subject[15].include?(legacy_priority_case.bfkey)).to be true
+      expect(subject[16].include?(ready_priority_hearing_case.uuid)).to be true
+      expect(subject[16].include?(ready_priority_evidence_case.uuid)).to be true
+      expect(subject[16].include?(ready_priority_direct_case.uuid)).to be true
 
       expect(subject.last).to eq COPY::PRIORITY_PUSH_WARNING_MESSAGE
     end

--- a/spec/models/concerns/by_docket_date_distribution_spec.rb
+++ b/spec/models/concerns/by_docket_date_distribution_spec.rb
@@ -169,4 +169,36 @@ describe ByDocketDateDistribution, :all_dbs do
       expect(return_array).to eq(nonpriority_count_hash)
     end
   end
+
+  context "#ama_statistics" do
+    before do
+      @new_acd.instance_variable_set(:@appeals, [])
+    end
+
+    it "returns a hash with keys" do
+      statistics = @new_acd.send(:ama_statistics)
+
+      expect(statistics).to include(:batch_size)
+      expect(statistics).to include(:total_batch_size)
+      expect(statistics).to include(:priority)
+      expect(statistics).to include(:nonpriority)
+      expect(statistics).to include(:algorithm)
+
+      priority_stats = statistics[:priority]
+      nonpriority_stats = statistics[:nonpriority]
+
+      expect(priority_stats).to include(:count)
+      expect(priority_stats).to include(:priority_target)
+      expect(nonpriority_stats).to include(:count)
+      expect(nonpriority_stats).to include(:priority_target)
+      expect(nonpriority_stats).to include(:direct_review_due_count)
+      expect(nonpriority_stats).to include(:legacy_hearing_backlog_count)
+      expect(nonpriority_stats).to include(:iterations)
+
+      @new_acd.dockets.each_key do |sym|
+        expect(priority_stats).to include(sym)
+        expect(nonpriority_stats).to include(sym)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves #{github issue number}

### Description

Distributions.statistics will now look like
```
  {"batch_size"=>12,
   "total_batch_size"=>132,
   "priority"=>{"count"=>126, "priority_target"=>nil, "legacy"=>23, "direct_review"=>16, "evidence_submission"=>22, "hearing"=>53},
   "nonpriority"=>{"count"=>161, "priority_target"=>12, "legacy"=>48, "direct_review"=>55, "evidence_submission"=>21, "hearing"=>37, "direct_review_due_count"=>55, "legacy_hearing_backlog_count"=>2, "iterations"=>0},
   "algorithm"=>"by_docket_date"},
```

Add and update lines to the Slack message to indicate count priority ready appeals for each docket and for Legacy Hearings tied to a VLJ

>  *Total Number of appeals _not_ distributed*: 4
>  *Number of legacy appeals _not_ distributed*: 4
>  *Number of direct_review appeals _not_ distributed*: 4
>  *Number of evidence_submission appeals _not_ distributed*: 4
>  *Number of hearing appeals _not_ distributed*: 4
>  *Number of Legacy Hearing Non Genpop appeals _not_ distributed*: 4
