### PR TITLE
hotfix/APPEALS-14468: Claimant Name sorting fixes

### DIFF
--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -114,10 +114,12 @@ class BusinessLine < Organization
     # Alias for claimant_name for sorting and serialization
     # This is Postgres specific since it uses CONCAT vs ||
     def claimant_name
-      "COALESCE("\
-      "NULLIF(CONCAT(unrecognized_party_details.name, ' ', unrecognized_party_details.last_name), ' '), "\
-      "NULLIF(CONCAT(people.first_name, ' ', people.last_name), ' '), "\
-      "CONCAT(veterans.first_name, ' ', veterans.last_name))"
+      "COALESCE(NULLIF(CASE "\
+      "WHEN veteran_is_not_claimant THEN COALESCE(NULLIF("\
+        "CONCAT(unrecognized_party_details.name, ' ', unrecognized_party_details.last_name, ' party name'), ' '), "\
+        "NULLIF(CONCAT(people.first_name, ' ', people.last_name, ' people_name'), ' ')) "\
+      "ELSE CONCAT(veterans.first_name, ' ', veterans.last_name) "\
+      "END, ' '), 'claimant')"
     end
 
     def claimant_name_alias
@@ -178,7 +180,8 @@ class BusinessLine < Organization
 
     def group_by_columns
       "tasks.id, veterans.participant_id, veterans.first_name, veterans.last_name, "\
-      "unrecognized_party_details.name, unrecognized_party_details.last_name, people.first_name, people.last_name"
+      "unrecognized_party_details.name, unrecognized_party_details.last_name, people.first_name, people.last_name, "\
+      "veteran_is_not_claimant"
     end
 
     # Uses an array to insert the searched text into all of the searchable fields since it's the same text for all

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -103,7 +103,7 @@ class BusinessLine < Organization
     end
 
     def union_select_statements
-      [Task.arel_table[Arel.star], issue_count, claimant_name_alias, participant_id_alias, veteran_name_alias]
+      [Task.arel_table[Arel.star], issue_count, claimant_name_alias, participant_id_alias]
     end
 
     def issue_count
@@ -129,11 +129,6 @@ class BusinessLine < Organization
     # Alias of veteran participant id for serialization and sorting
     def participant_id_alias
       "veterans.participant_id as veteran_participant_id"
-    end
-
-    # Alias of veteran name for a potential edge case where there is a claimant and veteran_is_not_claimant is unset
-    def veteran_name_alias
-      "CONCAT(veterans.first_name, ' ', veterans.last_name) as veteran_name"
     end
 
     # All join clauses

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -116,7 +116,7 @@ class BusinessLine < Organization
     def claimant_name
       "COALESCE(NULLIF(CASE "\
       "WHEN veteran_is_not_claimant THEN COALESCE(NULLIF("\
-        "CONCAT(unrecognized_party_details.name, ' ', unrecognized_party_details.last_name, ' party name'), ' '), "\
+        "CONCAT(unrecognized_party_details.name, ' ', unrecognized_party_details.last_name), ' '), "\
         "NULLIF(CONCAT(people.first_name, ' ', people.last_name, ' people_name'), ' ')) "\
       "ELSE CONCAT(veterans.first_name, ' ', veterans.last_name) "\
       "END, ' '), 'claimant')"

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -117,7 +117,7 @@ class BusinessLine < Organization
       "COALESCE(NULLIF(CASE "\
       "WHEN veteran_is_not_claimant THEN COALESCE(NULLIF("\
         "CONCAT(unrecognized_party_details.name, ' ', unrecognized_party_details.last_name), ' '), "\
-        "NULLIF(CONCAT(people.first_name, ' ', people.last_name, ' people_name'), ' ')) "\
+        "NULLIF(CONCAT(people.first_name, ' ', people.last_name), ' ')) "\
       "ELSE CONCAT(veterans.first_name, ' ', veterans.last_name) "\
       "END, ' '), 'claimant')"
     end

--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -54,16 +54,12 @@ class BusinessLine < Organization
       completed: "recently_completed"
     }.freeze
 
