### PR TITLE
msteele/APPEALS-10453

### DIFF
--- a/app/jobs/fetch_all_active_ama_appeals_job.rb
+++ b/app/jobs/fetch_all_active_ama_appeals_job.rb
@@ -131,9 +131,17 @@ class FetchAllActiveAmaAppealsJob < CaseflowJob
     { hearing_withdrawn: false }
   end
 
+  # Purpose: Set key value pair for hearing_postponed to help with appeal_states table insertion
+  #
+  # Params: Appeal object
+  #
+  # Return: Hash with a single key (scheduled_in_error) with a boolean value
   def map_appeal_hearing_scheduled_in_error_state(appeal)
-    # Code goes here ...
-    { scheduled_in_error: false }
+    if appeal.hearings&.max_by(&:id)&.disposition == Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error
+      { scheduled_in_error: true }
+    else
+      { scheduled_in_error: false }
+    end
   end
 
   def map_appeal_cancelled_state(appeal)

--- a/app/jobs/fetch_all_active_ama_appeals_job.rb
+++ b/app/jobs/fetch_all_active_ama_appeals_job.rb
@@ -140,7 +140,7 @@ class FetchAllActiveAmaAppealsJob < CaseflowJob
     end
   end
 
-  # Purpose: Set key value pair for hearing_postponed to help with appeal_states table insertion
+  # Purpose: Set key value pair for scheduled_in_error to help with appeal_states table insertion
   #
   # Params: Appeal object
   #

--- a/app/jobs/fetch_all_active_legacy_appeals_job.rb
+++ b/app/jobs/fetch_all_active_legacy_appeals_job.rb
@@ -131,9 +131,17 @@ class FetchAllActiveLegacyAppealsJob < CaseflowJob
     { hearing_withdrawn: false }
   end
 
+  # Purpose: Set key value pair for hearing_postponed to help with appeal_states table insertion
+  #
+  # Params: LegacyAppeal object
+  #
+  # Return: Hash with a single key (scheduled_in_error) with a boolean value
   def map_appeal_hearing_scheduled_in_error_state(appeal)
-    # Code goes here ...
-    { scheduled_in_error: false }
+    if appeal.hearings&.max_by(&:id)&.disposition == Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error
+      { scheduled_in_error: true }
+    else
+      { scheduled_in_error: false }
+    end
   end
 
   def map_appeal_cancelled_state(appeal)

--- a/app/jobs/fetch_all_active_legacy_appeals_job.rb
+++ b/app/jobs/fetch_all_active_legacy_appeals_job.rb
@@ -140,7 +140,7 @@ class FetchAllActiveLegacyAppealsJob < CaseflowJob
     end
   end
 
-  # Purpose: Set key value pair for hearing_postponed to help with appeal_states table insertion
+  # Purpose: Set key value pair for scheduled_in_error to help with appeal_states table insertion
   #
   # Params: LegacyAppeal object
   #

--- a/spec/jobs/fetch_all_active_ama_appeals_job_spec.rb
+++ b/spec/jobs/fetch_all_active_ama_appeals_job_spec.rb
@@ -117,6 +117,7 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
         expect(subject.send(:map_appeal_hearing_scheduled_state, ama_appeal)).to eq(hearing_scheduled: false)
       end
     end
+  end
 
   describe "#map_appeal_ihp_state" do
     context "when there is an active AMA Appeal with an active InformalHearingPresentationTask" do
@@ -259,6 +260,39 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         second_hearing
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: false)
+      end
+    end
+  end
+
+  describe "#map_appeal_hearing_scheduled_in_error_state(appeal)" do
+    let!(:scheduled_hearing) { create(:hearing) }
+    let!(:error_hearing) { create(:hearing, :scheduled_in_error) }
+    let(:error_appeal) { error_hearing.appeal }
+    let(:appeal) { scheduled_hearing.appeal }
+    let(:second_hearing) { create(:hearing, appeal: error_appeal)}
+    context "When the last hearing has a disposition of postponed" do
+      it "returns the correct hash with a boolean value of true" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
+      end
+    end
+
+    context "When the last hearing does not have a disposition of postponed" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, appeal)).to eq(scheduled_in_error: false)
+      end
+    end
+
+    context "When there are multiple hearings associated with an appeal and the last one is postponed" do
+      it "returns the correct hash with a boolean value of true" do
+        second_hearing.update(disposition: Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error)
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
+      end
+    end
+
+    context "When there are multiple hearings associated with an appeal and the last one is not postponed" do
+      it "returns the correct hash with a boolean value of false" do
+        second_hearing
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: false)
       end
     end
   end

--- a/spec/jobs/fetch_all_active_ama_appeals_job_spec.rb
+++ b/spec/jobs/fetch_all_active_ama_appeals_job_spec.rb
@@ -236,7 +236,8 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
     let!(:postponed_hearing) { create(:hearing, :postponed) }
     let(:postponed_appeal) { postponed_hearing.appeal }
     let(:appeal) { scheduled_hearing.appeal }
