### PR TITLE
Hotfix/appeals 9739.2

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -20,6 +20,7 @@
     "suming.react-proptypes-generate",
     "wingrunr21.vscode-ruby",
     "wmaurer.change-case",
-    "ziyasal.vscode-open-in-github"
+    "ziyasal.vscode-open-in-github",
+    "oracle.oracledevtools"
   ]
 }

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -221,10 +221,10 @@ class Document < CaseflowRecord
     :category_medical,
     :category_other,
     :category_procedural,
-    :previous_document_version_id,
+    :previous_document_version_id
   ].freeze
 
-  # updates documents with nested resources like tags in bulk
+  # updates documents and nested resources like tags to db in bulk
   def self.bulk_merge_and_update(document_structs)
     # Bulk update
     Document.import(document_structs,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -218,24 +218,19 @@ class Document < CaseflowRecord
   end
 
   COLUMNS_TO_UPDATE = [
-    :type,
-    :received_at,
-    :upload_date,
-    :vbms_document_id,
-    :series_id,
     :category_medical,
     :category_other,
     :category_procedural,
     :previous_document_version_id,
   ].freeze
 
-  # efficient version of merge_into that also saves to DB
+  # updates documents with nested resources like tags in bulk
   def self.bulk_merge_and_update(document_structs)
     # Bulk update
     Document.import(document_structs,
                     on_duplicate_key_update: {
                       conflict_target: [:vbms_document_id],
-                      columns: COLUMNS_TO_UPDATE
+                      columns: COLUMNS_TO_UPDATE + COLUMNS_TO_MERGE
                     },
                     recursive: true)
   end

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -24,6 +24,10 @@ class DocumentFetcher
 
   private
 
+  def current_user
+    RequestStore[:current_user]
+  end
+
   # Expect appeal.manifest_(vva|vbms)_fetched_at to be either nil or a Time objects
   def manifest_vbms_fetched_at=(fetched_at)
     @manifest_vbms_fetched_at = fetched_at.strftime(fetched_at_format) if fetched_at
@@ -75,10 +79,20 @@ class DocumentFetcher
     series_id_hash = Document.includes(:annotations, :tags)
       .where(series_id: created_docs_with_series_id.pluck(:series_id))
       .where.not(vbms_document_id: vbms_doc_ver_ids).group_by(&:series_id)
-    created_docs_with_series_id.map do |document|
-      # update the DB for each doc individually; this could be optimized if needed
-      previous_documents = series_id_hash[document.series_id]&.sort_by(&:id)
-      document.copy_metadata_from_document(previous_documents.last) if previous_documents.present?
+    # Feature toggle for bulk upload enabled
+    if FeatureToggle.enabled?(:bulk_upload_documents, user: current_user)
+      document_structs = created_docs_with_series_id.map do |document|
+        previous_documents = series_id_hash[document.series_id]&.sort_by(&:id)
+        document.prepare_metadata_from_document(previous_documents.last) if previous_documents.present?
+        document
+      end
+      Document.bulk_merge_and_update(document_structs)
+    # Feature toggle for bulk upload disabled
+    else
+      created_docs_with_series_id.map do |document|
+        previous_documents = series_id_hash[document.series_id]&.sort_by(&:id)
+        document.copy_metadata_from_document(previous_documents.last) if previous_documents.present?
+      end
     end
   end
 

--- a/app/services/document_fetcher.rb
+++ b/app/services/document_fetcher.rb
@@ -73,20 +73,26 @@ class DocumentFetcher
     documents.partition { |doc| vbms_doc_ver_ids.include?(doc.vbms_document_id) }
   end
 
-  def copy_metadata_from_document(created_docs_with_series_id, vbms_doc_ver_ids)
+  def copy_metadata_from_document(docs_with_series_id, vbms_doc_ver_ids)
+    # Feature toggle for bulk upload
+    ft_bulk_upload = FeatureToggle.enabled?(:bulk_upload_documents, user: current_user)
+    Rails.logger.info("Feature Flag Enabled: #{ft_bulk_upload} - Bulk Upload - CSS ID: #{current_user.css_id}")
+
     # Find the most recent saved document with the given series_id that is not in the list of vbms_doc_ver_ids passed
     # since vbms_doc_ver_ids have already been updated
     series_id_hash = Document.includes(:annotations, :tags)
-      .where(series_id: created_docs_with_series_id.pluck(:series_id))
+      .where(series_id: docs_with_series_id.pluck(:series_id))
       .where.not(vbms_document_id: vbms_doc_ver_ids).group_by(&:series_id)
+
     # Feature toggle for bulk upload enabled
-    if FeatureToggle.enabled?(:bulk_upload_documents, user: current_user)
-      document_structs = created_docs_with_series_id.map do |document|
+    if ft_bulk_upload == true
+      document_structs = docs_with_series_id.map do |document|
         previous_documents = series_id_hash[document.series_id]&.sort_by(&:id)
         document.prepare_metadata_from_document(previous_documents.last) if previous_documents.present?
         document
       end
       Document.bulk_merge_and_update(document_structs)
+
     # Feature toggle for bulk upload disabled
     else
       created_docs_with_series_id.map do |document|

--- a/app/views/reader/appeal/index.html.erb
+++ b/app/views/reader/appeal/index.html.erb
@@ -10,6 +10,7 @@
     featureToggles: {
       interfaceVersion2: FeatureToggle.enabled?(:interface_version_2, user: current_user),
       windowSlider: FeatureToggle.enabled?(:window_slider, user: current_user),
+      readerSelectorsMemoized: FeatureToggle.enabled?(:bulk_upload_documents, user: current_user),
     },
     buildDate: build_date
   }) %>

