### PR TITLE
Hotfix/appeals 14044 v2

### DIFF
--- a/app/jobs/va_notify_status_update_job.rb
+++ b/app/jobs/va_notify_status_update_job.rb
@@ -57,7 +57,7 @@ class VANotifyStatusUpdateJob < CaseflowJob
 
   private
 
-  # Description: Method that applies a query limit to the list of notification records that will get the status checked for 
+  # Description: Method that applies a query limit to the list of notification records that will get the status checked for
   # them from VA Notiufy
   #
   # Params: None
@@ -73,8 +73,8 @@ class VANotifyStatusUpdateJob < CaseflowJob
     end
   end
 
-  # Description: Method to query the Notification database for Notififcation records that have not been updated with a VA Notify Status 
-  # 
+  # Description: Method to query the Notification database for Notififcation records that have not been updated with a VA Notify Status
+  #
   # Params: None
   #
   # Retuns: Lits of Notification Active Record associations meeting the where condition
@@ -103,10 +103,10 @@ class VANotifyStatusUpdateJob < CaseflowJob
     Rails.logger.info(message)
   end
 
-  # Description: Method that will get the VA Notify Status for the notification based on notification type 
-  # 
+  # Description: Method that will get the VA Notify Status for the notification based on notification type
   #
-  # Params: 
+  #
+  # Params:
   # notification_id - The external id that VA Notify assigned to each notification. Can be for Email or SMS
   # type - Type of notification to get status for
   #   values - Email, SMS or Email and SMS
@@ -121,14 +121,17 @@ class VANotifyStatusUpdateJob < CaseflowJob
         { "sms_notification_status" => response.body["status"], "recipient_phone_number" => response.body["phone_number"] }
       end
     else
-      log_error("VA Notify API returned error for notification " + notification_id)
-      nil
+      begin
+      rescue StandardError
+        log_error("VA Notify API returned error for notification " + notification_id)
+        Raven.capture_exception(error, extra: { notification_id: notification_id, type: type })
+      end
     end
   end
 
   # Description: Method that will update the notification record values
   #
-  # Params: 
+  # Params:
   # notification_audit_record - Notification Record to be updated
   # to_update - Hash containing the column names and values to be updated
   #

--- a/lib/fakes/va_notify_service.rb
+++ b/lib/fakes/va_notify_service.rb
@@ -15,7 +15,18 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
     end
 
     def get_status(notification_id)
-      fake_status_response(notification_id)
+      if notification_id == "000000"
+        HTTPI::Response.new(
+          404,
+          {},
+          OpenStruct.new(
+            "error": "NotFoundError",
+            "message": "notification id not found"
+          )
+        )
+      else
+        fake_status_response(notification_id)
+      end
     end
 
     private

--- a/lib/fakes/va_notify_service.rb
+++ b/lib/fakes/va_notify_service.rb
@@ -15,18 +15,7 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
     end
 
     def get_status(notification_id)
-      if notification_id == "000000"
-        HTTPI::Response.new(
-          404,
-          {},
-          OpenStruct.new(
-            "error": "NotFoundError",
-            "message": "notification id not found"
-          )
-        )
-      else
-        fake_status_response(notification_id)
-      end
+      fake_status_response(notification_id)
     end
 
     private
@@ -121,45 +110,57 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
 
     # rubocop:disable Metrics/MethodLength
     def fake_status_response(notification_id)
-      HTTPI::Response.new(
-        200,
-        {},
-        OpenStruct.new(
-          "id": notification_id,
-          "body": "string",
-          "completed_at": "2022-08-08T16:20:50.090Z",
-          "created_at": "2022-08-08T16:20:50.090Z",
-          "created_by_name": "string",
-          "email_address": "user@example.com",
-          "line_1": "string",
-          "line_2": "string",
-          "line_3": "string",
-          "line_4": "string",
-          "line_5": "string",
-          "line_6": "string",
-          "phone_number": "+16502532222",
-          "postage": "string",
-          "postcode": "string",
-          "recipient_identifiers": [
-            {
-              "id_type" => "VAPROFILEID",
-              "id_value" => "string"
-            }
-          ],
-          "reference": "string",
-          "scheduled_for": "2022-08-08T16:20:50.090Z",
-          "sent_at": "2022-08-08T16:20:50.090Z",
-          "sent_by": "string",
-          "status": "created",
-          "subject": "string",
-          "template": {
-            "id" => "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-            "uri" => "string",
-            "version" => 0
-          },
-          "type" => "email"
+      # puts notification_id == "000000"
+      if notification_id != "000000"
+        HTTPI::Response.new(
+          200,
+          {},
+          OpenStruct.new(
+            "id": notification_id,
+            "body": "string",
+            "completed_at": "2022-08-08T16:20:50.090Z",
+            "created_at": "2022-08-08T16:20:50.090Z",
+            "created_by_name": "string",
+            "email_address": "user@example.com",
+            "line_1": "string",
+            "line_2": "string",
+            "line_3": "string",
+            "line_4": "string",
+            "line_5": "string",
+            "line_6": "string",
+            "phone_number": "+16502532222",
+            "postage": "string",
+            "postcode": "string",
+            "recipient_identifiers": [
+              {
+                "id_type" => "VAPROFILEID",
+                "id_value" => "string"
+              }
+            ],
+            "reference": "string",
+            "scheduled_for": "2022-08-08T16:20:50.090Z",
+            "sent_at": "2022-08-08T16:20:50.090Z",
+            "sent_by": "string",
+            "status": "created",
+            "subject": "string",
+            "template": {
+              "id" => "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+              "uri" => "string",
+              "version" => 0
+            },
+            "type" => "email"
+          )
         )
-      )
+      else
+        HTTPI::Response.new(
+          404,
+          {},
+          OpenStruct.new(
+            "error": "NotFoundError",
+            "message": "notification id not found"
+          )
+        )
+      end
     end
     # rubocop:enable Metrics/MethodLength
   end


### PR DESCRIPTION
Resolves #APPEALS-14044
https://vajira.max.gov/browse/APPEALS-14044

Description
Background: The VANotifyStatusUpdateJob is responsible for looking through all the VA Notify notifications that have an external id (ID of Record tracked in VA Notify) and the status of Success (Meaning sent to VA Notify) and hit the VA Notify API to to get the latest status from VA Notify.

Expected Behavior: The job processes all notifications and if encounters an error alerts and logs it and moves on
Actual Behavior: When the job runs into the an error from the API the jobs fails and stops processing

Acceptance Criteria
 Code compiles correctly
When the job calls out to the VA Notify API and the API returns an error the job captures that error and logs it
Error is logged using the rails logger
Error is sent to sentry using the Raven gem

Testing Plan
Go to ...
https://vajira.max.gov/browse/APPEALS-14483