### PR TITLE
APPEALS-10647 - Commit Cleanup CSS Fix

### DIFF
--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -139,7 +139,7 @@ class SelectSpecialIssuesView extends React.PureComponent {
         {this.getPageNote()}
       </p>
       {error && <Alert type="error" title={error.title} message={error.detail} />}
-      <div {...flexContainer} className="special-options">
+      <div {...flexContainer}>
         <div {...flexColumn}>
           {
             sectionsMap.noSpecialIssues && <CheckboxGroup


### PR DESCRIPTION
Resolves #{10647}

### Description
The special issues page was inheriting the "special-options" css from the _main.scss file, pushing over the checkboxes.  This was removed so that the items align correctly with their section titles.

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. Go to:
https://vajira.max.gov/browse/APPEALS-11655
https://vajira.max.gov/browse/APPEALS-11656

### User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
- BEFORE (Legacy)
![Screen Shot 2022-11-17 at 12 55 30 PM](https://user-images.githubusercontent.com/108023343/202524580-3da623a1-22c6-421f-999a-fc6ed795424b.png)

- AFTER (Legacy)
![Screen Shot 2022-11-17 at 12 54 38 PM](https://user-images.githubusercontent.com/108023343/202524623-69779f77-f854-484a-87e1-d2c6dc8365a4.png)


- BEFORE (AMA)
![Screen Shot 2022-11-17 at 12 55 38 PM](https://user-images.githubusercontent.com/108023343/202524600-3309d06e-ae91-44cd-a6b9-583a8ea6adc3.png)

- AFTER (AMA)
![Screen Shot 2022-11-17 at 12 54 50 PM](https://user-images.githubusercontent.com/108023343/202525283-fc86d460-67d0-4040-9c05-6e0b6cc73fac.png)