### PR TITLE
hotfix/Sort Veteran Participant ID Column Numerically

### DIFF
--- a/app/controllers/decision_reviews_controller.rb
+++ b/app/controllers/decision_reviews_controller.rb
@@ -165,7 +165,7 @@ class DecisionReviewsController < ApplicationController
       :search_query,
       { filter: [] },
       :page,
-      decision_issues: [:description, :disposition, :request_issue_id],
+      decision_issues: [:description, :disposition, :request_issue_id]
     )
   end
 end

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -277,7 +277,12 @@ class BusinessLine < Organization
 
     def order_clause
       if query_params[:sort_by] == "veteran_participant_id"
-        return Arel.sql("#{query_params[:sort_by]}::int #{query_params[:sort_order]}")
+        return Arel.sql(
+          ActiveRecord::Base.send(
+            :sanitize_sql_array,
+            ["#{query_params[:sort_by]}::int #{query_params[:sort_order]}"]
+          )
+        )
       end
 
       {

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -36,6 +36,7 @@ class BusinessLine < Organization
 
   class QueryBuilder
     attr_accessor :query_type, :parent, :query_params
+
     NUMBER_OF_SEARCH_FIELDS = 2
     TASK_FILTER_PREDICATES = {
       "VeteranRecordRequest" => Task.arel_table[:type].eq(VeteranRecordRequest.name),
@@ -76,7 +77,6 @@ class BusinessLine < Organization
       query_params[:sort_order] ||= DEFAULT_SORT_ORDER
     end
 
-    # TODO: Order will need to be changed when it is implemented
     def build_query
       Task.select(Arel.star)
         .from(combined_decision_review_tasks_query)
@@ -136,7 +136,7 @@ class BusinessLine < Organization
 
     # All join clauses
 
-    # Note: .left_joins(ama_appeal: :request_issues)
+    # NOTE: .left_joins(ama_appeal: :request_issues)
     # No longer works in the same way as the other joins because left outer join is forced to the end of the query by AR
     def board_grant_effectuation_task_appeals_requests_join
       "LEFT OUTER JOIN appeals ON appeals.id = tasks.appeal_id AND tasks.appeal_type = 'Appeal' "\
@@ -275,8 +275,11 @@ class BusinessLine < Organization
       }
     end
 
-    # TODO: Needs to be updated to work with ordering
     def order_clause
+      if query_params[:sort_by] == "veteran_participant_id"
+        return Arel.sql("#{query_params[:sort_by]}::int #{query_params[:sort_order]}")
+      end
+
       {
         query_params[:sort_by] => query_params[:sort_order].to_sym
       }

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -5,9 +5,9 @@ feature "NonComp Reviews Queue", :postgres do
     let!(:non_comp_org) { create(:business_line, name: "Non-Comp Org", url: "nco") }
     let(:user) { create(:default_user) }
 
-    let(:veteran_a) { create(:veteran, first_name: "Aaa") }
-    let(:veteran_b) { create(:veteran, first_name: "Bbb") }
-    let(:veteran_c) { create(:veteran, first_name: "Ccc") }
+    let(:veteran_a) { create(:veteran, first_name: "Aaa", participant_id: "12345") }
+    let(:veteran_b) { create(:veteran, first_name: "Bbb", participant_id: "601111772") }
+    let(:veteran_c) { create(:veteran, first_name: "Ccc", participant_id: "1002345") }
     let(:hlr_a) { create(:higher_level_review, veteran_file_number: veteran_a.file_number) }
     let(:hlr_b) { create(:higher_level_review, veteran_file_number: veteran_b.file_number) }
     let(:hlr_c) { create(:higher_level_review, veteran_file_number: veteran_c.file_number) }
@@ -172,8 +172,8 @@ feature "NonComp Reviews Queue", :postgres do
       )
       table_rows = current_table_rows
 
-      expect(table_rows.first.include?(hlr_c.veteran.participant_id.to_s)).to eq true
-      expect(table_rows.last.include?(hlr_a.veteran.participant_id.to_s)).to eq true
+      expect(table_rows.first.include?(hlr_b.veteran.participant_id)).to eq true
+      expect(table_rows.last.include?(hlr_a.veteran.participant_id)).to eq true
 
       # Participant ID asc
       order_buttons[:participant_id].click
