### PR TITLE
remove dead caseflow status link 

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -57,7 +57,7 @@
     "@babel/preset-react": "^7.12.7",
     "@babel/register": "^7.12.1",
     "@babel/runtime-corejs2": "^7.12.5",
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#12d7eb5",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7",
     "@fortawesome/fontawesome-free": "^5.3.1",
     "@hookform/resolvers": "^2.0.0-beta.5",
     "@reduxjs/toolkit": "^1.4.0",

--- a/client/package.json
+++ b/client/package.json
@@ -57,7 +57,7 @@
     "@babel/preset-react": "^7.12.7",
     "@babel/register": "^7.12.1",
     "@babel/runtime-corejs2": "^7.12.5",
-    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7",
+    "@department-of-veterans-affairs/caseflow-frontend-toolkit": "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#404b2041",
     "@fortawesome/fontawesome-free": "^5.3.1",
     "@hookform/resolvers": "^2.0.0-beta.5",
     "@reduxjs/toolkit": "^1.4.0",

--- a/client/test/app/containers/CaseWorker/__snapshots__/CaseWorkerIndex.test.js.snap
+++ b/client/test/app/containers/CaseWorker/__snapshots__/CaseWorkerIndex.test.js.snap
@@ -196,17 +196,6 @@ exports[`CaseWorkerIndex renders correctly 1`] = `
         class="cf-push-right"
       >
         <a
-          href="https://caseflow.statuspage.io"
-          target="_blank"
-        >
-          Track Caseflow Status
-        </a>
-        <span
-          data-css-1bblw8p=""
-        >
-          |
-        </span>
-        <a
           target="_blank"
         >
           Send feedback

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2529,9 +2529,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#12d7eb5":
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7":
   version "2.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#12d7eb5d0801009fd444249e4a1836dac42a4b35"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7b5eddb5f0eccc57d5f6d43ca7c5b5bc8"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2529,9 +2529,9 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7":
+"@department-of-veterans-affairs/caseflow-frontend-toolkit@https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#404b2041":
   version "2.6.1"
-  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#88d08ff7b5eddb5f0eccc57d5f6d43ca7c5b5bc8"
+  resolved "https://github.com/department-of-veterans-affairs/caseflow-frontend-toolkit#404b204153f483cc16f6c873622f77a71e20d4f6"
   dependencies:
     classnames "^2.2.5"
     glamor "^2.20.40"


### PR DESCRIPTION
Resolves [APPEALS-10422](https://vajira.max.gov/browse/APPEALS-10422)

### Description
- Updated client/package.json to use latest build of caseflow-frontend-toolkit

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Link is removed from Caseflow

### Testing Plan
1. Check each Caseflow app to ensure the "Track Caseflow Status" link is removed from the footer

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 [BEFORE](https://vajira.max.gov/secure/attachment/386889/Screen%20Shot%202022-10-19%20at%206.44.42%20PM.png) | [AFTER](https://vajira.max.gov/secure/attachment/391993/10422-after.png)
