### PR TITLE
HunJerBAH/APPEALS-4147 addition: Advance On Docket and Cavc Remand Fix

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -318,9 +318,8 @@ class Appeal < DecisionReview
     self&.clone_issues(parent_appeal)
     # update the child task tree with parent, passing CSS ID of user for validation
     self&.clone_task_tree(parent_appeal, user_css_id)
-    
     # if there is an AOD for the parent appeal, clone
-    unless AdvanceOnDocketMotion.where(appeal_id: parent_appeal.id).nil?
+    if !AdvanceOnDocketMotion.find_by(appeal_id: parent_appeal.id).nil?
       self&.clone_aod(parent_appeal)
     end
     # set split appeal process flag to false

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -318,6 +318,11 @@ class Appeal < DecisionReview
     self&.clone_issues(parent_appeal)
     # update the child task tree with parent, passing CSS ID of user for validation
     self&.clone_task_tree(parent_appeal, user_css_id)
+    
+    # if there is an AOD for the parent appeal, clone
+    unless AdvanceOnDocketMotion.where(appeal_id: parent_appeal.id).nil?
+      self&.clone_aod(parent_appeal)
+    end
     # set split appeal process flag to false
     self.appeal_split_process = false
     # set the duplication split flag
@@ -367,6 +372,19 @@ class Appeal < DecisionReview
       dup_issue&.decision_issue_id = decision_review_parent_to_child_hash[rd_issue.decision_issue_id]
       dup_issue&.save
     end
+  end
+
+  def clone_aod(parent_appeal)
+    # find the appeal AOD
+    aod = AdvanceOnDocketMotion.find_by(appeal_id: parent_appeal.id)
+    # create a new advance on docket for the duplicate appeal
+    AdvanceOnDocketMotion.create!(
+      user_id: aod.user_id,
+      person_id: claimant.person.id,
+      granted: aod.granted,
+      reason: aod.reason,
+      appeal: self
+    )
   end
 
   def clone_issue(issue)

--- a/app/models/cavc_remand.rb
+++ b/app/models/cavc_remand.rb
@@ -41,6 +41,7 @@ class CavcRemand < CaseflowRecord
   # amoeba gem for split appeal duplication
   amoeba do
     enable
+    exclude_association :power_of_attorney, if: :represented_by_attorney?
   end
 
   # called from the Add Cavc Date Modal


### PR DESCRIPTION
Adds an addition to [APPEALS-4147](https://vajira.max.gov/browse/APPEALS-4147)
### Description
As a developer I need to duplicate the appeal so that issues can be split between the original and the new appeal

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The advance_on_docket (aod) relation is maintained if the original appeal has an advance_on_docket. 
- [ ] This relation is maintained even if the advance_on_docket is **false** but there is an AdvanceOnDocketMotion in the database.
- [ ] Appeals with Cavc Remands and Intakes are able to be duplicated without a SQL error.

### Testing Plan
1. Open up the rails console. 
2. Run `appeal = Appeal.find(1)` to find an appeal. 
3. Currently, there are no `AdvanceOnDocketMotion`s that currently exist in the database, so we will need to create one for Appeal 1. To do this, run `aod = AdvanceOnDocketMotion.create!(appeal: appeal, user_id: 1, person_id: appeal.claimant.person.id, granted: true)`.  Confirm the relation exists by running `aod` in the terminal.
4. Now that the appeal has a AOD, we need to clone the appeal. To clone the appeal, run: 
5. `dup = appeal.amoeba_dup`
6. `dup.save`
7. `dup.finalize_split_apppeal(appeal, 'BVASYELLOW')
8. If the split was successful, the output should return **true**.
9. Check that the `advance_on_docket` was successful by running `dup.aod?`. The output should return **true**.
10. Compare the `AdvanceOnDocketMotion` models saved in the database by running:

- AdvanceOnDocketMotion.find_by(appeal_id: appeal.id)
- `AdvanceOnDocketMotion.find_by(appeal_id: dup.id)
![image](https://user-images.githubusercontent.com/99915461/198109544-fa526c8a-3410-4ffc-8827-7b64c2eb431e.png)

11. Make sure the `claimant` and `person` on the appeals are maintained. Run:
`appeal.claimant` and `dup.claimant` to test the claimant.
`appeal.claimant.person` and `dup.claimant.person` to test the person.
The claimant should be a little different...
![image](https://user-images.githubusercontent.com/99915461/198113451-f6e3f99b-1097-4266-84e7-fc427b92acba.png)
...but the person should be the same:
![image](https://user-images.githubusercontent.com/99915461/198113585-25c2bba3-c8ed-403e-9cc7-80f448a18955.png)

11. To test if the record is copied when an AOD has a status of `false`, run `appeal = Appeal.find(2)` followed by  `aod = AdvanceOnDocketMotion.create!(appeal: appeal, user_id: 1, person_id: appeal.claimant.person.id, granted: false)` to create the appeal and the record.
13. Repeat steps 5-10 to duplicate the appeal. Confirm the `AdvanceOnDocketMotion` was created for the split appeal:
![image](https://user-images.githubusercontent.com/99915461/198111489-ccff4d95-bc3c-43f0-be34-6cdbfecbb482.png)

To test the **cavc_remand** and **intake** relations, follow the tests below.
1. Run `appeal= Appeal.find(1713)`. Confirm the appeal has a cavc_remand by running `appeal.cavc_remand`
2. Clone the appeal by running 

- `dup = appeal.amoeba_dup`
- `dup.save`
- `dup.finalize_split_appeal(appeal, 'BVASYELLOW')`
3. Confirm the clone worked by running. The `remand_appeal_id` should represent the appeal/dup appeal id respectively 

- `appeal.cavc_remand`
- `dup.cavc_remand`
![image](https://user-images.githubusercontent.com/99915461/198373560-9f0440bc-3bc2-4584-8431-376890e00bdc.png)

Confirm the `power_of_attorney` is maintained by running:

- `appeal.claimant.power_of_attorney`
- `dup.claimant.power_of_attorney`
Both should point to the same attorney.

![image](https://user-images.githubusercontent.com/99915461/198373914-023b8008-450f-415b-a4c0-734d48acadb8.png)

4. Confirm `intake` is maintained by running `appeal = Appeal.find(2000061110)` to find an appeal with an intake. Confirm by running `appeal.intake`. 
5. Clone the appeal by running 

- `dup = appeal.amoeba_dup`
- `dup.save`
- `dup.finalize_split_appeal(appeal, 'BVASYELLOW')`

6. Confirm the intake was maintained by running 

- `appeal.intake`
- `dup.intake`
![image](https://user-images.githubusercontent.com/99915461/198374436-161a386b-789f-4b8c-8841-52a800740299.png)

Again, confirm the power of attorney by running:
- `appeal.claimant.power_of_attorney`
- `dup.claimant.power_of_attorney`
Both should point to the same attorney.
![image](https://user-images.githubusercontent.com/99915461/198374655-3b49b4f9-17a2-4ecb-ba5f-f7c461057677.png)

