### PR TITLE
Hotfix: Add Safe-Navigation Operators to Claimant Calls

### DIFF
--- a/app/models/decision_document.rb
+++ b/app/models/decision_document.rb
@@ -67,7 +67,7 @@ class DecisionDocument < CaseflowRecord
 
     if appeal.is_a?(Appeal)
       create_board_grant_effectuations!
-      fail NotImplementedError if appeal.claimant.unrecognized_claimant?
+      fail NotImplementedError if appeal.claimant&.unrecognized_claimant?
 
       # We do not want to process Board Grant Effectuations or create remand supplemental claims
       # for appeals with unrecognized appellants because claim establishment

--- a/app/models/decision_review_intake.rb
+++ b/app/models/decision_review_intake.rb
@@ -49,7 +49,7 @@ class DecisionReviewIntake < Intake
       payee_code: (need_payee_code? ? request_params[:payee_code] : nil)
     )
 
-    if claimant.unrecognized_claimant?
+    if claimant&.unrecognized_claimant?
       claimant.save_unrecognized_details!(
         request_params[:unlisted_claimant],
         request_params[:poa]

--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -133,7 +133,7 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :appellant_phone_number do |object|
-    object.claimant.unrecognized_claimant? ? object.claimant&.phone_number : nil
+    object.claimant&.unrecognized_claimant? ? object.claimant&.phone_number : nil
   end
 
   attribute :appellant_email_address do |object|
@@ -149,11 +149,11 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :appellant_party_type do |appeal|
-    appeal.claimant.unrecognized_claimant? ? appeal.claimant&.party_type : nil
+    appeal.claimant&.unrecognized_claimant? ? appeal.claimant&.party_type : nil
   end
 
   attribute :unrecognized_appellant_id do |appeal|
-    appeal.claimant.unrecognized_claimant? ? appeal.claimant&.unrecognized_appellant&.id : nil
+    appeal.claimant&.unrecognized_claimant? ? appeal.claimant&.unrecognized_appellant&.id : nil
   end
 
   attribute :has_poa do |appeal|


### PR DESCRIPTION
Resolves #{github issue number}

## Description
This PR aims to resolve "NoMethodError: undefined method `unrecognized_claimant?` for nil:NilClass" errors. It will also resolve "NotImplementedError" errors whenever processing decision documents.

## Acceptance Criteria
- [ ] Appeals without claimants can be serialized via the [WorkQueue::AppealSerializer](https://github.com/department-of-veterans-affairs/caseflow/blob/ad88b5f000f13badb9f8457f770bc045c7992ce0/app/models/serializers/work_queue/appeal_serializer.rb) without an exception being thrown.
- [ ] Decision documents for appeals without claimants can be processed without a `NotImpletentedError` exception being thrown ([here](https://github.com/department-of-veterans-affairs/caseflow/blob/ad88b5f000f13badb9f8457f770bc045c7992ce0/app/models/decision_document.rb#L70)).

## Testing Plan

### Caseflow Search

1. Obtain an appeal and delete the claimants associated with it:
```ruby
a = Appeal.first

a.claimants.each(&:delete)
```

2. Log into Caseflow as a user that has access to [Search](http://localhost:3000/search) (ex: `BVADWISE`)

3. Search for the veteran's file number that is associated with the appeal:

```ruby
a.veteran.file_number
```

4. The cases for the veteran should appear and you should not see an error. Here is an example of the error that is currently being seen in production:
<img width="494" alt="no-claimant-search-error" src="https://user-images.githubusercontent.com/99351305/210086722-46112f11-97e8-4e45-a43a-de8af7f0e3d0.PNG">

^ You will want to make sure that this does **NOT** appear!

### Decision Document Processing

5. Creating a `BvaDispatchTask` on the appeal:
```ruby
bdt = BvaDispatchTask.create_from_root_task(a.root_task)

bdt.children.each(&:delete)
```

6. For brevity, assign all BvaDispatchTasks to your current user:
```ruby
a.tasks.each { |t| t.update!(assigned_to: User.find_by_css_id("BVAISHAW")) if t.type == BvaDispatchTask.name }
```

7. Create an IDT key-token pair for the current user and activate the token:
```ruby
key, token = Idt::Token.generate_one_time_key_and_proposed_token

Idt::Token.activate_proposed_token(key, "BVAISHAW")
```

8. Copy the activated token to your clipboard:
```ruby
puts token
=>
# This is just a sample token. Yours will differ.
4f3633b4fa9e73b0cb385d9998738675b8137643d0d70ee5f92718ed4e8133f30fc311c442eb76083369268015a01175fe6dbcf73ee386078e35f584ff4f24cc
```

9. Use curl (outside of Rails console) to submit and process a decision document:
```bash
curl -XPOST -H 'TOKEN: <your-token>' -H "Content-type: application/json" -d '{
  "file": "some-document",
  "redacted_document_location": "\\bvacofil1.dva.gov\archdata$\something.txt",
  "decision_date": "December 30, 2022",
  "citation_number": "A19062124"
}' 'http://localhost:3000/idt/api/v1/appeals/<appeal-id>/outcode'
```

Replace `<your-token>` with your token, and `<appeal-id>` with:
```ruby
a.external_id
```

Here is an example:
```bash
curl -XPOST -H 'TOKEN: 4f3633b4fa9e73b0cb385d9998738675b8137643d0d70ee5f92718ed4e8133f30fc311c442eb76083369268015a01175fe6dbcf73ee386078e35f584ff4f24cc' -H "Content-type: application/json" -d '{
  "file": "some-document",
  "redacted_document_location": "\\bvacofil1.dva.gov\archdata$\something.txt",
  "decision_date": "December 30, 2022",
  "citation_number": "A19062124"
}' 'http://localhost:3000/idt/api/v1/appeals/b66e177f-624a-4a8c-af49-846e5b299b9c/outcode'
```

10. You should receive an error, however the error should **not** be a `NotImplementedError`.
```bash
{"message":"IDT Standard Error ID: 8df90417-3d50-4c71-a53c-27c1cc29893e Unexpected error: Appeal#power_of_attorney delegated to claimant.power_of_attorney, but claimant is nil:

...
```

If there is not a claimant on an appeal with a decision document being submitted for it, there are numerous issues. This hotfix focuses only on `unrecognized_claimant?`'s role in this model.

11. Despite this error, the decision document should still be created. You can confirm it with the below command:

```ruby
[7] pry(main)> a.decision_documents
[2022-12-30 11:12:35 -0500]   DecisionDocument Load (11.5ms)  SELECT "decision_documents".* FROM "decision_documents" WHERE "decision_documents"."appeal_id" = $1 AND "decision_documents"."appeal_type" = $2  [["appeal_id", 1], ["appeal_type", "Appeal"]]
=> [#<DecisionDocument:0x00005577dba62a18
  id: 154,
  appeal_id: 1,
  appeal_type: "Appeal",
  attempted_at: nil,
  canceled_at: nil,
  citation_number: "A19062124",
  created_at: Fri, 30 Dec 2022 16:05:01 UTC +00:00,
  decision_date: Fri, 30 Dec 2022,
  error: nil,
  last_submitted_at: Fri, 30 Dec 2022 16:05:01 UTC +00:00,
  processed_at: nil,
  redacted_document_location: "\\bvacofil1.dva.govarchdata$something.txt",
  submitted_at: Fri, 30 Dec 2022 16:05:01 UTC +00:00,
  updated_at: Fri, 30 Dec 2022 16:05:01 UTC +00:00,
  uploaded_to_vbms_at: nil>]
  ```

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
