### PR TITLE
Min/APPEALS-13520 (#17937)

### DIFF
--- a/app/jobs/hearings/travel_board_hearing_sync_job.rb
+++ b/app/jobs/hearings/travel_board_hearing_sync_job.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+# rubocop:disable Layout/LineLength
+# rubocop:disable Metrics/MethodLength
+class Hearings::TravelBoardHearingSyncJob < CaseflowJob
+  queue_with_priority :low_priority
+
+  before_perform do |job|
+    JOB_ATTR = job
+  end
+
+  BATCH_LIMIT = ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"]
+
+  # Active Job that syncs all travel board hearing from vacols onto Caseflow
+  def perform
+    RequestStore[:current_user] = User.system_user
+    create_schedule_hearing_tasks(sync_travel_board_appeals)
+  end
+
+  private
+
+  # Purpose: Create hearing task tree for appeals
+  # Params:  legacy_appeals - The list of appeals to create task trees for
+  # Return:  The vacols appeals that just got had their location codes updated to caseflow
+  def create_schedule_hearing_tasks(legacy_appeals)
+    log_info("Constructing task tree for new travel board legacy appeals...")
+    appeals = legacy_appeals || []
+    generated_tree_count = 0
+    appeals.each do |appeal|
+      begin
+        root_task = RootTask.find_or_create_by!(appeal: appeal, assigned_to: Bva.singleton)
+        ScheduleHearingTask.create!(appeal: appeal, parent: root_task)
+
+        AppealRepository.update_location!(appeal, LegacyAppeal::LOCATION_CODES[:caseflow])
+        generated_tree_count += 1
+      rescue StandardError => error
+        log_error("#{error.class}: #{error.message} for vacols id:#{appeal.vacols_id} on #{JOB_ATTR&.class} of ID:#{JOB_ATTR&.job_id}\n #{error.backtrace.join("\n")}")
+        next
+      end
+    end
+      .compact
+    log_info("Created #{generated_tree_count} task trees out of #{appeals.length} legacy appeals")
+    appeals
+  end
+
+  # Purpose: Logging info messages to the console
+  def log_info(message)
+    Rails.logger.info(message)
+  end
+
+  # Purpose: Logging error messages to the console
+  def log_error(message)
+    Rails.logger.error(message)
+  end
+
+  # Purpose: Fetches a list of all vacols ids from the database
+  # Return: The list of vacols ids
+  def fetch_all_vacols_ids
+    LegacyAppeal.all.pluck(:vacols_id)
+  end
+
+  # Purpose: Fetches all travel board appeals from VACOLS that aren't already in Caseflow
+  # and creates a legacy appeal for each
+  # Params: exclude_ids - A list of vacols ids that already exist in Caseflow
+  #         limit - The max number of appeals to process
+  # Return: All the newly created legacy appeals
+  def fetch_vacols_travel_board_appeals(exclude_ids, limit)
+    cases = VACOLS::Case
+      .where(
+        # Travel Board Hearing Request
+        bfhr: VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value],
+        # Current Location
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        # Video Hearing Request Indicator
+        bfdocind: nil,
+        # Datetime of Decision
+        bfddec: nil
+      )
+      .where.not(bfkey: exclude_ids)
+      .includes(:correspondent, :folder, :case_issues)
+      .first(limit)
+      .map do |vacols_case|
+        begin
+          AppealRepository.build_appeal(vacols_case, true)
+        rescue StandardError => error
+          log_error("#{error.class}: #{error.message} for vacols id:#{vacols_case.bfkey} on #{JOB_ATTR&.class} of ID:#{JOB_ATTR&.job_id}\n #{error.backtrace.join("\n")}")
+          next
+        end
+      end
+      .compact
+    log_info("Fetched #{cases.length} travel board appeals from VACOLS")
+    cases
+  end
+
+  # Purpose: Wrapper method to determine batch size of travel board appeals to sync
+  # Return: All the newly created legacy appeals
+  def sync_travel_board_appeals
+    log_info("Fetching travel board appeals from vacols for syncing...")
+    if BATCH_LIMIT.is_a?(String)
+      fetch_vacols_travel_board_appeals(fetch_all_vacols_ids, BATCH_LIMIT.to_i)
+    else
+      log_info("No BATCH LIMIT environment variable provided. Defaulting to 250")
+      fetch_vacols_travel_board_appeals(fetch_all_vacols_ids, 250)
+    end
+  end
+end
+# rubocop:enable Metrics/MethodLength
+# rubocop:enable Layout/LineLength

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,6 +90,9 @@ Rails.application.configure do
   # Quarterly Notifications Batch Sizes
   ENV["QUARTERLY_NOTIFICATIONS_JOB_BATCH_SIZE"] ||= "1000"
 
+  # Travel Board Sync Batch Size
+  ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"] ||= "250"
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -104,4 +104,7 @@ Rails.application.configure do
 
   # Quarterly Notifications Batch Sizes
   ENV["QUARTERLY_NOTIFICATIONS_JOB_BATCH_SIZE"] ||= "1000"
