### PR TITLE
Updated what is considered active request issue.

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -136,7 +136,7 @@ class RequestIssue < CaseflowRecord
     # "Active" issues are issues that need decisions.
     # They show up as contentions in VBMS and issues in Caseflow Queue.
     def active
-      eligible.where(closed_at: nil)
+      eligible.where(closed_at: nil, split_issue_status: [nil, "in_progress"])
     end
 
     def active_or_ineligible

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -52,10 +52,12 @@ feature "Higher-Level Review", :all_dbs do
   before do
     FeatureToggle.enable!(:filed_by_va_gov_hlr)
     FeatureToggle.enable!(:updated_intake_forms)
+    FeatureToggle.enable!(:use_ama_activation_date)
   end
   after do
     FeatureToggle.disable!(:filed_by_va_gov_hlr)
     FeatureToggle.disable!(:updated_intake_forms)
+    FeatureToggle.enable!(:use_ama_activation_date)
   end
 
   it "Creates an end product and contentions for it" do

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -687,6 +687,31 @@ describe RequestIssue, :all_dbs do
     end
   end
 
+  context ".active when request issue has been split off a appeal and is nil or 'in_progress' after split" do
+    subject { RequestIssue.active }
+
+    let!(:active_request_issue) { create(:request_issue, split_issue_status: nil) }
+    let!(:split_request_issue) { create(:request_issue, split_issue_status: "in_progress") }
+
+    it "filters by whether the split_issue_status is nil" do
+      expect(active_request_issue.split_issue_status).to be(nil)
+      expect(split_request_issue.split_issue_status).to eq("in_progress")
+      expect(subject.find_by(id: active_request_issue.id)).to eq(active_request_issue)
+      expect(subject.find_by(id: split_request_issue.id)).to eq(split_request_issue)
+    end
+  end
+
+  context "Request issues from original appeal are inactive when they don't go to a split appeal" do
+    subject { RequestIssue.active }
+
+    let!(:on_hold_request_issue) { create(:request_issue, split_issue_status: "on_hold") }
+
+    it "filters by whether the split_issue_status is on_hold" do
+      expect(on_hold_request_issue.split_issue_status).to eq("on_hold")
+      expect(subject.find_by(id: on_hold_request_issue.id)).to eq(nil)
+    end
+  end
+
   context ".active_or_decided_or_withdrawn" do
     subject { RequestIssue.active_or_decided_or_withdrawn }
 


### PR DESCRIPTION
Resolves #{APPEALS-10710-V4}

### Description
Changes the definition of a active request issue with a appeal is split from the new feature work. 

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. Intake a appeal any appeal with at least 2 request request issues (this is considered the original appeal). Notice the two request issues you created. Soon, one request of the original appeal, that is not sent to the split appeal will remain "on_hold" considering the request_issue inactive (and will no longer display on the front end) while the request issue selected for the new split appeal will be active and will render to the frontend. Split the appeal with a "SPL" SSC and/or COB user. Observe: 1. Disappearance of request_issue(s) of the "original" appeal. Observe: 2. The new "split appeal" with the active request_issue(s).

![image](https://user-images.githubusercontent.com/96748497/201194537-5f22a2a2-402b-4917-8704-6ccd5ffa3a32.png)
Image 1: This image is before any code changes where there was 3 active issues; where two issues were split to the new appeal. Thus showing 3 "active" original request issues and 2 "active" split request issues. 

![image](https://user-images.githubusercontent.com/96748497/201195127-918d164a-ea3d-4ada-875a-dabe22d15879.png)
Image 2: This image is the after effect of the code change (same appeal as above), where there was 3 active issues; where two issues were split to the new appeal. Now showing 1"active" original request issues and 2"active" split request issues. 


