### PR TITLE
hotfix/APPEALS-12418 prevent cases from double-assigning on simultaneous distribution

### DIFF
--- a/app/models/concerns/distribution_concern.rb
+++ b/app/models/concerns/distribution_concern.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module DistributionConcern
+  extend ActiveSupport::Concern
+
+  private
+
+  def assign_judge_tasks_for_appeals(appeals, judge)
+    appeals.map do |appeal|
+      next nil unless appeal.tasks.open.of_type(:JudgeAssignTask).count == 0
+
+      distribution_task_assignee_id = appeal.tasks.of_type(:DistributionTask).first.assigned_to_id
+      Rails.logger.info("Calling JudgeAssignTaskCreator for appeal #{appeal.id} with judge #{judge.css_id}")
+      JudgeAssignTaskCreator.new(appeal: appeal,
+                                 judge: judge,
+                                 assigned_by_id: distribution_task_assignee_id).call
+    end
+  end
+
+  def cancel_previous_judge_assign_task(appeal, judge_id)
+    appeal.tasks.of_type(:JudgeAssignTask).where.not(assigned_to_id: judge_id).update(status: :cancelled)
+  end
+end

--- a/app/models/concerns/distribution_concern.rb
+++ b/app/models/concerns/distribution_concern.rb
@@ -7,7 +7,7 @@ module DistributionConcern
 
   def assign_judge_tasks_for_appeals(appeals, judge)
     appeals.map do |appeal|
-      next nil unless appeal.tasks.open.of_type(:JudgeAssignTask).count == 0
+      next nil unless appeal.tasks.open.of_type(:DistributionTask).any?
 
       distribution_task_assignee_id = appeal.tasks.of_type(:DistributionTask).first.assigned_to_id
       Rails.logger.info("Calling JudgeAssignTaskCreator for appeal #{appeal.id} with judge #{judge.css_id}")

--- a/app/models/concerns/distribution_concern.rb
+++ b/app/models/concerns/distribution_concern.rb
@@ -7,6 +7,9 @@ module DistributionConcern
 
   def assign_judge_tasks_for_appeals(appeals, judge)
     appeals.map do |appeal|
+      # If an appeal does not have an open DistributionTask, then it has already been distributed by automatic
+      # case distribution and a new JudgeAssignTask should not be created. This should only occur if two users
+      # request a distribution simultaneously.
       next nil unless appeal.tasks.open.of_type(:DistributionTask).any?
 
       distribution_task_assignee_id = appeal.tasks.of_type(:DistributionTask).first.assigned_to_id

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -92,12 +92,13 @@ class Docket
       if distributed_case && task.appeal.can_redistribute_appeal?
         distributed_case.flag_redistribution(task)
         distributed_case.rename_for_redistribution!
-        distribution.distributed_cases.create!(case_id: task.appeal.uuid,
-                                               docket: docket_type,
-                                               priority: priority,
-                                               ready_at: task.appeal.ready_for_distribution_at,
-                                               task: task)
+        new_dist_case = distribution.distributed_cases.create!(case_id: task.appeal.uuid,
+                                                               docket: docket_type,
+                                                               priority: priority,
+                                                               ready_at: task.appeal.ready_for_distribution_at,
+                                                               task: task)
         cancel_previous_judge_assign_task(task.appeal, distribution.judge.id)
