### PR TITLE
HunJerBAH/APPEALS-4133: Update Search Queries 

### DIFF
--- a/app/controllers/split_appeal_controller.rb
+++ b/app/controllers/split_appeal_controller.rb
@@ -25,8 +25,6 @@ class SplitAppealController < ApplicationController
     # unpack params
     appeal = Appeal.find(params[:appeal_id])
     split_issues = params[:appeal_split_issues]
-    split_other_reason = params[:split_other_reason]
-    split_reason = params[:split_reason]
     user_css_id = params[:user_css_id]
 
     # set the appeal_split_process to true
@@ -35,7 +33,7 @@ class SplitAppealController < ApplicationController
     dup_appeal = appeal.amoeba_dup
     # save the duplicate
     dup_appeal.save!
-    create_split_task(appeal, split_reason, split_other_reason, user_css_id)
+    create_split_task(appeal, params)
     # run extra duplicate methods to finish split
     dup_appeal.finalize_split_appeal(appeal, user_css_id, split_issues)
     # set the appeal split process to false
@@ -47,7 +45,11 @@ class SplitAppealController < ApplicationController
     render json: { split_appeal: dup_appeal, original_appeal: appeal }, status: :created
   end
 
-  def create_split_task(appeal, split_reason, split_other_reason, user_css_id)
+  def create_split_task(appeal, params)
+    split_other_reason = params[:split_other_reason]
+    split_reason = params[:split_reason]
+    user_css_id = params[:user_css_id]
+
     split_user = User.find_by_css_id user_css_id
     instructions = if split_other_reason.strip.empty?
                      split_reason

--- a/app/controllers/split_appeal_controller.rb
+++ b/app/controllers/split_appeal_controller.rb
@@ -12,84 +12,77 @@ class SplitAppealController < ApplicationController
         split_issues = params[:appeal_split_issues]
         split_other_reason = params[:split_other_reason]
         split_reason = params[:split_reason]
-
+        user_css_id = params[:user_css_id]
         # Returns a 404 Not Found error if the appeal can not be found to be split
         begin
           appeal = Appeal.find(appeal_id)
         rescue StandardError
           return render plain: "404 Not Found", status: :not_found
         end
-
-        # set the appeal_split_process to true
-        appeal.appeal_split_process = true
-
-        # duplicate appeal
-        dup_appeal = appeal.amoeba_dup
-        # save the duplicate
-        dup_appeal.save!
-        # Setting the user_css_id
-        user_css_id = params[:user_css_id]
-        split_user = User.find_by_css_id user_css_id
-        instructions = if split_other_reason.strip.empty?
-                         split_reason
-                       else
-                         split_other_reason
-                       end
-        Task.transaction do
-          spt = SplitAppealTask.create!(
-            appeal: appeal,
-            parent: appeal.root_task,
-            assigned_to: split_user,
-            assigned_by: split_user,
-            assigned_at: Time.zone.now
-          )
-          spt.instructions.push(instructions)
-          spt.update!(status: Constants.TASK_STATUSES.completed)
-        end
-        # run extra duplicate methods to finish split
-        dup_appeal.finalize_split_appeal(appeal, user_css_id, split_issues)
-        # set the appeal split process to false
-        appeal.appeal_split_process = false
-        # send success response
-        dup_appeal.reload
-        appeal.reload
-        render json: { split_appeal: dup_appeal, original_appeal: appeal }, status: :created
-        create_split_record = [
-          appeal_id = dup_appeal.id,
-          appeal_type = dup_appeal.docket_type,
-          appeal_uuid = dup_appeal.uuid,
-          created_at = Time.zone.now.utc,
-          created_by_id = current_user.id,
-          original_appeal_id = appeal.id,
-          original_appeal_uuid = appeal.uuid,
-          original_request_issue_ids = appeal.request_issues.ids,
-          relationship_type = "split_appeal",
-          split_other_reason = split_other_reason,
-          split_reason = split_reason,
-          split_request_issue_ids = split_issues,
-          updated_at = Time.zone.now.utc,
-          updated_by_id = current_user.id,
-          working_split_status = Constants.TASK_STATUSES.in_progress
-        ]
-
-        SplitCorrelationTable.create!(
-          appeal_id: create_split_record[0],
-          appeal_type: create_split_record[1],
-          appeal_uuid: create_split_record[2],
-          created_at: create_split_record[3],
-          created_by_id: create_split_record[4],
-          original_appeal_id: create_split_record[5],
-          original_appeal_uuid: create_split_record[6],
-          original_request_issue_ids: create_split_record[7],
-          relationship_type: create_split_record[8],
-          split_other_reason: create_split_record[9],
-          split_reason: create_split_record[10],
-          split_request_issue_ids: create_split_record[11],
-          updated_at: create_split_record[12],
-          updated_by_id: create_split_record[13],
-          working_split_status: create_split_record[14]
-        )
+        # process the split
+        process_split(appeal, split_issues, split_reason, split_other_reason, user_css_id)
       end
     end
+  end
+
+  private
+
+  def process_split(appeal, split_issues, split_reason, split_other_reason, user_css_id)
+    # set the appeal_split_process to true
+    appeal.appeal_split_process = true
+    # duplicate appeal
+    dup_appeal = appeal.amoeba_dup
+    # save the duplicate
+    dup_appeal.save!
+    create_split_task(appeal, split_reason, split_other_reason, user_css_id)
+    # run extra duplicate methods to finish split
+    dup_appeal.finalize_split_appeal(appeal, user_css_id, split_issues)
+    # set the appeal split process to false
+    appeal.appeal_split_process = false
+    dup_appeal.reload
+    appeal.reload
+    # create a split correlation record
+    create_split_correlation_record(dup_appeal, appeal, split_issues, split_reason, split_other_reason)
+    render json: { split_appeal: dup_appeal, original_appeal: appeal }, status: :created
+  end
+
+  def create_split_task(appeal, split_reason, split_other_reason, user_css_id)
+    split_user = User.find_by_css_id user_css_id
+    instructions = if split_other_reason.strip.empty?
+                     split_reason
+                   else
+                     split_other_reason
+                   end
+    Task.transaction do
+      spt = SplitAppealTask.create!(
+        appeal: appeal,
+        parent: appeal.root_task,
+        assigned_to: split_user,
+        assigned_by: split_user,
+        assigned_at: Time.zone.now
+      )
+      spt.instructions.push(instructions)
+      spt.update!(status: Constants.TASK_STATUSES.completed)
+    end
+  end
+
+  def create_split_correlation_record(dup_appeal, appeal, split_issues, split_reason, split_other_reason)
+    SplitCorrelationTable.create!(
+      appeal_id: dup_appeal.id,
+      appeal_type: dup_appeal.docket_type,
+      appeal_uuid: dup_appeal.uuid,
+      created_at: Time.zone.now.utc,
+      created_by_id: current_user.id,
+      original_appeal_id: appeal.id,
+      original_appeal_uuid: appeal.uuid,
+      original_request_issue_ids: appeal.request_issues.ids,
+      relationship_type: "split_appeal",
+      split_other_reason: split_other_reason,
+      split_reason: split_reason,
+      split_request_issue_ids: split_issues,
+      updated_at: Time.zone.now.utc,
+      updated_by_id: current_user.id,
+      working_split_status: Constants.TASK_STATUSES.in_progress
+    )
   end
 end

