### PR TITLE
Min/APPEALS-13520

### DIFF
--- a/app/jobs/hearings/travel_board_hearing_sync_job.rb
+++ b/app/jobs/hearings/travel_board_hearing_sync_job.rb
@@ -24,7 +24,8 @@ class Hearings::TravelBoardHearingSyncJob < CaseflowJob
   # Return:  The vacols appeals that just got had their location codes updated to caseflow
   def create_schedule_hearing_tasks(legacy_appeals)
     log_info("Constructing task tree for new travel board legacy appeals...")
-    (legacy_appeals || []).each do |appeal|
+    appeals = legacy_appeals || []
+    appeals.each do |appeal|
       begin
         root_task = RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
         ScheduleHearingTask.create!(appeal: appeal, parent: root_task)

--- a/app/jobs/hearings/travel_board_hearing_sync_job.rb
+++ b/app/jobs/hearings/travel_board_hearing_sync_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class TravelBoardHearingSyncJob < CaseflowJob
+  queue_with_priority :low_priority
+
+  # Active Job that syncs all travel board hearing from vacols onto Caseflow
+  def perform
+    fetch_vacols_travel_board_appeals(fetch_all_vacols_ids)
+  end
+
+  private
+
+  def fetch_all_vacols_ids
+    LegacyAppeal.all.pluck(:vacols_id)
+  end
+
+  def fetch_vacols_travel_board_appeals(exclude_ids)
+    VACOLS::Case
+      .where(
+        # Travel Board Hearing Request
+        bfhr: VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value],
+        # Current Location
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        # Video Hearing Request Indicator
+        bfdocind: nil,
+        # Datetime of Decision
+        bfddec: nil
+      )
+      .where.not(bfkey: exclude_ids)
+      .includes(:correspondent, :folder, :case_issues)
+      .map do |vacols_case|
+        AppealRepository.build_appeal(vacols_case, true)
+      end
+  end
+end

--- a/app/jobs/hearings/travel_board_hearing_sync_job.rb
+++ b/app/jobs/hearings/travel_board_hearing_sync_job.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TravelBoardHearingSyncJob < CaseflowJob
+class Hearings::TravelBoardHearingSyncJob < CaseflowJob
   queue_with_priority :low_priority
 
   before_perform do |job|
@@ -33,6 +33,10 @@ class TravelBoardHearingSyncJob < CaseflowJob
   # Purpose: Logging info messages to the console
   def log_info(message)
     Rails.logger.info(message)
+  end
+
+  def log_error(message)
+    Rails.logger.error(message)
   end
 
   # Purpose: Fetches a list of all vacols ids from the database
@@ -68,7 +72,7 @@ class TravelBoardHearingSyncJob < CaseflowJob
         begin
           AppealRepository.build_appeal(vacols_case, true)
         rescue Exception => error
-          Rails.logger.error("#{error.class}: #{error.message} for vacols id:#{vacols_case.bfkey} on #{JOB_ATTR.class} of ID:#{JOB_ATTR.job_id}\n #{error.backtrace.join("\n")}")
+          log_error("#{error.class}: #{error.message} for vacols id:#{vacols_case.bfkey} on #{JOB_ATTR.class} of ID:#{JOB_ATTR.job_id}\n #{error.backtrace.join("\n")}")
           next
         end
       end
@@ -80,7 +84,7 @@ class TravelBoardHearingSyncJob < CaseflowJob
   # Return: All the newly created legacy appeals
   def sync_travel_board_appeals
     log_info("Fetching travel board appeals from vacols for syncing...")
-    if BATCH_LIMIT.is_a?(String) || BATCH_LIMIT.is_a?(Integer)
+    if BATCH_LIMIT.is_a?(String)
       fetch_vacols_travel_board_appeals(fetch_all_vacols_ids, BATCH_LIMIT.to_i)
     else
       log_info("No BATCH LIMIT environment variable provided. Defaulting to 250")

--- a/app/jobs/hearings/travel_board_hearing_sync_job.rb
+++ b/app/jobs/hearings/travel_board_hearing_sync_job.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/RescueException
 # rubocop:disable Layout/LineLength
 class Hearings::TravelBoardHearingSyncJob < CaseflowJob
   queue_with_priority :low_priority
@@ -31,7 +30,7 @@ class Hearings::TravelBoardHearingSyncJob < CaseflowJob
         ScheduleHearingTask.create!(appeal: appeal, parent: root_task)
 
         AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
-      rescue Exception => error
+      rescue StandardError => error
         log_error("#{error.class}: #{error.message} for vacols id:#{appeal.vacols_id} on #{JOB_ATTR&.class} of ID:#{JOB_ATTR&.job_id}\n #{error.backtrace.join("\n")}")
         next
       end
