### PR TITLE
TYLERB/APPEALS-12440: VHA Claim Review Establishment Feature Toggle creation

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -149,7 +149,8 @@ class IntakesController < ApplicationController
       filedByVaGovHlr: FeatureToggle.enabled?(:filed_by_va_gov_hlr, user: current_user),
       updatedIntakeForms: FeatureToggle.enabled?(:updated_intake_forms, user: current_user),
       eduPreDocketAppeals: FeatureToggle.enabled?(:edu_predocket_appeals, user: current_user),
-      updatedAppealForm: FeatureToggle.enabled?(:updated_appeal_form, user: current_user)
+      updatedAppealForm: FeatureToggle.enabled?(:updated_appeal_form, user: current_user),
+      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user)
     }
   end
 

--- a/client/app/intake/components/BenefitType.jsx
+++ b/client/app/intake/components/BenefitType.jsx
@@ -16,7 +16,8 @@ export default class BenefitType extends React.PureComponent {
       featureToggles,
     } = this.props;
 
-    const canSelectVhaBenefit = userCanSelectVha && featureToggles.vhaClaimReviewEstablishment;
+    // If the feature toggle is off then all users should be able to select vha
+    const canSelectVhaBenefit = featureToggles.vhaClaimReviewEstablishment ? userCanSelectVha : true;
 
     return <div className="cf-benefit-type" style={{ marginTop: '10px' }} >
       <RadioField

--- a/client/app/intake/components/BenefitType.jsx
+++ b/client/app/intake/components/BenefitType.jsx
@@ -13,8 +13,10 @@ export default class BenefitType extends React.PureComponent {
       onChange,
       register,
       userCanSelectVha,
-      featureToggles
+      featureToggles,
     } = this.props;
+
+    const canSelectVhaSwitch = userCanSelectVha && featureToggles.vhaClaimReviewEstablishment;
 
     return <div className="cf-benefit-type" style={{ marginTop: '10px' }} >
       <RadioField
@@ -22,7 +24,7 @@ export default class BenefitType extends React.PureComponent {
         label="What is the Benefit Type?"
         strongLabel
         vertical
-        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, userCanSelectVha, featureToggles)}
+        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, canSelectVhaSwitch)}
         onChange={onChange}
         value={value}
         errorMessage={errorMessage}

--- a/client/app/intake/components/BenefitType.jsx
+++ b/client/app/intake/components/BenefitType.jsx
@@ -16,7 +16,7 @@ export default class BenefitType extends React.PureComponent {
       featureToggles,
     } = this.props;
 
-    const canSelectVhaSwitch = userCanSelectVha && featureToggles.vhaClaimReviewEstablishment;
+    const canSelectVhaBenefit = userCanSelectVha && featureToggles.vhaClaimReviewEstablishment;
 
     return <div className="cf-benefit-type" style={{ marginTop: '10px' }} >
       <RadioField
@@ -24,7 +24,7 @@ export default class BenefitType extends React.PureComponent {
         label="What is the Benefit Type?"
         strongLabel
         vertical
-        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, canSelectVhaSwitch)}
+        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, canSelectVhaBenefit)}
         onChange={onChange}
         value={value}
         errorMessage={errorMessage}

--- a/client/app/intake/components/BenefitType.jsx
+++ b/client/app/intake/components/BenefitType.jsx
@@ -12,7 +12,8 @@ export default class BenefitType extends React.PureComponent {
       errorMessage,
       onChange,
       register,
-      userCanSelectVha
+      userCanSelectVha,
+      featureToggles
     } = this.props;
 
     return <div className="cf-benefit-type" style={{ marginTop: '10px' }} >
@@ -21,7 +22,7 @@ export default class BenefitType extends React.PureComponent {
         label="What is the Benefit Type?"
         strongLabel
         vertical
-        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, userCanSelectVha)}
+        options={formatBenefitTypeRadioOptions(BENEFIT_TYPES, userCanSelectVha, featureToggles)}
         onChange={onChange}
         value={value}
         errorMessage={errorMessage}

