### PR TITLE
Kamalam7/appeals 13362

### DIFF
--- a/app/models/tasks/letter_task.rb
+++ b/app/models/tasks/letter_task.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class LetterTask < Task
+end

--- a/app/models/tasks/send_final_notification_letter_task.rb
+++ b/app/models/tasks/send_final_notification_letter_task.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class SendFinalNotificationLetterTask < LetterTask
+  validates :parent, presence: true
+
+  def available_actions(user)
+    if assigned_to.user_has_access?(user) # feature toggle will go here
+      SEND_FINAL_NOTIFICATION_LETTER_TASK_ACTIONS
+    else
+      []
+    end
+  end
+
+  SEND_FINAL_NOTIFICATION_LETTER_TASK_ACTIONS = [
+    Constants.TASK_ACTIONS.MARK_FINAL_NOTIFICATION_LETTER_TASK_COMPLETE.to_h,
+    Constants.TASK_ACTIONS.RESEND_INITIAL_NOTIFICATION_LETTER.to_h,
+    Constants.TASK_ACTIONS.RESEND_FINAL_NOTIFICATION_LETTER.to_h,
+    Constants.TASK_ACTIONS.CANCEL_FINAL_NOTIFICATION_LETTER_TASK.to_h
+  ].freeze
+end

--- a/app/models/tasks/send_initial_notification_letter_task.rb
+++ b/app/models/tasks/send_initial_notification_letter_task.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class SendInitialNotificationLetterTask < LetterTask
+  validates :parent, presence: true
+
+  def label
+    "Send Initial Notification Letter"
+  end
+
+  def available_actions(user)
+    return [] unless assigned_to.user_has_access?(user)
+
+    task_actions = Array.new(SEND_INITIAL_NOTIFICATION_LETTER_TASK_ACTIONS)
+
+    task_actions
+  end
+
+  SEND_INITIAL_NOTIFICATION_LETTER_TASK_ACTIONS = [
+    Constants.TASK_ACTIONS.MARK_TASK_AS_COMPLETE_CC.to_h,
+    Constants.TASK_ACTIONS.PROCEED_FINAL_NOTIFICATION_LETTER_CC.to_h,
+    Constants.TASK_ACTIONS.CANCEL_FINAL_NOTIFICATION_LETTER_TASK.to_h
+  ].freeze
+end

--- a/app/views/appeals/edit.html.erb
+++ b/app/views/appeals/edit.html.erb
@@ -17,6 +17,7 @@
       correctClaimReviews: FeatureToggle.enabled?(:correct_claim_reviews, user: current_user),
       covidTimelinessExemption: FeatureToggle.enabled?(:covid_timeliness_exemption, user: current_user),
       split_appeal_workflow: FeatureToggle.enabled?(:split_appeal_workflow, user: current_user),
+      cc_appeal_workflow: FeatureToggle.enabled?(:cc_appeal_workflow, user: current_user),
       vhaPreDocketAppeals: false
     }
   }) %>

--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -47,7 +47,8 @@
       vso_virtual_opt_in: FeatureToggle.enabled?(:vso_virtual_opt_in, user: current_user),
       das_case_timeliness: FeatureToggle.enabled?(:das_case_timeliness, user: current_user),
       split_appeal_workflow: FeatureToggle.enabled?(:split_appeal_workflow, user: current_user),
-      das_case_timeline: FeatureToggle.enabled?(:das_case_timeline, user: current_user)
+      das_case_timeline: FeatureToggle.enabled?(:das_case_timeline, user: current_user),
+      cc_appeal_workflow: FeatureToggle.enabled?(:cc_appeal_workflow, user: current_user)
     }
   }) %>
 <% end %>

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -458,5 +458,17 @@
     "label": "Return to Board Intake",
     "value": "modal/vha_caregiver_support_return_to_board_intake",
     "func": "vha_caregiver_support_return_to_board_intake"
+  },
+  "RESEND_INITIAL_NOTIFICATION_LETTER":{
+    "label": "Resend initial notification letter"
+  },
+  "RESEND_FINAL_NOTIFICATION_LETTER":{
+    "label": "Resend final notification letter"
+  },
+  "MARK_FINAL_NOTIFICATION_LETTER_TASK_COMPLETE": {
+    "label": "Mark task complete"
+  },
+  "CANCEL_FINAL_NOTIFICATION_LETTER_TASK": {
+    "label": "Cancel task"
   }
 }

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -469,6 +469,18 @@
     "label": "Mark task complete"
   },
   "CANCEL_FINAL_NOTIFICATION_LETTER_TASK": {
-    "label": "Cancel task"
+    "label": "Cancel task",
+    "value": "modal/cancel_task",
+    "func": "cancel_task_data"
+  },
+  "MARK_TASK_AS_COMPLETE_CC": {
+    "label": "Mark task complete",
+    "value": "modal/mark_task_complete",
+    "func": "cancel_task_data"
+  },
+  "PROCEED_FINAL_NOTIFICATION_LETTER_CC": {
+    "label": "Proceed to final notification letter",
+    "value": "modal/final_notification_letter",
+    "func": "cancel_task_data"
   }
 }

