### PR TITLE
HunJerBAH/APPEALS-10618: Prevent VRR Task from Being Created for VHA Tasks

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -18,6 +18,9 @@ class RequestIssue < CaseflowRecord
   # don't need to try as frequently as default 3 hours
   DEFAULT_REQUIRES_PROCESSING_RETRY_WINDOW_HOURS = 12
 
+  # list of benefit types not wanting a VRR task created
+  BUSINESS_LINES_NOT_WANTING_VRR_TASKS = ["vha"]
+
   belongs_to :decision_review, polymorphic: true
   belongs_to :end_product_establishment, dependent: :destroy
   has_many :request_decision_issues, dependent: :destroy
@@ -535,7 +538,7 @@ class RequestIssue < CaseflowRecord
   end
 
   def requires_record_request_task?
-    return false if predocket_needed?
+    return false if predocket_needed? || BUSINESS_LINES_NOT_WANTING_VRR_TASKS.include?(benefit_type)
 
     eligible? && !is_unidentified && !benefit_type_requires_payee_code?
   end

--- a/spec/models/request_issue_spec.rb
+++ b/spec/models/request_issue_spec.rb
@@ -510,6 +510,14 @@ describe RequestIssue, :all_dbs do
       end
     end
 
+    context "issue is vha" do
+      let(:benefit_type) { "vha" }
+
+      it "does not require a record request task" do
+        expect(nonrating_request_issue.requires_record_request_task?).to eq false
+      end
+    end
+
     context "issue benefit type is education" do
       let(:benefit_type) { "education" }
 


### PR DESCRIPTION
Resolved [APPEALS-10618](https://vajira.max.gov/browse/APPEALS-10618)

### Description
Currently all VHA benefit type appeals enter pre-docketing, which prevents the creation of the Veteran Record Request task.

Recently we have learned that the VHA never utilized this task, even prior to the implementation of pre-docketing.

The purpose of this ticket is to ensure that once we make pre-docketing optional for VHA appeals, we do not create the VRR task on the appeal

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] When a VHA issue is selected, a VRR task is not created upon intaking the appeal.

### Testing Plan
1. Go to Intake as an intake user (I used BVADWISE)
![image](https://user-images.githubusercontent.com/99915461/204036298-23341d83-5208-4f74-a00b-84974a02aae7.png)
2. Select **decision review** from the dropdown menu.
![image](https://user-images.githubusercontent.com/99915461/204036361-fa61bcd3-ffb9-456b-8d03-deec5dd4cd50.png)
3. Enter a veteran's ssn number from the database. For my test, I used **252407352**.
4. Fill out the form with the review option being **evidence submission**. Click continue
![image](https://user-images.githubusercontent.com/99915461/204036591-53e1f2bc-cf9e-4a05-ba55-b444d8cc5d89.png)
5. Click **Add issues** to add issues to the appeal. 
![image](https://user-images.githubusercontent.com/99915461/204036639-3deeee07-01fd-4162-b7d7-4e0b739ac496.png)
6. Fill out the form with the benefit type being **Veterans Health Administration** and click **add this issue** when the form is filled out to add the issue to the appeal.
![image](https://user-images.githubusercontent.com/99915461/204036735-cfa37c9f-a0ab-403e-813a-bedb67269a33.png)
7. Click **submit appeal**
![image](https://user-images.githubusercontent.com/99915461/204036770-b13c44db-e053-4183-bd7b-373d7e738a29.png)
8. The appeal should be complete. Save the veteran file number to search for the case.
![image](https://user-images.githubusercontent.com/99915461/204036863-b25110b0-5e32-4552-b1f9-f01afc9eb07c.png)
9. Click **search cases** and enter in the veteran file number in the search bar. Click the **docket number** to open up the veteran's case.
10. Scroll down to the **Case Timeline**. The Veteran Record Request should not be on the case timeline.
![image](https://user-images.githubusercontent.com/99915461/204037137-5670694d-1fb9-4788-a85f-54aa94ecaf7d.png)