### PR TITLE
hotfix/APPEALS-11111

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -40,7 +40,7 @@ class ExternalApi::VBMSService
 
   def self.upload_document_to_vbms(appeal, uploadable_document)
     @vbms_client ||= init_vbms_client
-    response = initialize_upload(appeal.veteran_file_number, uploadable_document)
+    response = initialize_upload(appeal, uploadable_document)
     upload_document(appeal.veteran_file_number, response.upload_token, uploadable_document.pdf_location)
   end
 

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -46,11 +46,15 @@ class ExternalApi::VBMSService
 
   def self.upload_document_to_vbms_veteran(veteran_file_number, uploadable_document)
     @vbms_client ||= init_vbms_client
-    response = initialize_upload(veteran_file_number, uploadable_document)
+    response = initialize_upload_veteran(veteran_file_number, uploadable_document)
     upload_document(veteran_file_number, response.upload_token, uploadable_document.pdf_location)
   end
 
-  def self.initialize_upload(veteran_file_number, uploadable_document)
+  def self.initialize_upload()
+
+  end
+
+  def self.initialize_upload_veteran(veteran_file_number, uploadable_document)
     content_hash = Digest::SHA1.hexdigest(File.read(uploadable_document.pdf_location))
     filename = uploadable_document.document_name.presence || SecureRandom.uuid + File.basename(uploadable_document.pdf_location)
     request = VBMS::Requests::InitializeUpload.new(

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -50,8 +50,20 @@ class ExternalApi::VBMSService
     upload_document(veteran_file_number, response.upload_token, uploadable_document.pdf_location)
   end
 
-  def self.initialize_upload()
-
+  def self.initialize_upload(appeal, uploadable_document)
+    content_hash = Digest::SHA1.hexdigest(File.read(uploadable_document.pdf_location))
+    filename = SecureRandom.uuid + File.basename(uploadable_document.pdf_location)
+    request = VBMS::Requests::InitializeUpload.new(
+      content_hash: content_hash,
+      filename: filename,
+      file_number: appeal.veteran_file_number,
+      va_receive_date: Time.zone.now,
+      doc_type: uploadable_document.document_type_id,
+      source: uploadable_document.source,
+      subject: uploadable_document.document_type,
+      new_mail: true
+    )
+    send_and_log_request(appeal.veteran_file_number, request)
   end
 
   def self.initialize_upload_veteran(veteran_file_number, uploadable_document)


### PR DESCRIPTION
Resolves APPEALS-11111

Bug Discretion
When using IDT to outcode decision documents the async job that uploads the decision documents to vbms are erroring out with changes made to the vbms external service

### Description

Remove an issue found with the outcode functionality that was bleedover from the new IDT endpoint.

Test Plan:
[[Test UAT (External) - IDT - VBMS Service changes cause decision document upload errors](https://vajira.max.gov/browse/APPEALS-11112)](https://vajira.max.gov/browse/APPEALS-11112)