--- a/app/controllers/split_appeal_controller.rb
+++ b/app/controllers/split_appeal_controller.rb
@@ -83,7 +83,7 @@ class SplitAppealController < ApplicationController
       relationship_type: "split_appeal",
       split_other_reason: params[:split_other_reason],
       split_reason: params[:split_reason],
-      split_request_issue_ids: params[:appeal_split_issues],
+      split_request_issue_ids: dup_appeal.request_issues.ids,
       updated_at: Time.zone.now.utc,
       updated_by_id: current_user.id,
       working_split_status: Constants.TASK_STATUSES.in_progress

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -350,7 +350,6 @@ class Appeal < DecisionReview
   # clone issues clones request_issues the user selected
   # and anydecision_issues/decision_request_issues tied to the request issue
   def clone_issues(parent_appeal, split_request_issues)
-
     # cycle the split_request_issues list from the payload
     split_request_issues.each do |r_issue_id|
       # find the request issue from the parent appeal
@@ -375,18 +374,7 @@ class Appeal < DecisionReview
 
       # copy the request_decision_issues
       r_issue.request_decision_issues.each do |rd_issue|
-        # get the decision issue id
-        decision_issue_id = rd_issue.decision_issue_id
-        # get the decision issue
-        d_issue = DecisionIssue.find(decision_issue_id)
-        # clone decision issue
-        dup_d_issue = clone_issue(d_issue)
-        # clone request_decision_issue
-        dup_rd_issue = rd_issue.amoeba_dup
-        # set the request_issue_id and decision_issue_id
-        dup_rd_issue.request_issue_id = dup_r_issue.id
-        dup_rd_issue.decision_issue_id = dup_d_issue.id
-        dup_rd_issue.save!
+        clone_request_decision_issue(rd_issue, dup_r_issue)
       end
     end
   end
@@ -408,7 +396,22 @@ class Appeal < DecisionReview
     dup_issue = issue.amoeba_dup
     dup_issue.decision_review_id = id
     dup_issue.save
-    return dup_issue
+    dup_issue
+  end
+
+  def clone_request_decision_issue(rd_issue, dup_r_issue)
+    # get the decision issue id
+    decision_issue_id = rd_issue.decision_issue_id
+    # get the decision issue
+    d_issue = DecisionIssue.find(decision_issue_id)
+    # clone decision issue
+    dup_d_issue = clone_issue(d_issue)
+    # clone request_decision_issue
+    dup_rd_issue = rd_issue.amoeba_dup
+    # set the request_issue_id and decision_issue_id
+    dup_rd_issue.request_issue_id = dup_r_issue.id
+    dup_rd_issue.decision_issue_id = dup_d_issue.id
+    dup_rd_issue.save!
   end
 
   def clone_ihp_drafts(parent_appeal)
@@ -499,7 +502,7 @@ class Appeal < DecisionReview
     dup_task.save
 
     # return the task id to be added to the dict
-    return dup_task.id
+    dup_task.id
   end
 
   def clone_task_w_parent(original_task, parent_task_id)
@@ -538,7 +541,7 @@ class Appeal < DecisionReview
     end
 
     # return the task id to be added to the dict
-    return dup_task.id
+    dup_task.id
   end
 
   def docket_name

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -308,7 +308,6 @@ class Appeal < DecisionReview
   end
 
   # finalize_split_appeal contains all the methods to finish the amoeba split
-  # these methods are below in PRIVATE
   def finalize_split_appeal(parent_appeal, user_css_id, split_issues)
     # update the child task tree with parent, passing CSS ID of user for validation
     self&.clone_task_tree(parent_appeal, user_css_id)
@@ -330,6 +329,219 @@ class Appeal < DecisionReview
     self.duplicate_split_appeal = true
     # set the parent original split appeal flat
     parent_appeal.original_split_appeal = true
