### PR TITLE
jshields/APPEALS-11293

### DIFF
--- a/client/app/queue/CaseTitle.jsx
+++ b/client/app/queue/CaseTitle.jsx
@@ -80,7 +80,8 @@ CaseTitle.propTypes = {
 
 CaseTitle.defaultProps = {
   taskType: 'Draft Decision',
-  analyticsSource: 'queue_task'
+  analyticsSource: 'queue_task',
+  titleHeader: ''
 };
 
 const CaseTitleScaffolding = (props) => (


### PR DESCRIPTION
Resolves APPEALS-11293

### Description
The veteran name that is displayed on the header of the Case Details page is no longer displaying.

### Steps to reproduce:
1. Log into the UAT testing environment https://oumuamua.caseflowdemo.com/ 

2. Sign in as [BVAAABSHIRE](http://localhost:3000/queue/appeals/2800804#BVAAABSHIRE%20(VACO))

3. Navigate to a case detail in that users queue

Expected Result: Veteran Name shows in the Header
Actual Result: Veteran Name does not show in the header

### Test Plan
https://vajira.max.gov/browse/APPEALS-11295 