--- a/spec/models/send_final_notification_letter_task_spec.rb
+++ b/spec/models/send_final_notification_letter_task_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe SendFinalNotificationLetterTask do
+  let(:user) { create(:user) }
+  let(:cob_team) { ClerkOfTheBoard.singleton }
+  let(:root_task) { create(:root_task) }
+  let(:distribution_task) { create(:distribution_task, parent: root_task) }
+  let(:task_class) { SendFinalNotificationLetterTask }
+  before do
+    cob_team.add_user(user)
+  end
+
+  describe ".verify_user_can_create" do
+    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name} }
+    let(:distribution_task_id) { distribution_task.id }
+
+    context "when no distribution_task exists for appeal" do
+      let(:distribution_task_id) { nil }
+
+      it "throws an error" do
+        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    # test contexts for successfully creating task when an appeal has a CC will go here once other tasks are made
+  end
+
+  describe ".available_actions" do
+    let(:final_notification_letter_task) {
+      task_class.create!(appeal: distribution_task.appeal, parent_id: distribution_task.id, assigned_to: cob_team)
+    }
+
+    let(:available_task_actions) do
+      [
+        Constants.TASK_ACTIONS.MARK_FINAL_NOTIFICATION_LETTER_TASK_COMPLETE.to_h,
+        Constants.TASK_ACTIONS.RESEND_INITIAL_NOTIFICATION_LETTER.to_h,
+        Constants.TASK_ACTIONS.RESEND_FINAL_NOTIFICATION_LETTER.to_h,
+        Constants.TASK_ACTIONS.CANCEL_TASK.to_h
+      ]
+    end
+
+    context "the user is not a member of COB" do
+      let(:non_cob_user) { create(:user) }
+
+      subject { final_notification_letter_task.available_actions(non_cob_user) }
+
+      it "returns no actions" do
+        expect(subject).to_not eql(available_task_actions)
+        expect(subject).to eql([])
+      end
+    end
+
+    context "the user is a member of COB" do
+      subject { final_notification_letter_task.available_actions(user) }
+
+      it "returns the task actions" do
+        expect(subject).to eql(available_task_actions)
+      end
+    end
+  end
+end

--- a/spec/models/send_initial_notification_letter_task_spec.rb
+++ b/spec/models/send_initial_notification_letter_task_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe SendInitialNotificationLetterTask do
+  let(:user) { create(:user) }
+  let(:cob_team) { ClerkOfTheBoard.singleton }
+  let(:root_task) { create(:root_task) }
+  let(:distribution_task) { create(:distribution_task, parent: root_task) }
+  let(:task_class) { SendInitialNotificationLetterTask }
+  before do
+    cob_team.add_user(user)
+  end
+
+  describe ".verify_user_can_create" do
+    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name } }
+    let(:distribution_task_id) { distribution_task.id }
+
+    context "when no distribution_task exists for appeal" do
+      let(:distribution_task_id) { nil }
+
+      it "throws an error" do
+        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    # test contexts for successfully creating task when an appeal has a CC will go here once other tasks are made
+  end
+
+  describe ".available_actions" do
+    let(:send_initial_notification_letter_task) { task_class.create!(appeal: distribution_task.appeal, parent_id: distribution_task.id, assigned_to: cob_team) }
+
+    let(:available_task_actions) do
+      [
+        Constants.TASK_ACTIONS.MARK_TASK_AS_COMPLETE_CC.to_h,
+        Constants.TASK_ACTIONS.PROCEED_FINAL_NOTIFICATION_LETTER_CC.to_h,
+        Constants.TASK_ACTIONS.CANCEL_FINAL_NOTIFICATION_LETTER_TASK.to_h
+      ]
+    end
+
+    context "the user is not a member of COB" do
+      let(:non_cob_user) { create(:user) }
+
+      subject { send_initial_notification_letter_task.available_actions(non_cob_user) }
+
+      it "returns no actions" do
+        expect(subject).to_not eql(available_task_actions)
+        expect(subject).to eql([])
+      end
+    end
+
+    context "the user is a member of COB" do
+      subject { send_initial_notification_letter_task.available_actions(user) }
+
+      it "returns the task actions" do
+        expect(subject).to eql(available_task_actions)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #APPEALS-13362

Description
Send initial notification letter task is created for the contested claim appeals. The send initial notification letter is the newly created child task which inherits from distribution task.
Send initial notification letter task is used to set reminders for COB users to send a notification letter to appellants that have contested claims.  
 
Acceptance Criteria
 Code compiles correctly

1. The "Send Initial Notification Letter” task should have a parent class of LetterTask
     Class signature will look like "SendInitialNotificationLetterTask < LetterTask"
      LetterTask will be a new class that inherits from Task and is empty currently
      Class signature will look like "LetterTask < Task"
       [APPEALS-13371](https://vajira.max.gov/browse/APPEALS-13371) also includes this AC

2. The "Send Initial Notification Letter” task is a blocking task for the following tasks, as in this task should be added as the child task to these tasks depending on the docket of the appeal:
      schedule hearing task for hearing docketed appeals
      evidence submission window task for evidence docketed appeals
      distribution task for direct docketed appeals

3. The "Send Initial Notification Letter” task is assigned to the Clerk of the Board organization
The "Send Initial Notification Letter” task contains the following task actions
Mark task as complete
Proceed to final notification letter
Cancel task

