### PR TITLE
Release/APPEALS-9391  Removal of CAVC Check Box from Special Issues Selections

### DIFF
--- a/app/controllers/special_issues_controller.rb
+++ b/app/controllers/special_issues_controller.rb
@@ -50,7 +50,7 @@ class SpecialIssuesController < ApplicationController
               :us_territory_claim_american_samoa_guam_northern_mariana_isla,
               :us_territory_claim_puerto_rico_and_virgin_islands,
               :burn_pit, :military_sexual_trauma, :blue_water,
-              :us_court_of_appeals_for_veterans_claims, :no_special_issues)
+              :no_special_issues)
   end
 
   def record_not_found

--- a/client/app/constants/SpecialIssues.js
+++ b/client/app/constants/SpecialIssues.js
@@ -330,7 +330,7 @@ export const SPECIAL_ISSUES = [
     },
     nonCompensation: true,
     queueSection: 'issuesOnAppeal',
-    queueSectionOrder: 12
+    queueSectionOrder: 11
   }
 ];
 
@@ -364,16 +364,6 @@ export const AMA_SPECIAL_ISSUES = [
     unhandled: null,
     queueSection: 'issuesOnAppeal',
     queueSectionOrder: 1,
-    isAmaRelevant: true
-  },
-  {
-    display: 'US Court of Appeals for Veterans Claims (CAVC)',
-    queueDisplay: 'US Court of Appeals for Veterans Claims (CAVC)',
-    specialIssue: 'usCourtOfAppealsForVeteransClaims',
-    snakeCase: 'us_court_of_appeals_for_veterans_claims',
-    unhandled: null,
-    queueSection: 'issuesOnAppeal',
-    queueSectionOrder: 11,
     isAmaRelevant: true
   },
   {

--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -139,7 +139,7 @@ class SelectSpecialIssuesView extends React.PureComponent {
         {this.getPageNote()}
       </p>
       {error && <Alert type="error" title={error.title} message={error.detail} />}
-      <div {...flexContainer} className="special-options">
+      <div {...flexContainer}>
         <div {...flexColumn}>
           {
             sectionsMap.noSpecialIssues && <CheckboxGroup

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -79,7 +79,6 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
       expect(page).to have_content("Military Sexual Trauma (MST)")
-      expect(page).to have_content("US Court of Appeals for Veterans Claims (CAVC)")
       find("label", text: "Blue Water").click
       click_on "Continue"
 
@@ -269,7 +268,6 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
       expect(page).to have_content("Military Sexual Trauma (MST)")
-      expect(page).to have_content("US Court of Appeals for Veterans Claims (CAVC)")
       find("label", text: "Burn Pit").click
       click_on "Continue"
 

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -192,7 +192,6 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
       expect(page).to have_content("Military Sexual Trauma (MST)")
-      expect(page).to have_content("US Court of Appeals for Veterans Claims (CAVC)")
       find("label", text: "Blue Water").click
       expect(page.find("#blue_water", visible: false).checked?).to eq true
       find("label", text: "No Special Issues").click


### PR DESCRIPTION
Resolves [APPEALS-9391](https://vajira.max.gov/browse/APPEALS-9391)

### BUSINESS IMPACT
#### APPEALS-9391
- As a VLJ, I need the CAVC Check Box removed from the Special Issues Selections page, so that there is no longer confusion on if the box should be checked

### Testing Plan
1. Go to APPEALS-9391

### BEFORE
### Legacy case Special issues
<img width="1367" alt="Screen Shot 2022-12-12 at 10 13 23 AM" src="https://user-images.githubusercontent.com/112115264/207123386-a5d562b7-cf85-43ae-90f6-97535b310d71.png">

### AMA Case Special issues
<img width="1385" alt="Screen Shot 2022-12-12 at 10 14 06 AM" src="https://user-images.githubusercontent.com/112115264/207123349-0bb66825-62f3-46c5-b598-9c4f656bf7be.png">

### AFTER
### Legacy case Special issues
<img width="1422" alt="Screen Shot 2022-12-12 at 10 28 35 AM" src="https://user-images.githubusercontent.com/112115264/207125241-f4400ce5-bc8a-49e2-a34d-deb3e69d59e1.png">

### AMA Case Special issues
<img width="1404" alt="Screen Shot 2022-12-12 at 10 27 24 AM" src="https://user-images.githubusercontent.com/112115264/207125034-9fc0fd3e-dc0c-4455-bdd5-ad1829c8b730.png">
