### PR TITLE
Craig/appeals 10578

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+browser_tools_versions: &browser_versions
+  chrome-version: 106.0.5249.119
+  firefox-version: 106.0.1
+
 commands:
   install_ruby_dependencies:
     description: "Install Ruby Dependencies"
@@ -202,7 +206,9 @@ jobs:
           name: Setup testfiles directory
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
+
       - install_ruby_dependencies
 
       - install_dockerize
@@ -335,7 +341,8 @@ jobs:
           - COVERAGE_DIR: /home/circleci/coverage
     resource_class: large
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency

--- a/app/models/mpi_update_person_event.rb
+++ b/app/models/mpi_update_person_event.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class MpiUpdatePersonEvent < CaseflowRecord
+  belongs_to :api_key, optional: false
+
+  validates :update_type, presence: true
+
+  enum update_type: {
+    no_veteran: "NO_VETERAN",
+    already_deceased: "ALREADY_DECEASED",
+    missing_deceased_info: "MISSING_DECEASED_INFO",
+    successful: "SUCCESSFUL",
+    error: "ERROR"
+  }
+end

--- a/db/migrate/20221025164533_add_mpi_update_person_events_table.rb
+++ b/db/migrate/20221025164533_add_mpi_update_person_events_table.rb
@@ -1,0 +1,11 @@
+class AddMpiUpdatePersonEventsTable < Caseflow::Migration
+  def change
+    create_table :mpi_update_person_events do |t|
+      t.references :api_key, foreign_key: true, null: false, comment: "API Key used to initiate the event"
+      t.string     :update_type, null: false, comment: "Type or Result of update"
+      t.json       :info, comment: "Additional information about the update"
+      t.timestamp  :created_at, comment: "Timestamp of when update was initiated"
+      t.timestamp  :completed_at, comment: "Timestamp of when update was completed, regardless of success or failure"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_18_173134) do
+ActiveRecord::Schema.define(version: 2022_10_25_164533) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1076,6 +1076,15 @@ ActiveRecord::Schema.define(version: 2022_10_18_173134) do
     t.index ["updated_at"], name: "index_messages_on_updated_at"
   end
 
+  create_table "mpi_update_person_events", force: :cascade do |t|
+    t.bigint "api_key_id", null: false, comment: "API Key used to initiate the event"
+    t.datetime "completed_at", comment: "Timestamp of when update was completed, regardless of success or failure"
+    t.datetime "created_at", comment: "Timestamp of when update was initiated"
+    t.json "info", comment: "Additional information about the update"
+    t.string "update_type", null: false, comment: "Type or Result of update"
+    t.index ["api_key_id"], name: "index_mpi_update_person_events_on_api_key_id"
+  end
+
   create_table "nod_date_updates", comment: "Tracks changes to an AMA appeal's receipt date (aka, NOD date)", force: :cascade do |t|
     t.bigint "appeal_id", null: false, comment: "Appeal for which the NOD date is being edited"
     t.string "change_reason", null: false, comment: "Reason for change: entry_error or new_info"
@@ -1819,6 +1828,7 @@ ActiveRecord::Schema.define(version: 2022_10_18_173134) do
   add_foreign_key "legacy_issue_optins", "request_issues"
   add_foreign_key "legacy_issues", "request_issues"
   add_foreign_key "messages", "users"
+  add_foreign_key "mpi_update_person_events", "api_keys"
   add_foreign_key "nod_date_updates", "appeals"
   add_foreign_key "nod_date_updates", "users"
   add_foreign_key "non_availabilities", "schedule_periods"

--- a/spec/models/mpi_person_update_event_spec.rb
+++ b/spec/models/mpi_person_update_event_spec.rb
@@ -34,6 +34,7 @@ describe MpiUpdatePersonEvent do
         .to raise_error(ArgumentError)
     end
 
+    # creates an array of events, then reject any where .valid? is true and count the result
     it "succeeds with an api_key and each valid update_type" do
       updates = []
       i = 0

--- a/spec/models/mpi_person_update_event_spec.rb
+++ b/spec/models/mpi_person_update_event_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+describe MpiUpdatePersonEvent do
+  let(:api_key) { ApiKey.create!(consumer_name: "Test API Key") }
+  let(:invalid_update_type) { "invalid_update_type" }
+  let(:valid_update_types) do
+    {
+      no_veteran: "NO_VETERAN",
+      already_deceased: "ALREADY_DECEASED",
+      missing_deceased_info: "MISSING_DECEASED_INFO",
+      successful: "SUCCESSFUL",
+      error: "ERROR"
+    }
+  end
+
+  context "validation" do
+    it "fails with no api_key or update_type" do
+      update = MpiUpdatePersonEvent.new
+
+      expect(update.valid?).to eq(false)
+      expect(update.errors.details).to have_key(:api_key)
+      expect(update.errors.details).to have_key(:update_type)
+    end
+
+    it "fails with an api_key but no update_type" do
+      update = MpiUpdatePersonEvent.new(api_key: api_key)
+
+      expect(update.valid?).to eq(false)
+      expect(update.errors.details).to have_key(:update_type)
+    end
+
+    it "fails with an api_key and invalid update_type" do
+      expect { MpiUpdatePersonEvent.new(api_key: api_key, update_type: invalid_update_type) }
+        .to raise_error(ArgumentError)
+    end
+
+    it "succeeds with an api_key and each valid update_type" do
+      updates = []
+      i = 0
+      valid_update_types.each do |update_type_sym, _update_type_text|
+        updates[i] = MpiUpdatePersonEvent.new(api_key: api_key, update_type: update_type_sym)
+        i += 1
+      end
+      updates.reject!(&:valid?)
+
+      expect(updates.count).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
Resolves [APPEALS-10578](https://vajira.max.gov/browse/APPEALS-10578)

### Description
- Added mpi_person_update_events table
- Added MpiPersonUpdateEvent model
- Added tests for model validations

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Table is created when running make migrate

### Database Changes
*Only for Schema Changes*

* [x] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [x] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [x] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [x] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [x] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [x] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [x] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [x] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)