@@ -184,7 +184,7 @@ feature "NonComp Reviews Queue", :postgres do
       table_rows = current_table_rows
 
       expect(table_rows.first.include?(hlr_a.veteran.participant_id)).to eq true
-      expect(table_rows.last.include?(hlr_c.veteran.participant_id)).to eq true
+      expect(table_rows.last.include?(hlr_b.veteran.participant_id)).to eq true
 
       # Issue count desc
       order_buttons[:issues_count].click
@@ -287,8 +287,7 @@ feature "NonComp Reviews Queue", :postgres do
       )
 
       # Blank out the input and verify that there are once again 2 on the page
-      sleep(2)
-      fill_in "search", with: ""
+      fill_in("search", with: nil, fill_options: { clear: :backspace })
       expect(page).to have_content("Higher-Level Review", count: 2)
     end
 
@@ -307,8 +306,7 @@ feature "NonComp Reviews Queue", :postgres do
       )
 
       # Blank out the input and verify that there are once again 2 on the page
-      sleep(2)
-      fill_in "search", with: ""
+      fill_in("search", with: nil, fill_options: { clear: :backspace })
       expect(page).to have_content("Higher-Level Review", count: 2)
     end
 


### PR DESCRIPTION
### Description

The Veteran Participant ID column's values are strings of numbers. It was noticed that these values are being sorted using string comparisons instead of numeric comparisons, which causes tasks to appear out of order.

With string comparison, strings are compared character-by-character, from left-to-right. This means that the string `"6231"` will be considered to be greater than `"60000000000000000001"` since the second character of `"6231"` (`2`) has a higher ASCII value than that of `"60000000000000000001"` (`0`).

This pull request casts the values of the participant ID column to integers before ordering them so that `60000000000000000001` can be identified as a larger value than `6231`.

### Testing Plan
1. Run the following commands in the Rails console in order to populate the VHA business line's decision review queue:
```ruby
new_vha_tasks = Array.new(100).map { FactoryBot.create(:higher_level_review_vha_task) }

Array.new(100).each { FactoryBot.create(:supplemental_claim_vha_task) }

new_vha_tasks.each do |task|
  task.appeal.veteran.update!(participant_id: rand(100..999_999_999).to_s)
end
```
2. Log into Caseflow as a VHA business line user (ex: `ACBAUERVVHAH`)
3. Navigate to the VHA's decision review queue ([Link for locahost](http://localhost:3000/decision_reviews/vha))

![no-sort](https://user-images.githubusercontent.com/99351305/213898680-ee427fc3-a0ec-41da-9e1f-92eecb74ee0d.png)

4. Click on the "double-arrow" icon to the right of the "Veteran Participant Id" column header.
    - The URL should now be `/decision_reviews/vha?tab=in_progress&page=1&sort_by=veteranParticipantIdColumn&order=desc`
    - The first row on the first page should contain the highest participant ID (numerically).
    - As your move through subsequent pages, the participant IDs should **decrease**.
    - The last row on the last page should contain the lowest participant ID (numerically).
  
![desc-sort](https://user-images.githubusercontent.com/99351305/213898684-589a4bdd-dc0b-4587-8f67-c92b0bb8e644.png)

5. Click on the "double-arrow" icon again.
    - The URL should now be `/decision_reviews/vha?tab=in_progress&page=1&sort_by=veteranParticipantIdColumn&order=asc`
    - The first row on the first page should contain the lowest participant ID (numerically).
    - As your move through subsequent pages, the participant IDs should **increase**.
    - The last row on the last page should contain the highest participant ID (numerically).
  
![asc-sort](https://user-images.githubusercontent.com/99351305/213898689-604559de-56fe-4178-b2a9-1a1a4d97eac7.png)

6. Enter a search query that corresponds with some subset of the queue. Validate that the sorting for the participant ID column works with a search query active.
7. Feel free to clear the search query at this time.
8. Filter the queue by task type by clicking on the "funnel" icon next to the "Type" column header. Select either SC or HLR, but not both. Validate that the sorting for the participant ID column works with a task filter active.
9. You may clear the filter by clicking on the "Clear all filters" link above the queue table.
10. Please ensure that the sorting behaviors of all other columns have been left intact.

