### PR TITLE
Testing Pinning CI Browser Versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,8 +203,8 @@ jobs:
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
       - browser-tools/install-browser-tools:
-        chrome-version: 106.0.5249.119
-        firefox-version: 106.0.1
+          chrome-version: 106.0.5249.119
+          firefox-version: 106.0.1
 
       - install_ruby_dependencies
 
@@ -339,8 +339,8 @@ jobs:
     resource_class: large
     steps:
       - browser-tools/install-browser-tools:
-        chrome-version: 106.0.5249.119
-        firefox-version: 106.0.1
+          chrome-version: 106.0.5249.119
+          firefox-version: 106.0.1
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+browser_tools_versions: &browser_versions
+  chrome-version: 106.0.5249.119
+  firefox-version: 106.0.1
+
 commands:
   install_ruby_dependencies:
     description: "Install Ruby Dependencies"
@@ -203,8 +207,7 @@ jobs:
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
       - browser-tools/install-browser-tools:
-          chrome-version: 106.0.5249.119
-          firefox-version: 106.0.1
+          <<: *browser_versions
 
       - install_ruby_dependencies
 
@@ -339,8 +342,7 @@ jobs:
     resource_class: large
     steps:
       - browser-tools/install-browser-tools:
-          chrome-version: 106.0.5249.119
-          firefox-version: 106.0.1
+          <<: *browser_versions
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,7 +202,10 @@ jobs:
           name: Setup testfiles directory
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+        chrome-version: 106.0.5249.119
+        firefox-version: 106.0.1
+
       - install_ruby_dependencies
 
       - install_dockerize

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,7 +338,9 @@ jobs:
           - COVERAGE_DIR: /home/circleci/coverage
     resource_class: large
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+        chrome-version: 106.0.5249.119
+        firefox-version: 106.0.1
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency


### PR DESCRIPTION
Testing pinning browser versions in CI config to the ones last known to work.

Using the branch for APPEALS-9138 to test it with as CI test failures were recently observed with it (and I happened to have it open already).