### PR TITLE
HunJerBAH/APPEALS-33: BGS Power of Attorney Seed Data Fix

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -707,17 +707,36 @@ class Fakes::BGSService
     RequestStore[:current_user]
   end
 
+  def generate_random_file_number
+    Kernel.srand(1)
+    value = rand(700_000_000...733_792_224).to_s
+
+    # make sure the value is unique for both file number and participant id
+    while BgsPowerOfAttorney.find_by(file_number: value).nil? == false &&
+          BgsPowerOfAttorney.find_by(participant_id: value).nil? == false
+
+      value = rand(700_000_000...733_792_224).to_s
+    end
+    # return the value
+    value
+  end
+
   def default_power_of_attorney_record
+    # generate random file number and participant id to prevent unique id collisions
+    # with test data
+    file_number = generate_random_file_number
+    ptcpnt_id = generate_random_file_number
+
     {
-      file_number: "633792224",
+      file_number: file_number,
       power_of_attorney:
         {
           legacy_poa_cd: "3QQ",
           nm: FakeConstants.BGS_SERVICE.DEFAULT_POA_NAME,
           org_type_nm: "POA Attorney",
-          ptcpnt_id: "600153863"
+          ptcpnt_id: ptcpnt_id
         },
-      ptcpnt_id: "600085544"
+      ptcpnt_id: ptcpnt_id
     }
   end
 


### PR DESCRIPTION
Resolves [APPEALS-33](https://vajira.max.gov/browse/APPEALS-33)

### Description
During testing for APPEALS-33, we found that the fake bgs service used when creating seed data for demo/local was creating multiple POAs for appeals that had the same participant id and file number. These unique identifiers were creating a SQL duplicate primary key violation that was preventing new appeals from being able to go through the intake process. The changes will randomizes the participant ids and file numbers of default POAs generated by the bgs service used to seed local/demo environments to prevent this issue from occurring in the future.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Problem veteran file numbers are able to go through the intake process without any error messages. These problem veteran file numbers are:
1. 200000002
2. 200000004
3. 400000002
4. 400000003
5. 400000004
6. 400000005
7. 400000006
8. 400000008
9. 400000009
10. 400000011
11. 400000015

### Testing Plan
1. Go to local/demo and sign in as BVADWISE. 
2. Click on the **intake** tab and **start** to intake a new appeal.
3. Select **Decision review: Board Appeal Notice of Disagreement** from the dropdown menu.
4. Enter a veteran file number from the list above. 
5. Fill out the form like the screenshot and click the button to continue
![image](https://user-images.githubusercontent.com/99915461/210005271-c80d9b8a-919d-4b0c-b7c2-f3a7cf433a09.png)
6. Click the **add issue** button and fill out the form like the screenshot below. Make sure the type is VHA and pre-docket is **no**.  Click **Add issue** to add the issue.
![image](https://user-images.githubusercontent.com/99915461/210005393-6c675930-fab8-4b6c-bd21-537a1610086c.png)
7.  Click **establish the appeal**.
![image](https://user-images.githubusercontent.com/99915461/210005427-fc71c127-d45c-4d88-b706-b2d446dff3df.png)
8. You should be greeted by a green success banner.
![image](https://user-images.githubusercontent.com/99915461/210005462-c4779d83-9082-4d70-9064-9718ad8e4f3d.png)
9. Repeat these steps for each of the veteran file numbers listed above to confirm the new seed data is working properly. 