+
+  # Travel Board Sync Batch Size
+  ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"] ||= "250"
 end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -38,5 +38,6 @@ SCHEDULED_JOBS = {
     "poll_docketed_legacy_appeals_job" => PollDocketedLegacyAppealsJob,
     "fetch_all_active_ama_appeals_job" => FetchAllActiveAmaAppealsJob,
     "fetch_all_active_legacy_appeals_job" => FetchAllActiveLegacyAppealsJob,
-    "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob
+    "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob,
+    "travel_board_hearing_sync_job" => Hearings::TravelBoardHearingSyncJob
 }.freeze

--- a/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
+++ b/spec/jobs/fetch_hearing_locations_for_veterans_job_spec.rb
@@ -95,7 +95,7 @@ describe FetchHearingLocationsForVeteransJob do
         it "returns only appeals with scheduled hearings tasks without an admin action or who are in location 57" do
           job.create_schedule_hearing_tasks
           expect(job.appeals.pluck(:id)).to contain_exactly(
-            legacy_appeal.id, legacy_appeal_2.id, appeal.id, LegacyAppeal.last.id
+            legacy_appeal.id, legacy_appeal_2.id, appeal.id
           )
         end
       end

--- a/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
+++ b/spec/jobs/hearings/travel_board_hearing_sync_job_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+describe Hearings::TravelBoardHearingSyncJob do
+  let(:current_user) { create(:user, roles: ["System Admin"]) }
+  let(:vacols_ids) { %w[123450 123451 123452 123453 123454 123455 123456 123457 123458 123459] }
+  let(:new_caseflow_vacols_ids) { %w[123450 123451 123452 123453 123455 123458 123459] }
+  let(:legacy_appeal) { create(:legacy_appeal) }
+  let(:existing_caseflow_vacols_ids) { LegacyAppeal.all.pluck(:vacols_id) }
+  # rubocop:disable Style/BlockDelimiters
+  let(:cases) {
+    create_list(:case, 10) do |vacols_case, i|
+      bfhr = (i == 4 || i == 7) ? "1" : VACOLS::Case::HEARING_PREFERENCE_TYPES_V2[:TRAVEL_BOARD][:vacols_value]
+      vacols_case.update!(
+        bfkey: vacols_ids[i],
+        bfcurloc: LegacyAppeal::LOCATION_CODES[:schedule_hearing],
+        bfhr: bfhr
+      )
+    end
+  }
+  # rubocop:enable Style/BlockDelimiters
+
+  describe "#perform" do
+    subject { Hearings::TravelBoardHearingSyncJob.new }
+
+    before do
+      current_user
+      vacols_ids
+      cases
+      legacy_appeal
+    end
+
+    context "no environment variable provided" do
+      it "limit parameter should default to 250 when fetching" do
+        expect(subject).to receive(:fetch_vacols_travel_board_appeals).with(existing_caseflow_vacols_ids, 250)
+        subject.perform
+      end
+
+      it "fetches and creates travel board legacy appeals that were not in caseflow before" do
+        expect(subject.send(:fetch_vacols_travel_board_appeals, LegacyAppeal.all.pluck(:vacols_id), 250)
+          .pluck(:vacols_id)).to eq(new_caseflow_vacols_ids)
+        subject.perform
+      end
+
+      it "creates task trees for the newly created legacy appeals" do
+        subject.perform
+        expect(ScheduleHearingTask.all.count).to eq(new_caseflow_vacols_ids.length)
+      end
+    end
+
+    context "Exceptions raised during processes" do
+      before do
+        Hearings::TravelBoardHearingSyncJob::JOB_ATTR = nil
+      end
+      it "logs out error when exception occurs when creating new legacy appeals" do
+        allow(AppealRepository).to receive(:build_appeal).and_raise(StandardError)
+        expect(Rails.logger).to receive(:error).at_least(:once)
+        subject.perform
+      end
+
+      it "logs out error when exception occurs when creating new task trees" do
+        allow(ScheduleHearingTask).to receive(:create!).and_raise(StandardError)
+        expect(Rails.logger).to receive(:error).at_least(:once)
+        subject.perform
+      end
+    end
+
+    context "Batch limit environment variable set to 500" do
+      before do
+        Hearings::TravelBoardHearingSyncJob::BATCH_LIMIT = "500"
+      end
+
+      it "limit paramter should be 500 when fetching" do
+        expect(subject).to receive(:fetch_vacols_travel_board_appeals).with(existing_caseflow_vacols_ids, 500)
+        subject.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves APPEALS-13520

### Description
Added a new job called travel_board_hearing_sync_job.rb to sync travel board appeals not already in Vacols by creating new legacy appeals for vacols cases not in Caseflow and creating task trees for it

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Queries Vacols appeals that have travel board hearing ready to be scheduled
- [ ] The appeals vacols ids are checked against LegacyAppeal table to ensure none are already in caseflow
- [ ] The vacols appeals have new legacy appeal records added for them
- [ ] The new legacy appeals created have the task tree built out for them

### Testing Plan
https://vajira.max.gov/browse/APPEALS-14039