### PR TITLE
Hotfix/Pin CI Browser Versions and Update circleci/browser-tools Orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ commands:
             DISABLE_FACTORY_BOT_INITIALIZERS: 1
 
 orbs:
-  browser-tools: circleci/browser-tools@1.2
+  browser-tools: circleci/browser-tools@1.4.0
 jobs:
   # build workspace
   build_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+browser_tools_versions: &browser_versions
+  chrome-version: 106.0.5249.119
+  firefox-version: 106.0.1
+
 commands:
   install_ruby_dependencies:
     description: "Install Ruby Dependencies"
@@ -202,7 +206,9 @@ jobs:
           name: Setup testfiles directory
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
+
       - install_ruby_dependencies
 
       - install_dockerize
@@ -335,7 +341,8 @@ jobs:
           - COVERAGE_DIR: /home/circleci/coverage
     resource_class: large
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency


### PR DESCRIPTION
This PR is in response to CI test failures occurring suddenly after the Chrome v107.0.5304,62 update yesterday.

It performs the following:
  - Pins the versions of Chrome and Firefox in the CI config to where they were on 10/24/2022 prior to issues being observed.
  - Upgrades the circleci/browser-tools orb from v1.2 to v1.4.0