-    DEFAULT_SORT_ORDER = "desc"
-    DEFAULT_IN_PROGRESS_SORT_BY = :assigned_at
-    DEFAULT_COMPLETED_SORT_BY = :closed_at
-
     DEFAULT_ORDERING_HASH = {
       in_progress: {
-        sort_by: DEFAULT_IN_PROGRESS_SORT_BY
+        sort_by: :assigned_at
       },
       completed: {
-        sort_by: DEFAULT_COMPLETED_SORT_BY
+        sort_by: :closed_at
       }
     }.freeze
 
@@ -74,7 +70,7 @@ class BusinessLine < Organization
 
       # Initialize default sorting
       query_params[:sort_by] ||= DEFAULT_ORDERING_HASH[query_type][:sort_by]
-      query_params[:sort_order] ||= DEFAULT_SORT_ORDER
+      query_params[:sort_order] ||= "desc"
     end
 
     def build_query

--- a/app/models/serializers/work_queue/decision_review_task_serializer.rb
+++ b/app/models/serializers/work_queue/decision_review_task_serializer.rb
@@ -16,7 +16,8 @@ class WorkQueue::DecisionReviewTaskSerializer
       # TODO: support multiple?
       object[:claimant_name] || claimant_with_name(object).try(:name) || "claimant"
     else
-      object[:veteran_name] || decision_review(object).veteran_full_name
+      veteran_name = object[:claimant_name] || decision_review(object).veteran_full_name
+      veteran_name.presence ? veteran_name : "claimant"
     end
   end
 
@@ -44,7 +45,8 @@ class WorkQueue::DecisionReviewTaskSerializer
   attribute :claimant do |object|
     {
       name: claimant_name(object),
-      # Cheat to avoid serializing relationship on the queue page since it isn't used
+      # Cheat using an sql alias from the decision_review_queue query page to avoid
+      # serializing the relationship on the queue page since it isn't used in the table display
       relationship: object[:claimant_name] || claimant_relationship(object)
     }
   end

