### PR TITLE
HunJerBAH/Appeals 33: Null receipt date fix

### DIFF
--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -86,8 +86,16 @@ class TaskSorter
       # load hash with the receipt date and task id
       task_id_to_receipt_date_hash[task.id] = appeal_receipt_date
     end
+
     # sort the hash so the dates are in ascending order (oldest first), and return the id of the tasks (keys)
-    task_id_to_receipt_date_hash.sort_by { |_, receipt_date_id| receipt_date_id }.to_h.keys
+    # remove null values
+    null_receipt_date_values = task_id_to_receipt_date_hash.select { |_, value| value.nil? }.keys
+    # remove null values
+    task_id_to_receipt_date_hash.compact!
+    # sort the tasks
+    sorted_hash = task_id_to_receipt_date_hash.sort_by { |_, receipt_date_id| receipt_date_id }.to_h.keys
+    # add the null values back into set
+    sorted_hash.concat(null_receipt_date_values)
   end
 
   def default_order_clause


### PR DESCRIPTION
Resolves [APPEALS-33](https://vajira.max.gov/browse/APPEALS-33)

### Description
During production release on 12/29/22, we found that several AMA appeals have missing receipt dates that were breaking the BVA Intake table because it was sorting by receipt date. This fix adds error handling to remove null values from the sort and put them at the top/bottom of the table sort. 

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] appeals with null receipt date values are maintained in the BVA Intake table
- [ ] The BVA Intake table displays properly

### Testing Plan
1. Sign in as BVADWISE. Go to Intake
2. Select Decision Review: Board Appeal (first option) and click continue
3. For the veteran file number, use one of these IDs:
200000002
200000004
400000002
400000003

4. Fill out the form and click the button to continue
![image](https://user-images.githubusercontent.com/99915461/210074905-dda0fe8b-34ee-454b-bda7-a12a7dd3ed37.png)

5. Click **add issue** and fill out the form. Make sure to select VHA as the issue type and predocket as **yes.** Click the button to continue. 
![image](https://user-images.githubusercontent.com/99915461/210075020-09db0c33-a60f-4eda-a972-6b3d3aae9e70.png)

6. You should see the intake success banner. 
7. Repeat steps 2-6 until you have 2 or 3 appeals intaked 
8. Now that multiple appeals have been intaked, we need to delete the receipt date from one or two to duplicate the issue.
9. Go into Metabase or the local database and run this SQL query:
`select detail_id, created_at  from intakes i 
order by created_at desc `

This query will give you the latest appeals you just intaked at the top and the appeal ID. Copy one of the detail IDs.

10. Open up the rails console. 
11. To find the appeal, run `appeal = Appeal.find(DETAIL_ID_HERE)`
12. To remove the receipt date from the appeal, run: `appeal.receipt_date = nil` followed by `appeal.save!`. Confirm the receipt date was removed by running `appeal.receipt_date`. 
![image](https://user-images.githubusercontent.com/99915461/210076525-95a60a1b-8ff5-4527-ae8c-f96d81780615.png)
13. Go back to Caseflow and navigate to the Queue app by clicking on **search** and then clicking the **Queue** icon in the top right.
14. Click on **switch view** and select **BVA Intake** team cases. 
![image](https://user-images.githubusercontent.com/99915461/210076938-68866cb0-e022-4a34-a7c7-270e82e59b33.png)

16. The table should load and the null receipt date appeal should display as **invalid date**
![image](https://user-images.githubusercontent.com/99915461/210076965-347214b5-8d54-476f-bd6e-5567ccedd4a3.png)