+        new_dist_case
       elsif !distributed_case
         distribution.distributed_cases.create!(case_id: task.appeal.uuid,
                                                docket: docket_type,

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -2,6 +2,7 @@
 
 class Docket
   include ActiveModel::Model
+  include DistributionConcern
 
   def docket_type
     fail Caseflow::Error::MustImplementInSubclass
@@ -132,22 +133,6 @@ class Docket
 
   def docket_appeals
     Appeal.where(docket_type: docket_type).extending(Scopes)
-  end
-
-  def assign_judge_tasks_for_appeals(appeals, judge)
-    appeals.map do |appeal|
-      next nil unless appeal.tasks.open.of_type(:JudgeAssignTask).count == 0
-
-      distribution_task_assignee_id = appeal.tasks.of_type(:DistributionTask).first.assigned_to_id
-      Rails.logger.info("Calling JudgeAssignTaskCreator for appeal #{appeal.id} with judge #{judge.css_id}")
-      JudgeAssignTaskCreator.new(appeal: appeal,
-                                 judge: judge,
-                                 assigned_by_id: distribution_task_assignee_id).call
-    end
-  end
-
-  def cancel_previous_judge_assign_task(appeal, judge_id)
-    appeal.tasks.of_type(:JudgeAssignTask).where.not(assigned_to_id: judge_id).update(status: :cancelled)
   end
 
   def use_by_docket_date?

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -82,7 +82,11 @@ class Docket
   def distribute_appeals(distribution, priority: false, genpop: nil, limit: 1, style: "push")
     appeals = appeals(priority: priority, ready: true, genpop: genpop, judge: distribution.judge).limit(limit)
     tasks = assign_judge_tasks_for_appeals(appeals, distribution.judge)
+    Rails.logger.info("$$$$$ tasks")
+    Rails.logger.info(tasks)
     tasks.map do |task|
+      next if task.nil?
+
       # If a distributed case already exists for this appeal, alter the existing distributed case's case id.
       # This is modeled after the allow! method in the redistributed_case model
       distributed_case = DistributedCase.find_by(case_id: task.appeal.uuid)
@@ -133,6 +137,8 @@ class Docket
 
   def assign_judge_tasks_for_appeals(appeals, judge)
     appeals.map do |appeal|
+      next nil unless appeal.tasks.open.of_type(:JudgeAssignTask).count == 0
+
       distribution_task = appeal.tasks.of_type(:DistributionTask).first
       distribution_task_assignee_id = appeal.tasks.of_type(:DistributionTask).first.assigned_to_id
       Rails.logger.info("Assigning judge task for appeal #{appeal.id}")

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -77,7 +77,7 @@ class Docket
     appeals(priority: true, ready: true).pluck(:uuid)
   end
 
-  # rubocop:disable Lint/UnusedMethodArgument
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize, Lint/UnusedMethodArgument
   # :reek:FeatureEnvy
   def distribute_appeals(distribution, priority: false, genpop: nil, limit: 1, style: "push")
     appeals = appeals(priority: priority, ready: true, genpop: genpop, judge: distribution.judge).limit(limit)
@@ -106,7 +106,7 @@ class Docket
       end
     end
   end
-  # rubocop:enable Lint/UnusedMethodArgument
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize, Lint/UnusedMethodArgument
 
   def self.nonpriority_decisions_per_year
     Appeal.extending(Scopes).nonpriority

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -97,7 +97,9 @@ class Docket
                                                                priority: priority,
                                                                ready_at: task.appeal.ready_for_distribution_at,
                                                                task: task)
+        # In a race condition for distributions, two JudgeAssignTasks will be created; this cancels the first one
         cancel_previous_judge_assign_task(task.appeal, distribution.judge.id)
+        # Returns the new DistributedCase as expected by calling methods; case in elsif is implicitly returned
         new_dist_case
       elsif !distributed_case
         distribution.distributed_cases.create!(case_id: task.appeal.uuid,

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -119,7 +119,7 @@ class QueueRepository
       transaction do
         unless VACOLS::Case.find(vacols_id).bfcurloc == judge.vacols_uniq_id
           fail(Caseflow::Error::LegacyCaseAlreadyAssignedError,
-               message: "Case already assigned. Please refresh the page to get the latest appeal status.")
+               message: "That case has already been assigned. Please refresh the page to update your queue.")
         end
 
         update_location_to_attorney(vacols_id, attorney)

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -118,7 +118,8 @@ class QueueRepository
     def assign_case_to_attorney!(assigned_by:, judge:, attorney:, vacols_id:)
       transaction do
         unless VACOLS::Case.find(vacols_id).bfcurloc == judge.vacols_uniq_id
-          fail Caseflow::Error::LegacyCaseAlreadyAssignedError, message: "Case already assigned"
+          fail(Caseflow::Error::LegacyCaseAlreadyAssignedError,
+               message: "Case already assigned. Please refresh the page to get the latest appeal status.")
         end
 
         update_location_to_attorney(vacols_id, attorney)

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -36,18 +36,20 @@ class JudgeAssignTaskCreator
       assigning_user = @assigned_by_id.nil? ? nil : User.find(@assigned_by_id)
     rescue ActiveRecord::RecordNotFound
       Rails.logger.error("Could not locate a user with id #{@assigned_by_id} who reassigned a judge assign task.")