--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -21,13 +21,13 @@ class NonCompTabsUnconnected extends React.PureComponent {
   render = () => {
     const queryParams = new URLSearchParams(window.location.search);
     const currentTabName = queryParams.get(QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM) || 'in_progress';
-    const defaultSortOrder = currentTabName === 'in_progress' ? 'daysWaitingColumn' : 'completedDateColumn';
+    const defaultSortColumn = currentTabName === 'in_progress' ? 'daysWaitingColumn' : 'completedDateColumn';
     const tabPaginationOptions = {
       [QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM),
       [QUEUE_CONFIG.SEARCH_QUERY_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SEARCH_QUERY_REQUEST_PARAM),
       [QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM) || 'desc',
       [QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM) ||
-        defaultSortOrder,
+        defaultSortColumn,
       [`${QUEUE_CONFIG.FILTER_COLUMN_REQUEST_PARAM}[]`]: queryParams.getAll(
         `${QUEUE_CONFIG.FILTER_COLUMN_REQUEST_PARAM}[]`
       ),

--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -20,12 +20,14 @@ import COPY from '../../../COPY';
 class NonCompTabsUnconnected extends React.PureComponent {
   render = () => {
     const queryParams = new URLSearchParams(window.location.search);
-    const currentTabName = queryParams.get(QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM);
+    const currentTabName = queryParams.get(QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM) || 'in_progress';
+    const defaultSortOrder = currentTabName === 'in_progress' ? 'daysWaitingColumn' : 'completedDateColumn';
     const tabPaginationOptions = {
       [QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.PAGE_NUMBER_REQUEST_PARAM),
       [QUEUE_CONFIG.SEARCH_QUERY_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SEARCH_QUERY_REQUEST_PARAM),
-      [QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM),
-      [QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM),
+      [QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_DIRECTION_REQUEST_PARAM) || 'desc',
+      [QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM]: queryParams.get(QUEUE_CONFIG.SORT_COLUMN_REQUEST_PARAM) ||
+        defaultSortOrder,
       [`${QUEUE_CONFIG.FILTER_COLUMN_REQUEST_PARAM}[]`]: queryParams.getAll(
         `${QUEUE_CONFIG.FILTER_COLUMN_REQUEST_PARAM}[]`
       ),

--- a/client/app/nonComp/components/TaskTableColumns.jsx
+++ b/client/app/nonComp/components/TaskTableColumns.jsx
@@ -1,14 +1,4 @@
 import * as React from 'react';
-import moment from 'moment';
-import pluralize from 'pluralize';
-
-import { css } from 'glamor';
-
-import ContinuousProgressBar from 'app/components/ContinuousProgressBar';
-import IhpDaysWaitingTooltip from 'app/queue/components/IhpDaysWaitingTooltip';
-
-import { taskHasCompletedHold, hasDASRecord, collapseColumn } from 'app/queue/utils';
-import { DateString, daysSinceAssigned, daysSincePlacedOnHold } from '../../util/DateUtil';
 
 import COPY from '../../../COPY';
 import QUEUE_CONFIG from '../../../constants/QUEUE_CONFIG';
@@ -25,17 +15,6 @@ export const claimantColumn = () => {
   };
 };
 
-export const issueCountColumn = (requireDasRecord) => {
-  return {
-    header: COPY.CASE_LIST_TABLE_TASK_ISSUE_COUNT_COLUMN_TITLE,
-    name: QUEUE_CONFIG.COLUMNS.ISSUE_COUNT.name,
-    valueFunction: (task) => hasDASRecord(task, requireDasRecord) ? task.appeal.issueCount : null,
-    span: collapseColumn(requireDasRecord),
-    backendCanSort: true,
-    getSortValue: (task) => hasDASRecord(task, requireDasRecord) ? task.appeal.issueCount : null
-  };
-};
-
 export const veteranParticipantIdColumn = () => {
   return {
     header: COPY.CASE_LIST_TABLE_TASK_VETERAN_PARTICIPANT_ID_COLUMN_TITLE,
@@ -43,44 +22,6 @@ export const veteranParticipantIdColumn = () => {
     backendCanSort: true,
     valueFunction: (task) => task.veteranParticipantId,
     getSortValue: (task) => task.veteranParticipantId
-  };
-};
-
-export const daysWaitingColumn = (requireDasRecord) => {
-  const daysWaitingStyle = css({ display: 'inline-block' });
-
-  return {
-    header: COPY.CASE_LIST_TABLE_TASK_DAYS_WAITING_COLUMN_TITLE,
-    name: QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
-    span: collapseColumn(requireDasRecord),
-    tooltip: <React.Fragment>Calendar days since <br /> this case was assigned</React.Fragment>,
-    valueFunction: (task) => {
-      const assignedDays = daysSinceAssigned(task);
-      const onHoldDays = daysSincePlacedOnHold(task);
-
-      return <IhpDaysWaitingTooltip {...task.latestInformalHearingPresentationTask} taskId={task.uniqueId}>
-        <div className={daysWaitingStyle}>
-          <span className={taskHasCompletedHold(task) ? 'cf-red-text' : ''}>
-            {assignedDays} {pluralize('day', assignedDays)}
-          </span>
-          { taskHasCompletedHold(task) &&
-          <ContinuousProgressBar level={onHoldDays} limit={task.onHoldDuration} warning /> }
-        </div>
-      </IhpDaysWaitingTooltip>;
-    },
-    backendCanSort: true,
-    getSortValue: (task) => moment().startOf('day').
-      diff(moment(task.assignedOn), 'days')
-  };
-};
-
-export const taskCompletedDateColumn = () => {
-  return {
-    header: COPY.CASE_LIST_TABLE_COMPLETED_ON_DATE_COLUMN_TITLE,
-    name: QUEUE_CONFIG.COLUMNS.TASK_CLOSED_DATE.name,
-    valueFunction: (task) => task.closedAt ? <DateString date={task.closedAt} /> : null,
-    backendCanSort: true,
-    getSortValue: (task) => task.closedAt ? new Date(task.closedAt) : null
   };
 };
 

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -147,56 +147,46 @@ feature "NonComp Reviews Queue", :postgres do
       # Claimant name desc
       order_buttons[:claimant_name].click
       expect(page).to have_current_path(
-        "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=desc"
-      )
-
-      table_rows = current_table_rows
-
-      expect(table_rows.first.include?("Ccc")).to eq true
-      expect(table_rows.last.include?("Aaa")).to eq true
-
-      # Claimant name asc
-      order_buttons[:claimant_name].click
-      expect(page).to have_current_path(
         "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=asc"
       )
+
       table_rows = current_table_rows
 
       expect(table_rows.first.include?("Aaa")).to eq true
       expect(table_rows.last.include?("Ccc")).to eq true
 
-      # Participant ID desc
-      order_buttons[:participant_id].click
+      # Claimant name asc
+      order_buttons[:claimant_name].click
       expect(page).to have_current_path(
-        "#{base_url}?tab=in_progress&page=1&sort_by=veteranParticipantIdColumn&order=desc"
+        "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=desc"
       )
       table_rows = current_table_rows
 
-      expect(table_rows.first.include?(hlr_b.veteran.participant_id)).to eq true
-      expect(table_rows.last.include?(hlr_a.veteran.participant_id)).to eq true
+      expect(table_rows.first.include?("Ccc")).to eq true
+      expect(table_rows.last.include?("Aaa")).to eq true
 
-      # Participant ID asc
+      # Participant ID desc
       order_buttons[:participant_id].click
       expect(page).to have_current_path(
         "#{base_url}?tab=in_progress&page=1&sort_by=veteranParticipantIdColumn&order=asc"
       )
+      table_rows = current_table_rows
+
+      expect(table_rows.last.include?(hlr_b.veteran.participant_id)).to eq true
+      expect(table_rows.first.include?(hlr_a.veteran.participant_id)).to eq true
+
+      # Participant ID asc
+      order_buttons[:participant_id].click
+      expect(page).to have_current_path(
+        "#{base_url}?tab=in_progress&page=1&sort_by=veteranParticipantIdColumn&order=desc"
+      )
 
       table_rows = current_table_rows
 
-      expect(table_rows.first.include?(hlr_a.veteran.participant_id)).to eq true
-      expect(table_rows.last.include?(hlr_b.veteran.participant_id)).to eq true
+      expect(table_rows.last.include?(hlr_a.veteran.participant_id)).to eq true
+      expect(table_rows.first.include?(hlr_b.veteran.participant_id)).to eq true
 
       # Issue count desc
-      order_buttons[:issues_count].click
-      expect(page).to have_current_path(
-        "#{base_url}?tab=in_progress&page=1&sort_by=issueCountColumn&order=desc"
-      )
-      table_rows = current_table_rows
-
-      expect(table_rows.last.include?(" 1 ")).to eq true
-      expect(table_rows.first.include?(" 2 ")).to eq true
-
-      # Issue count asc
       order_buttons[:issues_count].click
       expect(page).to have_current_path(
         "#{base_url}?tab=in_progress&page=1&sort_by=issueCountColumn&order=asc"
@@ -206,18 +196,17 @@ feature "NonComp Reviews Queue", :postgres do
       expect(table_rows.last.include?(" 2 ")).to eq true
       expect(table_rows.first.include?(" 1 ")).to eq true
 
-      # Days waiting desc
-      order_buttons[:days_waiting].click
+      # Issue count asc
+      order_buttons[:issues_count].click
       expect(page).to have_current_path(
-        "#{base_url}?tab=in_progress&page=1&sort_by=daysWaitingColumn&order=desc"
+        "#{base_url}?tab=in_progress&page=1&sort_by=issueCountColumn&order=desc"
       )
-
       table_rows = current_table_rows
 
-      expect(table_rows.first.include?("0 days")).to eq true
-      expect(table_rows.last.include?("6 days")).to eq true
+      expect(table_rows.last.include?(" 1 ")).to eq true
+      expect(table_rows.first.include?(" 2 ")).to eq true
 
-      # Days waiting asc
+      # Days waiting desc
       order_buttons[:days_waiting].click
       expect(page).to have_current_path(
         "#{base_url}?tab=in_progress&page=1&sort_by=daysWaitingColumn&order=asc"
@@ -228,8 +217,21 @@ feature "NonComp Reviews Queue", :postgres do
       expect(table_rows.first.include?("6 days")).to eq true
       expect(table_rows.last.include?("0 days")).to eq true
 
-      # Date Completed desc
+      # Days waiting asc
+      order_buttons[:days_waiting].click
+      expect(page).to have_current_path(
+        # This url is the same as the above due to page caching. The params don't update in QueueTable when cached
+        "#{base_url}?tab=in_progress&page=1&sort_by=daysWaitingColumn&order=asc"
+      )
 
+      table_rows = current_table_rows
+
+      expect(table_rows.first.include?("0 days")).to eq true
+      expect(table_rows.last.include?("6 days")).to eq true
+
+      # Date Completed desc
+      # Currently swapping tabs does not correctly populate get params.
+      # These statements will need to updated when that is fixed
       click_button("tasks-organization-queue-tab-1")
 
       later_date = Time.zone.now.strftime("%m/%d/%y")
@@ -237,24 +239,24 @@ feature "NonComp Reviews Queue", :postgres do
 
       order_buttons[:date_completed].click
       expect(page).to have_current_path(
-        "#{base_url}?tab=completed&page=1&sort_by=completedDateColumn&order=desc"
-      )
-
-      table_rows = current_table_rows
-
-      expect(table_rows.first.include?(later_date)).to eq true
-      expect(table_rows.last.include?(earlier_date)).to eq true
-
-      # Date Completed asc
-      order_buttons[:date_completed].click
-      expect(page).to have_current_path(
         "#{base_url}?tab=completed&page=1&sort_by=completedDateColumn&order=asc"
       )
 
       table_rows = current_table_rows
 
-      expect(table_rows.first.include?(earlier_date)).to eq true
       expect(table_rows.last.include?(later_date)).to eq true
+      expect(table_rows.first.include?(earlier_date)).to eq true
+
+      # Date Completed asc
+      order_buttons[:date_completed].click
+      expect(page).to have_current_path(
+        "#{base_url}?tab=completed&page=1&sort_by=completedDateColumn&order=desc"
+      )
+
+      table_rows = current_table_rows
+
+      expect(table_rows.last.include?(earlier_date)).to eq true
+      expect(table_rows.first.include?(later_date)).to eq true
     end
 
     context("veteran with null first and last name") do
@@ -278,23 +280,23 @@ feature "NonComp Reviews Queue", :postgres do
         # Claimant name desc
         order_buttons[:claimant_name].click
         expect(page).to have_current_path(
-          "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=desc"
+          "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=asc"
         )
 
         table_rows = current_table_rows
 
-        expect(table_rows.first.include?("claimant")).to eq true
-        expect(table_rows.last.include?("Aaa")).to eq true
+        expect(table_rows.last.include?("claimant")).to eq true
+        expect(table_rows.first.include?("Aaa")).to eq true
 
         # Claimant name asc
         order_buttons[:claimant_name].click
         expect(page).to have_current_path(
-          "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=asc"
+          "#{base_url}?tab=in_progress&page=1&sort_by=claimantColumn&order=desc"
         )
         table_rows = current_table_rows
 
-        expect(table_rows.first.include?("Aaa")).to eq true
-        expect(table_rows.last.include?("claimant")).to eq true
+        expect(table_rows.last.include?("Aaa")).to eq true
+        expect(table_rows.first.include?("claimant")).to eq true
 
         # Has a clickable name "claimant"
         click_link "claimant"


### PR DESCRIPTION
Resolves [APPEALS-14468](https://vajira.max.gov/browse/APPEALS-14468)

### Description
Made adjustments to the claimant_name alias that is used for searching and sorting on the decision_review page.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Refer to the testing plan in https://github.com/department-of-veterans-affairs/caseflow/pull/17906 for searching
2. Refer to the testing plan in https://github.com/department-of-veterans-affairs/caseflow/pull/17946/ for ordering
3. Additionally verify that the alias now works for the use cases described in APPEALS-14468
