### PR TITLE
Veteran extract featuretoggle

### DIFF
--- a/app/controllers/admin_controller.rb
+++ b/app/controllers/admin_controller.rb
@@ -27,7 +27,11 @@ class AdminController < ApplicationController
     )
     .last
 
-    last_completed_time = prev_event&.completed_at&.utc&.to_date || Time.at(0).utc.to_date
+    if FeatureToggle.enabled?(:vet_extract_timestamp, user: current_user)
+      last_completed_time = prev_event&.completed_at&.utc&.to_date || Time.at(0).utc.to_date
+    else
+      last_completed_time = Time.at(0).utc.to_date
+    end
 
     results = VACOLS::Correspondent.extract(last_completed_time)
 

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -8,7 +8,8 @@
     applicationUrls: application_urls,
     feedbackUrl: feedback_url,
     featureToggles: {
-      sys_admin_page: FeatureToggle.enabled?(:sys_admin_page, user: current_user)
+      sys_admin_page: FeatureToggle.enabled?(:sys_admin_page, user: current_user),
+      vet_extract_timestamp: FeatureToggle.enabled?(:vet_extract_timestamp, user: current_user)
     }
   }) %>
 <% end %>


### PR DESCRIPTION
Resolves #{github issue number}

### Description
When enabled, the featureToggle will use last successful veteran_extract SystemAdminEvent's `completed_at` time as part of the next extract calcuation.

### Acceptance Criteria
- [ ] Code compiles correctly