--- a/client/app/intake/components/BenefitType.stories.js
+++ b/client/app/intake/components/BenefitType.stories.js
@@ -14,7 +14,8 @@ export default {
 const defaultProps = {
   register: () => null,
   formName: 'higherLevelReview',
-  userCanSelectVha: false
+  userCanSelectVha: false,
+  featureToggles: { vhaClaimReviewEstablishment: true }
 };
 
 const Template = (args) => {

--- a/client/app/intake/pages/formGenerator.jsx
+++ b/client/app/intake/pages/formGenerator.jsx
@@ -293,7 +293,7 @@ const FormGenerator = (props) => {
           errorData={props.veteranInvalidFields}
         />
       )}
-      {!props.userIsVhaEmployee && isHlrOrScForm && (
+      {!props.userIsVhaEmployee && isHlrOrScForm && props.featureToggles.vhaClaimReviewEstablishment && (
         <div style={{ marginBottom: '3rem' }}>
           <Alert title={COPY.INTAKE_VHA_CLAIM_REVIEW_REQUIREMENT_TITLE} type="info">
             <span dangerouslySetInnerHTML={{ __html: buildVHAInfoBannerMessage() }} />
@@ -363,7 +363,8 @@ FormGenerator.propTypes = {
   setHomelessnessType: PropTypes.func,
   homelessnessError: PropTypes.string,
   isReviewed: PropTypes.bool,
-  userIsVhaEmployee: PropTypes.bool
+  userIsVhaEmployee: PropTypes.bool,
+  featureToggles: PropTypes.object,
 };
 export default connect(
   (state, props) => ({
@@ -398,7 +399,8 @@ export default connect(
     homelessnessError: state[props.formName].homelessnessError,
     homelessnessUserInteraction: state[props.formName].homelessnessUserInteraction,
     isReviewed: state[props.formName].isReviewed,
-    userIsVhaEmployee: state.userInformation.userIsVhaEmployee
+    userIsVhaEmployee: state.userInformation.userIsVhaEmployee,
+    featureToggles: state.featureToggles,
   }),
   (dispatch) => bindActionCreators({
     setDocketType,

--- a/client/app/intake/pages/formGenerator.stories.js
+++ b/client/app/intake/pages/formGenerator.stories.js
@@ -69,7 +69,8 @@ const defaultArgs = {
     filedByVaGovHlr: true,
     updatedAppealForm: true,
     updatedIntakeForms: true,
-    useAmaActivationDate: true
+    useAmaActivationDate: true,
+    vhaClaimReviewEstablishment: true,
   },
 };
 
@@ -99,6 +100,10 @@ const FullReduxDecorator = (Story, options) => {
   state.rampRefiling.relationships = relationships;
   state.rampElection.isStarted = 'STARTED';
   state.rampElection.relationships = relationships;
+
+  if (args.featureToggles.vhaClaimReviewEstablishment) {
+    state.featureToggles.vhaClaimReviewEstablishment = args.featureToggles.vhaClaimReviewEstablishment;
+  }
 
   if (args.userIsVhaEmployee) {
     state.userInformation.userIsVhaEmployee = args.userIsVhaEmployee;

--- a/client/app/intake/reducers/featureToggles.js
+++ b/client/app/intake/reducers/featureToggles.js
@@ -22,6 +22,9 @@ const updateFromServerFeatures = (state, featureToggles) => {
     },
     updatedAppealForm: {
       $set: Boolean(featureToggles.updatedAppealForm)
+    },
+    vhaClaimReviewEstablishment: {
+      $set: Boolean(featureToggles.vhaClaimReviewEstablishment)
     }
   });
 };
@@ -34,7 +37,8 @@ export const mapDataToFeatureToggle = (data = { featureToggles: {} }) =>
       filedByVaGovHlr: false,
       updatedIntakeForms: false,
       eduPreDocketAppeals: false,
-      updatedAppealForm: false
+      updatedAppealForm: false,
+      vhaClaimReviewEstablishment: false,
     },
     data.featureToggles
   );

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -85,11 +85,11 @@ export const getDefaultPayeeCode = (state, claimant) => {
   return (claimant ? _.find(state.relationships, { value: claimant }).defaultPayeeCode : null);
 };
 
-export const formatBenefitTypeRadioOptions = (options, userCanSelectVha, featureToggles) => {
+export const formatBenefitTypeRadioOptions = (options, userCanSelectVha) => {
   return _.map(options, (value, key) => {
     const radioData = { value: key, displayText: value };
 
-    if (key === 'vha' && !userCanSelectVha && featureToggles.vhaClaimReviewEstablishment) {
+    if (key === 'vha' && !userCanSelectVha) {
       return {
         ...radioData,
         disabled: true,

--- a/client/app/intake/util/index.js
+++ b/client/app/intake/util/index.js
@@ -85,11 +85,11 @@ export const getDefaultPayeeCode = (state, claimant) => {
   return (claimant ? _.find(state.relationships, { value: claimant }).defaultPayeeCode : null);
 };
 
-export const formatBenefitTypeRadioOptions = (options, userCanSelectVha) => {
+export const formatBenefitTypeRadioOptions = (options, userCanSelectVha, featureToggles) => {
   return _.map(options, (value, key) => {
     const radioData = { value: key, displayText: value };
 
-    if (key === 'vha' && !userCanSelectVha) {
+    if (key === 'vha' && !userCanSelectVha && featureToggles.vhaClaimReviewEstablishment) {
       return {
         ...radioData,
         disabled: true,

--- a/client/test/app/intake/components/BenefitType.test.js
+++ b/client/test/app/intake/components/BenefitType.test.js
@@ -13,7 +13,8 @@ const defaultProps = {
   onChange: jest.fn(),
   register: jest.fn(),
   formName: 'higherLevelReview',
-  userCanSelectVha: false
+  userCanSelectVha: false,
+  featureToggles: { vhaClaimReviewEstablishment: true },
 };
 
 const vhaTooltipText = sprintf(COPY.INTAKE_VHA_CLAIM_REVIEW_REQUIREMENT, COPY.VHA_BENEFIT_EMAIL_ADDRESS);

--- a/client/test/app/intake/components/BenefitType.test.js
+++ b/client/test/app/intake/components/BenefitType.test.js
@@ -73,6 +73,30 @@ describe('BenefitType', () => {
       });
     });
 
+    describe('when the user is a VHA staff member with feature toggle disabled', () => {
+      const props = {
+        ...defaultProps,
+        featureToggles: { vhaClaimReviewEstablishment: false }
+
+      };
+
+      beforeEach(() => {
+        renderBenefitType(props);
+      });
+
+      it('The "Veterans Health Administration" option is enabled', () => {
+        expect(getVhaRadioOption()).not.toBeDisabled();
+      });
+
+      it('Tooltip does not appear whenever VHA option is hovered over', () => {
+        hoverOverRadioOption(getVhaRadioOption());
+
+        expect(
+          screen.queryByText(vhaTooltipText)
+        ).not.toBeInTheDocument();
+      });
+    });
+
     describe('when the user is a VHA staff member', () => {
       const props = {
         ...defaultProps,
@@ -118,6 +142,30 @@ describe('BenefitType', () => {
         await waitFor(() => {
           expect(getVhaOptionTooltip()).toBeVisible();
         });
+      });
+    });
+
+    describe('when the user is a VHA staff member with feature toggle disabled', () => {
+      const props = {
+        ...defaultProps,
+        featureToggles: { vhaClaimReviewEstablishment: false }
+
+      };
+
+      beforeEach(() => {
+        renderBenefitType(props);
+      });
+
+      it('The "Veterans Health Administration" option is enabled', () => {
+        expect(getVhaRadioOption()).not.toBeDisabled();
+      });
+
+      it('Tooltip does not appear whenever VHA option is hovered over', () => {
+        hoverOverRadioOption(getVhaRadioOption());
+
+        expect(
+          screen.queryByText(vhaTooltipText)
+        ).not.toBeInTheDocument();
       });
     });
 

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -470,8 +470,13 @@ feature "Intake Review Page", :postgres do
       let(:current_user) { create(:user, roles: ["Admin Intake"]) }
 
       before do
+        FeatureToggle.enable!(:vha_claim_review_establishment)
         User.authenticate!(user: current_user)
         navigate_to_review_page(form_type)
+      end
+
+      after do
+        FeatureToggle.disable!(:vha_claim_review_establishment)
       end
 
       it "Should display the VHA HLR SC Permissions Update Information Banner" do

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -502,6 +502,26 @@ feature "Intake Review Page", :postgres do
         end
       end
     end
+
+    context "Current user is not a member of the VHA business line with feature toggle disabled" do
+      let(:vha_business_line) { create(:business_line, name: benefit_type_label, url: "vha") }
+      let(:current_user) { create(:user, roles: ["Admin Intake"]) }
+
+      before do
+        FeatureToggle.disable!(:vha_claim_review_establishment)
+        User.authenticate!(user: current_user)
+        navigate_to_review_page(form_type)
+      end
+
+      it "Should not display the VHA HLR SC Permissions Update Information Banner" do
+        expect(page).to_not have_content("HLR And SC Permissions Update")
+        expect(page).to_not have_link(COPY::VHA_BENEFIT_EMAIL_ADDRESS, href: email_href)
+      end
+
+      it "VHA benefit type radio option is enabled" do
+        expect(page).to have_field benefit_type_label, disabled: false, visible: false
+      end
+    end
   end
 
   describe "Intaking a claim review" do


### PR DESCRIPTION
Resolves [APPEALS-12440](https://vajira.max.gov/browse/APPEALS-12440)

### Description
Created a feature toggle named :vha_claim_review_establishment  to enable/disable the new banner and vha benefit type button disabling feature for the VHA Claim Review Establishment feature work.

### Acceptance Criteria
- [ ] Feature Flag ":vha_claim_review_establishment" enabled
  - [ ] Banner is present on the page when the feature flag is enabled
  - [ ] The Vha benefit type radio option is disabled when the feature flag is enabled
- [ ] Feature Flag ":vha_claim_review_establishment" disabled
  - [ ] Banner is absent from the page when the feature flag is disabled
  - [ ] The Vha benefit type radio option is enabled when the feature flag is disabled

### Testing Plan
1. Login with a regular intake user BVAISHAW will work
2. Start up the rails console and disable the feature flag
```ruby
  FeatureToggle.disable!(:vha_claim_review_establishment)
```
3. Navigate to the /intake page
4. Start a higher level review intake
5. Verify that the banner is missing from the page
6. Cancel the intake
7. Go to the console turn on the feature flag
8. Restart another intake for an HLR
```
make enable-feature-flags
```
You can also enable it from the rails console
```ruby
  FeatureToggle.enable!(:vha_claim_review_establishment)
```
9. Verify that the banner is present on the page and the vha benefit type is properly disabled.
 https://bipuiux.invisionapp.com/console/share/QTCKRDXAHEN/953715694
![image](https://user-images.githubusercontent.com/109369527/202564454-274332d6-538d-48f4-82b8-9851895d3fb8.png)
![image](https://user-images.githubusercontent.com/109369527/206297564-350fb1aa-0338-439f-888a-d47af4a24808.png)


### Storybook Story
- [ ] Updated Benefit Type storybook file
- [ ] Updated FormGenerator storybook file