### PR TITLE
master test fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,9 @@
 version: 2.1
 
+browser_tools_versions: &browser_versions
+  chrome-version: 106.0.5249.119
+  firefox-version: 106.0.1
+
 commands:
   install_ruby_dependencies:
     description: "Install Ruby Dependencies"
@@ -202,7 +206,8 @@ jobs:
           name: Setup testfiles directory
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
 
       - install_ruby_dependencies
 
@@ -336,7 +341,8 @@ jobs:
           - COVERAGE_DIR: /home/circleci/coverage
     resource_class: large
     steps:
-      - browser-tools/install-browser-tools
+      - browser-tools/install-browser-tools:
+          <<: *browser_versions
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,5 @@
 version: 2.1
 
-browser_tools_versions: &browser_versions
-  chrome-version: 106.0.5249.119
-  firefox-version: 106.0.1
-
 commands:
   install_ruby_dependencies:
     description: "Install Ruby Dependencies"
@@ -206,8 +202,7 @@ jobs:
           name: Setup testfiles directory
           command: ~/project/ci-bin/capture-log "mkdir -p ~/project/tmp/testfiles"
 
-      - browser-tools/install-browser-tools:
-          <<: *browser_versions
+      - browser-tools/install-browser-tools
 
       - install_ruby_dependencies
 
@@ -341,8 +336,7 @@ jobs:
           - COVERAGE_DIR: /home/circleci/coverage
     resource_class: large
     steps:
-      - browser-tools/install-browser-tools:
-          <<: *browser_versions
+      - browser-tools/install-browser-tools
       - checkout
       - run:
           name: Install python-2 as a node-gyp@3.8.0 dependency