+  end
+
+  # clones cavc_remand. Uses user_css_id that did the split to complete the remand split
+  def clone_cavc_remand(parent_appeal, user_css_id)
+    # get cavc remand from the parent appeal
+    original_remand = parent_appeal.cavc_remand
+    # clone w error handling
+    dup_remand = original_remand&.amoeba_dup
+    # set appeal id to remand_appeal_id
+    dup_remand&.remand_appeal_id = id
+    # set source appeal id to parent appeal
+    dup_remand&.source_appeal = parent_appeal
+    # set request store to the user that split the appeal
+    RequestStore[:current_user] = User.find_by_css_id user_css_id
+    # save
+    dup_remand&.save
+  end
+
+  # clone issues clones request_issues the user selected
+  # and anydecision_issues/decision_request_issues tied to the request issue
+  def clone_issues(parent_appeal, split_request_issues)
+    # cycle the split_request_issues list from the payload
+    split_request_issues.each do |r_issue_id|
+      # find the request issue from the parent appeal
+      r_issue = parent_appeal.request_issues.find(r_issue_id.to_i)
+
+      fail IssueAlreadyDuplicated if r_issue.split_issue_status == "on_hold"
+
+      dup_r_issue = clone_issue(r_issue)
+
+      # set original issue on hold and duplicate issue to in_progress
+      r_issue.update!(
+        split_issue_status: Constants.TASK_STATUSES.on_hold
+      )
+      r_issue.save!
+      dup_r_issue.update!(
+        split_issue_status: Constants.TASK_STATUSES.in_progress
+      )
+      dup_r_issue.save!
+
+      # skip copying decision issues if there aren't any
+      next if r_issue.request_decision_issues.empty?
+
+      # copy the request_decision_issues
+      r_issue.request_decision_issues.each do |rd_issue|
+        clone_request_decision_issue(rd_issue, dup_r_issue)
+      end
+    end
+  end
+
+  def clone_aod(parent_appeal)
+    # find the appeal AOD
+    aod = AdvanceOnDocketMotion.find_by(appeal_id: parent_appeal.id)
+    # create a new advance on docket for the duplicate appeal
+    AdvanceOnDocketMotion.create!(
+      user_id: aod.user_id,
+      person_id: claimant.person.id,
+      granted: aod.granted,
+      reason: aod.reason,
+      appeal: self
+    )
+  end
+
+  def clone_issue(issue)
+    dup_issue = issue.amoeba_dup
+    dup_issue.decision_review_id = id
+    dup_issue.save
+    dup_issue
+  end
+
+  def clone_request_decision_issue(rd_issue, dup_r_issue)
+    # get the decision issue id
+    decision_issue_id = rd_issue.decision_issue_id
+    # get the decision issue
+    d_issue = DecisionIssue.find(decision_issue_id)
+    # clone decision issue
+    dup_d_issue = clone_issue(d_issue)
+    # clone request_decision_issue
+    dup_rd_issue = rd_issue.amoeba_dup
+    # set the request_issue_id and decision_issue_id
+    dup_rd_issue.request_issue_id = dup_r_issue.id
+    dup_rd_issue.decision_issue_id = dup_d_issue.id
+    dup_rd_issue.save!
+  end
+
+  def clone_ihp_drafts(parent_appeal)
+    # get the list of ihp_drafts from the appeal
+    original_ihp_drafts = IhpDraft.where(appeal_id: parent_appeal.id)
+    # for each ihp_draft, amoeba clone it
+    original_ihp_drafts.each do |draft|
+      # clone draft
+      dup_draft = draft&.amoeba_dup
+      # set the appeal_id to this appeal
+      dup_draft&.appeal_id = id
+      # save the clone
+      dup_draft&.save
+    end
+  end
+
+  def clone_hearings(parent_appeal)
+    parent_appeal.hearings.each do |hearing|
+      # clone hearing
+      dup_hearing = hearing&.amoeba_dup
+      # assign to current appeal
+      dup_hearing&.appeal_id = id
+
+      # set split process on dup_hearing
+      dup_hearing.appeal.appeal_split_process = true
+      dup_hearing&.save
+    end
+  end
+
+  def clone_task_tree(parent_appeal, user_css_id)
+    # get the task tree from the parent
+    parent_ordered_tasks = parent_appeal.tasks.order(:created_at)
+    # define hash to store parent/child relationship values
+    task_parent_to_child_hash = {}
+
+    while parent_appeal.tasks.count != tasks.count && !parent_appeal.tasks.nil?
+      # cycle each task in the parent
+      parent_ordered_tasks.each do |task|
+        # skip this task if the task has been copied (already in the hash)
+        next if task_parent_to_child_hash.key?(task.id)
+
+        # if the value has a parent and isn't in the dictionary, try to find it in the dictionary or else skip it
+        if !task.parent_id.nil?
+          # if the parent value hasn't been created, skip
+          next if !task_parent_to_child_hash.key?(task.parent_id)
+
+          # otherwise reassign old parent task to new from hash
+          cloned_task_id = clone_task_w_parent(task, task_parent_to_child_hash[task.parent_id])
+
+        else
+          # else create the task that doesn't have a parent
+          cloned_task_id = clone_task(task, user_css_id)
+        end
+        # add the parent/clone id to the hash set
+        task_parent_to_child_hash[task.id] = cloned_task_id
+
+        # break if the tree count is the same
+        break if parent_appeal.tasks.count == tasks.count
+      end
+      # break if the tree count is the same
+      break if parent_appeal.tasks.count == tasks.count
+    end
+  end
+
+  # clone_task is used for splitting an appeal, tie to css_id for split
+  def clone_task(original_task, user_css_id)
+    # clone the task
+    dup_task = original_task.amoeba_dup
+
+    # assign the task to this appeal
+    dup_task.appeal_id = id
+
+    # set the status to assigned as placeholder
+    dup_task.status = "assigned"
+
+    # set the appeal split process to true for the task
+    dup_task.appeal.appeal_split_process = true
+
+    # save the task
+    dup_task.save
+
+    # set the status to the correct status
+    dup_task.status = original_task.status
+
+    # set request store to the user that split the appeal
+    RequestStore[:current_user] = User.find_by_css_id user_css_id
+
+    dup_task.save
+
+    # return the task id to be added to the dict
+    dup_task.id
+  end
+
+  def clone_task_w_parent(original_task, parent_task_id)
+    # clone the task
+    dup_task = original_task.amoeba_dup
+
+    # assign the task to this appeal
+    dup_task.appeal_id = id
+
+    # set the status to assigned as placeholder
+    dup_task.status = "assigned"
+
+    # set the parent to the parent_task_id
+    dup_task.parent_id = parent_task_id
+
+    # set the appeal split process to true for the task
+    dup_task.appeal.appeal_split_process = true
+
+    # save the task
+    dup_task.save(validate: false)
+
+    # set the status to the correct status
+    dup_task.status = original_task.status
+
+    dup_task.save(validate: false)
+
+    # if the status is cancelled, pull the original canceled ID
+    if dup_task.status == "cancelled" && !original_task.cancelled_by_id.nil?
+
+      # set request store to original task canceller to handle verification
+      RequestStore[:current_user] = User.find(original_task.cancelled_by_id)
+
+      # confirm task just in case no prompt
+      dup_task.cancelled_by_id = original_task.cancelled_by_id
+      dup_task.save(validate: false)
+    end
+
+    # return the task id to be added to the dict
+    dup_task.id
   end
 
   def docket_name
@@ -696,220 +908,6 @@ class Appeal < DecisionReview
 
   def default_docket_number_from_receipt_date
     "#{receipt_date.strftime('%y%m%d')}-#{id}"
