### PR TITLE
Hotfix/APPEALS-12611

### DIFF
--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -117,7 +117,9 @@ class SendNotificationJob < CaseflowJob
     if @va_notify_email
       response = VANotifyService.send_email_notifications(message.participant_id, notification_audit_record.id.to_s, email_template_id, status, first_name)
       if !response.nil? && response != ""
-        to_update = { notification_content: response.body["content"]["body"], email_notification_external_id: response.body["id"] }
+        to_update = { notification_content: response.body["content"]["body"],
+                      email_notification_content: response.body["content"]["body"],
+                      email_notification_external_id: response.body["id"] }
         update_notification_audit_record(notification_audit_record, to_update)
       end
     end
@@ -125,7 +127,9 @@ class SendNotificationJob < CaseflowJob
     if @va_notify_sms
       response = VANotifyService.send_sms_notifications(message.participant_id, notification_audit_record.id.to_s, sms_template_id, status, first_name)
       if !response.nil? && response != ""
-        to_update = { notification_content: response.body["content"]["body"], sms_notification_external_id: response.body["id"] }
+        to_update = {
+          sms_notification_content: response.body["content"]["body"], sms_notification_external_id: response.body["id"]
+        }
         update_notification_audit_record(notification_audit_record, to_update)
       end
     end

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -106,13 +106,7 @@ class SendNotificationJob < CaseflowJob
     sms_template_id = event.sms_template_id
     quarterly_sms_template_id = NotificationEvent.find_by(event_type: "Quarterly Notification").sms_template_id
     appeal = Appeal.find_by_uuid(message.appeal_id) || LegacyAppeal.find_by(vacols_id: message.appeal_id)
-    first_name = (
-      if appeal.class.to_s == "Appeal"
-        appeal&.claimant&.first_name || "Appellant"
-      else
-        appeal.claimant[:first_name] || "Appellant"
-      end
-    )
+    first_name = appeal&.appellant_first_name || "Appellant"
     status = message.appeal_status || ""
     if @va_notify_email
       response = VANotifyService.send_email_notifications(message.participant_id, notification_audit_record.id.to_s, email_template_id, status, first_name)

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -104,8 +104,15 @@ class SendNotificationJob < CaseflowJob
     event = NotificationEvent.find_by(event_type: message.template_name)
     email_template_id = event.email_template_id
     sms_template_id = event.sms_template_id
-    appeal = Appeal.find_by_uuid(message.appeal_id)
-    first_name = appeal&.appellant_first_name || "Appellant"
+    quarterly_sms_template_id = NotificationEvent.find_by(event_type: "Quarterly Notification").sms_template_id
+    appeal = Appeal.find_by_uuid(message.appeal_id) || LegacyAppeal.find_by(vacols_id: message.appeal_id)
+    first_name = (
+      if appeal.class.to_s == "Appeal"
+        appeal&.claimant&.first_name || "Appellant"
+      else
+        appeal.claimant[:first_name] || "Appellant"
+      end
+    )
     status = message.appeal_status || ""
     if @va_notify_email
       response = VANotifyService.send_email_notifications(message.participant_id, notification_audit_record.id.to_s, email_template_id, status, first_name)

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -147,7 +147,7 @@ class SendNotificationJob < CaseflowJob
   # Purpose: Method to create a new notification table row for the appeal
   #
   # Params:
-  # - appeals_id - UUID or Vacols id of the appeals the event triggered
+  # - appeals_id - UUID or vacols_id of the appeals the event triggered
   # - appeals_type - Polymorphic column to identify the type of appeal
   # - - Appeal
   # - - LegacyAppeal

--- a/app/models/serializers/work_queue/notification_serializer.rb
+++ b/app/models/serializers/work_queue/notification_serializer.rb
@@ -10,4 +10,6 @@ class WorkQueue::NotificationSerializer
   attribute :email_notification_status
   attribute :sms_notification_status
   attribute :notification_content
+  attribute :email_notification_content
+  attribute :sms_notification_content
 end

