### PR TITLE
msteel/APPEALS-9773

### DIFF
--- a/app/models/serializers/idt/v1/appeal_details_serializer.rb
+++ b/app/models/serializers/idt/v1/appeal_details_serializer.rb
@@ -49,7 +49,7 @@ class Idt::V1::AppealDetailsSerializer
           middle_name: claimant.middle_name,
           last_name: claimant.last_name,
           full_name: claimant.last_name.present? ? nil : claimant.name&.upcase,
-          name_suffix: "",
+          name_suffix: claimant.suffix,
           address: address,
           representative: claimant.representative_name ? representative : nil
         }

--- a/spec/models/serializers/idt/appeal_details_serializer_spec.rb
+++ b/spec/models/serializers/idt/appeal_details_serializer_spec.rb
@@ -130,6 +130,15 @@ describe Idt::V1::AppealDetailsSerializer, :postgres do
       expect(claimant_attributes[:full_name]).to be nil
     end
 
+    it "includes the name suffix if present" do
+      allow_any_instance_of(Claimant).to receive(:suffix).and_return("PhD")
+
+      serialized_attributes = subject.serializable_hash[:data][:attributes]
+
+      claimant_attributes = serialized_attributes[:appellants].first
+      expect(claimant_attributes[:name_suffix]).to eq "PhD"
+    end
+
     context "when the claimant is missing last name, but has full name" do
       it "populates full name in appellant attributes" do
         allow_any_instance_of(Claimant).to receive(:name).and_return("Full Name")


### PR DESCRIPTION
Resolves APPEALS-9773

### Description
The name_suffix for claimants was originally returning an empty string in the AppealDetailSerializer. This has been updated to return the proper suffix if one is given for the claimant.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
https://vajira.max.gov/browse/APPEALS-10222