-  end
-
-  # start of private SPLIT APPEAL methods
-  # clones cavc_remand. Uses user_css_id that did the split to complete the remand split
-  def clone_cavc_remand(parent_appeal, user_css_id)
-    # get cavc remand from the parent appeal
-    original_remand = parent_appeal.cavc_remand
-    # clone w error handling
-    dup_remand = original_remand&.amoeba_dup
-    # set appeal id to remand_appeal_id
-    dup_remand&.remand_appeal_id = id
-    # set source appeal id to parent appeal
-    dup_remand&.source_appeal = parent_appeal
-    # set request store to the user that split the appeal
-    RequestStore[:current_user] = User.find_by_css_id user_css_id
-    # save
-    dup_remand&.save
-  end
-
-  # clone issues clones request_issues the user selected
-  # and anydecision_issues/decision_request_issues tied to the request issue
-  def clone_issues(parent_appeal, split_request_issues)
-    # cycle the split_request_issues list from the payload
-    split_request_issues.each do |r_issue_id|
-      # find the request issue from the parent appeal
-      r_issue = parent_appeal.request_issues.find(r_issue_id.to_i)
-
-      fail IssueAlreadyDuplicated if r_issue.split_issue_status == "on_hold"
-
-      dup_r_issue = clone_issue(r_issue)
-
-      # set original issue on hold and duplicate issue to in_progress
-      r_issue.update!(
-        split_issue_status: Constants.TASK_STATUSES.on_hold
-      )
-      r_issue.save!
-      dup_r_issue.update!(
-        split_issue_status: Constants.TASK_STATUSES.in_progress
-      )
-      dup_r_issue.save!
-
-      # skip copying decision issues if there aren't any
-      next if r_issue.request_decision_issues.empty?
-
-      # copy the request_decision_issues
-      r_issue.request_decision_issues.each do |rd_issue|
-        clone_request_decision_issue(rd_issue, dup_r_issue)
-      end
-    end
-  end
-
-  def clone_aod(parent_appeal)
-    # find the appeal AOD
-    aod = AdvanceOnDocketMotion.find_by(appeal_id: parent_appeal.id)
-    # create a new advance on docket for the duplicate appeal
-    AdvanceOnDocketMotion.create!(
-      user_id: aod.user_id,
-      person_id: claimant.person.id,
-      granted: aod.granted,
-      reason: aod.reason,
-      appeal: self
-    )
-  end
-
-  def clone_issue(issue)
-    dup_issue = issue.amoeba_dup
-    dup_issue.decision_review_id = id
-    dup_issue.save
-    dup_issue
-  end
-
-  def clone_request_decision_issue(rd_issue, dup_r_issue)
-    # get the decision issue id
-    decision_issue_id = rd_issue.decision_issue_id
-    # get the decision issue
-    d_issue = DecisionIssue.find(decision_issue_id)
-    # clone decision issue
-    dup_d_issue = clone_issue(d_issue)
-    # clone request_decision_issue
-    dup_rd_issue = rd_issue.amoeba_dup
-    # set the request_issue_id and decision_issue_id
-    dup_rd_issue.request_issue_id = dup_r_issue.id
-    dup_rd_issue.decision_issue_id = dup_d_issue.id
-    dup_rd_issue.save!
-  end
-
-  def clone_ihp_drafts(parent_appeal)
-    # get the list of ihp_drafts from the appeal
-    original_ihp_drafts = IhpDraft.where(appeal_id: parent_appeal.id)
-    # for each ihp_draft, amoeba clone it
-    original_ihp_drafts.each do |draft|
-      # clone draft
-      dup_draft = draft&.amoeba_dup
-      # set the appeal_id to this appeal
-      dup_draft&.appeal_id = id
-      # save the clone
-      dup_draft&.save
-    end
-  end
-
-  def clone_hearings(parent_appeal)
-    parent_appeal.hearings.each do |hearing|
-      # clone hearing
-      dup_hearing = hearing&.amoeba_dup
-      # assign to current appeal
-      dup_hearing&.appeal_id = id
-
-      # set split process on dup_hearing
-      dup_hearing.appeal.appeal_split_process = true
-      dup_hearing&.save
-    end
-  end
-
-  def clone_task_tree(parent_appeal, user_css_id)
-    # get the task tree from the parent
-    parent_ordered_tasks = parent_appeal.tasks.order(:created_at)
-    # define hash to store parent/child relationship values
-    task_parent_to_child_hash = {}
-
-    while parent_appeal.tasks.count != tasks.count && !parent_appeal.tasks.nil?
-      # cycle each task in the parent
-      parent_ordered_tasks.each do |task|
-        # skip this task if the task has been copied (already in the hash)
-        next if task_parent_to_child_hash.key?(task.id)
-
-        # if the value has a parent and isn't in the dictionary, try to find it in the dictionary or else skip it
-        if !task.parent_id.nil?
-          # if the parent value hasn't been created, skip
-          next if !task_parent_to_child_hash.key?(task.parent_id)
-
-          # otherwise reassign old parent task to new from hash
-          cloned_task_id = clone_task_w_parent(task, task_parent_to_child_hash[task.parent_id])
-
-        else
-          # else create the task that doesn't have a parent
-          cloned_task_id = clone_task(task, user_css_id)
-        end
-        # add the parent/clone id to the hash set
-        task_parent_to_child_hash[task.id] = cloned_task_id
-
-        # break if the tree count is the same
-        break if parent_appeal.tasks.count == tasks.count
-      end
-      # break if the tree count is the same
-      break if parent_appeal.tasks.count == tasks.count
-    end
-  end
-
-  # clone_task is used for splitting an appeal, tie to css_id for split
-  def clone_task(original_task, user_css_id)
-    # clone the task
-    dup_task = original_task.amoeba_dup
-
-    # assign the task to this appeal
-    dup_task.appeal_id = id
-
-    # set the status to assigned as placeholder
-    dup_task.status = "assigned"
-
-    # set the appeal split process to true for the task
-    dup_task.appeal.appeal_split_process = true
-
-    # save the task
-    dup_task.save
-
-    # set the status to the correct status
-    dup_task.status = original_task.status
-
-    # set request store to the user that split the appeal
-    RequestStore[:current_user] = User.find_by_css_id user_css_id
-
-    dup_task.save
-
-    # return the task id to be added to the dict
-    dup_task.id
-  end
-
-  def clone_task_w_parent(original_task, parent_task_id)
-    # clone the task
-    dup_task = original_task.amoeba_dup
-
-    # assign the task to this appeal
-    dup_task.appeal_id = id
-
-    # set the status to assigned as placeholder
-    dup_task.status = "assigned"
-
-    # set the parent to the parent_task_id
-    dup_task.parent_id = parent_task_id
-
-    # set the appeal split process to true for the task
-    dup_task.appeal.appeal_split_process = true
-
-    # save the task
-    dup_task.save(validate: false)
-
-    # set the status to the correct status
-    dup_task.status = original_task.status
-
-    dup_task.save(validate: false)
-
-    # if the status is cancelled, pull the original canceled ID
-    if dup_task.status == "cancelled" && !original_task.cancelled_by_id.nil?
-
-      # set request store to original task canceller to handle verification
-      RequestStore[:current_user] = User.find(original_task.cancelled_by_id)
-
-      # confirm task just in case no prompt
-      dup_task.cancelled_by_id = original_task.cancelled_by_id
-      dup_task.save(validate: false)
-    end
-
-    # return the task id to be added to the dict
-    dup_task.id
   end
 end
 # rubocop:enable Metrics/ClassLength

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -404,19 +404,6 @@ class Appeal < DecisionReview
     )
   end
 