--- a/client/app/queue/components/NotificationTable.jsx
+++ b/client/app/queue/components/NotificationTable.jsx
@@ -38,6 +38,7 @@ const NotificationTable = ({ appealId, modalState, openModal, closeModal }) => {
         email_notification_status,
         sms_notification_status,
         notification_content,
+        sms_notification_content,
         notification_type,
         recipient_email,
         recipient_phone_number,
@@ -57,7 +58,7 @@ const NotificationTable = ({ appealId, modalState, openModal, closeModal }) => {
 
       const sms_notification = {
         status: sms_notification_status === 'Success' ? 'Sent' : sms_notification_status,
-        content: notification_content,
+        content: sms_notification_content,
         notification_type: 'Text',
         // eslint-disable-next-line no-negated-condition
         recipient_information: recipient_phone_number === '' ? null : recipient_phone_number,
@@ -73,6 +74,7 @@ const NotificationTable = ({ appealId, modalState, openModal, closeModal }) => {
         tableNotifications.push(sms_notification);
       }
     }
+    console.log(tableNotifications);
 
     return tableNotifications;
   };

--- a/client/app/queue/components/NotificationTable.jsx
+++ b/client/app/queue/components/NotificationTable.jsx
@@ -74,7 +74,6 @@ const NotificationTable = ({ appealId, modalState, openModal, closeModal }) => {
         tableNotifications.push(sms_notification);
       }
     }
-    console.log(tableNotifications);
 
     return tableNotifications;
   };

--- a/db/migrate/20221215192716_add_sms_notification_content_to_notifications.rb
+++ b/db/migrate/20221215192716_add_sms_notification_content_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddSmsNotificationContentToNotifications < Caseflow::Migration
+  def change
+    add_column :notifications, :sms_notification_content, :string, null: true, comment: "Full SMS Text Content of Notification"
+  end
+end

--- a/db/migrate/20221215193736_update_notification_content_column_name_to_email_notification_content_in_notifications.rb
+++ b/db/migrate/20221215193736_update_notification_content_column_name_to_email_notification_content_in_notifications.rb
@@ -1,9 +1,0 @@
-class UpdateNotificationContentColumnNameToEmailNotificationContentInNotifications < Caseflow::Migration
-  def up
-    rename_column :notifications, :notification_content, :email_notification_content, comment: "Full Email Text Content of Notification"
-  end
-
-  def down
-    rename_column :notifications, :email_notification_content, :notification_content, comment: "Full Text Content of Notification"
-  end
-end

--- a/db/migrate/20221215193736_update_notification_content_column_name_to_email_notification_content_in_notifications.rb
+++ b/db/migrate/20221215193736_update_notification_content_column_name_to_email_notification_content_in_notifications.rb
@@ -1,0 +1,9 @@
+class UpdateNotificationContentColumnNameToEmailNotificationContentInNotifications < Caseflow::Migration
+  def up
+    rename_column :notifications, :notification_content, :email_notification_content, comment: "Full Email Text Content of Notification"
+  end
+
+  def down
+    rename_column :notifications, :email_notification_content, :notification_content, comment: "Full Text Content of Notification"
+  end
+end

--- a/db/migrate/20221215202259_add_email_notification_content_to_notifications.rb
+++ b/db/migrate/20221215202259_add_email_notification_content_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddEmailNotificationContentToNotifications < Caseflow::Migration
+  def change
+    add_column :notifications, :email_notification_content, :string, null: true, comment: "Full Email Text Content of Notification"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_11_14_191336) do
+ActiveRecord::Schema.define(version: 2022_12_15_192716) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1128,7 +1128,8 @@ ActiveRecord::Schema.define(version: 2022_11_14_191336) do
     t.string "participant_id", comment: "ID of Participant"
     t.string "recipient_email", comment: "Participant's Email Address"
     t.string "recipient_phone_number", comment: "Participants Phone Number"
-    t.string "sms_notification_external_id", comment: "VA Notify Notification Id for the sms notification send through their API "
+    t.string "sms_notification_content", comment: "Full SMS Text Content of Notification"
+    t.string "sms_notification_external_id"
     t.string "sms_notification_status", comment: "Status of SMS/Text Notification"
     t.datetime "updated_at", comment: "TImestamp of when Notification was Updated"
     t.index ["appeals_id", "appeals_type"], name: "index_appeals_notifications_on_appeals_id_and_appeals_type"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1118,7 +1118,7 @@ ActiveRecord::Schema.define(version: 2022_12_15_202259) do
     t.string "appeals_type", null: false, comment: "Type of Appeal"
     t.datetime "created_at", comment: "Timestamp of when Noticiation was Created"
     t.boolean "email_enabled", default: true, null: false
