### PR TITLE
fix previous task assigned on to match priorloc to decass date

### DIFF
--- a/app/models/legacy_tasks/judge_legacy_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_task.rb
@@ -16,8 +16,10 @@ class JudgeLegacyTask < LegacyTask
       # sets previous_task.assigned_on to the first time the case was sent to the attorney
       # or the associated decass value if a priorloc doesn't exist
       assigned_at_time =
-        appeal.location_history.filter(&:with_attorney?).first&.locdout.try(:to_datetime) ||
-        record.assigned_to_attorney_date.try(:to_datetime)
+        appeal.location_history
+          .filter(&:with_attorney?)
+          .filter { |loc| loc.locdout.to_date == record.assigned_to_attorney_date.to_date }
+          .first&.locdout.try(:to_datetime) || record.assigned_to_attorney_date.try(:to_datetime)
 
       JudgeLegacyDecisionReviewTask.new(
         task.instance_values.merge("previous_task" => LegacyTask.new(assigned_at: assigned_at_time))

--- a/db/seeds/static_test_data.rb
+++ b/db/seeds/static_test_data.rb
@@ -365,6 +365,10 @@ module Seeds
       create(:priorloc, lockey: vc.bfkey, locdin: 4.weeks.ago, locdout: 5.weeks.ago, locstout: judge.slogid, locstto: "CASEFLOW_judge")
       create(:priorloc, lockey: vc.bfkey, locdin: 3.weeks.ago, locdout: 4.weeks.ago, locstout: "CASEFLOW_judge", locstto: judge.slogid)
       create(:priorloc, lockey: vc.bfkey, locdin: 2.weeks.ago, locdout: 3.weeks.ago, locstout: judge.slogid, locstto: atty.slogid)
+      # set DECASS value correctly to match the above priorloc
+      decass = VACOLS::Decass.find_by(defolder: vc.bfkey)
+      decass.deassign = 3.weeks.ago.to_date
+      decass.save!
       create(:priorloc, lockey: vc.bfkey, locdin: 1.week.ago, locdout: 2.weeks.ago, locstout: atty.slogid, locstto: "CASEFLOW_atty")
       create(:priorloc, lockey: vc.bfkey, locdin: Time.zone.now, locdout: 1.week.ago, locstout: "CASEFLOW_atty", locstto: atty.slogid)
       create(:priorloc, lockey: vc.bfkey, locdout: Time.zone.now, locstout: atty.slogid, locstto: judge.slogid)

--- a/db/seeds/static_test_data.rb
+++ b/db/seeds/static_test_data.rb
@@ -357,8 +357,8 @@ module Seeds
     def case_with_bad_decass_for_timeline_range_checks
       Time.zone = 'EST'
       vet = create_veteran
-      judge = VACOLS::Staff.find_by_css_id("BVABDANIEL")
-      atty = VACOLS::Staff.find_by_css_id("BVABBLOCK")
+      judge = VACOLS::Staff.find_or_create_by(sdomainid: "BVABDANIEL")
+      atty = VACOLS::Staff.find_or_create_by(sdomainid: "BVABBLOCK")
       vc = create(:case, :assigned, user: User.find_by_css_id("BVABDANIEL"), bfcorlid: "#{vet.file_number}S")
       create(:legacy_appeal, vacols_case: vc)
       create(:priorloc, lockey: vc.bfkey, locdin: 5.weeks.ago, locdout: 5.weeks.ago - 1.day, locstout: judge.slogid, locstto: judge.slogid)


### PR DESCRIPTION
Resolves APPEALS-12712

### Description
- Modified judge_legacy_task previous_task.assigned_at to match decass.deassign to a  priorloc.with_attorney? instead of just getting the first priorloc.with_attorney?