-  def clone_aod(parent_appeal)
-    # find the appeal AOD
-    aod = AdvanceOnDocketMotion.find_by(appeal_id: parent_appeal.id)
-    # create a new advance on docket for the duplicate appeal
-    AdvanceOnDocketMotion.create!(
-      user_id: aod.user_id,
-      person_id: claimant.person.id,
-      granted: aod.granted,
-      reason: aod.reason,
-      appeal: self
-    )
-  end
-
   def clone_issue(issue)
     dup_issue = issue.amoeba_dup
     dup_issue.decision_review_id = id

--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -87,6 +87,9 @@ class Appeal < DecisionReview
     validates_associated :claimants
   end
 
+  # error for already split issue
+  class IssueAlreadyDuplicated < StandardError; end
+
   scope :active, lambda {
     joins(:tasks)
       .group("appeals.id")
@@ -352,6 +355,9 @@ class Appeal < DecisionReview
     split_request_issues.each do |r_issue_id|
       # find the request issue from the parent appeal
       r_issue = parent_appeal.request_issues.find(r_issue_id.to_i)
+
+      fail IssueAlreadyDuplicated if r_issue.split_issue_status == "on_hold"
+
       dup_r_issue = clone_issue(r_issue)
 
       # set original issue on hold and duplicate issue to in_progress

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -136,7 +136,7 @@ class RequestIssue < CaseflowRecord
     # "Active" issues are issues that need decisions.
     # They show up as contentions in VBMS and issues in Caseflow Queue.
     def active
-      eligible.where(closed_at: nil)
+      eligible.where(closed_at: nil, split_issue_status: [nil, "in_progress"])
     end
 
     def active_or_ineligible

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -137,7 +137,6 @@ class RequestIssue < CaseflowRecord
     # They show up as contentions in VBMS and issues in Caseflow Queue.
     def active
       eligible.where(closed_at: nil, split_issue_status: [nil, "in_progress"])
-
     end
 
     def active_or_ineligible

--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -137,6 +137,7 @@ class RequestIssue < CaseflowRecord
     # They show up as contentions in VBMS and issues in Caseflow Queue.
     def active
       eligible.where(closed_at: nil, split_issue_status: [nil, "in_progress"])
+
     end
 
     def active_or_ineligible

--- a/app/models/split_correlation_table.rb
+++ b/app/models/split_correlation_table.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
 
 class SplitCorrelationTable < CaseflowRecord
+  # to remove old columns
+  self.ignored_columns = [:split_request_issue_ids, :original_request_issue_ids]
 end

--- a/client/app/queue/CaseTimeline.jsx
+++ b/client/app/queue/CaseTimeline.jsx
@@ -7,6 +7,7 @@ import { caseTimelineTasksForAppeal } from './selectors';
 
 export const CaseTimeline = ({ appeal }) => {
   const tasks = useSelector((state) => caseTimelineTasksForAppeal(state, { appealId: appeal.externalId }));
+
   const canEditNodDate = useSelector((state) => state.ui.canEditNodDate);
 
   return (

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -7,7 +7,7 @@ class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
   end
   def down
     change_table "split_correlation_tables" do |t|
-      t.remove :split_request_issue_id, :original_request_issue_id
+      safety_assured { t.remove :split_request_issue_id, :original_request_issue_id }
       t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
       t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
     end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -2,14 +2,16 @@ class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
   def up
     change_table "split_correlation_tables" do |t|
       t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
-      safety_assured { t.remove :split_request_issue_ids, :original_request_issue_ids }
     end
+    safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids }
+    safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids }
   end
   def down
     change_table "split_correlation_tables" do |t|
-      safety_assured { t.remove :split_request_issue_id, :original_request_issue_id }
       t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
       t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
     end
+    safety_assured { remove_column :split_correlation_tables, :split_request_issue_id }
+    safety_assured { remove_column :split_correlation_tables, :original_request_issue_id }
   end
 end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -1,0 +1,8 @@
+class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
+  def change
+    change_table "split_correlation_tables" do |t|
+      t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
+      safety_assured { t.remove :split_request_issue_ids, :original_request_issue_ids }
+    end
+  end
+end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -3,8 +3,8 @@ class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
     # change_table "split_correlation_tables" do |t|
     #   t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     # end
-    add_column :split_correlation_tables, :split_request_issue_id, :integer, null: false, comment: comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
-    add_column :split_correlation_tables, :original_request_issue_id, :integer, null: false, comment: comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
+    add_column :split_correlation_tables, :split_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
+    add_column :split_correlation_tables, :original_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids }
     safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids }
   end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -1,19 +1,8 @@
 class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
   def change
-    # change_table "split_correlation_tables" do |t|
-    #   t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
-    # end
     add_column :split_correlation_tables, :split_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     add_column :split_correlation_tables, :original_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids, :integer }
     safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids, :integer }
   end