-      new_task, _old_task, _new_children = open_judge_assign_task.reassign({
+      new_task, old_task, _new_children = open_judge_assign_task.reassign({
                                                                              assigned_to_type: @judge.class.name,
                                                                              assigned_to_id: @judge.id,
                                                                              appeal: appeal
                                                                            }, nil)
+      old_task.cancelled!
       return new_task
     end
-    new_task, _old_task, _new_children = open_judge_assign_task.reassign({
+    new_task, old_task, _new_children = open_judge_assign_task.reassign({
                                                                            assigned_to_type: @judge.class.name,
                                                                            assigned_to_id: @judge.id,
                                                                            appeal: appeal
                                                                          }, assigning_user)
+    old_task.cancelled!
     new_task
   end
 

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -8,11 +8,13 @@ class JudgeAssignTaskCreator
   end
 
   def call
+    return nil if appeal.tasks.closed.of_type(:DistributionTask).any?
+
     Rails.logger.info("Assigning judge task for appeal #{appeal.id}")
     task = reassign_or_create
     Rails.logger.info("Assigned judge task with task id #{task.id} to #{task.assigned_to.css_id}")
 
-    Rails.logger.info("Closing distribution task for appeal #{appeal.id}")
+    Rails.logger.info("Closing distribution task for appeal #{appeal.id} with task id #{task.id}")
     close_distribution_tasks_for_appeal if appeal.is_a?(Appeal)
     Rails.logger.info("Closed distribution task for appeal #{appeal.id}")
 
@@ -36,24 +38,22 @@ class JudgeAssignTaskCreator
       assigning_user = @assigned_by_id.nil? ? nil : User.find(@assigned_by_id)
     rescue ActiveRecord::RecordNotFound
       Rails.logger.error("Could not locate a user with id #{@assigned_by_id} who reassigned a judge assign task.")
-      new_task, old_task, _new_children = open_judge_assign_task.reassign({
-                                                                             assigned_to_type: @judge.class.name,
-                                                                             assigned_to_id: @judge.id,
-                                                                             appeal: appeal
-                                                                           }, nil)
-      old_task.cancelled!
+      new_task, _old_task, _new_children = open_judge_assign_task.reassign({
+                                                                            assigned_to_type: @judge.class.name,
+                                                                            assigned_to_id: @judge.id,
+                                                                            appeal: appeal
+                                                                          }, nil)
       return new_task
     end
-    new_task, old_task, _new_children = open_judge_assign_task.reassign({
-                                                                           assigned_to_type: @judge.class.name,
-                                                                           assigned_to_id: @judge.id,
-                                                                           appeal: appeal
-                                                                         }, assigning_user)
-    old_task.cancelled!
+    new_task, _old_task, _new_children = open_judge_assign_task.reassign({
+                                                                          assigned_to_type: @judge.class.name,
+                                                                          assigned_to_id: @judge.id,
+                                                                          appeal: appeal
+                                                                        }, assigning_user)
     new_task
   end
 
   def close_distribution_tasks_for_appeal
-    appeal.tasks.of_type(:DistributionTask).update(status: :completed)
+    appeal.tasks.of_type(:DistributionTask).first.update!(status: :completed)
   end
 end

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -8,6 +8,10 @@ class JudgeAssignTaskCreator
   end
 
   def call
+    # If an appeal does not have an open DistributionTask, then it has already been distributed by automatic
+    # case distribution and a new JudgeAssignTask should not be created. This should only occur if two users
+    # request a distribution simultaneously. The check for LegacyAppeal was added for the Legacy DAS
+    # deprecation code in app/workflows/das_deprecation/case_distribution
     return nil unless appeal.tasks.open.of_type(:DistributionTask).any? || appeal.is_a?(LegacyAppeal)
 
     Rails.logger.info("Assigning judge task for appeal #{appeal.id}")

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -8,7 +8,7 @@ class JudgeAssignTaskCreator
   end
 
   def call
-    return nil if appeal.tasks.closed.of_type(:DistributionTask).any?
+    return nil unless appeal.tasks.open.of_type(:DistributionTask).any? || appeal.is_a?(LegacyAppeal)
 
     Rails.logger.info("Assigning judge task for appeal #{appeal.id}")
     task = reassign_or_create
@@ -54,6 +54,6 @@ class JudgeAssignTaskCreator
   end
 
   def close_distribution_tasks_for_appeal
-    appeal.tasks.of_type(:DistributionTask).first.update!(status: :completed)
+    appeal.tasks.of_type(:DistributionTask).update(status: :completed)
   end
 end

--- a/app/workflows/judge_assign_task_creator.rb
+++ b/app/workflows/judge_assign_task_creator.rb
@@ -39,17 +39,17 @@ class JudgeAssignTaskCreator
     rescue ActiveRecord::RecordNotFound
       Rails.logger.error("Could not locate a user with id #{@assigned_by_id} who reassigned a judge assign task.")
       new_task, _old_task, _new_children = open_judge_assign_task.reassign({
-                                                                            assigned_to_type: @judge.class.name,
-                                                                            assigned_to_id: @judge.id,
-                                                                            appeal: appeal
-                                                                          }, nil)
+                                                                             assigned_to_type: @judge.class.name,
+                                                                             assigned_to_id: @judge.id,
+                                                                             appeal: appeal
+                                                                           }, nil)
       return new_task
     end
     new_task, _old_task, _new_children = open_judge_assign_task.reassign({
-                                                                          assigned_to_type: @judge.class.name,
-                                                                          assigned_to_id: @judge.id,
-                                                                          appeal: appeal
-                                                                        }, assigning_user)
+                                                                           assigned_to_type: @judge.class.name,
+                                                                           assigned_to_id: @judge.id,
+                                                                           appeal: appeal
+                                                                         }, assigning_user)
     new_task
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_14_191336) do
+ActiveRecord::Schema.define(version: 2022_11_15_202338) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1076,6 +1076,15 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
     t.index ["updated_at"], name: "index_messages_on_updated_at"
   end
 