--- a/client/app/components/icons/UnselectedFilterIcon.jsx
+++ b/client/app/components/icons/UnselectedFilterIcon.jsx
@@ -5,12 +5,16 @@ import { ICON_SIZES, COLORS } from '../../constants/AppConstants';
 export const UnselectedFilterIcon = (props) => {
   const { getRef, className, color, strokeColor, size, ...restProps } = props;
 
+  // classnames unselected-filter-icon-border-1 and unselected-filter-icon-inner-1 are used as selectors for tests
+  // and do not have any associated CSS rules
   return <svg height={size} viewBox="0 0 21 21" {...restProps}
     ref={getRef} className={`${className} unselected-filter-icon`}>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g>
-        <rect className="unselected-filter-icon-border-1" stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
-        <path className="unselected-filter-icon-inner-1" d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
+        <rect className="unselected-filter-icon-border-1"
+          stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
+        <path className="unselected-filter-icon-inner-1"
+          d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
       11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667
       9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2
       4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2

--- a/client/app/components/icons/UnselectedFilterIcon.jsx
+++ b/client/app/components/icons/UnselectedFilterIcon.jsx
@@ -10,7 +10,7 @@ export const UnselectedFilterIcon = (props) => {
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g>
         <rect className="unselected-filter-icon-border" stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
-        <path d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
+        <path className="unselected-filter-icon-inner" d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
       11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667
       9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2
       4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2

--- a/client/app/components/icons/UnselectedFilterIcon.jsx
+++ b/client/app/components/icons/UnselectedFilterIcon.jsx
@@ -9,7 +9,7 @@ export const UnselectedFilterIcon = (props) => {
     ref={getRef} className={`${className} unselected-filter-icon`}>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g>
-        <rect stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
+        <rect className="unselected-filter-icon-border" stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
         <path d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
       11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667
       9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2

--- a/client/app/components/icons/UnselectedFilterIcon.jsx
+++ b/client/app/components/icons/UnselectedFilterIcon.jsx
@@ -9,8 +9,8 @@ export const UnselectedFilterIcon = (props) => {
     ref={getRef} className={`${className} unselected-filter-icon`}>
     <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
       <g>
-        <rect className="unselected-filter-icon-border" stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
-        <path className="unselected-filter-icon-inner" d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
+        <rect className="unselected-filter-icon-border-1" stroke={strokeColor} fill={color} fillRule="nonzero" x="0.5" y="0.5" width="20" height="20" rx="2"></rect>
+        <path className="unselected-filter-icon-inner-1" d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667
       11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667
       9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2
       4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2

--- a/client/app/queue/caseEvaluation/CaseTimelinessTimeline.jsx
+++ b/client/app/queue/caseEvaluation/CaseTimelinessTimeline.jsx
@@ -55,10 +55,10 @@ export const CaseTimelinessTimeline = (props) => {
 
   }
 
-  const oldestAttorneyTask = attorneyChildrenTasks[0].attorneyTask;
+  const oldestAttorneyTask = attorneyChildrenTasks[0]?.attorneyTask;
 
   // If AMA use oldest attorney task and recalculate total days assigned
-  dateAssigned = moment(oldestAttorneyTask.createdAt);
+  dateAssigned = moment(oldestAttorneyTask?.createdAt);
   daysAssigned = Math.max(0, decisionSubmitted.startOf('day').diff(dateAssigned, 'days'));
 
   return (

--- a/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
@@ -276,7 +276,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -287,6 +287,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />
@@ -380,7 +381,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -391,6 +392,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />
@@ -484,7 +486,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -495,6 +497,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />
@@ -1412,7 +1415,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1423,6 +1426,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />
@@ -1516,7 +1520,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1527,6 +1531,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />
@@ -1620,7 +1625,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
-                                class="unselected-filter-icon-border"
+                                class="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1631,6 +1636,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                                 y="0.5"
                               />
                               <path
+                                class="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />

--- a/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/ColocatedTaskListView.test.js.snap
@@ -276,6 +276,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -379,6 +380,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -482,6 +484,7 @@ exports[`ColocatedTaskListView assigned tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1409,6 +1412,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1512,6 +1516,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"
@@ -1615,6 +1620,7 @@ exports[`ColocatedTaskListView on hold tab renders correctly 1`] = `
                           >
                             <g>
                               <rect
+                                class="unselected-filter-icon-border"
                                 fill="#fff"
                                 fill-rule="nonzero"
                                 height="20"

--- a/client/test/app/queue/__snapshots__/NotificationTable.test.js.snap
+++ b/client/test/app/queue/__snapshots__/NotificationTable.test.js.snap
@@ -62,6 +62,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
+                        class="unselected-filter-icon-border"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -183,6 +184,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
+                        class="unselected-filter-icon-border"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -236,6 +238,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
+                        class="unselected-filter-icon-border"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -289,6 +292,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
+                        class="unselected-filter-icon-border"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"

--- a/client/test/app/queue/__snapshots__/NotificationTable.test.js.snap
+++ b/client/test/app/queue/__snapshots__/NotificationTable.test.js.snap
@@ -62,7 +62,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
-                        class="unselected-filter-icon-border"
+                        class="unselected-filter-icon-border-1"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -73,6 +73,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                         y="0.5"
                       />
                       <path
+                        class="unselected-filter-icon-inner-1"
                         d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                         fill="#212121"
                       />
@@ -184,7 +185,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
-                        class="unselected-filter-icon-border"
+                        class="unselected-filter-icon-border-1"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -195,6 +196,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                         y="0.5"
                       />
                       <path
+                        class="unselected-filter-icon-inner-1"
                         d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                         fill="#212121"
                       />
@@ -238,7 +240,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
-                        class="unselected-filter-icon-border"
+                        class="unselected-filter-icon-border-1"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -249,6 +251,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                         y="0.5"
                       />
                       <path
+                        class="unselected-filter-icon-inner-1"
                         d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                         fill="#212121"
                       />
@@ -292,7 +295,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                   >
                     <g>
                       <rect
-                        class="unselected-filter-icon-border"
+                        class="unselected-filter-icon-border-1"
                         fill="#fff"
                         fill-rule="nonzero"
                         height="20"
@@ -303,6 +306,7 @@ exports[`NotificationTable matches snapshot 1`] = `
                         y="0.5"
                       />
                       <path
+                        class="unselected-filter-icon-inner-1"
                         d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                         fill="#212121"
                       />

--- a/client/test/app/queue/__snapshots__/NotificationsView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/NotificationsView.test.js.snap
@@ -244,7 +244,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
-                              class="unselected-filter-icon-border"
+                              class="unselected-filter-icon-border-1"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -255,6 +255,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                               y="0.5"
                             />
                             <path
+                              class="unselected-filter-icon-inner-1"
                               d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                               fill="#212121"
                             />
@@ -366,7 +367,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
-                              class="unselected-filter-icon-border"
+                              class="unselected-filter-icon-border-1"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -377,6 +378,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                               y="0.5"
                             />
                             <path
+                              class="unselected-filter-icon-inner-1"
                               d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                               fill="#212121"
                             />
@@ -420,7 +422,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
-                              class="unselected-filter-icon-border"
+                              class="unselected-filter-icon-border-1"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -431,6 +433,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                               y="0.5"
                             />
                             <path
+                              class="unselected-filter-icon-inner-1"
                               d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                               fill="#212121"
                             />
@@ -474,7 +477,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
-                              class="unselected-filter-icon-border"
+                              class="unselected-filter-icon-border-1"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -485,6 +488,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                               y="0.5"
                             />
                             <path
+                              class="unselected-filter-icon-inner-1"
                               d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                               fill="#212121"
                             />

--- a/client/test/app/queue/__snapshots__/NotificationsView.test.js.snap
+++ b/client/test/app/queue/__snapshots__/NotificationsView.test.js.snap
@@ -244,6 +244,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
+                              class="unselected-filter-icon-border"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -365,6 +366,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
+                              class="unselected-filter-icon-border"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -418,6 +420,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
+                              class="unselected-filter-icon-border"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"
@@ -471,6 +474,7 @@ exports[`NotificationsTest matches snapshot 1`] = `
                         >
                           <g>
                             <rect
+                              class="unselected-filter-icon-border"
                               fill="#fff"
                               fill-rule="nonzero"
                               height="20"

--- a/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
+++ b/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
@@ -1021,7 +1021,7 @@ exports[`QueueTable render() Can filter rows 1`] = `
                           >
                             <g>
                               <rect
-                                className="unselected-filter-icon-border"
+                                className="unselected-filter-icon-border-1"
                                 fill="#fff"
                                 fillRule="nonzero"
                                 height="20"
@@ -1032,6 +1032,7 @@ exports[`QueueTable render() Can filter rows 1`] = `
                                 y="0.5"
                               />
                               <path
+                                className="unselected-filter-icon-inner-1"
                                 d="M16.2335889,6.4 L11.5555083,10.8333333 L11.5555083,14.8333333 C11.5555083,15.0166667 11.3972274,15.1666667 11.2037729,15.1666667 L9.7968314,15.1666667 C9.60337694,15.1666667 9.44509602,15.0166667 9.44509602,14.8333333 L9.44509602,10.8333333 L4.76701542,6.4 C4.55597419,6.2 4.69666834,5.83333333 5.01323019,5.83333333 L15.9697874,5.83333333 C16.303936,5.83333333 16.4446301,6.2 16.2335889,6.4 Z"
                                 fill="#212121"
                               />

--- a/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
+++ b/client/test/app/queue/__snapshots__/QueueTable.test.js.snap
@@ -1021,6 +1021,7 @@ exports[`QueueTable render() Can filter rows 1`] = `
                           >
                             <g>
                               <rect
+                                className="unselected-filter-icon-border"
                                 fill="#fff"
                                 fillRule="nonzero"
                                 height="20"

--- a/db/seeds/static_test_data.rb
+++ b/db/seeds/static_test_data.rb
@@ -357,9 +357,11 @@ module Seeds
     def case_with_bad_decass_for_timeline_range_checks
       Time.zone = 'EST'
       vet = create_veteran
-      judge = VACOLS::Staff.find_by_css_id("BVABDANIEL")
-      atty = VACOLS::Staff.find_by_css_id("BVABBLOCK")
-      vc = create(:case, :assigned, user: User.find_by_css_id("BVABDANIEL"), bfcorlid: "#{vet.file_number}S")
+      cf_judge = User.find_by_css_id("BVABDANIEL") || create(:user, :judge, :with_vacols_judge_record)
+      cf_atty = User.find_by_css_id("BVABBLOCK") || create(:user, :with_vacols_attorney_record)
+      judge = VACOLS::Staff.find_by_css_id(cf_judge.css_id)
+      atty = VACOLS::Staff.find_by_css_id(cf_atty.css_id)
+      vc = create(:case, :assigned, user: cf_judge, bfcorlid: "#{vet.file_number}S")
       create(:legacy_appeal, vacols_case: vc)
       create(:priorloc, lockey: vc.bfkey, locdin: 5.weeks.ago, locdout: 5.weeks.ago - 1.day, locstout: judge.slogid, locstto: judge.slogid)
       create(:priorloc, lockey: vc.bfkey, locdin: 4.weeks.ago, locdout: 5.weeks.ago, locstout: judge.slogid, locstto: "CASEFLOW_judge")

--- a/spec/feature/hearings/assign_hearings_table_spec.rb
+++ b/spec/feature/hearings/assign_hearings_table_spec.rb
@@ -325,8 +325,8 @@ RSpec.feature "Assign Hearings Table" do
 
         step "check if the filter options are as expected" do
           expect(page).to have_content("Suggested Location")
-          expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
-          page.find_all(".unselected-filter-icon-inner")[1].click
+          expect(page).to have_selector(".unselected-filter-icon-inner-1", count: 3)
+          page.find_all(".unselected-filter-icon-inner-1")[1].click
           expect(page).to have_content("#{Appeal.first.suggested_hearing_location.formatted_location} (1)")
           expect(page).to have_content("#{Appeal.second.suggested_hearing_location.formatted_location} (1)")
           expect(page).to have_content("#{Appeal.third.suggested_hearing_location.formatted_location} (1)")
@@ -359,8 +359,8 @@ RSpec.feature "Assign Hearings Table" do
 
         step "check if the filter options are as expected" do
           expect(page).to have_content("Power of Attorney (POA)")
-          expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
-          page.find_all(".unselected-filter-icon-inner").last.click
+          expect(page).to have_selector(".unselected-filter-icon-inner-1", count: 3)
+          page.find_all(".unselected-filter-icon-inner-1").last.click
           expect(page).to have_content("#{Appeal.first.representative_name} (1)")
           expect(page).to have_content("#{Appeal.second.representative_name} (1)")
           expect(page).to have_content("#{Appeal.third.representative_name} (1)")
@@ -455,8 +455,8 @@ RSpec.feature "Assign Hearings Table" do
 
           step "check if the filter options are as expected" do
             expect(page).to have_content("Hearing Type")
-            expect(page).to have_selector(".unselected-filter-icon-inner", count: 3)
-            page.find_all(".unselected-filter-icon-inner").first.click
+            expect(page).to have_selector(".unselected-filter-icon-inner-1", count: 3)
+            page.find_all(".unselected-filter-icon-inner-1").first.click
             expect(page).to have_content("Virtual (1)")
             expect(page).to have_content("Video (1)")
             expect(page).to have_content("former Travel (1)")

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -124,7 +124,11 @@ RSpec.feature "Notifications View" do
     end
 
     it "table can filter by each column, and filter by multiple columns at once" do
-      visit(appeal_notifications_page)
+      visit appeal_case_details_page
+      click_link("View notifications sent to appellant")
+      # notifications page opens in new browser window so go to that window
+      page.switch_to_window(page.windows.last)
+      expect(page).to have_current_path(appeal_notifications_page)
 
       # by event type
       filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
@@ -200,7 +204,11 @@ RSpec.feature "Notifications View" do
     end
 
     it "notification page can properly navigate pages and event modal behaves properly" do
-      visit(appeal_notifications_page)
+      visit appeal_case_details_page
+      click_link("View notifications sent to appellant")
+      # notifications page opens in new browser window so go to that window
+      page.switch_to_window(page.windows.last)
+      expect(page).to have_current_path(appeal_notifications_page)
 
       # next button moves to next page
       click_on("Next", match: :first)

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -4,9 +4,12 @@ require "spec_helper"
 
 RSpec.feature "Notifications View" do
   let(:user_roles) { ["System Admin"] }
+  before(:all) do
+    Seeds::NotificationEvents.new.seed!
+  end
+
   before do
     User.authenticate!(roles: user_roles)
-    Seeds::NotificationEvents.new.seed!
   end
 
   context "ama appeal" do

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -242,23 +242,6 @@ RSpec.feature "Notifications View" do
       expect(page).not_to have_selector("div", class: "cf-modal-body")
       expect(page).not_to have_selector("section", id: "modal_id")
     end
-
-    # it "modal behaves properly" do
-    #   visit(appeal_notifications_page)
-
-    #   # modal appears when clicking on an event type
-    #   event_type_cell = page.find("td", match: :first).find("a")
-    #   event_type_cell.click
-    #   expect(page).to have_selector("div", class: "cf-modal-body")
-
-    #   # background darkens and disables clicking when modal is open
-    #   expect(page).to have_selector("section", id: "modal_id")
-
-    #   # clicking close button on modal removes dark background and closes modal
-    #   click_on("Close")
-    #   expect(page).not_to have_selector("div", class: "cf-modal-body")
-    #   expect(page).not_to have_selector("section", id: "modal_id")
-    # end
   end
 
   # rubocop:disable Style/BlockDelimiters

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -143,7 +143,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by event type" do
         visit(ama_notifications_page)
-        filter = page.find("rect", class: "unselected-filter-icon-border", match: :first)
+        filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Appeal docketed")
         filter_option.click(x: 5, y: 5)
@@ -156,7 +156,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by notification type" do
         visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[1]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[1]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Email")
         filter_option.click(x: 5, y: 5)
@@ -169,7 +169,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by recipient information" do
         visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[2]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[2]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Example@example.com")
         filter_option.click(x: 5, y: 5)
@@ -182,7 +182,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by status" do
         visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[3]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[3]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Delivered")
         filter_option.click(x: 5, y: 5)
@@ -195,7 +195,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter mutliple columns at once" do
         visit(ama_notifications_page)
-        filters = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)
+        filters = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)
         filters[0].click(x: 5, y: 5)
         page.find("li", class: "cf-filter-option-row", text: "Hearing scheduled").click(x: 5, y: 5)
         filters[1].click(x: 5, y: 5)
@@ -407,7 +407,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by event type" do
         visit(legacy_notifications_page)
-        filter = page.find("rect", class: "unselected-filter-icon-border", match: :first)
+        filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Appeal docketed")
         filter_option.click(x: 5, y: 5)
@@ -420,7 +420,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by notification type" do
         visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[1]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[1]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Email")
         filter_option.click(x: 5, y: 5)
@@ -433,7 +433,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by recipient information" do
         visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[2]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[2]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Example@example.com")
         filter_option.click(x: 5, y: 5)
@@ -446,7 +446,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter by status" do
         visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)[3]
+        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[3]
         filter.click(x: 5, y: 5)
         filter_option = page.find("li", class: "cf-filter-option-row", text: "Delivered")
         filter_option.click(x: 5, y: 5)
@@ -459,7 +459,7 @@ RSpec.feature "Notifications View" do
 
       scenario "can filter mutliple columns at once" do
         visit(legacy_notifications_page)
-        filters = page.all("rect", class: "unselected-filter-icon-border", minimum: 1)
+        filters = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)
         filters[0].click(x: 5, y: 5)
         page.find("li", class: "cf-filter-option-row", text: "Hearing scheduled").click(x: 5, y: 5)
         filters[1].click(x: 5, y: 5)

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -4,12 +4,9 @@ require "spec_helper"
 
 RSpec.feature "Notifications View" do
   let(:user_roles) { ["System Admin"] }
-  before(:all) do
-    Seeds::NotificationEvents.new.seed!
-  end
-
   before do
     User.authenticate!(roles: user_roles)
+    Seeds::NotificationEvents.new.seed!
   end
 
   context "ama appeal" do

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -85,7 +85,7 @@ RSpec.feature "Notifications View" do
       seed_notifications
     end
 
-    it "notifications page link appears, page has full table of notifications and correct information in first row" do
+    it "notifications page link appears, page has full table with correct information, and can sort by date" do
       visit appeal_case_details_page
       click_link("View notifications sent to appellant")
       # notifications page opens in new browser window so go to that window
@@ -115,21 +115,16 @@ RSpec.feature "Notifications View" do
       # correct status
       status_cell = page.all("td", minimum: 1)[4]
       expect(status_cell).to have_content("Delivered")
-    end
-
-    it "table can sort by date, filter by each column, and filter by multiple columns at once" do
-      visit(appeal_notifications_page)
 
       # sort by notification date
       sort = page.all("svg", class: "table-icon", minimum: 1)[1]
       sort.click(x: 5, y: 5)
       cell = page.all("td", minimum: 1)[1]
       expect(cell).to have_content("11/08/2022")
+    end
 
-      # revert sort change
-      sort.click(x: 5, y: 5)
-      cell = page.all("td", minimum: 1)[1]
-      expect(cell).to have_content("11/01/2022")
+    it "table can filter by each column, and filter by multiple columns at once" do
+      visit(appeal_notifications_page)
 
       # by event type
       filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)

--- a/spec/feature/queue/appeal_notifications_page_spec.rb
+++ b/spec/feature/queue/appeal_notifications_page_spec.rb
@@ -4,48 +4,48 @@ require "spec_helper"
 
 RSpec.feature "Notifications View" do
   let(:user_roles) { ["System Admin"] }
-  before do
-    User.authenticate!(roles: user_roles)
-    Seeds::NotificationEvents.new.seed!
+  before { User.authenticate!(roles: user_roles) }
+
+  shared_examples "without notifications" do
+    it "notification page link will not show up" do
+      visit appeal_case_details_page
+      expect(page).to have_no_link("View notifications sent to appellant")
+    end
   end
 
-  context "ama appeal" do
-    let(:appeal) do
-      create(:appeal)
-    end
-    let(:ama_notifications_page) { "queue/appeals/#{appeal.uuid}/notifications" }
-    let(:seed_ama_notifications) do
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-01",
+  shared_examples "with notifications" do
+    let(:seed_notifications) do
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-01",
                             event_type: "Appeal docketed", notification_type: "Email and SMS",
-                            recipient_email: "example@example.com",recipient_phone_number: "555-555-5555",
+                            recipient_email: "example@example.com", recipient_phone_number: "555-555-5555",
                             email_notification_status: "delivered", sms_notification_status: "delivered",
                             notification_content: "Your appeal at the Board of Veteran's Appeals has been docketed. "\
                             "We must work cases in the order your VA Form 9 substantive appeal (for Legacy) or VA "\
                             "Form 10182 (for AMA) was received. We will update you with any progress. If you have "\
                             "any questions please reach out to your Veterans Service Organization or representative "\
                             "or log onto VA.gov for additional information.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-02",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-02",
                             event_type: "Hearing scheduled", notification_type: "Email and SMS",
                             recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
+                            email_notification_status: "delivered", sms_notification_status: "temporary-failure",
                             notification_content: "Your hearing has been scheduled with a Veterans Law Judge at the "\
                             "Board of Veterans' Appeals. You will be notified of the details in writing shortly.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-03",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-03",
                             event_type: "Privacy Act request pending", notification_type: "Email and SMS",
                             recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
+                            email_notification_status: "delivered", sms_notification_status: "temporary-failure",
                             notification_content: "You or your representative filed a Privacy Act request. The Board "\
                             "placed your appeal on hold until this request is satisfied.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-04",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-04",
                             event_type: "Privacy Act request complete", notification_type: "Email and SMS",
                             recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
+                            email_notification_status: "delivered", sms_notification_status: "temporary-failure",
                             notification_content: "The Privacy Act request has been satisfied and the Board will "\
                             "continue processing your appeal at this time. The Board must work cases in docket order "\
                             "(the order received) If you have any questions please reach out to your Veterans Service "\
                             "Organization or representative, if you have one, or log onto VA.gov for additional "\
                             "information")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-05",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-05",
                             event_type: "Withdrawal of hearing", notification_type: "Email and SMS",
                             recipient_email: nil, recipient_phone_number: nil, email_notification_status: "Success",
                             sms_notification_status: "temporary-failure",
@@ -55,7 +55,7 @@ RSpec.feature "Notifications View" do
                             "Veterans Service Organization or representative, if you have one, or contact the "\
                             "hearing coordinator for your region. For a list of hearing coordinators by region "\
                             "with contact information, please visit https://www.bva.va.gov.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-06",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-06",
                             event_type: "VSO IHP pending", notification_type: "Email and SMS", recipient_email: nil,
                             recipient_phone_number: nil, email_notification_status: "Success",
                             sms_notification_status: "Success",
@@ -63,7 +63,7 @@ RSpec.feature "Notifications View" do
                             "has been assigned to your Veterans Service Organization to provide written argument. "\
                             "Once the argument has been received, the Board of Veterans' Appeals will resume "\
                             "processing of your appeal.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-07",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-07",
                             event_type: "VSO IHP complete", notification_type: "Email and SMS",
                             recipient_email: nil, recipient_phone_number: nil, email_notification_status: "Success",
                             sms_notification_status: "Success",
@@ -72,7 +72,7 @@ RSpec.feature "Notifications View" do
                             "it must work cases in docket order (the order received). If you have any questions "\
                             "please reach out to your Veterans Service Organization or log onto VA.gov for additional "\
                             "information.")
-      create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2022-11-08",
+      create(:notification, appeals_id: appeals_id, appeals_type: appeal.class.name, event_date: "2022-11-08",
                             event_type: "Appeal decision mailed (Non-contested claims)",
                             notification_type: "Email and SMS", recipient_email: nil, recipient_phone_number: nil,
                             email_notification_status: "Success", sms_notification_status: "permanent-failure",
@@ -80,461 +80,212 @@ RSpec.feature "Notifications View" do
                             "that will be sent to you and to your representative, if you have one, shortly.")
     end
 
-    before(:example) do
-      appeal
-      # ensure backend code runs for visiting queue app before going to notifications pages
-      visit "queue/appeals/#{appeal.uuid}"
+    before do
+      Seeds::NotificationEvents.new.seed!
+      seed_notifications
     end
 
-    context "without notifications" do
-      scenario "notification page link will not show up" do
-        visit "queue/appeals/#{appeal.uuid}"
-        expect(page).to have_no_link("View notifications sent to appellant")
-      end
+    it "notifications page link appears, page has full table of notifications and correct information in first row" do
+      visit appeal_case_details_page
+      click_link("View notifications sent to appellant")
+      # notifications page opens in new browser window so go to that window
+      page.switch_to_window(page.windows.last)
+      expect(page).to have_current_path(appeal_notifications_page)
+
+      # table is filled with notifications
+      table = page.find("tbody")
+      expect(table).to have_selector("tr", count: 15)
+
+      # correct event type
+      event_type_cell = page.find("td", match: :first)
+      expect(event_type_cell).to have_content("Appeal docketed")
+
+      # correct notification date
+      date_cell = page.all("td", minimum: 1)[1]
+      expect(date_cell).to have_content("11/01/2022")
+
+      # correct notification type
+      notification_type_cell = page.all("td", minimum: 1)[2]
+      expect(notification_type_cell).to have_content("Email")
+
+      # correct recipient information
+      recipient_info_cell = page.all("td", minimum: 1)[3]
+      expect(recipient_info_cell).to have_content("example@example.com")
+
+      # correct status
+      status_cell = page.all("td", minimum: 1)[4]
+      expect(status_cell).to have_content("Delivered")
     end
 
-    context "with notifications" do
-      before(:example) do
-        seed_ama_notifications
-      end
+    it "table can sort by date, filter by each column, and filter by multiple columns at once" do
+      visit(appeal_notifications_page)
 
-      scenario "visits notifications page for ama appeal" do
-        visit "queue/appeals/#{appeal.uuid}"
-        click_link("View notifications sent to appellant")
-        page.switch_to_window(page.windows.last)
-        expect(page).to have_current_path("/queue/appeals/#{appeal.uuid}/notifications")
-      end
+      # sort by notification date
+      sort = page.all("svg", class: "table-icon", minimum: 1)[1]
+      sort.click(x: 5, y: 5)
+      cell = page.all("td", minimum: 1)[1]
+      expect(cell).to have_content("11/08/2022")
 
-      scenario "sees correct event type in first row of table" do
-        visit(ama_notifications_page)
-        cell = page.find("td", match: :first)
-        expect(cell).to have_content("Appeal docketed")
-      end
+      # revert sort change
+      sort.click(x: 5, y: 5)
+      cell = page.all("td", minimum: 1)[1]
+      expect(cell).to have_content("11/01/2022")
 
-      scenario "sees correct notification date in first row of table" do
-        visit(ama_notifications_page)
-        cell = page.all("td", minimum: 1)[1]
-        expect(cell).to have_content("11/01/2022")
-      end
+      # by event type
+      filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
+      filter.click(x: 5, y: 5)
+      filter_option = page.find("li", class: "cf-filter-option-row", text: "Appeal docketed")
+      filter_option.click(x: 5, y: 5)
+      table = page.find("tbody")
+      cells = table.all("td", minimum: 1)
+      expect(table).to have_selector("tr", count: 2)
+      expect(cells[0]).to have_content("Appeal docketed")
+      expect(cells[5]).to have_content("Appeal docketed")
 
-      scenario "sees correct notification type in first row of table" do
-        visit(ama_notifications_page)
-        cell = page.all("td", minimum: 1)[2]
-        expect(cell).to have_content("Email")
-      end
+      # clear filter
+      filter.click(x: 5, y: 5)
+      page.find("button", text: "Clear Event filter").click
 
-      scenario "sees correct recipient information in first row of table" do
-        visit(ama_notifications_page)
-        cell = page.all("td", minimum: 1)[3]
-        expect(cell).to have_content("example@example.com")
-      end
+      # by notification type
+      filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[1]
+      filter.click(x: 5, y: 5)
+      filter_option = page.find("li", class: "cf-filter-option-row", text: "Email")
+      filter_option.click(x: 5, y: 5)
+      table = page.find("tbody")
+      cells = table.all("td", minimum: 1)
+      expect(table).to have_selector("tr", count: 8)
+      expect(cells[2]).to have_content("Email")
+      expect(cells[37]).to have_content("Email")
 
-      scenario "sees correct status in first row of table" do
-        visit(ama_notifications_page)
-        cell = page.all("td", minimum: 1)[4]
-        expect(cell).to have_content("Delivered")
-      end
+      # clear filter
+      filter.click(x: 5, y: 5)
+      page.find("button", text: "Clear Notification type filter").click
 
-      scenario "table is filled with a full page of notifications" do
-        visit(ama_notifications_page)
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 15)
-      end
+      # by recipient information
+      filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[2]
+      filter.click(x: 5, y: 5)
+      filter_option = page.find("li", class: "cf-filter-option-row", text: "Example@example.com")
+      filter_option.click(x: 5, y: 5)
+      table = page.find("tbody")
+      cells = table.all("td", minimum: 1)
+      expect(table).to have_selector("tr", count: 4)
+      expect(cells[3]).to have_content("example@example.com")
+      expect(cells[18]).to have_content("example@example.com")
 
-      scenario "can filter by event type" do
-        visit(ama_notifications_page)
-        filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Appeal docketed")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 2)
-        expect(cells[0]).to have_content("Appeal docketed")
-        expect(cells[5]).to have_content("Appeal docketed")
-      end
+      # clear filter
+      filter.click(x: 5, y: 5)
+      page.find("button", text: "Clear Recipient information filter").click
 
-      scenario "can filter by notification type" do
-        visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[1]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Email")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 8)
-        expect(cells[2]).to have_content("Email")
-        expect(cells[37]).to have_content("Email")
-      end
+      # by status
+      filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[3]
+      filter.click(x: 5, y: 5)
+      filter_option = page.find("li", class: "cf-filter-option-row", text: "Delivered")
+      filter_option.click(x: 5, y: 5)
+      table = page.find("tbody")
+      cells = table.all("td", minimum: 1)
+      expect(table).to have_selector("tr", count: 5)
+      expect(cells[4]).to have_content("Delivered")
+      expect(cells[24]).to have_content("Delivered")
 
-      scenario "can filter by recipient information" do
-        visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[2]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Example@example.com")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 4)
-        expect(cells[3]).to have_content("example@example.com")
-        expect(cells[18]).to have_content("example@example.com")
-      end
+      # clear filter
+      filter.click(x: 5, y: 5)
+      page.find("button", text: "Clear Status filter").click
 
-      scenario "can filter by status" do
-        visit(ama_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[3]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Delivered")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 5)
-        expect(cells[4]).to have_content("Delivered")
-        expect(cells[24]).to have_content("Delivered")
-      end
-
-      scenario "can filter mutliple columns at once" do
-        visit(ama_notifications_page)
-        filters = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)
-        filters[0].click(x: 5, y: 5)
-        page.find("li", class: "cf-filter-option-row", text: "Hearing scheduled").click(x: 5, y: 5)
-        filters[1].click(x: 5, y: 5)
-        page.find("li", class: "cf-filter-option-row", text: "Text").click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 1)
-        expect(cells[0]).to have_content("Hearing scheduled")
-        expect(cells[2]).to have_content("Text")
-      end
-
-      scenario "can sort by notification date" do
-        visit(ama_notifications_page)
-        sort = page.all("svg", class: "table-icon", minimum: 1)[1]
-        sort.click(x: 5, y: 5)
-        cell = page.all("td", minimum: 1)[1]
-        expect(cell).to have_content("11/08/2022")
-      end
-
-      scenario "can move to next page of notifications" do
-        visit(ama_notifications_page)
-        click_on("Next", match: :first)
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 1)
-      end
-
-      scenario "clicking on a numbered page button will render that page" do
-        visit(ama_notifications_page)
-        pagination = page.find(class: "cf-pagination-pages", match: :first)
-        pagination.find("Button", text: "2", match: :first).click
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 1)
-      end
-
-      scenario "next button disabled when on the last page" do
-        visit(ama_notifications_page)
-        click_on("Next", match: :first)
-        expect(page).to have_button("Next", disabled: true)
-      end
-
-      scenario "prev button moves to previous page" do
-        visit(ama_notifications_page)
-        click_on("Next", match: :first)
-        click_on("Prev", match: :first)
-        cell = page.find("td", match: :first)
-        expect(cell).to have_content("Appeal docketed")
-      end
-
-      scenario "prev button disabled on the first page" do
-        visit(ama_notifications_page)
-        expect(page).to have_button("Prev", disabled: true)
-      end
-
-      scenario "modal appears when clicking on an event type" do
-        visit(ama_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        expect(page).to have_selector("div", class: "cf-modal-body")
-      end
-
-      scenario "background darkened and disables clicking after opening modal" do
-        visit(ama_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        expect(page).to have_selector("section", id: "modal_id")
-      end
-
-      scenario "closing the modal should remove the dark background and the modal" do
-        visit(ama_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        click_on("Close")
-        expect(page).not_to have_selector("div", class: "cf-modal-body")
-        expect(page).not_to have_selector("section", id: "modal_id")
-      end
+      # by multiple columns at once
+      filters = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)
+      filters[0].click(x: 5, y: 5)
+      page.find("li", class: "cf-filter-option-row", text: "Hearing scheduled").click(x: 5, y: 5)
+      filters[1].click(x: 5, y: 5)
+      page.find("li", class: "cf-filter-option-row", text: "Text").click(x: 5, y: 5)
+      table = page.find("tbody")
+      cells = table.all("td", minimum: 1)
+      expect(table).to have_selector("tr", count: 1)
+      expect(cells[0]).to have_content("Hearing scheduled")
+      expect(cells[2]).to have_content("Text")
     end
+
+    it "notification page can properly navigate pages and event modal behaves properly" do
+      visit(appeal_notifications_page)
+
+      # next button moves to next page
+      click_on("Next", match: :first)
+      table = page.find("tbody")
+      expect(table).to have_selector("tr", count: 1)
+
+      # next button disabled while on last page
+      expect(page).to have_button("Next", disabled: true)
+
+      # prev button moves to previous page
+      click_on("Prev", match: :first)
+      event_type_cell = page.find("td", match: :first)
+      expect(event_type_cell).to have_content("Appeal docketed")
+
+      # prev button disabled on the first page
+      expect(page).to have_button("Prev", disabled: true)
+
+      # clicking numbered page button renders correct page
+      pagination = page.find(class: "cf-pagination-pages", match: :first)
+      pagination.find("Button", text: "2", match: :first).click
+      table = page.find("tbody")
+      expect(table).to have_selector("tr", count: 1)
+
+      # modal appears when clicking on an event type
+      event_type_cell = page.find("td", match: :first).find("a")
+      event_type_cell.click
+      expect(page).to have_selector("div", class: "cf-modal-body")
+
+      # background darkens and disables clicking when modal is open
+      expect(page).to have_selector("section", id: "modal_id")
+
+      # clicking close button on modal removes dark background and closes modal
+      click_on("Close")
+      expect(page).not_to have_selector("div", class: "cf-modal-body")
+      expect(page).not_to have_selector("section", id: "modal_id")
+    end
+
+    # it "modal behaves properly" do
+    #   visit(appeal_notifications_page)
+
+    #   # modal appears when clicking on an event type
+    #   event_type_cell = page.find("td", match: :first).find("a")
+    #   event_type_cell.click
+    #   expect(page).to have_selector("div", class: "cf-modal-body")
+
+    #   # background darkens and disables clicking when modal is open
+    #   expect(page).to have_selector("section", id: "modal_id")
+
+    #   # clicking close button on modal removes dark background and closes modal
+    #   click_on("Close")
+    #   expect(page).not_to have_selector("div", class: "cf-modal-body")
+    #   expect(page).not_to have_selector("section", id: "modal_id")
+    # end
+  end
+
+  # rubocop:disable Style/BlockDelimiters
+  context "ama appeal" do
+    let(:appeal) { create(:appeal) }
+    let(:appeals_id) { appeal.uuid }
+    let(:appeal_case_details_page) { "/queue/appeals/#{appeal.uuid}" }
+    let(:appeal_notifications_page) { "/queue/appeals/#{appeal.uuid}/notifications" }
+
+    before { appeal }
+
+    context "without notifications" do include_examples "without notifications"; end
+
+    context "with notifications" do include_examples "with notifications"; end
   end
 
   context "legacy appeal" do
-    let(:legacy_appeal) do
-      create(:legacy_appeal, :with_veteran,
-             vacols_case: create(:case, :aod))
-    end
-    let(:legacy_notifications_page) { "queue/appeals/#{legacy_appeal.vacols_id}/notifications" }
-    let(:seed_legacy_notifications) do
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-01",
-                            event_type: "Appeal docketed", notification_type: "Email and SMS",
-                            recipient_email: "example@example.com",recipient_phone_number: "555-555-5555",
-                            email_notification_status: "delivered", sms_notification_status: "delivered",
-                            notification_content: "Your appeal at the Board of Veteran's Appeals has been docketed. "\
-                            "We must work cases in the order your VA Form 9 substantive appeal (for Legacy) or VA "\
-                            "Form 10182 (for AMA) was received. We will update you with any progress. If you have "\
-                            "any questions please reach out to your Veterans Service Organization or representative "\
-                            "or log onto VA.gov for additional information.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-02",
-                            event_type: "Hearing scheduled", notification_type: "Email and SMS",
-                            recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
-                            notification_content: "Your hearing has been scheduled with a Veterans Law Judge at the "\
-                            "Board of Veterans' Appeals. You will be notified of the details in writing shortly.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-03",
-                            event_type: "Privacy Act request pending", notification_type: "Email and SMS",
-                            recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
-                            notification_content: "You or your representative filed a Privacy Act request. The Board "\
-                            "placed your appeal on hold until this request is satisfied.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-04",
-                            event_type: "Privacy Act request complete", notification_type: "Email and SMS",
-                            recipient_email: "example@example.com", recipient_phone_number: nil,
-                            email_notification_status: "delivered",  sms_notification_status: "temporary-failure",
-                            notification_content: "The Privacy Act request has been satisfied and the Board will "\
-                            "continue processing your appeal at this time. The Board must work cases in docket order "\
-                            "(the order received) If you have any questions please reach out to your Veterans Service "\
-                            "Organization or representative, if you have one, or log onto VA.gov for additional "\
-                            "information")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-05",
-                            event_type: "Withdrawal of hearing", notification_type: "Email and SMS",
-                            recipient_email: nil, recipient_phone_number: nil, email_notification_status: "Success",
-                            sms_notification_status: "temporary-failure",
-                            notification_content: "You or your representative have requested to withdraw your hearing "\
-                            "request. The Board will continue processing your appeal, but it must work cases in "\
-                            "docket order (the order received). For more information please reach out to your "\
-                            "Veterans Service Organization or representative, if you have one, or contact the "\
-                            "hearing coordinator for your region. For a list of hearing coordinators by region "\
-                            "with contact information, please visit https://www.bva.va.gov.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-06",
-                            event_type: "VSO IHP pending", notification_type: "Email and SMS", recipient_email: nil,
-                            recipient_phone_number: nil, email_notification_status: "Success",
-                            sms_notification_status: "Success",
-                            notification_content: "You filed an appeal with the Board of Veterans' Appeals. Your case "\
-                            "has been assigned to your Veterans Service Organization to provide written argument. "\
-                            "Once the argument has been received, the Board of Veterans' Appeals will resume "\
-                            "processing of your appeal.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-07",
-                            event_type: "VSO IHP complete", notification_type: "Email and SMS",
-                            recipient_email: nil, recipient_phone_number: nil, email_notification_status: "Success",
-                            sms_notification_status: "Success",
-                            notification_content: "The Board of Veterans' Appeals received the written argument from "\
-                            "your Veterans Service Organization. The Board will continue processing your appeal, but "\
-                            "it must work cases in docket order (the order received). If you have any questions "\
-                            "please reach out to your Veterans Service Organization or log onto VA.gov for additional "\
-                            "information.")
-      create(:notification, appeals_id: legacy_appeal.vacols_id, appeals_type: "LegacyAppeal", event_date: "2022-11-08",
-                            event_type: "Appeal decision mailed (Non-contested claims)",
-                            notification_type: "Email and SMS", recipient_email: nil, recipient_phone_number: nil,
-                            email_notification_status: "Success", sms_notification_status: "permanent-failure",
-                            notification_content: "The Board of Veterans' Appeals issued a decision on your appeal "\
-                            "that will be sent to you and to your representative, if you have one, shortly.")
-    end
+    let(:appeal) { create(:legacy_appeal, :with_veteran, vacols_case: create(:case, :aod)) }
+    let(:appeals_id) { appeal.vacols_id }
+    let(:appeal_case_details_page) { "/queue/appeals/#{appeal.vacols_id}" }
+    let(:appeal_notifications_page) { "/queue/appeals/#{appeal.vacols_id}/notifications" }
 
-    before(:example) do
-      legacy_appeal
-    end
+    before { appeal }
 
-    context "without notifications" do
-      scenario "notification page link will not show up" do
-        visit "queue/appeals/#{legacy_appeal.vacols_id}"
-        expect(page).to have_no_link("View notifications sent to appellant")
-      end
-    end
+    context "without notifications" do include_examples "without notifications"; end
 
-    context "with notifications" do
-      before(:example) do
-        seed_legacy_notifications
-      end
-
-      scenario "visits notifications page for legacy appeal" do
-        visit "queue/appeals/#{legacy_appeal.vacols_id}"
-        click_link("View notifications sent to appellant")
-        page.switch_to_window(page.windows.last)
-        expect(page).to have_current_path("/queue/appeals/#{legacy_appeal.vacols_id}/notifications")
-      end
-
-      scenario "sees correct event type in first row of table" do
-        visit(legacy_notifications_page)
-        cell = page.find("td", match: :first)
-        expect(cell).to have_content("Appeal docketed")
-      end
-
-      scenario "sees correct notification date in first row of table" do
-        visit(legacy_notifications_page)
-        cell = page.all("td", minimum: 1)[1]
-        expect(cell).to have_content("11/01/2022")
-      end
-
-      scenario "sees correct notification type in first row of table" do
-        visit(legacy_notifications_page)
-        cell = page.all("td", minimum: 1)[2]
-        expect(cell).to have_content("Email")
-      end
-
-      scenario "sees correct recipient information in first row of table" do
-        visit(legacy_notifications_page)
-        cell = page.all("td", minimum: 1)[3]
-        expect(cell).to have_content("example@example.com")
-      end
-
-      scenario "sees correct status in first row of table" do
-        visit(legacy_notifications_page)
-        cell = page.all("td", minimum: 1)[4]
-        expect(cell).to have_content("Delivered")
-      end
-
-      scenario "table is filled with a full page of notifications" do
-        visit(legacy_notifications_page)
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 15)
-      end
-
-      scenario "can filter by event type" do
-        visit(legacy_notifications_page)
-        filter = page.find("rect", class: "unselected-filter-icon-border-1", match: :first)
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Appeal docketed")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 2)
-        expect(cells[0]).to have_content("Appeal docketed")
-        expect(cells[5]).to have_content("Appeal docketed")
-      end
-
-      scenario "can filter by notification type" do
-        visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[1]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Email")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 8)
-        expect(cells[2]).to have_content("Email")
-        expect(cells[37]).to have_content("Email")
-      end
-
-      scenario "can filter by recipient information" do
-        visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[2]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Example@example.com")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 4)
-        expect(cells[3]).to have_content("example@example.com")
-        expect(cells[18]).to have_content("example@example.com")
-      end
-
-      scenario "can filter by status" do
-        visit(legacy_notifications_page)
-        filter = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)[3]
-        filter.click(x: 5, y: 5)
-        filter_option = page.find("li", class: "cf-filter-option-row", text: "Delivered")
-        filter_option.click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 5)
-        expect(cells[4]).to have_content("Delivered")
-        expect(cells[24]).to have_content("Delivered")
-      end
-
-      scenario "can filter mutliple columns at once" do
-        visit(legacy_notifications_page)
-        filters = page.all("rect", class: "unselected-filter-icon-border-1", minimum: 1)
-        filters[0].click(x: 5, y: 5)
-        page.find("li", class: "cf-filter-option-row", text: "Hearing scheduled").click(x: 5, y: 5)
-        filters[1].click(x: 5, y: 5)
-        page.find("li", class: "cf-filter-option-row", text: "Text").click(x: 5, y: 5)
-        table = page.find("tbody")
-        cells = table.all("td", minimum: 1)
-        expect(table).to have_selector("tr", count: 1)
-        expect(cells[0]).to have_content("Hearing scheduled")
-        expect(cells[2]).to have_content("Text")
-      end
-
-      scenario "can sort by notification date" do
-        visit(legacy_notifications_page)
-        sort = page.all("svg", class: "table-icon", minimum: 1)[1]
-        sort.click(x: 5, y: 5)
-        cell = page.all("td", minimum: 1)[1]
-        expect(cell).to have_content("11/08/2022")
-      end
-
-      scenario "can move to next page of notifications" do
-        visit(legacy_notifications_page)
-        click_on("Next", match: :first)
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 1)
-      end
-
-      scenario "clicking on a numbered page button will render that page" do
-        visit(legacy_notifications_page)
-        pagination = page.find(class: "cf-pagination-pages", match: :first)
-        pagination.find("Button", text: "2", match: :first).click
-        table = page.find("tbody")
-        expect(table).to have_selector("tr", count: 1)
-      end
-
-      scenario "next button disabled when on the last page" do
-        visit(legacy_notifications_page)
-        click_on("Next", match: :first)
-        expect(page).to have_button("Next", disabled: true)
-      end
-
-      scenario "prev button moves to previous page" do
-        visit(legacy_notifications_page)
-        click_on("Next", match: :first)
-        click_on("Prev", match: :first)
-        cell = page.find("td", match: :first)
-        expect(cell).to have_content("Appeal docketed")
-      end
-
-      scenario "prev button disabled on the first page" do
-        visit(legacy_notifications_page)
-        expect(page).to have_button("Prev", disabled: true)
-      end
-
-      scenario "modal appears when clicking on an event type" do
-        visit(legacy_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        expect(page).to have_selector("div", class: "cf-modal-body")
-      end
-
-      scenario "background darkened and disables clicking after opening modal" do
-        visit(legacy_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        expect(page).to have_selector("section", id: "modal_id")
-      end
-
-      scenario "closing the modal should remove the dark background and the modal" do
-        visit(legacy_notifications_page)
-        cell = page.find("td", match: :first)
-        cell.click
-        click_on("Close")
-        expect(page).not_to have_selector("div", class: "cf-modal-body")
-        expect(page).not_to have_selector("section", id: "modal_id")
-      end
-    end
+    context "with notifications" do include_examples "with notifications"; end
   end
+  # rubocop:enable Style/BlockDelimiters
 end

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
 
       click_on "Save"
 
-      expect(page).to have_content "This field is required"
+      expect(page).to have_content "Text box field is required"
       fill_in "Text Box", with: decision_issue_text
 
       find(".cf-select__control", text: "Select disposition").click

--- a/spec/feature/queue/case_assignment_spec.rb
+++ b/spec/feature/queue/case_assignment_spec.rb
@@ -129,7 +129,7 @@ RSpec.feature "Case Assignment flows", :all_dbs do
       # step "tries to submit incomplete actions, corrects error"
       click_on COPY::ADD_COLOCATED_TASK_SUBMIT_BUTTON_LABEL
 
-      expect(page).to have_content COPY::FORM_ERROR_FIELD_REQUIRED
+      expect(page).to have_content COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED
 
       within all('div[id^="action_"]')[1] do
         fill_in COPY::ADD_COLOCATED_TASK_INSTRUCTIONS_LABEL, with: generate_words(4)

--- a/spec/feature/queue/colocated_task_queue_spec.rb
+++ b/spec/feature/queue/colocated_task_queue_spec.rb
@@ -130,8 +130,8 @@ RSpec.feature "ColocatedTask", :all_dbs do
         find("div", class: "cf-select__option", text: "#{hold_duration_days} days").click
         click_on(COPY::MODAL_SUBMIT_BUTTON)
 
-        # Instructions field is required
-        expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
+        # Notes field is required
+        expect(page).to have_content(COPY::NOTES_ERROR_FIELD_REQUIRED)
 
         # Add instructions and try again
         fill_in("instructions", with: "some text")

--- a/spec/feature/queue/colocated_task_queue_spec.rb
+++ b/spec/feature/queue/colocated_task_queue_spec.rb
@@ -131,7 +131,7 @@ RSpec.feature "ColocatedTask", :all_dbs do
         click_on(COPY::MODAL_SUBMIT_BUTTON)
 
         # Instructions field is required
-        expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+        expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
 
         # Add instructions and try again
         fill_in("instructions", with: "some text")
@@ -187,7 +187,7 @@ RSpec.feature "ColocatedTask", :all_dbs do
       find("button", text: COPY::CHANGE_TASK_TYPE_SUBHEAD).click
 
       # Instructions field is required
-      expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+      expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
 
       # Add instructions and try again
       instructions = generate_words(5)

--- a/spec/feature/queue/mail_task_spec.rb
+++ b/spec/feature/queue/mail_task_spec.rb
@@ -120,7 +120,7 @@ RSpec.feature "MailTasks", :postgres do
       find("button", text: COPY::CHANGE_TASK_TYPE_SUBHEAD).click
 
       # Instructions field is required
-      expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+      expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
 
       # Add instructions and try again
       new_instructions = generate_words(5)

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -960,7 +960,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         expect(page).to have_content(COPY::PRE_DOCKET_MODAL_BODY)
 
         find("button", text: COPY::MODAL_RETURN_BUTTON).click
-        expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+        expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
 
         instructions_textarea = find("textarea", id: "taskInstructions")
         instructions_textarea.send_keys("Incorrect RPO. Please review.")

--- a/spec/feature/queue/special_case_movement_task_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
 
         # Validate before moving on
         click_on "Continue"
-        expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
+        expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
         find("label", text: "Death dismissal").click
         fill_in("cancellationInstructions", with: "Instructions for cancellation")
         click_on "Continue"

--- a/spec/feature/queue/task_queue_spec.rb
+++ b/spec/feature/queue/task_queue_spec.rb
@@ -674,7 +674,7 @@ feature "Task queue", :all_dbs do
         expect(page).to have_content(
           format(COPY::ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION, organization.name)
         )
-        page.find_all("path.unselected-filter-icon-inner").first.click
+        page.find_all("path.unselected-filter-icon-inner-1").first.click
         expect(page).to have_content("#{Task.label} (#{unassigned_count / 2})")
         expect(page).to have_content("#{FoiaTask.label} (#{foia_task_count})")
       end
@@ -682,7 +682,7 @@ feature "Task queue", :all_dbs do
       it "filters tasks correctly and updates the url" do
         visit(organization.path)
         expect(find("tbody").find_all("tr").length).to eq(unassigned_count)
-        page.find_all("path.unselected-filter-icon-inner").first.click
+        page.find_all("path.unselected-filter-icon-inner-1").first.click
         page.find("label", text: "#{FoiaTask.label} (#{foia_task_count})").click
         expect(find("tbody").find_all("tr").length).to eq(foia_task_count)
         expect(URI.parse(current_url).query).to eq "#{default_query_string}&#{query_string}"

--- a/spec/jobs/retrieve_and_cache_reader_documents_job_spec.rb
+++ b/spec/jobs/retrieve_and_cache_reader_documents_job_spec.rb
@@ -23,7 +23,7 @@ describe RetrieveAndCacheReaderDocumentsJob, :postgres do
       end
       let(:high_priority_task3) do
         create(
-          :ama_task,
+          :task,
           assigned_to: user2, status: Constants.TASK_STATUSES.assigned, assigned_to_type: User.name,
           type: JudgeAssignTask.name, appeal: appeal2
         )
@@ -42,9 +42,11 @@ describe RetrieveAndCacheReaderDocumentsJob, :postgres do
         [high_priority_task1, high_priority_task2, high_priority_task3, high_priority_task4]
       end
 
+      # .sort will convert the hash output of subject to an array and sort by User ID, without
+      # sort the test can fail due to the ActiveRecord in subject returning user2 before user1
       it "should only fetch tasks assigned to user" do
-        returned_user1_task1 = subject.to_a[0][1][0]
-        returned_user2_task3 = subject.to_a[1][1][0]
+        returned_user1_task1 = subject.sort[0][1][0]
+        returned_user2_task3 = subject.sort[1][1][0]
 
         expect(returned_user1_task1.assigned_to_id).to eq(user1.id)
         expect(returned_user1_task1.assigned_to_id).to_not eq(user2.id)
@@ -52,8 +54,8 @@ describe RetrieveAndCacheReaderDocumentsJob, :postgres do
         expect(returned_user2_task3.assigned_to_id).to_not eq(user1.id)
       end
       it "should only fetch documents assigned to user" do
-        returned_user2 = subject.to_a[1][0]
-        returned_user2_task3 = subject.to_a[1][1][0]
+        returned_user2 = subject.sort[1][0]
+        returned_user2_task3 = subject.sort[1][1][0]
 
         expect(user2.efolder_documents_fetched_at).to be_nil
         expect(returned_user2_task3.assigned_to_id).to eq(user2.id)

--- a/spec/jobs/retrieve_and_cache_reader_documents_job_spec.rb
+++ b/spec/jobs/retrieve_and_cache_reader_documents_job_spec.rb
@@ -44,6 +44,7 @@ describe RetrieveAndCacheReaderDocumentsJob, :postgres do
 
       # .sort will convert the hash output of subject to an array and sort by User ID, without
       # sort the test can fail due to the ActiveRecord in subject returning user2 before user1
+      # rubocop:disable Style/RedundantSort
       it "should only fetch tasks assigned to user" do
         returned_user1_task1 = subject.sort[0][1][0]
         returned_user2_task3 = subject.sort[1][1][0]
@@ -61,6 +62,7 @@ describe RetrieveAndCacheReaderDocumentsJob, :postgres do
         expect(returned_user2_task3.assigned_to_id).to eq(user2.id)
         expect(returned_user2.efolder_documents_fetched_at).to_not be_nil
       end
+      # rubocop:enable Style/RedundantSort
     end
   end
 end

--- a/spec/models/dispatch/task_spec.rb
+++ b/spec/models/dispatch/task_spec.rb
@@ -78,7 +78,8 @@ describe Dispatch::Task, :postgres do
       FakeTask.create(aasm_state: :reviewed, completed_at: Time.zone.now)
     end
 
-    it { is_expected.to eq([task_completed_this_morning, task_completed_tonight]) }
+    # .sort added in case ActiveRecord returns tasks out of order in subject
+    it { is_expected.to eq([task_completed_this_morning, task_completed_tonight].sort) }
   end
 
   context ".completed_success" do


### PR DESCRIPTION
- added dummy class to <rect> in UnselectedFilterIcon to fix rspec tests
- changed constants in tests to match updates to components
- added safe navigation operators to CaseTimelinessTimeline.jsx to prevent Evaluate Decision page from crashing on a case that was returned to a judge by BVA Dispatch
- modified static_test_data seed to not require the Users seed to have already been run
- added .sort() to retrieve_and_cache_reader_documents_job_spec.rb and task_spec.rb to prevent flaky test if ActiveRecord returns objects in an unexpected order
- refactored appeal_notifications_page_spec.rb to use shared examples for AMA and legacy scenarios, and reduce the run time by combining similar tests to minimize the number of database wipes