-  # def down
-  #   change_table "split_correlation_tables" do |t|
-  #     t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
-  #     t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
-  #   end
-  #   safety_assured { remove_column :split_correlation_tables, :split_request_issue_id }
-  #   safety_assured { remove_column :split_correlation_tables, :original_request_issue_id }
-  # end
 end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -5,8 +5,8 @@ class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
     # end
     add_column :split_correlation_tables, :split_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     add_column :split_correlation_tables, :original_request_issue_id, :integer, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
-    safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids }
-    safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids }
+    safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids, :integer }
+    safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids, :integer }
   end
   # def down
   #   change_table "split_correlation_tables" do |t|

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -1,8 +1,15 @@
 class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
-  def change
+  def up
     change_table "split_correlation_tables" do |t|
       t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
       safety_assured { t.remove :split_request_issue_ids, :original_request_issue_ids }
+    end
+  end
+  def down
+    change_table "split_correlation_tables" do |t|
+      t.remove :split_request_issue_id, :original_request_issue_id
+      t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
+      t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
     end
   end
 end

--- a/db/migrate/20221114191336_change_split_correlation_tables.rb
+++ b/db/migrate/20221114191336_change_split_correlation_tables.rb
@@ -1,17 +1,19 @@
 class ChangeSplitCorrelationTables < ActiveRecord::Migration[5.2]
-  def up
-    change_table "split_correlation_tables" do |t|
-      t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
-    end
+  def change
+    # change_table "split_correlation_tables" do |t|
+    #   t.integer :split_request_issue_id, :original_request_issue_id, null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
+    # end
+    add_column :split_correlation_tables, :split_request_issue_id, :integer, null: false, comment: comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
+    add_column :split_correlation_tables, :original_request_issue_id, :integer, null: false, comment: comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     safety_assured { remove_column :split_correlation_tables, :split_request_issue_ids }
     safety_assured { remove_column :split_correlation_tables, :original_request_issue_ids }
   end
