### PR TITLE
FY23Q1.3.1 Production Deployment

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -20,6 +20,7 @@
     "suming.react-proptypes-generate",
     "wingrunr21.vscode-ruby",
     "wmaurer.change-case",
-    "ziyasal.vscode-open-in-github"
+    "ziyasal.vscode-open-in-github",
+    "oracle.oracledevtools"
   ]
 }

--- a/app/views/reader/appeal/index.html.erb
+++ b/app/views/reader/appeal/index.html.erb
@@ -10,6 +10,7 @@
     featureToggles: {
       interfaceVersion2: FeatureToggle.enabled?(:interface_version_2, user: current_user),
       windowSlider: FeatureToggle.enabled?(:window_slider, user: current_user),
+      readerSelectorsMemoized: FeatureToggle.enabled?(:bulk_upload_documents, user: current_user),
     },
     buildDate: build_date
   }) %>

--- a/client/app/2.0/screens/reader/DocumentList.jsx
+++ b/client/app/2.0/screens/reader/DocumentList.jsx
@@ -7,6 +7,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 // Local Dependencies
 import { recordSearch, fetchDocuments } from 'utils/reader';
 import { documentListScreen } from 'store/reader/selectors';
+import { documentListScreenMemoized } from 'store/reader/selectorsMemoized';
 import {
   setSearch,
   clearSearch as clear,
@@ -35,7 +36,8 @@ import { selectComment } from 'store/reader/annotationLayer';
 
 const DocumentList = (props) => {
   // Get the Document List state
-  const state = useSelector(documentListScreen);
+  const state = props.featureToggles.readerSelectorsMemoized ?
+    useSelector(documentListScreenMemoized) : useSelector(documentListScreen);
 
   // Create the Dispatcher
   const dispatch = useDispatch();
@@ -104,7 +106,7 @@ DocumentList.propTypes = {
   singleDocumentMode: PropTypes.bool,
   match: PropTypes.object,
   annotations: PropTypes.array,
-
+  featureToggles: PropTypes.object,
   // Required actions
   setCategoryFilter: PropTypes.func,
 };

--- a/client/app/2.0/screens/reader/DocumentViewer.jsx
+++ b/client/app/2.0/screens/reader/DocumentViewer.jsx
@@ -9,6 +9,7 @@ import { getPageCoordinatesOfMouseEvent } from 'utils/reader';
 import { pdfWrapper } from 'styles/reader/Document/PDF';
 import { fetchDocuments, openDownloadLink } from 'utils/reader/document';
 import { documentScreen } from 'store/reader/selectors';
+import { documentScreenMemoized } from 'store/reader/selectorsMemoized';
 import { DocumentHeader } from 'components/reader/DocumentViewer/Header';
 import { DocumentSidebar } from 'components/reader/DocumentViewer/Sidebar';
 import { DocumentFooter } from 'components/reader/DocumentViewer/Footer';
@@ -58,7 +59,8 @@ import { KeyboardInfo } from 'app/2.0/components/reader/DocumentViewer/modals/Ke
  */
 const DocumentViewer = (props) => {
   // Get the Document List state
-  const state = useSelector(documentScreen);
+  const state = props.featureToggles.readerSelectorsMemoized ?
+    useSelector(documentScreenMemoized) : useSelector(documentScreen);
 
   // Create the Dispatcher
   const dispatch = useDispatch();
@@ -397,6 +399,7 @@ DocumentViewer.propTypes = {
   singleDocumentMode: PropTypes.bool,
   match: PropTypes.object,
   annotations: PropTypes.array,
+  featureToggles: PropTypes.object,
 };
 
 export default DocumentViewer;

--- a/client/app/2.0/store/reader/selectorsMemoized.js
+++ b/client/app/2.0/store/reader/selectorsMemoized.js
@@ -1,16 +1,34 @@
 // Local Dependencies
 import { documentCategories } from 'store/constants/reader';
 import { documentsView, formatTagOptions, formatTagValue, formatCategoryName } from 'utils/reader';
+import { createSelector } from 'reselect';
 import { isEmpty } from 'lodash';
 
 /**
  * Filtered Documents state
  */
-export const filteredDocuments = ({ reader }) =>
-  reader.documentList.filteredDocIds.reduce(
-    (list, id) => ({ ...list, [id]: reader.documentList.documents[id] }),
+
+const getFilteredDocIds = (state) => state.reader.documentList.filteredDocIds;
+const getAllDocs = (state) => state.reader.documentList.documents;
+const getView = (state) => state.reader.documentList.view;
+const getSelectedDoc = (state) => state.reader.documentViewer.selected;
+const getFilterCriteria = (state) => state.reader.documentList.filterCriteria
+
+export const getFilteredDocuments = createSelector(
+  [getFilteredDocIds, getAllDocs],
+  (filteredDocIds, allDocs) => filteredDocIds.reduce(
+    (list, id) => ({ ...list, [id]: allDocs[id] }),
     {}
-  );
+  )
+)
+
+export const getdocsFiltered = createSelector(
+  [getFilterCriteria], (filterCriteria) => {
+    return filterCriteria.searchQuery ||
+      !isEmpty(filterCriteria.category) ||
+      !isEmpty(filterCriteria.tag)
+  }
+)
 
 /**
  * Selector for the Documents
@@ -19,11 +37,11 @@ export const filteredDocuments = ({ reader }) =>
  */
 export const documentState = (state) => {
   // Set the filtered documents
-  const documents = filteredDocuments(state);
+  const documents = getFilteredDocuments(state);
 
   // Calculate the number of documents
-  const docsCount = state.reader.documentList.filteredDocIds ?
-    state.reader.documentList.filteredDocIds.length :
+  const docsCount = getFilteredDocIds(state) ?
+    getFilteredDocIds(state).length :
     Object.values(documents).length;
 
   // Return the Filtered Documents and count
@@ -35,33 +53,35 @@ export const documentState = (state) => {
  * @param {Object} state -- The current Redux Store state
  * @returns {Object} -- The Documents List State
  */
-export const documentListScreen = (state) => {
+export const documentListScreenMemoized = (state) => {
   // Get the filtered documents and count
   const { documents, docsCount } = documentState(state);
 
-  Object.values(state.reader.documentList.documents).
+  Object.values(getAllDocs(state)).
     reduce((list, doc) => [...list, ...doc.tags], []).
     filter((tags, index, list) => list.findIndex((tag) => tag.text === tags.text) === index);
+
+  const getDocumentsView = createSelector([getAllDocs, getFilterCriteria, getView],
+    (docs, filterCriteria, view) => {
+      return documentsView(Object.values(docs), filterCriteria, view);
+    });
+
+  const docsFiltered = getdocsFiltered(state);
+  
+  const documentView = getDocumentsView(state);
 
   return {
     documents,
     docsCount,
-    docsFiltered:
-      state.reader.documentList.filterCriteria.searchQuery ||
-      !isEmpty(state.reader.documentList.filterCriteria.category) ||
-      !isEmpty(state.reader.documentList.filterCriteria.tag),
-    tagOptions: formatTagOptions(state.reader.documentList.documents),
-    currentDocument: state.reader.documentViewer.selected,
-    storeDocuments: state.reader.documentList.documents,
+    docsFiltered,
+    tagOptions: formatTagOptions(getAllDocs(state)),
+    currentDocument: getSelectedDoc(state),
+    storeDocuments: getAllDocs(state),
     documentList: state.reader.documentList,
     comments: state.reader.annotationLayer.comments,
-    documentsView: documentsView(
-      Object.values(documents),
-      state.reader.documentList.filterCriteria,
-      state.reader.documentList.view
-    ),
-    filterCriteria: state.reader.documentList.filterCriteria,
-    filteredDocIds: state.reader.documentList.filteredDocIds,
+    documentsView: documentView,
+    filterCriteria: getFilterCriteria(state),
+    filteredDocIds: getFilteredDocIds(state),
     searchCategoryHighlights:
       state.reader.documentList.searchCategoryHighlights,
     manifestVbmsFetchedAt: state.reader.documentList.manifestVbmsFetchedAt,
@@ -78,41 +98,57 @@ export const documentListScreen = (state) => {
  * @param {Object} state -- The current Redux Store state
  * @returns {Object} -- The Document State
  */
-export const documentScreen = (state) => {
+export const documentScreenMemoized = (state) => {
   // Get the filtered documents and count
   const { documents, docsCount } = documentState(state);
-  const categories = Object.keys(documentCategories).reduce((list, key) => {
-    // Set the current Category
-    const cat = state.reader.documentViewer.selected[formatCategoryName(key)] ? key : '';
 
-    // Return the Categories Object
-    return {
-      ...list,
-      [cat]: true
-    };
-  }, {});
-
+  const getCategories = createSelector(getSelectedDoc, (selectedDoc) => {
+    return Object.keys(documentCategories).reduce((list, key) => {
+      // Set the current Category
+      const cat = selectedDoc[formatCategoryName(key)] ? key : '';
+      // Return the Categories Object
+      return {
+        ...list,
+        [cat]: true
+      };
+    }, {})
+  })
+  
+  const categories = getCategories(state);
   // Filter the comments for the current document
-  const comments = state.reader.annotationLayer.comments.filter((comment) =>
-    comment.document_id === state.reader.documentViewer.selected.id);
+
+  const getAllComments = state => state.reader.annotationLayer.comments
+  const getComments = createSelector([getAllComments, getSelectedDoc],
+    (allComments, selectedDoc) =>
+    allComments.filter((comment) =>
+    comment.document_id === selectedDoc.id)
+    );
+    
+  const comments = getComments(state);
+  // Get the tag options for the current document
+  const getTagOptions = createSelector([getAllDocs],
+    (allDocs) => {
+      return formatTagValue(
+        formatTagOptions(allDocs)
+      )
+    })
+  const tagOptions = getTagOptions(state)
+
+  const docsFiltered = getdocsFiltered(state);
+
 
   return {
     documents,
     docsCount,
     categories,
     comments,
-    docsFiltered:
-      state.reader.documentList.filterCriteria.searchQuery ||
-      !isEmpty(state.reader.documentList.filterCriteria.category) ||
-      !isEmpty(state.reader.documentList.filterCriteria.tag),
+    docsFiltered,
     currentPageIndex: state.reader.documentViewer.currentPageIndex,
     pendingTag: state.reader.documentViewer.pendingTag,
     editingTag: state.reader.documentViewer.editingTag,
     pendingCategory: state.reader.documentViewer.pendingCategory,
     documentTags: state.reader.documentViewer.tags,
-    tagOptions: formatTagValue(
-      formatTagOptions(state.reader.documentList.documents)
-    ),
+    tagOptions,
     viewport: state.reader.documentViewer.viewport,
     keyboardInfoOpen: state.reader.documentViewer.keyboardInfoOpen,
     pendingDeletion: state.reader.annotationLayer.pendingDeletion,
@@ -127,14 +163,14 @@ export const documentScreen = (state) => {
     windowingOverscan: state.reader.documentViewer.windowingOverscan,
     deleteCommentId: state.reader.documentViewer.deleteCommentId,
     shareCommentId: state.reader.documentViewer.shareCommentId,
-    filterCriteria: state.reader.documentList.filterCriteria,
+    filterCriteria: getFilterCriteria(state),
     openSections: state.reader.documentViewer.openedAccordionSections,
-    currentDocument: state.reader.documentViewer.selected,
-    filteredDocIds: state.reader.documentList.filteredDocIds,
+    currentDocument: getSelectedDoc(state),
+    filteredDocIds: getFilteredDocIds(state),
     appeal: state.reader.appeal.selected,
     searchCategoryHighlights:
       state.reader.documentList.searchCategoryHighlights,
-    storeDocuments: state.reader.documentList.documents,
+    storeDocuments: getAllDocs(state),
     annotationLayer: state.reader.annotationLayer,
     hidePdfSidebar: state.reader.documentViewer.hidePdfSidebar,
     hideSearchBar: state.reader.documentViewer.hideSearchBar,


### PR DESCRIPTION
Resolves
- https://vajira.max.gov/browse/APPEALS-9739
- https://vajira.max.gov/browse/APPEALS-9740

### Business Impact
Improves performance of Reader application.  Memoization improvements to Reader client application decrease render times and increase interaction response.  Bulk upload decreases the number of request made to the database and decreases overall request time.  These improvements will allow Reader users to complete their tasks faster. See [metrics](https://boozallen.sharepoint.com/:p:/r/teams/VABID/appeals/Documents/Sprint%20Reviews/External%20Sprint%20Review/0002AE_0003_1003AG_AJ_AK_AL_BID_Sprint_Review_FY23Q1.2_11082022.pptx?d=w78b9cef1e5914692a8eb597cd9777843&csf=1&web=1&e=ZopzXt) 


### Description
- As an Optimization ART developer, I need to memoize the selector functions for the DocumentList component redux store so that the selectors do not run again if provided the same data causing the components to not re-render when data has not changed.
- As an Optimization ART developer,I need to manipulate the format of the data in the original algorithm for bulk upload. So that caseflow makes a single bulk update request to update the documents in the database instead of multiple individual update requests to update each document in the database.


### Acceptance Criteria
Bulk Upload
- The ruby service "document_fetcher.rb" is updated so the method named "copy_metadata_from_document" no longer uses active record instance method "update" via "document.rb" method "copy_metadata_from_document" but instead uses class method "import" provided by "activerecord-import library"
- When DocumentFetcher#copy_metadata_from_document is called, only a single network request to DB is made for the updating of the documents
- When the API end point Reader:Documents#index is requested and there are new documents from VBMS that need to be created and have metadata added to them, only a single network request to DB is made for the updating of the documents
- When the API end point Reader:Documents#index is requested and there are new documents from VBMS that need to be created and have metadata added to them, they should receive the same data back
- Backend code test are updated for new bulk upload
- Data manipulation of original algorithm clearly identified 
- Data from original algorithm is manipulated into format needed for bulk upload

Memoization
- Reselect library memoizes selectors in the DocumentList component tree that perform calculations or rely on arrays or hashes of data.
- When a selector that has been memoized is triggered with the same values then it should not cause another render.
- When a selector that has been memoized is triggered with a new value then it should cause another render.
- When a user performs the task which triggers the memoized selector, the functionality should succeed as expected.
- Reselect library memoizes selectors in the DocumentViewer component tree that perform calculations or rely on arrays or hashes of data.
- When a selector that has been memoized is triggered with the same values then it should not cause another render.
- When a selector that has been memoized is triggered with a new value then it should cause another render.
- When a user performs the task which triggers the memoized selector, the functionality should succeed as expected.
- Documentation for each memoized selector should be added to the wiki for reference
- 
### Testing Plan
1. https://vajira.max.gov/browse/APPEALS-11000

### Text Execution
Only test required is successful build, tests have been completed in demo environment

### User Facing Changes

No visual
