### PR TITLE
APPEALS-12997 removed colored text from rails logging in

### DIFF
--- a/app/models/prepend/va_notify/privacy_act_pending.rb
+++ b/app/models/prepend/va_notify/privacy_act_pending.rb
@@ -42,7 +42,7 @@ module PrivacyActPending
     if PRIVACY_ACT_TASKS.include?(type) && !PRIVACY_ACT_TASKS.include?(parent&.type)
       MetricsService.record("Updating PRIVACY_ACT_PENDING column in Appeal States Table to TRUE and
                              PRIVACY_ACT_COMPLETE to FALSE "\
-        "for #{appeal.class} ID #{appeal.id}".yellow,
+        "for #{appeal.class} ID #{appeal.id}",
                             service: nil,
                             name: "AppellantNotification.appeal_mapper") do
         AppellantNotification.appeal_mapper(appeal.id, appeal.class.to_s, "privacy_act_pending")


### PR DESCRIPTION
Resolves #{APPEALS-12997}

### Description
Removed colored text from Rails Logging.

### Acceptance Criteria
- [ ] Code compiles correctly