-  def down
-    change_table "split_correlation_tables" do |t|
-      t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
-      t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
-    end
-    safety_assured { remove_column :split_correlation_tables, :split_request_issue_id }
-    safety_assured { remove_column :split_correlation_tables, :original_request_issue_id }
-  end
+  # def down
+  #   change_table "split_correlation_tables" do |t|
+  #     t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
+  #     t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
+  #   end
+  #   safety_assured { remove_column :split_correlation_tables, :split_request_issue_id }
+  #   safety_assured { remove_column :split_correlation_tables, :original_request_issue_id }
+  # end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_184724) do
+ActiveRecord::Schema.define(version: 2022_11_14_191336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1446,11 +1446,11 @@ ActiveRecord::Schema.define(version: 2022_10_25_184724) do
     t.integer "created_by_id", null: false, comment: "The user css_id that created the split appeal."
     t.integer "original_appeal_id", null: false, comment: "The original appeal id from where the split appeal appeal_id was created from."
     t.string "original_appeal_uuid", null: false, comment: "The original source appeal uuid from where the split was generated from."
-    t.integer "original_request_issue_ids", null: false, comment: "An array of the original request issue IDs that were transferred to the split appeal.", array: true
+    t.integer "original_request_issue_id", null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     t.string "relationship_type", default: "split_appeal", comment: "The new split_appeal relationship type created from the split and maybe used for future correlations."
     t.string "split_other_reason", comment: "The other reason for splitting the appeal from comment section."
     t.string "split_reason", comment: "Reason for splitting the appeal from drop menu."
-    t.integer "split_request_issue_ids", null: false, comment: "An array of the split request issue IDs that were transferred to the split appeal.", array: true
+    t.integer "split_request_issue_id", null: false, comment: "The original request issue id and the corresponding request issue id created from the split appeal process."
     t.datetime "updated_at", comment: "The datetime when the split appeal was updated at."
     t.integer "updated_by_id", comment: "The user css_id who most recently updated the split appeal workflow."
     t.string "working_split_status", default: "in_progress", null: false, comment: "The work flow status of the split appeal (i.e. on_hold, in_progress, cancelled, completed)."

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -461,7 +461,7 @@ module Seeds
     end
 
     def create_task_at_quality_review(
-      # created Code Climate issue for unused.
+      # created Code Climate issue for unused variable.
       # judge_name = "Madhu Judge_CaseAtQR Burnham", attorney_name = "Bailey Attorney_CaseAtQR Eoin"
     )
       vet = create(

--- a/db/seeds/tasks.rb
+++ b/db/seeds/tasks.rb
@@ -461,7 +461,8 @@ module Seeds
     end
 
     def create_task_at_quality_review(
-      judge_name = "Madhu Judge_CaseAtQR Burnham", attorney_name = "Bailey Attorney_CaseAtQR Eoin"
+      # created Code Climate issue for unused.
+      # judge_name = "Madhu Judge_CaseAtQR Burnham", attorney_name = "Bailey Attorney_CaseAtQR Eoin"
     )
       vet = create(
         :veteran,

--- a/spec/controllers/split_appeal_controller_spec.rb
+++ b/spec/controllers/split_appeal_controller_spec.rb
@@ -41,6 +41,19 @@ RSpec.describe SplitAppealController, type: :controller do
         expect(appeal.stream_docket_number).to eq(dup_appeal.stream_docket_number)
         expect(appeal.veteran_file_number).to eq(dup_appeal.veteran_file_number)
         expect(dup_appeal.request_issues.count).to eq(2)
+
+      end
+
+      it "it sets the split request_issues on hold and removes them from the original appeal active" do
+        post :split_appeal, params: valid_params
+        expect(response.status).to eq 201
+        dup_appeal = Appeal.last
+        request_issue.reload
+        request_issue2.reload
+        expect(dup_appeal.request_issues.active.count).to eq(2)
+        expect(appeal.request_issues.active.count).to eq(1)
+        expect(request_issue.split_issue_status).to eq("on_hold")
+        expect(request_issue2.split_issue_status).to eq("on_hold")
       end
 
       it "creates a split record for SplitCorrelationTable in DB and tasks" do

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -2246,7 +2246,7 @@ describe Appeal, :all_dbs do
         expect(original_decision_issue.subject_text).to eq(dup_decision_issue.subject_text)
       end
 
-      it "should only duplicate the request issues selected and set the original issue to 'on hold'" do
+      it "duplicates the request issues selected, sets the original issue to 'on hold' and not active" do
         original_appeal = create(
           :appeal, #:with_decision_issue,
           request_issues: create_list(:request_issue, 4, :nonrating, notes: "test notes"),
@@ -2266,8 +2266,11 @@ describe Appeal, :all_dbs do
         original_appeal.reload
         expect(dup_appeal.request_issues.count).not_to eq(original_appeal.request_issues.count)
         expect(dup_appeal.request_issues.count).to eq(1)
+        expect(dup_appeal.request_issues.active.count).to eq(1)
+        expect(original_appeal.request_issues.active.count).to eq(3)
         expect(dup_appeal.request_issues.first.split_issue_status).to eq("in_progress")
         expect(original_appeal.request_issues.first.split_issue_status).to eq("on_hold")
+
         expect(dup_appeal.veteran_file_number).to eq(original_appeal.veteran_file_number)
         expect(dup_appeal.decision_issues.count).to eq(original_appeal.decision_issues.count)
         expect(original_decision_issue.id).not_to eq(dup_decision_issue.id)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1983,7 +1983,7 @@ describe Appeal, :all_dbs do
 
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues )
+        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
         original_cfs = original_appeal.claims_folder_searches.first
         dup_cfs = dup_appeal.claims_folder_searches.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1525,10 +1525,18 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = appeal_with_numerous_issues.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         if appeal.evidence_submission_docket? && (appeal.docket_name == "evidence_submission")
           dup_appeal = appeal_with_numerous_issues.amoeba_dup
           dup_appeal.save
-          dup_appeal.finalize_split_appeal(appeal_with_numerous_issues, "APPEAL_USER", all_request_issues)
+          dup_appeal.finalize_split_appeal(appeal_with_numerous_issues, params)
 
           expect(dup_appeal.id).not_to eq(appeal_with_numerous_issues.id)
           expect(dup_appeal.uuid).not_to eq(appeal_with_numerous_issues.uuid)
@@ -1571,11 +1579,19 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = appeal_with_hearings.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: appeal_with_hearings.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         original_hearing = create(:hearing, appeal: appeal_with_hearings)
         if appeal_with_hearings.hearing_docket? && (appeal_with_hearings.docket_name == "hearing")
           dup_appeal = appeal_with_hearings.amoeba_dup
           dup_appeal.save
-          dup_appeal.finalize_split_appeal(appeal_with_hearings, "APPEAL_USER", all_request_issues)
+          dup_appeal.finalize_split_appeal(appeal_with_hearings, params)
           duplicated_hearing = dup_appeal.hearings.first
           expect(dup_appeal.id).not_to eq(appeal_with_hearings.id)
           expect(dup_appeal.uuid).not_to eq(appeal_with_hearings.uuid)
@@ -1612,11 +1628,19 @@ describe Appeal, :all_dbs do
           request_issues: create_list(:request_issue, 4, :nonrating, notes: "test notes")
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
+
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         original_hearing = create(:hearing, appeal: original_appeal)
         original_hearing_email_recipient = create(:hearing_email_recipient, hearing: original_hearing)
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         duplicated_hearing_email_recipient = dup_appeal.hearings.first.email_recipients.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
@@ -1646,9 +1670,17 @@ describe Appeal, :all_dbs do
                                  parent: root_task, assigned_at: Date.new(2001, 2, 3)
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
+
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         dup_informal_hearing_task = dup_appeal.tasks.where(type: "IhpColocatedTask").first
 
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -1681,12 +1713,20 @@ describe Appeal, :all_dbs do
           claimants: [create(:claimant)]
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
+
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         subject { claimant.advanced_on_docket_motion_granted?(original_appeal) }
         AdvanceOnDocketMotion.create_or_update_by_appeal(original_appeal, granted: true, reason: "age")
         expect(subject).to be_truthy
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         dup_claimant = dup_appeal.claimants.first
         original_claimant = original_appeal.claimants.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -1722,9 +1762,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
         expect(dup_appeal.veteran_file_number).to eq(original_appeal.veteran_file_number)
@@ -1758,9 +1806,17 @@ describe Appeal, :all_dbs do
           request_issues: create_list(:request_issue, 4, :nonrating, notes: "test notes")
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
+
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
         expect(dup_appeal.veteran_file_number).to eq(original_appeal.veteran_file_number)
@@ -1791,9 +1847,17 @@ describe Appeal, :all_dbs do
         original_appellant_substitution = create(:appellant_substitution, target_appeal_id: original_appeal.id)
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         dup_appellant_substitution = dup_appeal.appellant_substitution
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
@@ -1819,9 +1883,16 @@ describe Appeal, :all_dbs do
         create(:available_hearing_locations, :RO17, appeal: original_appeal)
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
 
         available_hearing_locations = dup_appeal.available_hearing_locations.first
         original_available_hearing_location = original_appeal.available_hearing_locations.first
@@ -1865,9 +1936,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         dup_appeal_view = dup_appeal.appeal_views.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
@@ -1890,9 +1969,17 @@ describe Appeal, :all_dbs do
         original_appeal.docket_switch = create(:docket_switch)
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         dup_docket_switch = dup_appeal.docket_switch
         original_docket_switch = original_appeal.docket_switch
 
@@ -1927,9 +2014,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_ihp_draft = IhpDraft.where(appeal: original_appeal).first
         dup_ihp_draft = IhpDraft.where(appeal: dup_appeal).first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -1952,9 +2047,17 @@ describe Appeal, :all_dbs do
         original_work_mode = WorkMode.create(appeal_id: original_appeal.id, appeal_type: "Appeal")
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         expect(dup_appeal.id).not_to eq(original_appeal.id)
         expect(dup_appeal.uuid).not_to eq(original_appeal.uuid)
         expect(dup_appeal.veteran_file_number).to eq(original_appeal.veteran_file_number)
@@ -1981,9 +2084,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_cfs = original_appeal.claims_folder_searches.first
         dup_cfs = dup_appeal.claims_folder_searches.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2012,9 +2123,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_ndu = original_appeal.nod_date_updates.first
         dup_ndu = dup_appeal.nod_date_updates.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2044,9 +2163,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_rsb_job = original_appeal.record_synced_by_job.first
         dup_rsb_job = dup_appeal.record_synced_by_job.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2071,9 +2198,17 @@ describe Appeal, :all_dbs do
         SpecialIssueList.create(appeal_id: original_appeal.id, appeal_type: "Appeal", blue_water: true)
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_ndu = original_appeal.special_issue_list
         dup_ndu = dup_appeal.special_issue_list
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2133,9 +2268,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_power_of_attorney = original_appeal.power_of_attorney
         dup_power_of_attorney = dup_appeal.power_of_attorney
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2177,9 +2320,17 @@ describe Appeal, :all_dbs do
         original_appeal.request_issues_updates = [original_riu]
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_request_issues_update = original_appeal.request_issues_updates.first
         dup_request_issues_update = dup_appeal.request_issues_updates.first
         expect(dup_appeal.id).not_to eq(original_appeal.id)
@@ -2218,14 +2369,21 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
 
         expect do
           dup_appeal.finalize_split_appeal(
             original_appeal,
-            "APPEAL_USER",
-            all_request_issues
+            params
           ).to raise_error(Appeal::IssueAlreadyDuplicated)
         end
         # the appeal is not duplicated
@@ -2236,7 +2394,7 @@ describe Appeal, :all_dbs do
     context "when an appeal has numerous decision issues" do
       it "should duplicate the appeals and numerous decision issues for the same veteran" do
         original_appeal = create(
-          :appeal, #:with_decision_issue,
+          :appeal,
           request_issues: create_list(:request_issue, 4, :nonrating, notes: "test notes"),
           decision_issues: create_list(:decision_issue, 1)
         )
@@ -2247,9 +2405,17 @@ describe Appeal, :all_dbs do
         )
         all_request_issues = original_appeal.request_issues.ids.map(&:to_s)
 
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: all_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
+
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", all_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_decision_issue = original_appeal.decision_issues.first
         dup_decision_issue = dup_appeal.decision_issues.first
 
@@ -2287,9 +2453,17 @@ describe Appeal, :all_dbs do
           decision_issue: original_appeal.decision_issues.first
         )
         selected_request_issues = [original_appeal.request_issues.first.id.to_s]
+
+        params = {
+          appeal_id: original_appeal.id,
+          appeal_split_issues: selected_request_issues,
+          split_reason: "Other",
+          split_other_reason: "Some Other Reason",
+          user_css_id: regular_user.css_id
+        }
         dup_appeal = original_appeal.amoeba_dup
         dup_appeal.save
-        dup_appeal.finalize_split_appeal(original_appeal, "APPEAL_USER", selected_request_issues)
+        dup_appeal.finalize_split_appeal(original_appeal, params)
         original_decision_issue = original_appeal.decision_issues.first
         dup_decision_issue = dup_appeal.decision_issues.first
         original_appeal.reload


### PR DESCRIPTION
Resolves [APPEALS-4133](https://vajira.max.gov/browse/APPEALS-4133)

### Description
As a developer, in order to satisfy the requirements for Split Appeals, I need for the system to have the ability to have more than one appeal/lane with the same Docket Number in order to implement the Split Appeals functionality.  For this to happen the complete Caseflow system needs to be updated in order to allow queries to produce, as a result, more than one appeal. 

### Acceptance Criteria
- [ ] All queries and internal functions that handle and/or are impacted by having more than one appeal with the same docket number are identified
- [ ] All queries and internal functions that handle and/or are impacted by having more than one appeal with the same docket number are corrected to consider split appeals.  
- [ ] Update functions are validated to ensure that only the correct appeal lane is updated (in the case of more than one appeal with the same docket number)

### Testing Plan
1. Go to Demo and sign in as a SSC member.
2. Go to **queue** and **search cases**. Enter a veteran file number from the database. I used 673020132
![image](https://user-images.githubusercontent.com/99915461/200672730-e5f676fa-5a6e-4c1d-bc7a-69f53bc643ca.png)
3. Click on the docket number to go to the Case Details page. 
![image](https://user-images.githubusercontent.com/99915461/200672914-191cc820-c3e4-46b2-af74-35078145916f.png)
4. Click on **Correct Issues** to navigate to the add issues page.
![image](https://user-images.githubusercontent.com/99915461/200672969-f1e45726-d991-49b2-9409-0d6f5078467a.png)
5. Click add issues. Fill out the form. Do this twice to add 2 issues to the appeal. Click **save**. The issues will appear on the appeal.
![image](https://user-images.githubusercontent.com/99915461/200673268-aa13b8be-59c7-471e-885e-6586ecaace54.png)
![image](https://user-images.githubusercontent.com/99915461/200673333-56b1c3df-ca46-4196-80c2-6149401cfa3f.png)
![image](https://user-images.githubusercontent.com/99915461/200673419-9f69e79b-4ea7-47ba-890a-5ce21071a9c1.png)
6. Click **correct issues** again to navigate to the add issues page. 
7. Click on the **split appeal** button.
8. Fill out the dropdown and select at least 1 of the issues to split off. Click **continue**.
![image](https://user-images.githubusercontent.com/99915461/200673668-e2823312-701a-4fa1-abe2-d06029bfd884.png)
9. Click **split appeal** on the next page to split the appeal.
![image](https://user-images.githubusercontent.com/99915461/200673747-1b99c9e7-ad22-4619-99e0-c962c957561f.png)
10. You should see a green success banner and only 1 issue on the appeal.
![image](https://user-images.githubusercontent.com/99915461/200673995-08875f98-778a-4f7b-8e1e-bd63fc5e3616.png)
11. Copy the veteran file number. Click **search cases** at the top. Put the veteran file number in the search bar. You should see 2 appeals with 1 issue each. Open them both up to make sure the correct issue was split. 
![image](https://user-images.githubusercontent.com/99915461/200674184-df48869c-5e82-466b-bc7d-5448604d3dda.png)
![image](https://user-images.githubusercontent.com/99915461/200674315-0cb30558-11d2-46ae-b678-a5020b12961b.png)
![image](https://user-images.githubusercontent.com/99915461/200674342-b7b153b9-8d40-45d7-b3b1-87fe646cc3e7.png)