+  create_table "mpi_update_person_events", force: :cascade do |t|
+    t.bigint "api_key_id", null: false, comment: "API Key used to initiate the event"
+    t.datetime "completed_at", comment: "Timestamp of when update was completed, regardless of success or failure"
+    t.datetime "created_at", comment: "Timestamp of when update was initiated"
+    t.json "info", comment: "Additional information about the update"
+    t.string "update_type", null: false, comment: "Type or Result of update"
+    t.index ["api_key_id"], name: "index_mpi_update_person_events_on_api_key_id"
+  end
+
   create_table "nod_date_updates", comment: "Tracks changes to an AMA appeal's receipt date (aka, NOD date)", force: :cascade do |t|
     t.bigint "appeal_id", null: false, comment: "Appeal for which the NOD date is being edited"
     t.string "change_reason", null: false, comment: "Reason for change: entry_error or new_info"
@@ -1421,6 +1430,7 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
     t.boolean "national_cemetery_administration", default: false
     t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues, added belatedly"
     t.boolean "nonrating_issue", default: false
+    t.boolean "pact_act", default: false, comment: "The Sergeant First Class (SFC) Heath Robinson Honoring our Promise to Address Comprehensive Toxics (PACT) Act"
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false
     t.boolean "radiation", default: false
@@ -1478,6 +1488,17 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
     t.index ["updated_at"], name: "index_supplemental_claims_on_updated_at"
     t.index ["uuid"], name: "index_supplemental_claims_on_uuid"
     t.index ["veteran_file_number"], name: "index_supplemental_claims_on_veteran_file_number"
+  end
+
+  create_table "system_admin_events", force: :cascade do |t|
+    t.datetime "completed_at", comment: "Timestamp of when event was completed without error"
+    t.datetime "created_at", comment: "Timestamp of when event was initiated"
+    t.datetime "errored_at", comment: "Timestamp of when event failed due to error"
+    t.string "event_type", null: false, comment: "Type of event"
+    t.json "info", comment: "Additional information about the event"
+    t.datetime "updated_at", comment: "Timestamp of when event was last updated"
+    t.bigint "user_id", null: false, comment: "User who initiated the event"
+    t.index ["user_id"], name: "index_system_admin_events_on_user_id"
   end
 
   create_table "tags", id: :serial, force: :cascade do |t|
