### PR TITLE
HunJerBAH APPEALS-11762 

### DIFF
--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -13,8 +13,11 @@ class TaskSorter
   def initialize(args)
     super
 
-    # Default to sorting by AOD, case type, and docket number.
-    @column ||= QueueColumn.from_name(Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name)
+    # new default to APPEAL RECEIPT DATE
+    # old default to sorting by AOD, case type, and docket number.
+    # @column ||= QueueColumn.from_name(Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name)
+    # changed to receipt date
+    @column ||= QueueColumn.from_name(Constants.QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name)
     @sort_order ||= Constants.QUEUE_CONFIG.COLUMN_SORT_ORDER_ASC
     @tasks ||= Task.none
 
@@ -42,6 +45,9 @@ class TaskSorter
 
   def order_clause
     case column.name
+    when Constants.QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name
+      # get the array of ids with the tasks sorted and pass to custom order clause
+      Arel.sql(receipt_date_order_clause(receipt_date_sorted_array))
     when Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name
       Task.order_by_appeal_priority_clause(order: sort_order)
     when Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name
@@ -51,6 +57,31 @@ class TaskSorter
     else
       Arel.sql(default_order_clause)
     end
+  end
+
+  # creates SQL query using sorted appeal receipt date array
+  def receipt_date_order_clause(sorted_array)
+    order_clause = "CASE #{Task.table_name}.id "
+    sorted_array.each_with_index do |id, index|
+      order_clause += "WHEN #{id} THEN #{index} "
+    end
+    order_clause += "ELSE #{sorted_array.length} END"
+  end
+
+  # sorts the tasks by the appeal receipt date and returns an array of task ids
+  def receipt_date_sorted_array
+    # create hash to hold task id and appeal receipt date
+    task_id_to_receipt_date_hash = {}
+    # cycle the cached tasks
+    tasks.with_assignees.with_assigners.with_cached_appeals.each do |task|
+      # get the appeal assigned to the task
+      appeal_receipt_date = Appeal.find(task.appeal_id).receipt_date
+      # load hash with the receipt date and task id
+      task_id_to_receipt_date_hash[task.id] = appeal_receipt_date
+    end
+    # sort the hash so the dates are in descending order, and return the id of the tasks (keys)
+    # binding.pry
+    task_id_to_receipt_date_hash.sort_by { |_, v| v }.to_h.keys
   end
 
   def default_order_clause


### PR DESCRIPTION
Resolves [APPEALS-11762](https://vajira.max.gov/browse/APPEALS-11762)

### Description
Added functionality that auto-sorts the intake table by the receipt date column in order from oldest to newest (oldest at top). 

### Acceptance Criteria
- [ ] Code compiles correctly

A 10182 Receipt Date column is added to the following BVA Intake queue tabs
- [ ] Pending
- [ ] Ready for Review
- [ ] Action Required

- [ ] Column header: 10182 Receipt Date

- [ ] Column values are derived from the  <What is the Receipt Date of this form?> field populated during mail Intake 
format: mm/dd/yyyy

The following BVA Intake queue tabs default sort order is based on 10182 Receipt Date ascending order (oldest on top)
- [ ] Pending
- [ ] Ready for Review
- [ ] Action Required 

- [ ] User has the ability to sort column in ascending / descending order

### Testing Plan
1. Sign in as an intake user (BVADWISE) and go to mail intake to intake some appeals
![image](https://user-images.githubusercontent.com/99915461/207371107-fa5aaabe-f781-443d-a1a4-2fe99b80f195.png)
2. Select decision review from the dropdown and click the button to continue.
![image](https://user-images.githubusercontent.com/99915461/207371207-717a463e-1816-46ff-b68a-e60b22dab9f4.png)
3. Enter a veteran file number. I used 053250020 on my local demo data (might be different for demo).
![image](https://user-images.githubusercontent.com/99915461/207371863-5cd9e103-81b9-4212-bd63-77713751069c.png)
4. Fill out the form and click continue.
![image](https://user-images.githubusercontent.com/99915461/207371981-d0899e13-f805-4ac2-ae01-c7d2539fc452.png)
5. Click add issue.
6. Fill out the form that appears. Make sure to select **Veteran Health Administration** from the Benefit Type options for it to enter the proper workflow. Click add issue when finished filling out the form
![image](https://user-images.githubusercontent.com/99915461/207372310-7abc5387-fe9c-43a8-bfcb-167e56edec3b.png)
7. Click submit appeal.
![image](https://user-images.githubusercontent.com/99915461/207372440-28be61f2-43ea-4090-b1c5-47c44ddddec9.png)
8. You will be greeted by a success banner. Click **begin next intake**.
![image](https://user-images.githubusercontent.com/99915461/207372559-b833a753-44c7-4c1c-b90c-46878bd1cee7.png)
9. Repeat steps 2-8 until you have about 3-5 appeals. All appeals must have a different decision date and be VHA issues in order to test the functionality.
10. Once you have enough appeals, click **search cases** to navigate to queue.
![image](https://user-images.githubusercontent.com/99915461/207372979-2153beee-fabc-4506-9bc3-050a6ca8e2c5.png)
11. Click the **queue** icon in the top left to get to the queue home page.
![image](https://user-images.githubusercontent.com/99915461/207373145-86b01ce6-facd-4bae-b695-6e0875184d84.png)
12. Click **switch views** and select **BVA Intake team cases**
![image](https://user-images.githubusercontent.com/99915461/207373287-ae700b24-e074-455e-bb00-f1bf42522c15.png)
13. On the BVA Intake cases page, you should see the newly added **10182 Receipt Date** column. Make sure the appeals are in the correct descending order with the oldest date at the top of the table and the most recent date at the bottom.
![image](https://user-images.githubusercontent.com/99915461/207373477-868f646b-2dcf-4a97-8f44-cb6081fd7d82.png)