@@ -78,14 +77,13 @@ class Hearings::TravelBoardHearingSyncJob < CaseflowJob
       .map do |vacols_case|
         begin
           AppealRepository.build_appeal(vacols_case, true)
-        rescue Exception => error
+        rescue StandardError => error
           log_error("#{error.class}: #{error.message} for vacols id:#{vacols_case.bfkey} on #{JOB_ATTR&.class} of ID:#{JOB_ATTR&.job_id}\n #{error.backtrace.join("\n")}")
           next
         end
       end
       .compact
   end
-  # rubocop:enable Lint/RescueException
   # rubocop:enable Layout/LineLength
 
   # Purpose: Wrapper method to determine batch size of travel board appeals to sync

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,6 +90,9 @@ Rails.application.configure do
   # Quarterly Notifications Batch Sizes
   ENV["QUARTERLY_NOTIFICATIONS_JOB_BATCH_SIZE"] ||= "1000"
 
+  # Travel Board Sync Batch Size
+  ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"] ||= "250"
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -104,4 +104,7 @@ Rails.application.configure do
 
   # Quarterly Notifications Batch Sizes
   ENV["QUARTERLY_NOTIFICATIONS_JOB_BATCH_SIZE"] ||= "1000"
+
+  # Travel Board Sync Batch Size
+  ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"] ||= "250"
 end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -38,6 +38,6 @@ SCHEDULED_JOBS = {
     "poll_docketed_legacy_appeals_job" => PollDocketedLegacyAppealsJob,
     "fetch_all_active_ama_appeals_job" => FetchAllActiveAmaAppealsJob,
     "fetch_all_active_legacy_appeals_job" => FetchAllActiveLegacyAppealsJob,
-    "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob
+    "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob,
     "travel_board_hearing_sync_job" => Hearings::TravelBoardHearingSyncJob
 }.freeze

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -39,4 +39,5 @@ SCHEDULED_JOBS = {
     "fetch_all_active_ama_appeals_job" => FetchAllActiveAmaAppealsJob,
     "fetch_all_active_legacy_appeals_job" => FetchAllActiveLegacyAppealsJob,
     "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob
+    "travel_board_hearing_sync_job" => Hearings::TravelBoardHearingSyncJob
 }.freeze

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -95,7 +95,7 @@ describe FetchHearingLocationsForVeteransJob do
         it "returns only appeals with scheduled hearings tasks without an admin action or who are in location 57" do
           job.create_schedule_hearing_tasks
           expect(job.appeals.pluck(:id)).to contain_exactly(
-            legacy_appeal.id, legacy_appeal_2.id, appeal.id, LegacyAppeal.last.id
+            legacy_appeal.id, legacy_appeal_2.id, appeal.id
           )
         end
       end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -2,17 +2,22 @@
 
 describe Hearings::TravelBoardHearingSyncJob do
   let(:current_user) { create(:user, roles: ["System Admin"]) }
-  let(:vacols_ids) { %w[12340 12341 12342 12343 12344 12345 12346 12347 12348 12349] }
+  let(:vacols_ids) { %w[123450 123451 123452 123453 123454 123455 123456 123457 123458 123459] }
+  let(:new_caseflow_vacols_ids) { %w[123450 123451 123452 123453 123455 123458 123459] }
   let(:legacy_appeal) { create(:legacy_appeal) }
   let(:cases) {
     create_list(:case, 10) do |vacols_case, i|
-      bfcurloc = (i == 4 || i == 7) ? "1" : LegacyAppeal::LOCATION_CODES[:schedule_hearing]
-      vacols_case.update!(bfkey: vacols_ids[i], bfcurloc: bfcurloc)
+      bfhr = (i == 4 || i == 7) ? "1" : VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value]
+      vacols_case.update!(
+        bfkey: vacols_ids[i],
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        bfhr: bfhr
+      )
     end
   }
 
   describe "#perform" do
-    subject { Hearings::TravelBoardHearingSyncJob.new.perform }
+    subject { Hearings::TravelBoardHearingSyncJob.new }
 
     before do
       current_user
@@ -22,8 +27,8 @@ describe Hearings::TravelBoardHearingSyncJob do
     end
 
     it "fetches and creates travel board legacy appeals that were not in caseflow before" do
-      expect(LegacyAppeal.all.pluck(:vacols_id))
-      subject
+      expect(subject.send(:fetch_vacols_travel_board_appeals, LegacyAppeal.all.pluck(:vacols_id), 250)
+        .pluck(:vacols_id)).to eq(new_caseflow_vacols_ids)
     end
   end
 end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+describe Hearings::TravelBoardHearingSyncJob do
+
+end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -5,6 +5,7 @@ describe Hearings::TravelBoardHearingSyncJob do
   let(:vacols_ids) { %w[123450 123451 123452 123453 123454 123455 123456 123457 123458 123459] }
   let(:new_caseflow_vacols_ids) { %w[123450 123451 123452 123453 123455 123458 123459] }
   let(:legacy_appeal) { create(:legacy_appeal) }