@@ -1832,6 +1853,7 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
   add_foreign_key "legacy_issue_optins", "request_issues"
   add_foreign_key "legacy_issues", "request_issues"
   add_foreign_key "messages", "users"
+  add_foreign_key "mpi_update_person_events", "api_keys"
   add_foreign_key "nod_date_updates", "appeals"
   add_foreign_key "nod_date_updates", "users"
   add_foreign_key "non_availabilities", "schedule_periods"
@@ -1857,6 +1879,7 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
   add_foreign_key "sent_hearing_email_events", "users", column: "sent_by_id"
   add_foreign_key "split_correlation_tables", "users", column: "created_by_id"
   add_foreign_key "split_correlation_tables", "users", column: "updated_by_id"
+  add_foreign_key "system_admin_events", "users"
   add_foreign_key "task_timers", "tasks"
   add_foreign_key "tasks", "tasks", column: "parent_id"
   add_foreign_key "tasks", "users", column: "assigned_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_15_202338) do
+ActiveRecord::Schema.define(version: 2022_11_14_191336) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1076,15 +1076,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_202338) do
     t.index ["updated_at"], name: "index_messages_on_updated_at"
   end
 
-  create_table "mpi_update_person_events", force: :cascade do |t|
-    t.bigint "api_key_id", null: false, comment: "API Key used to initiate the event"
-    t.datetime "completed_at", comment: "Timestamp of when update was completed, regardless of success or failure"
-    t.datetime "created_at", comment: "Timestamp of when update was initiated"
-    t.json "info", comment: "Additional information about the update"
-    t.string "update_type", null: false, comment: "Type or Result of update"
-    t.index ["api_key_id"], name: "index_mpi_update_person_events_on_api_key_id"
-  end
-
   create_table "nod_date_updates", comment: "Tracks changes to an AMA appeal's receipt date (aka, NOD date)", force: :cascade do |t|
     t.bigint "appeal_id", null: false, comment: "Appeal for which the NOD date is being edited"
     t.string "change_reason", null: false, comment: "Reason for change: entry_error or new_info"
@@ -1430,7 +1421,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_202338) do
     t.boolean "national_cemetery_administration", default: false
     t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues, added belatedly"
     t.boolean "nonrating_issue", default: false
-    t.boolean "pact_act", default: false, comment: "The Sergeant First Class (SFC) Heath Robinson Honoring our Promise to Address Comprehensive Toxics (PACT) Act"
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false
     t.boolean "radiation", default: false
@@ -1488,17 +1478,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_202338) do
     t.index ["updated_at"], name: "index_supplemental_claims_on_updated_at"
     t.index ["uuid"], name: "index_supplemental_claims_on_uuid"
     t.index ["veteran_file_number"], name: "index_supplemental_claims_on_veteran_file_number"
-  end
-
-  create_table "system_admin_events", force: :cascade do |t|
-    t.datetime "completed_at", comment: "Timestamp of when event was completed without error"
-    t.datetime "created_at", comment: "Timestamp of when event was initiated"
-    t.datetime "errored_at", comment: "Timestamp of when event failed due to error"
-    t.string "event_type", null: false, comment: "Type of event"
-    t.json "info", comment: "Additional information about the event"
-    t.datetime "updated_at", comment: "Timestamp of when event was last updated"
-    t.bigint "user_id", null: false, comment: "User who initiated the event"
-    t.index ["user_id"], name: "index_system_admin_events_on_user_id"
   end
 
   create_table "tags", id: :serial, force: :cascade do |t|
@@ -1853,7 +1832,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_202338) do
   add_foreign_key "legacy_issue_optins", "request_issues"
   add_foreign_key "legacy_issues", "request_issues"
   add_foreign_key "messages", "users"
-  add_foreign_key "mpi_update_person_events", "api_keys"
   add_foreign_key "nod_date_updates", "appeals"
   add_foreign_key "nod_date_updates", "users"
   add_foreign_key "non_availabilities", "schedule_periods"
@@ -1879,7 +1857,6 @@ ActiveRecord::Schema.define(version: 2022_11_15_202338) do
   add_foreign_key "sent_hearing_email_events", "users", column: "sent_by_id"
   add_foreign_key "split_correlation_tables", "users", column: "created_by_id"
   add_foreign_key "split_correlation_tables", "users", column: "updated_by_id"