-    t.string "email_notification_content", comment: "Full Email Text Content of Notification"
+    t.text "email_notification_content", comment: "Full Email Text Content of Notification"
     t.string "email_notification_external_id", comment: "VA Notify Notification Id for the email notification send through their API "
     t.string "email_notification_status", comment: "Status of the Email Notification"
     t.date "event_date", null: false, comment: "Date of Event"
@@ -1129,7 +1129,7 @@ ActiveRecord::Schema.define(version: 2022_12_15_202259) do
     t.string "participant_id", comment: "ID of Participant"
     t.string "recipient_email", comment: "Participant's Email Address"
     t.string "recipient_phone_number", comment: "Participants Phone Number"
-    t.string "sms_notification_content", comment: "Full SMS Text Content of Notification"
+    t.text "sms_notification_content", comment: "Full SMS Text Content of Notification"
     t.string "sms_notification_external_id"
     t.string "sms_notification_status", comment: "Status of SMS/Text Notification"
     t.datetime "updated_at", comment: "TImestamp of when Notification was Updated"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_15_192716) do
+ActiveRecord::Schema.define(version: 2022_12_15_202259) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1118,6 +1118,7 @@ ActiveRecord::Schema.define(version: 2022_12_15_192716) do
     t.string "appeals_type", null: false, comment: "Type of Appeal"
     t.datetime "created_at", comment: "Timestamp of when Noticiation was Created"
     t.boolean "email_enabled", default: true, null: false
+    t.string "email_notification_content", comment: "Full Email Text Content of Notification"
     t.string "email_notification_external_id", comment: "VA Notify Notification Id for the email notification send through their API "
     t.string "email_notification_status", comment: "Status of the Email Notification"
     t.date "event_date", null: false, comment: "Date of Event"

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -263,10 +263,15 @@ describe SendNotificationJob, type: :job do
         expect(VANotifyService).to receive(:send_email_notifications)
         SendNotificationJob.perform_now(good_message.to_json)
       end
-      it "updates the notification_audit_record with content" do
+      it "updates the notification_content field with content" do
         FeatureToggle.enable!(:va_notify_email)
         SendNotificationJob.perform_now(good_message.to_json)
         expect(Notification.last.notification_content).not_to eq(nil)
+      end
+      it "updates the email_notification_content field with content" do
+        FeatureToggle.enable!(:va_notify_email)
+        SendNotificationJob.perform_now(good_message.to_json)
+        expect(Notification.last.email_notification_content).not_to eq(nil)
       end
       it "updates the notification_audit_record with email_notification_external_id" do
         FeatureToggle.enable!(:va_notify_email)
@@ -286,10 +291,10 @@ describe SendNotificationJob, type: :job do
         expect(VANotifyService).to receive(:send_sms_notifications)
         SendNotificationJob.perform_now(good_message.to_json)
       end
-      it "updates the notification_audit_record with content" do
+      it "updates the sms_notification_content field with content" do
         FeatureToggle.enable!(:va_notify_sms)
         SendNotificationJob.perform_now(good_message.to_json)
-        expect(Notification.last.notification_content).not_to eq(nil)
+        expect(Notification.last.sms_notification_content).not_to eq(nil)
       end
       it "updates the notification_audit_record with sms_notification_external_id" do
         FeatureToggle.enable!(:va_notify_sms)


### PR DESCRIPTION
Resolves #{APPEALS-12611}

### Description
Add SMS NOTIFICATION CONTENT & EMAIL NOTIFICATION CONTENT columns to Notifications table.  Update Send Notification Job to update columns appropriately with content when sending an SMS or Email.  Remove colored text when using Rails Logger.

### Acceptance Criteria
- [x] A new column named sms_notification_content needs to be added to the notifications table.                       
    - [x] Column needs to be NULLABLE                                                                                                           
    - [x] Column comment should read "Full SMS Text Content of Notification".                                         
    - [x] Column should have the TEXT datatype
- [x] A new column named email_notification_content needs to be added to the notifications table.                       
    - [x] Column needs to be NULLABLE                                                                                                           
    - [x] Column comment should read "Full Email Text Content of Notification".                                       
    - [x] Column should have the TEXT datatype
- [x] Update send_notification_job.rb to store returned sms notification content from VA Notify in the sms_notification_content field and returned email notification content from VA Notify in both the email_notification_content field as well as the notification_content field.
- [x] Remove colored text from Rails Logging used in files located in app/models/prepend/va_notify

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-12614

### Test Execution
1. Go to https://vajira.max.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-12615&testIssueKey=APPEALS-12614
2. https://vajira.max.gov/browse/APPEALS-12615