### PR TITLE
HunJerBAH/APPEALS 11762 fix

### DIFF
--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -175,4 +175,8 @@ class WorkQueue::TaskSerializer
   attribute :unscheduled_hearing_notes do |object|
     object.try(:unscheduled_hearing_notes)
   end
+
+  attribute :appeal_receipt_date do |object|
+    object.appeal.try(:receipt_date)
+  end
 end

--- a/app/models/serializers/work_queue/task_serializer.rb
+++ b/app/models/serializers/work_queue/task_serializer.rb
@@ -179,4 +179,7 @@ class WorkQueue::TaskSerializer
   attribute :appeal_receipt_date do |object|
     object.appeal.try(:receipt_date)
   end
+
+  attribute :days_since_last_status_change, &:calculated_last_change_duration
+  attribute :days_since_board_intake, &:calculated_duration_from_board_intake
 end

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -15,7 +15,6 @@ class TaskSorter
 
     # new default to APPEAL RECEIPT DATE
     # old default to sorting by AOD, case type, and docket number.
-    # @column ||= QueueColumn.from_name(Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name)
     # changed to receipt date
     @column ||= QueueColumn.from_name(Constants.QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name)
     @sort_order ||= Constants.QUEUE_CONFIG.COLUMN_SORT_ORDER_ASC
@@ -61,6 +60,10 @@ class TaskSorter
 
   # creates SQL query using sorted appeal receipt date array
   def receipt_date_order_clause(sorted_array)
+    # if the sort order is desc order, flip the array
+    if sort_order.eql? Constants.QUEUE_CONFIG.COLUMN_SORT_ORDER_DESC
+      sorted_array = sorted_array.reverse
+    end
     order_clause = "CASE #{Task.table_name}.id "
     sorted_array.each_with_index do |id, index|
       order_clause += "WHEN #{id} THEN #{index} "
@@ -79,8 +82,7 @@ class TaskSorter
       # load hash with the receipt date and task id
       task_id_to_receipt_date_hash[task.id] = appeal_receipt_date
     end
-    # sort the hash so the dates are in descending order, and return the id of the tasks (keys)
-    # binding.pry
+    # sort the hash so the dates are in ascending order (oldest first), and return the id of the tasks (keys)
     task_id_to_receipt_date_hash.sort_by { |_, v| v }.to_h.keys
   end
 

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -661,7 +661,7 @@ export default class QueueTable extends React.PureComponent {
           bodyClassName={bodyClassName ?? ''}
           rowClassNames={rowClassNames}
           bodyStyling={bodyStyling}
-          {...this.props}
+          {...this.state}
         />
         <FooterRow rowObjects={[]} columns={columns} />
       </table>

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -145,7 +145,7 @@ class QueueTableBuilder extends React.PureComponent {
       [QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name]: taskCompletedDateColumn(),
       [QUEUE_CONFIG.COLUMNS.TASK_TYPE.name]: taskColumn(tasks, filterOptions),
       [QUEUE_CONFIG.COLUMNS.DAYS_SINCE_INTAKE.name]: daysSinceIntakeColumn(requireDasRecord),
-      [QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name]: receiptDateColumn(tasks, filterOptions),
+      [QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name]: receiptDateColumn(),
     };
 
     return functionForColumn[column.name];

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -359,19 +359,16 @@ export const daysSinceIntakeColumn = (requireDasRecord) => {
   };
 };
 
-export const receiptDateColumn = (requireDasRecord) => {
+export const receiptDateColumn = () => {
   return {
     header: COPY.CASE_LIST_TABLE_10182,
     name: QUEUE_CONFIG.COLUMNS.RECEIPT_DATE_INTAKE.name,
-    span: collapseColumn(requireDasRecord),
     align: 'center',
     valueFunction: (task) => {
-      // console.log(`maite ${JSON.stringify(task.appeal_receipt_date)}`);
       return moment(task.appeal_receipt_date).format('MM/DD/YYYY');
-
     },
     backendCanSort: true,
-    getSortValue: (task) => task.daysSinceBoardIntake
+    getSortValue: (task) => task.appeal_receipt_date
   };
 };
 


### PR DESCRIPTION
Resolves [APPEALS-11762](https://vajira.max.gov/browse/APPEALS-11762)

### Description
Resolved queue organization table issue that was causing table columns to not populate with values.

### Acceptance Criteria

A 10182 Receipt Date column is added to the following BVA Intake queue tabs
- [ ] Pending
- [ ] Ready for Review
- [ ] Action Required

- [ ] Column header: 10182 Receipt Date

- [ ] Column values are derived from the  <What is the Receipt Date of this form?> field populated during mail Intake
format: mm/dd/yyyy

The following BVA Intake queue tabs default sort order is based on 10182 Receipt Date ascending order (oldest on top)
- [ ] Pending
- [ ] Ready for Review
- [ ] Action Required 

- [ ] User has the ability to sort column in ascending / descending order

### Testing Plan
1. Same testing plan as [ORIGINAL APPEALS 11762 TESTING PLAN](https://github.com/department-of-veterans-affairs/caseflow/pull/17812)
2. When you get to the end of the testing plan, click the arrows above the receipt date to sort the column by the receipt date
![image](https://user-images.githubusercontent.com/99915461/207645027-0b806441-0f86-402b-824c-eb7c9a3a4ca7.png)
![image](https://user-images.githubusercontent.com/99915461/207645062-1a736153-5fdb-4d7c-8f4f-b55f7bab4b38.png)
![image](https://user-images.githubusercontent.com/99915461/207645100-90235c52-9a7e-465c-8438-fd5fd4291080.png)