-  add_foreign_key "system_admin_events", "users"
   add_foreign_key "task_timers", "tasks"
   add_foreign_key "tasks", "tasks", column: "parent_id"
   add_foreign_key "tasks", "users", column: "assigned_by_id"


### PR DESCRIPTION
Resolves [APPEALS-12418](https://vajira.max.gov/browse/APPEALS-12418)

### Description
#### AMA
- Added checks and handling for existing JudgeAssignTasks
  - When creating a JudgeAssignTask for distribution, the assign_judge_tasks_for_appeals method will now check if any tasks of that type exist, and if so it will return nil instead of creating a new JudgeAssignTask
  - The distribute_appeals method, which uses the array returned from assign_judge_tasks_for_appeals, will now check each array value, and skip processing that value if it is nil
  - The redistribution logic in distribute_appeals will now cancel the first JudgeAssignTask if the case is redistributed
- Moved methods for creating judge assign tasks and cancelling previous judge assign tasks from docket.rb to a new concern, DistributionConcern, for use in the HearingRequestCaseDistributor
- Refactored the way the HearingRequestCaseDistributor distributes cases
   - Removed the Distribution.transaction block, which was causing failures on unique constraint (case_id) while adding the DistributedCase to the database. The same change was made for docket.rb in August 2021, [PR #16615](https://github.com/department-of-veterans-affairs/caseflow/pull/16615#discussion_r688562296)
   - Followed the pattern in docket.rb to get appeals -> create JudgeAssignTasks -> create (and rename, if redistributing) DistributedCases -> cancel previous JudgeAssignTask (if necessary)
- Removed duplicate logging statements from the assign_judge_tasks_for_appeals method. The method calls JudgeAssignTaskCreator, which has the identical log statements.
#### Legacy
- update error message to request a page refresh, after page is refresh legacy cases will not be showing for one of the judges

### Acceptance Criteria
- [x] Code compiles correctly
- [x] PushPriorityAppealsToJudges job runs without error
- [x] Requested distributions run without error

### UI Changes
Updates to error message when a user tries to assign a legacy case that isn't assigned to them
![Old legacy error message](https://user-images.githubusercontent.com/109101548/206554544-7ac37246-012e-4fc3-8b4c-96b2eddbc788.png)
![New legacy error message](https://user-images.githubusercontent.com/109101548/206554689-192d6a55-20c3-4738-bf8f-dbe9b754dc0d.png)


### Testing Plan
Using two separate web browsers (tested using Firefox and Chrome):
1. Go to caseflowdemo.com for the appropriate testing environment
2. Switch user to a judge; ensure that it is a different judge for each web browser (tested with DCREMIN and BDANIEL)
3. Go to the judge's queue
4. Go to the judge's Assign Team Cases page
5. Ensure the judge has no cases waiting to be assigned; if they do, assign all cases so none are waiting

Once both judges are ready:
1. Resize one of the web browser screens and drag it over the other so that the "Request more cases" buttons are as close to each other as possible (Firefox windows can be made smaller than Chrome, so it is easier to resize that and put it over the Chrome browser)
2. With the "Request more cases" buttons next to each other, click the button for the top browser, then click it for the bottom browser as quickly as possible (it will likely take two clicks on the second browser; one to shift focus to that program then another to actually interact with the button

After both distributions are finished:
1. Check the number of cases distributed for each judge. The first judge clicked should have their full number of cases (# of attorneys times three), but they second judge may not have their full number of cases (it is not specifically a problem if they do)
2. Check the docket numbers for the cases assigned to each judge. There should be at least one case that is present in both judges queues. Note the docket number for each duplicate case.
3. Using the judge that requested cases second, go to the case details page for a duplicate case and check who the listed VLJ is; it should be the judge who requested cases second. Additionally, verify that the case can be assigned to one of their attorneys.
4. Using the judge that requested cases first, **_from their assign team cases page_** attempt to assign the case to one of their attorneys. An error should display at the top of the page.
5. After verifying the error appears, refresh the page for the first judge. Verify that each duplicate case _does not_ appear in their list of cases to assign.

Repeat this process until a duplicate assignment has happened for an AMA Hearing case and Evidence Submisison/Direct Review case (evidence/direct review use the same code, so only one of those two types is required).

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