--- a/client/app/2.0/screens/reader/DocumentList.jsx
+++ b/client/app/2.0/screens/reader/DocumentList.jsx
@@ -7,6 +7,7 @@ import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolki
 // Local Dependencies
 import { recordSearch, fetchDocuments } from 'utils/reader';
 import { documentListScreen } from 'store/reader/selectors';
+import { documentListScreenMemoized } from 'store/reader/selectorsMemoized';
 import {
   setSearch,
   clearSearch as clear,
@@ -35,7 +36,10 @@ import { selectComment } from 'store/reader/annotationLayer';
 
 const DocumentList = (props) => {
   // Get the Document List state
-  const state = useSelector(documentListScreen);
+  // const state = useSelector(documentListScreen);
+
+  const state = props.featureToggles.readerSelectorsMemoized ?
+  useSelector(documentListScreenMemoized) : useSelector(documentListScreen);
 
   // Create the Dispatcher
   const dispatch = useDispatch();

--- a/client/app/2.0/screens/reader/DocumentViewer.jsx
+++ b/client/app/2.0/screens/reader/DocumentViewer.jsx
@@ -9,6 +9,7 @@ import { getPageCoordinatesOfMouseEvent } from 'utils/reader';
 import { pdfWrapper } from 'styles/reader/Document/PDF';
 import { fetchDocuments, openDownloadLink } from 'utils/reader/document';
 import { documentScreen } from 'store/reader/selectors';
+import { documentScreenMemoized } from 'store/reader/selectorsMemoized';
 import { DocumentHeader } from 'components/reader/DocumentViewer/Header';
 import { DocumentSidebar } from 'components/reader/DocumentViewer/Sidebar';
 import { DocumentFooter } from 'components/reader/DocumentViewer/Footer';
@@ -58,8 +59,9 @@ import { KeyboardInfo } from 'app/2.0/components/reader/DocumentViewer/modals/Ke
  */
 const DocumentViewer = (props) => {
   // Get the Document List state
-  const state = useSelector(documentScreen);
-
+  // const state = useSelector(documentScreen);
+  const state = props.featureToggles.readerSelectorsMemoized ?
+    useSelector(documentScreenMemoized) : useSelector(documentScreen);
   // Create the Dispatcher
   const dispatch = useDispatch();
 

--- a/client/app/2.0/store/reader/selectorsMemoized.js
+++ b/client/app/2.0/store/reader/selectorsMemoized.js
@@ -36,6 +36,7 @@ export const getdocsFiltered = createSelector(
  * @returns {Object} -- The Documents
  */
 export const documentState = (state) => {
+  console.log("Feature Flag Enabled - Bulk Upload")
   // Set the filtered documents
   const documents = getFilteredDocuments(state);
 

--- a/client/app/2.0/store/reader/selectorsMemoized.js
+++ b/client/app/2.0/store/reader/selectorsMemoized.js
@@ -1,0 +1,183 @@
+// Local Dependencies
+import { documentCategories } from 'store/constants/reader';
+import { documentsView, formatTagOptions, formatTagValue, formatCategoryName } from 'utils/reader';
+import { createSelector } from 'reselect';
+import { isEmpty } from 'lodash';
+
+/**
+ * Filtered Documents state
+ */
+
+const getFilteredDocIds = (state) => state.reader.documentList.filteredDocIds;
+const getAllDocs = (state) => state.reader.documentList.documents;
+const getView = (state) => state.reader.documentList.view;
+const getSelectedDoc = (state) => state.reader.documentViewer.selected;
+const getFilterCriteria = (state) => state.reader.documentList.filterCriteria
+
+export const getFilteredDocuments = createSelector(
+  [getFilteredDocIds, getAllDocs],
+  (filteredDocIds, allDocs) => filteredDocIds.reduce(
+    (list, id) => ({ ...list, [id]: allDocs[id] }),
+    {}
+  )
+)
+
+export const getdocsFiltered = createSelector(
+  [getFilterCriteria], (filterCriteria) => {
+    return filterCriteria.searchQuery ||
+      !isEmpty(filterCriteria.category) ||
+      !isEmpty(filterCriteria.tag)
+  }
+)
+
+/**
+ * Selector for the Documents
+ * @param {Object} state -- The current Redux Store state
+ * @returns {Object} -- The Documents
+ */
+export const documentState = (state) => {
+  // Set the filtered documents
+  const documents = getFilteredDocuments(state);
+
+  // Calculate the number of documents
+  const docsCount = getFilteredDocIds(state) ?
+    getFilteredDocIds(state).length :
+    Object.values(documents).length;
+
+  // Return the Filtered Documents and count
+  return { documents, docsCount };
+};
+
+/**
+ * State for the Document List Screen
+ * @param {Object} state -- The current Redux Store state
+ * @returns {Object} -- The Documents List State
+ */
+export const documentListScreenMemoized = (state) => {
+  // Get the filtered documents and count
+  const { documents, docsCount } = documentState(state);
+
+  Object.values(getAllDocs(state)).
+    reduce((list, doc) => [...list, ...doc.tags], []).
+    filter((tags, index, list) => list.findIndex((tag) => tag.text === tags.text) === index);
+
+  const getDocumentsView = createSelector([getAllDocs, getFilterCriteria, getView],
+    (docs, filterCriteria, view) => {
+      return documentsView(Object.values(docs), filterCriteria, view);
+    });
+
+  const docsFiltered = getdocsFiltered(state);
+
+  const documentView = getDocumentsView(state);
+
+  return {
+    documents,
+    docsCount,
+    docsFiltered,
+    tagOptions: formatTagOptions(getAllDocs(state)),
+    currentDocument: getSelectedDoc(state),
+    storeDocuments: getAllDocs(state),
+    documentList: state.reader.documentList,
+    comments: state.reader.annotationLayer.comments,
+    documentsView: documentView,
+    filterCriteria: getFilterCriteria(state),
+    filteredDocIds: getFilteredDocIds(state),
+    searchCategoryHighlights:
+      state.reader.documentList.searchCategoryHighlights,
+    manifestVbmsFetchedAt: state.reader.documentList.manifestVbmsFetchedAt,
+    manifestVvaFetchedAt: state.reader.documentList.manifestVvaFetchedAt,
+    queueRedirectUrl: state.reader.documentList.queueRedirectUrl,
+    queueTaskType: state.reader.documentList.queueTaskType,
+    appeal: state.reader.appeal.selected,
+    scale: state.reader.documentViewer.scale,
+  };
+};
+
+/**
+ * State for the Document Screen
+ * @param {Object} state -- The current Redux Store state
+ * @returns {Object} -- The Document State
+ */
+export const documentScreenMemoized = (state) => {
+  // Get the filtered documents and count
+  const { documents, docsCount } = documentState(state);
+
+  const getCategories = createSelector(getSelectedDoc, (selectedDoc) => {
+    return Object.keys(documentCategories).reduce((list, key) => {
+      // Set the current Category
+      const cat = selectedDoc[formatCategoryName(key)] ? key : '';
+      // Return the Categories Object
+      return {
+        ...list,
+        [cat]: true
+      };
+    }, {})
+  })
+
+  const categories = getCategories(state);
+  // Filter the comments for the current document
+
+  const getAllComments = state => state.reader.annotationLayer.comments
+  const getComments = createSelector([getAllComments, getSelectedDoc],
+    (allComments, selectedDoc) =>
+    allComments.filter((comment) =>
+    comment.document_id === selectedDoc.id)
+    );
+
+  const comments = getComments(state);
+  // Get the tag options for the current document
+  const getTagOptions = createSelector([getAllDocs],
+    (allDocs) => {
+      return formatTagValue(
+        formatTagOptions(allDocs)
+      )
+    })
+  const tagOptions = getTagOptions(state)
+
+  const docsFiltered = getdocsFiltered(state);
+
+
+  return {
+    documents,
+    docsCount,
+    categories,
+    comments,
+    docsFiltered,
+    currentPageIndex: state.reader.documentViewer.currentPageIndex,
+    pendingTag: state.reader.documentViewer.pendingTag,
+    editingTag: state.reader.documentViewer.editingTag,
+    pendingCategory: state.reader.documentViewer.pendingCategory,
+    documentTags: state.reader.documentViewer.tags,
+    tagOptions,
+    viewport: state.reader.documentViewer.viewport,
+    keyboardInfoOpen: state.reader.documentViewer.keyboardInfoOpen,
+    pendingDeletion: state.reader.annotationLayer.pendingDeletion,
+    droppedComment: state.reader.annotationLayer.droppedComment,
+    editingComment: state.reader.annotationLayer.editingComment,
+    addingComment: state.reader.annotationLayer.dropping,
+    movingComment: state.reader.annotationLayer.moving,
+    savingComment: state.reader.annotationLayer.saving,
+    selectedComment: state.reader.annotationLayer.selected,
+    search: state.reader.documentViewer.search,
+    canvasList: state.reader.documentViewer.canvasList,
+    windowingOverscan: state.reader.documentViewer.windowingOverscan,
+    deleteCommentId: state.reader.documentViewer.deleteCommentId,
+    shareCommentId: state.reader.documentViewer.shareCommentId,
+    filterCriteria: getFilterCriteria(state),
+    openSections: state.reader.documentViewer.openedAccordionSections,
+    currentDocument: getSelectedDoc(state),
+    filteredDocIds: getFilteredDocIds(state),
+    appeal: state.reader.appeal.selected,
+    searchCategoryHighlights:
+      state.reader.documentList.searchCategoryHighlights,
+    storeDocuments: getAllDocs(state),
+    annotationLayer: state.reader.annotationLayer,
+    hidePdfSidebar: state.reader.documentViewer.hidePdfSidebar,
+    hideSearchBar: state.reader.documentViewer.hideSearchBar,
+    scale: state.reader.documentViewer.scale,
+    errors: {
+      ...state.reader.documentViewer.errors,
+      comments: state.reader.annotationLayer.errors,
+    },
+  };
+};

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -288,6 +288,33 @@ describe Document, :postgres do
     end
   end
 
+  COLUMNS_TO_MERGE = [
+    :type,
+    :received_at,
+    :upload_date,
+    :vbms_document_id,
+    :series_id
+  ].freeze
+
+  COLUMNS_TO_UPDATE = [
+    :category_medical,
+    :category_other,
+    :category_procedural,
+    :previous_document_version_id
+  ].freeze
+
+  context "#bulk_merge_and_update" do
+    it "should only the following columnds #{COLUMNS_TO_UPDATE}" do
+      Document.COLUMNS_TO_UPDATE.should match_array(COLUMNS_TO_UPDATE)
+    end
+  end
+
+  context "#bulk_merge_and_save" do
+    it "should save the following columnds #{COLUMNS_TO_MERGE}" do
+      Document.COLUMNS_TO_MERGE.should match_array(COLUMNS_TO_MERGE)
+    end
+  end
+
   context "#serve!" do
     before do
       File.delete(file) if File.exist?(file)

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -305,13 +305,13 @@ describe Document, :postgres do
 
   context "#bulk_merge_and_update" do
     it "should only the following columnds #{COLUMNS_TO_UPDATE}" do
-      Document.COLUMNS_TO_UPDATE.should match_array(COLUMNS_TO_UPDATE)
+      Document::COLUMNS_TO_UPDATE.should match_array(COLUMNS_TO_UPDATE)
     end
   end
 
   context "#bulk_merge_and_save" do
     it "should save the following columnds #{COLUMNS_TO_MERGE}" do
-      Document.COLUMNS_TO_MERGE.should match_array(COLUMNS_TO_MERGE)
+      Document::COLUMNS_TO_MERGE.should match_array(COLUMNS_TO_MERGE)
     end
   end
 

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -194,6 +194,10 @@ describe DocumentFetcher, :postgres do
         expect(Document.third.series_id).to eq(saved_documents.first.series_id)
         expect(Document.third.series_id).to eq(saved_documents.second.series_id)
         expect(Document.third.category_medical).to eq(saved_documents.second.category_medical)
+        expect(Document.third.category_procedural).to eq(saved_documents.second.category_procedural)
+        expect(Document.third.category_other).to eq(saved_documents.second.category_other)
+        expect(Document.third.category_case_summary).to eq(saved_documents.second.category_case_summary)
+        expect(Document.third.previous_document_version_id).to eq(saved_documents.second.id)
       end
 
       context "when existing document has comments, tags, and categories" do
@@ -245,9 +249,8 @@ describe DocumentFetcher, :postgres do
           expect(DocumentsTag.count).to eq(3)
           expect(Document.second.documents_tags.first.tag.text).to eq(tag)
           expect(Document.third.documents_tags.first.tag.text).to eq(tag)
-
-          expect(Document.second.category_medical).to eq(true)
-          expect(Document.third.category_medical).to eq(true)
+          expect(Document.second.category_medical).to eq(saved_documents.second.category_medical)
+          expect(Document.third.category_medical).to eq(saved_documents.second.category_medical)
         end
 
         context "when the API returns two documents with the same series_id" do
@@ -319,29 +322,81 @@ describe DocumentFetcher, :postgres do
             DocumentsTag.create(document_id: doc.id, tag_id: doc_tag.id)
           end
         end
-        it "efficiently creates and updates documents" do
-          expect(Document.distinct.pluck(:type)).to eq(["Form 9"])
+        context "when feature toggle bulk upload disabled" do
+          before do
+            FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
+            RequestStore.store[:current_user] = nil
+          end
+          it "efficiently creates and updates documents without bulk update" do
+            expect(Document.distinct.pluck(:type)).to eq(["Form 9"])
+            # Uncomment the following to see all SQL queries made
+            # ActiveRecord::Base.logger = Logger.new(STDOUT)
+            query_data = SqlTracker.track do
+              document_fetcher.find_or_create_documents!
+            end
 
-          # Uncomment the following to see all SQL queries made
-          # ActiveRecord::Base.logger = Logger.new(STDOUT)
-          query_data = SqlTracker.track do
-            document_fetcher.find_or_create_documents!
+            # Uncomment the following to see a count of SQL queries
+            # pp query_data.values.pluck(:sql, :count)
+            doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
+            expect(doc_insert_queries.pluck(:count).max).to eq 1
+
+            # When metadata exists for a previous version of a document, queries are inefficient
+            annotns_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"annotations\"") }
+            expect(annotns_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+
+            doctags_insert_queries = query_data.values.select do |o|
+              o[:sql].start_with?("INSERT INTO \"documents_tags")
+            end
+            expect(doctags_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+            doc_update_queries = query_data.values.select do |o|
+              o[:sql].start_with?("UPDATE \"documents\"")
+            end
+            expect(doc_update_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+          end
+        end
+        context "when feature toggle bulk upload enabled" do
+          before do
+            FeatureToggle.enable!(:bulk_upload_documents, users: [user.css_id])
+            RequestStore.store[:current_user] = user
+          end
+          after do
+            FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
+            RequestStore.store[:current_user] = nil
           end
 
-          # Uncomment the following to see a count of SQL queries
-          # pp query_data.values.pluck(:sql, :count)
-          doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
-          expect(doc_insert_queries.pluck(:count).max).to eq 1
+          it "efficiently creates and updates documents" do
+            expect(Document.distinct.pluck(:type)).to eq(["Form 9"])
 
-          # When metadata exists for a previous version of a document, queries remain inefficient
-          annotns_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"annotations\"") }
-          expect(annotns_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+            # Uncomment the following to see all SQL queries made
+            # ActiveRecord::Base.logger = Logger.new(STDOUT)
+            query_data = SqlTracker.track do
+              document_fetcher.find_or_create_documents!
+            end
 
-          doctags_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents_tags") }
-          expect(doctags_insert_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+            # Uncomment the following to see a count of SQL queries
+            # pp query_data.values.pluck(:sql, :count)
 
-          doc_update_queries = query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }
-          expect(doc_update_queries.pluck(:count).max).to eq older_documents_with_metadata.count
+            doc_insert_queries = query_data.values.select do |o|
+              o[:sql].start_with?("INSERT INTO \"documents\"")
+            end
+            expect(doc_insert_queries.length).to eq 3
+
+            # When metadata exists for a previous version of a document, queries remain efficient
+            annotns_insert_queries = query_data.values.select do |o|
+              o[:sql].start_with?("INSERT INTO \"annotations\"")
+            end
+            expect(annotns_insert_queries.pluck(:count).max).to eq 1
+
+            doctags_insert_queries = query_data.values.select do |o|
+              o[:sql].start_with?("INSERT INTO \"documents_tags")
+            end
+            expect(doctags_insert_queries.pluck(:count).max).to eq 1
+
+            doc_update_queries = query_data.values.select do |o|
+              o[:sql].start_with?("UPDATE \"documents\"")
+            end
+            expect(doc_update_queries.pluck(:count).max).to eq nil
+          end
         end
 
         context "when there are duplicate documents returned from document_service" do
@@ -353,29 +408,72 @@ describe DocumentFetcher, :postgres do
             doc_with_diff_attrib = docs.third.dup.tap { |doc| doc.type = "Diff doc" }
             docs + [docs.first.dup, docs.second.dup, doc_with_diff_attrib]
           end
-          it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
-            expect(documents.map(&:vbms_document_id).count).to eq(53)
-            expect(documents.map(&:vbms_document_id).uniq.count).to eq(50)
-            expect(Document.count).to eq(saved_documents.count + older_documents_with_metadata.count)
-            expect(Document.find_by(vbms_document_id: documents.first.vbms_document_id)).not_to be_nil
-            expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
-            expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
-
-            expected_error_message = "Document records with duplicate vbms_document_id: fetched_documents"
-            expect(Raven).to receive(:capture_exception).with(
-              DocumentFetcher::DuplicateVbmsDocumentIdError.new(expected_error_message),
-              hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
-            )
-
-            query_data = SqlTracker.track do
-              document_fetcher.find_or_create_documents!
+          context "when feature toggle bulk upload enabled" do
+            before do
+              FeatureToggle.enable!(:bulk_upload_documents, users: [user.css_id])
+              RequestStore.store[:current_user] = user
             end
+            after do
+              FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
+              RequestStore.store[:current_user] = nil
+            end
+            it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
+              expect(documents.map(&:vbms_document_id).count).to eq(53)
+              expect(documents.map(&:vbms_document_id).uniq.count).to eq(50)
+              expect(Document.count).to eq(saved_documents.count + older_documents_with_metadata.count)
+              expect(Document.find_by(vbms_document_id: documents.first.vbms_document_id)).not_to be_nil
+              expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
+              expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
+              expected_error_message = "Document records with duplicate vbms_document_id: fetched_documents"
+              expect(Raven).to receive(:capture_exception).with(
+                DocumentFetcher::DuplicateVbmsDocumentIdError.new(expected_error_message),
+                hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
+              )
 
-            # pp query_data.values.pluck(:sql, :count)
-            doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
-            expect(doc_insert_queries.pluck(:count).max).to eq 1
-            expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }.pluck(:count).max)
-              .to eq(older_documents_with_metadata.count)
+              query_data = SqlTracker.track do
+                document_fetcher.find_or_create_documents!
+              end
+
+              # Uncomment the following to see a count of SQL queries
+              # pp query_data.values.pluck(:sql, :count)
+
+              doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
+              expect(doc_insert_queries.length).to eq 3
+              expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }.pluck(:count).max)
+                .to eq(nil)
+            end
+          end
+          context "when feature toggle bulk upload disabled" do
+            before do
+              FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
+              RequestStore.store[:current_user] = nil
+            end
+            it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
+              expect(documents.map(&:vbms_document_id).count).to eq(53)
+              expect(documents.map(&:vbms_document_id).uniq.count).to eq(50)
+              expect(Document.count).to eq(saved_documents.count + older_documents_with_metadata.count)
+              expect(Document.find_by(vbms_document_id: documents.first.vbms_document_id)).not_to be_nil
+              expect(Document.find_by(vbms_document_id: documents.second.vbms_document_id)).to be_nil
+              expect(Document.find_by(vbms_document_id: documents.third.vbms_document_id)).not_to be_nil
+
+              expected_error_message = "Document records with duplicate vbms_document_id: fetched_documents"
+              expect(Raven).to receive(:capture_exception).with(
+                DocumentFetcher::DuplicateVbmsDocumentIdError.new(expected_error_message),
+                hash_including(extra: hash_including(application: "reader", nonexact_dup_docs_count: 1))
+              )
+
+              query_data = SqlTracker.track do
+                document_fetcher.find_or_create_documents!
+              end
+
+              # Uncomment the following to see a count of SQL queries
+              # pp query_data.values.pluck(:sql, :count)
+
+              doc_insert_queries = query_data.values.select { |o| o[:sql].start_with?("INSERT INTO \"documents\"") }
+              expect(doc_insert_queries.pluck(:count).max).to eq 1
+              expect(query_data.values.select { |o| o[:sql].start_with?("UPDATE \"documents\"") }.pluck(:count).max)
+                .to eq(older_documents_with_metadata.count)
+            end
           end
         end
       end

--- a/spec/services/document_fetcher_spec.rb
+++ b/spec/services/document_fetcher_spec.rb
@@ -325,7 +325,7 @@ describe DocumentFetcher, :postgres do
         context "when feature toggle bulk upload disabled" do
           before do
             FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
-            RequestStore.store[:current_user] = nil
+            RequestStore[:current_user] = user
           end
           it "efficiently creates and updates documents without bulk update" do
             expect(Document.distinct.pluck(:type)).to eq(["Form 9"])
@@ -357,11 +357,11 @@ describe DocumentFetcher, :postgres do
         context "when feature toggle bulk upload enabled" do
           before do
             FeatureToggle.enable!(:bulk_upload_documents, users: [user.css_id])
-            RequestStore.store[:current_user] = user
+            RequestStore[:current_user] = user
           end
           after do
             FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
-            RequestStore.store[:current_user] = nil
+            RequestStore[:current_user] = user
           end
 
           it "efficiently creates and updates documents" do
@@ -411,11 +411,11 @@ describe DocumentFetcher, :postgres do
           context "when feature toggle bulk upload enabled" do
             before do
               FeatureToggle.enable!(:bulk_upload_documents, users: [user.css_id])
-              RequestStore.store[:current_user] = user
+              RequestStore[:current_user] = user
             end
             after do
               FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
-              RequestStore.store[:current_user] = nil
+              RequestStore[:current_user] = user
             end
             it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
               expect(documents.map(&:vbms_document_id).count).to eq(53)
@@ -446,7 +446,7 @@ describe DocumentFetcher, :postgres do
           context "when feature toggle bulk upload disabled" do
             before do
               FeatureToggle.disable!(:bulk_upload_documents, users: [user.css_id])
-              RequestStore.store[:current_user] = nil
+              RequestStore[:current_user] = user
             end
             it "deduplicates, sends warning to Sentry, and does not fail bulk upsert" do
               expect(documents.map(&:vbms_document_id).count).to eq(53)


### PR DESCRIPTION
Resolves bug related to updates from:
- https://vajira.max.gov/browse/APPEALS-9739
- https://vajira.max.gov/browse/APPEALS-9740

### Business Impact
**Hotfix:**
Updated tags after refresh were being overriden by the original tags due to a bug introduced in document fetcher.  Bug caused by bulk upload has been resolved by isolating the columns that need to be updated into a seprerate bulk update and bulk save methods.

**9739 + 9740:** Improves performance of Reader application.  Memoization improvements to Reader client application decrease render times and increase interaction response.  Bulk upload decreases the number of request made to the database and decreases overall request time.  These improvements will allow Reader users to complete their tasks faster. See [metrics](https://boozallen.sharepoint.com/:p:/r/teams/VABID/appeals/Documents/Sprint%20Reviews/External%20Sprint%20Review/0002AE_0003_1003AG_AJ_AK_AL_BID_Sprint_Review_FY23Q1.2_11082022.pptx?d=w78b9cef1e5914692a8eb597cd9777843&csf=1&web=1&e=ZopzXt) 


### Description
**Hotfix:**
- Bulk save must not include the tags because updates get lose on refresh whereas bulk update should

**9739 + 9740**
- As an Optimization ART developer, I need to memoize the selector functions for the DocumentList component redux store so that the selectors do not run again if provided the same data causing the components to not re-render when data has not changed.
- As an Optimization ART developer,I need to manipulate the format of the data in the original algorithm for bulk upload. So that caseflow makes a single bulk update request to update the documents in the database instead of multiple individual update requests to update each document in the database.


### Acceptance Criteria
**Bulk Upload**
- The ruby service "document_fetcher.rb" is updated so the method named "copy_metadata_from_document" no longer uses active record instance method "update" via "document.rb" method "copy_metadata_from_document" but instead uses class method "import" provided by "activerecord-import library"
- When DocumentFetcher#copy_metadata_from_document is called, only a single network request to DB is made for the updating of the documents
- When the API end point Reader:Documents#index is requested and there are new documents from VBMS that need to be created and have metadata added to them, only a single network request to DB is made for the updating of the documents
- When the API end point Reader:Documents#index is requested and there are new documents from VBMS that need to be created and have metadata added to them, they should receive the same data back
- Backend code test are updated for new bulk upload
- Data manipulation of original algorithm clearly identified 
- Data from original algorithm is manipulated into format needed for bulk upload

**Memoization**
- Reselect library memoizes selectors in the DocumentList component tree that perform calculations or rely on arrays or hashes of data.
- When a selector that has been memoized is triggered with the same values then it should not cause another render.
- When a selector that has been memoized is triggered with a new value then it should cause another render.
- When a user performs the task which triggers the memoized selector, the functionality should succeed as expected.
- Reselect library memoizes selectors in the DocumentViewer component tree that perform calculations or rely on arrays or hashes of data.
- When a selector that has been memoized is triggered with the same values then it should not cause another render.
- When a selector that has been memoized is triggered with a new value then it should cause another render.
- When a user performs the task which triggers the memoized selector, the functionality should succeed as expected.
- Documentation for each memoized selector should be added to the wiki for reference
- 
### Testing Plan
1. https://vajira.max.gov/browse/APPEALS-11000

### Text Execution

1. Sign in as test user
2. View queue
3. View documents list
4. Select a document to view
5. Add a new tag
6. Click the back button to go back to the documetns list
7. Hit the fresh button in the browser
8. Verify the tag you added is still listed.

### User Facing Changes

No visual