-    let(:second_hearing) { create(:hearing, appeal: postponed_appeal)}
+    let(:second_hearing) { create(:hearing, appeal: postponed_appeal) }
+    let(:empty_appeal) { create(:appeal) }
     context "When the last hearing has a disposition of postponed" do
       it "returns the correct hash with a boolean value of true" do
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: true)
@@ -260,6 +261,12 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         second_hearing
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: false)
+      end
+    end
+
+    context "When there are no hearings associated with an appeal" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_postponed_state, empty_appeal)).to eq(hearing_postponed: false)
       end
     end
   end
@@ -304,6 +311,7 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
     let(:error_appeal) { error_hearing.appeal }
     let(:appeal) { scheduled_hearing.appeal }
     let(:second_hearing) { create(:hearing, appeal: error_appeal)}
+    let(:empty_appeal) { create(:appeal) }
     context "When the last hearing has a disposition of postponed" do
       it "returns the correct hash with a boolean value of true" do
         expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
@@ -327,6 +335,12 @@ describe FetchAllActiveAmaAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         second_hearing
         expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: false)
+      end
+    end
+
+    context "When there are no hearings associated with an appeal" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, empty_appeal)).to eq(scheduled_in_error: false)
       end
     end
   end

--- a/spec/jobs/fetch_all_active_legacy_appeals_job_spec.rb
+++ b/spec/jobs/fetch_all_active_legacy_appeals_job_spec.rb
@@ -155,6 +155,7 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
         expect(subject.send(:map_appeal_hearing_scheduled_state, legacy_appeal)).to eq(hearing_scheduled: false)
       end
     end
+  end
 
   describe "#map_appeal_ihp_state" do
     context "when there is an active legacy appeal with an active IhpColocated Task" do
@@ -249,6 +250,39 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         new_case_hearing
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: false)
+      end
+    end
+  end
+
+  describe "#map_appeal_hearing_scheduled_in_error_state(appeal)" do
+    let!(:scheduled_hearing) { create(:legacy_hearing) }
+    let!(:error_hearing) { create(:legacy_hearing, disposition: "E") }
+    let(:error_appeal) { error_hearing.appeal }
+    let(:appeal) { scheduled_hearing.appeal }
+    let(:new_case_hearing) { create(:case_hearing, folder_nr: error_appeal.vacols_id) }
+    context "When the last hearing has a disposition of scheduled in error" do
+      it "returns the correct hash with a boolean value of true" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
+      end
+    end
+
+    context "When the last hearing does not have a disposition of scheduled in error" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, appeal)).to eq(scheduled_in_error: false)
+      end
+    end
+
+    context "When there are multiple hearings associated with an appeal and the last one is scheduled in error" do
+      it "returns the correct hash with a boolean value of true" do
+        new_case_hearing.update(hearing_disp: "E")
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
+      end
+    end
+
+    context "When there are multiple hearings associated with an appeal and the last one is not postponed" do
+      it "returns the correct hash with a boolean value of false" do
+        new_case_hearing
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: false)
       end
     end
   end

--- a/spec/jobs/fetch_all_active_legacy_appeals_job_spec.rb
+++ b/spec/jobs/fetch_all_active_legacy_appeals_job_spec.rb
@@ -227,6 +227,7 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
     let(:postponed_appeal) { postponed_hearing.appeal }
     let(:appeal) { scheduled_hearing.appeal }
     let(:new_case_hearing) { create(:case_hearing, folder_nr: postponed_appeal.vacols_id) }
+    let(:empty_appeal) { create(:legacy_appeal) }
     context "When the last hearing has a disposition of postponed" do
       it "returns the correct hash with a boolean value of true" do
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: true)
@@ -250,6 +251,12 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         new_case_hearing
         expect(subject.send(:map_appeal_hearing_postponed_state, postponed_appeal)).to eq(hearing_postponed: false)
+      end
+    end
+
+    context "When there are no hearings associated with an appeal" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_postponed_state, empty_appeal)).to eq(hearing_postponed: false)
       end
     end
   end
@@ -293,6 +300,7 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
     let(:error_appeal) { error_hearing.appeal }
     let(:appeal) { scheduled_hearing.appeal }
     let(:new_case_hearing) { create(:case_hearing, folder_nr: error_appeal.vacols_id) }
+    let(:empty_appeal) { create(:legacy_appeal) }
     context "When the last hearing has a disposition of scheduled in error" do
       it "returns the correct hash with a boolean value of true" do
         expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: true)
@@ -316,6 +324,12 @@ describe FetchAllActiveLegacyAppealsJob, type: :job do
       it "returns the correct hash with a boolean value of false" do
         new_case_hearing
         expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, error_appeal)).to eq(scheduled_in_error: false)
+      end
+    end
+
+    context "When there are no hearings associated with an appeal" do
+      it "returns the correct hash with a boolean value of false" do
+        expect(subject.send(:map_appeal_hearing_scheduled_in_error_state, empty_appeal)).to eq(scheduled_in_error: false)
       end
     end
   end


### PR DESCRIPTION
Resolves APPEALS-10453

### Description
Added logic to map_appeal_hearing_scheduled_in_error_state to determine if the most recent hearing on an appeal is scheduled_in_error.

### Acceptance Criteria
- [x] The method map_appeal_hearing_scheduled_in_error_state is updated on the data migration job with logic to determine from the appeal task tree whether: appeal_state.scheduled_in_error = true or false

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-12355