+  let(:existing_caseflow_vacols_ids) { LegacyAppeal.all.pluck(:vacols_id) }
   let(:cases) {
     create_list(:case, 10) do |vacols_case, i|
       bfhr = (i == 4 || i == 7) ? "1" : VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value]
@@ -26,9 +27,39 @@ describe Hearings::TravelBoardHearingSyncJob do
       legacy_appeal
     end
 
-    it "fetches and creates travel board legacy appeals that were not in caseflow before" do
-      expect(subject.send(:fetch_vacols_travel_board_appeals, LegacyAppeal.all.pluck(:vacols_id), 250)
-        .pluck(:vacols_id)).to eq(new_caseflow_vacols_ids)
+    context "no environment variable provided" do
+      it "limit parameter should default to 250 when fetching" do
+        expect(subject).to receive(:fetch_vacols_travel_board_appeals).with(existing_caseflow_vacols_ids, 250)
+        subject.perform
+      end
+
+      it "fetches and creates travel board legacy appeals that were not in caseflow before" do
+        expect(subject.send(:fetch_vacols_travel_board_appeals, LegacyAppeal.all.pluck(:vacols_id), 250)
+          .pluck(:vacols_id)).to eq(new_caseflow_vacols_ids)
+        subject.perform
+      end
+    end
+
+    context "Exceptions raised during processes" do
+      before do
+        Hearings::TravelBoardHearingSyncJob::JOB_ATTR = nil
+      end
+      it "logs out error when exception occurs when creating new legacy appeals" do
+        allow(AppealRepository).to receive(:build_appeal).and_raise(Exception)
+        expect(Rails.logger).to receive(:error).at_least(:once)
+        subject.perform
+      end
+    end
+
+    context "Batch limit environment variable set to 500" do
+      before do
+        Hearings::TravelBoardHearingSyncJob::BATCH_LIMIT = "500"
+      end
+
+      it "limit paramter should be 500 when fetching" do
+        expect(subject).to receive(:fetch_vacols_travel_board_appeals).with(existing_caseflow_vacols_ids, 500)
+        subject.perform
+      end
     end
   end
 end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
 describe Hearings::TravelBoardHearingSyncJob do
+  let(:current_user) { create(:user, roles: ["System Admin"]) }
+  let(:vacols_ids) { %w[12340 12341 12342 12343 12344 12345 12346 12347 12348 12349] }
+  let(:legacy_appeal) { create(:legacy_appeal) }
+  let(:cases) {
+    create_list(:case, 10) do |vacols_case, i|
+      bfcurloc = (i == 4 || i == 7) ? "1" : LegacyAppeal::LOCATION_CODES[:schedule_hearing]
+      vacols_case.update!(bfkey: vacols_ids[i], bfcurloc: bfcurloc)
+    end
+  }
 
+  describe "#perform" do
+    subject { Hearings::TravelBoardHearingSyncJob.new.perform }
+
+    before do
+      current_user
+      vacols_ids
+      cases
+      legacy_appeal
+    end
+
+    it "fetches and creates travel board legacy appeals that were not in caseflow before" do
+      expect(LegacyAppeal.all.pluck(:vacols_id))
+      subject
+    end
+  end
 end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -52,13 +52,13 @@ describe Hearings::TravelBoardHearingSyncJob do
         Hearings::TravelBoardHearingSyncJob::JOB_ATTR = nil
       end
       it "logs out error when exception occurs when creating new legacy appeals" do
-        allow(AppealRepository).to receive(:build_appeal).and_raise(Exception)
+        allow(AppealRepository).to receive(:build_appeal).and_raise(StandardError)
         expect(Rails.logger).to receive(:error).at_least(:once)
         subject.perform
       end
 
       it "logs out error when exception occurs when creating new task trees" do
-        allow(ScheduleHearingTask).to receive(:create!).and_raise(Exception)
+        allow(ScheduleHearingTask).to receive(:create!).and_raise(StandardError)
         expect(Rails.logger).to receive(:error).at_least(:once)
         subject.perform
       end


### PR DESCRIPTION
Resolves APPEALS-13520

### Description
Added a new job called travel_board_hearing_sync_job.rb to sync travel board appeals not already in Vacols by creating new legacy appeals for vacols cases not in Caseflow and creating task trees for it

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Queries Vacols appeals that have travel board hearing ready to be scheduled
- [ ] The appeals vacols ids are checked against LegacyAppeal table to ensure none are already in caseflow
- [ ] The vacols appeals have new legacy appeal records added for them
- [ ] The new legacy appeals created have the task tree built out for them

### Testing Plan
https://vajira.max.gov/browse/APPEALS-14039