### PR TITLE
APPEALS-10642 - Added pact_act column to special_issue_lists

### DIFF
--- a/db/migrate/20221115202338_add_pact_act_to_special_issue_lists.rb
+++ b/db/migrate/20221115202338_add_pact_act_to_special_issue_lists.rb
@@ -1,0 +1,9 @@
+class AddPactActToSpecialIssueLists < Caseflow::Migration
+  def up
+    add_column :special_issue_lists, :pact_act, :boolean, default: false, comment: "The Sergeant First Class (SFC) Heath Robinson Honoring our Promise to Address Comprehensive Toxics (PACT) Act"
+  end
+
+  def down
+    remove_column :special_issue_lists, :pact_act
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_25_184724) do
+ActiveRecord::Schema.define(version: 2022_11_15_202338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1420,6 +1420,7 @@ ActiveRecord::Schema.define(version: 2022_10_25_184724) do
     t.boolean "national_cemetery_administration", default: false
     t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues, added belatedly"
     t.boolean "nonrating_issue", default: false
+    t.boolean "pact_act", default: false, comment: "The Sergeant First Class (SFC) Heath Robinson Honoring our Promise to Address Comprehensive Toxics (PACT) Act"
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false
     t.boolean "radiation", default: false


### PR DESCRIPTION
Resolves #[APPEALS-10642](https://vajira.max.gov/browse/APPEALS-10642)
 
### Description
Added the pact_act column to the special_issue_lists DB; default is false.
 
### Acceptance Criteria
- [X] Code compiles correctly
 
### Testing Plan
1. Go to [#APPEALS-11537](https://vajira.max.gov/browse/APPEALS-11537)
 
### Database Changes
*Only for Schema Changes*
 
* [X] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [X] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [X] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))