### PR TITLE
JonathanCohen/APPEALS-8939 

### DIFF
--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -96,9 +96,10 @@ export const statusColumn = (notifications) => {
     tableData: notifications,
     valueName: 'Status',
     valueFunction: (notification) => {
-      const status = notification.status;
+      const { status } = notification;
 
-      return status.charAt(0).toUpperCase() + status.slice(1);
+      return NOTIFICATION_CONFIG.STATUSES[status.toUpperCase()] || status.charAt(0).toUpperCase() + status.slice(1);
     }
   };
 };
+

--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -98,6 +98,7 @@ export const statusColumn = (notifications) => {
     valueFunction: (notification) => {
       const { status } = notification;
 
+      console.log(NOTIFICATION_CONFIG.STATUSES[status.toUpperCase()] || status.charAt(0).toUpperCase() + status.slice(1));
       return NOTIFICATION_CONFIG.STATUSES[status.toUpperCase()] || status.charAt(0).toUpperCase() + status.slice(1);
     }
   };

--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -98,7 +98,6 @@ export const statusColumn = (notifications) => {
     valueFunction: (notification) => {
       const { status } = notification;
 
-      console.log(NOTIFICATION_CONFIG.STATUSES[status.toUpperCase()] || status.charAt(0).toUpperCase() + status.slice(1));
       return NOTIFICATION_CONFIG.STATUSES[status.toUpperCase()] || status.charAt(0).toUpperCase() + status.slice(1);
     }
   };

--- a/client/constants/NOTIFICATION_CONFIG.json
+++ b/client/constants/NOTIFICATION_CONFIG.json
@@ -24,6 +24,14 @@
       }
     },
     "COLUMN_SORT_ORDER_ASC": "asc",
-    "COLUMN_SORT_ORDER_DESC": "desc"
+    "COLUMN_SORT_ORDER_DESC": "desc",
+    "STATUSES": {
+      "SENT": "Pending Delivery",
+      "DELIVERED": "Delivered",
+      "TEMPORARY-FAILURE": "Pending Delivery",
+      "PERMANENT-FAILURE": "Failed Delivery",
+      "TECHNICAL-FAILURE": "Failed Delivery",
+      "PREFERENCES-DECLINED": "Opted-Out"
+    }
 }
 

--- a/client/constants/NOTIFICATION_CONFIG.json
+++ b/client/constants/NOTIFICATION_CONFIG.json
@@ -31,7 +31,7 @@
       "TEMPORARY-FAILURE": "Pending Delivery",
       "PERMANENT-FAILURE": "Failed Delivery",
       "TECHNICAL-FAILURE": "Failed Delivery",
-      "PREFERENCES-DECLINED": "Opted-Out"
+      "PREFERENCES-DECLINED": "Opted-out"
     }
 }
 

--- a/client/test/app/queue/NotificationTable.test.js
+++ b/client/test/app/queue/NotificationTable.test.js
@@ -106,6 +106,20 @@ describe('NotificationTable', () => {
     expect(row[19].textContent).toBe('Failed Delivery');
   });
 
+  it('Technical Failure status row should show failed delivery', async () => {
+    setup();
+    const row = await screen.findAllByRole('cell');
+
+    expect(row[24].textContent).toBe('Failed Delivery');
+  });
+
+  it('Preferences Declined status row should show opted out', async () => {
+    setup();
+    const row = await screen.findAllByRole('cell');
+
+    expect(row[34].textContent).toBe('Opted-out');
+  });
+
   it('matches snapshot', () => {
     const { container } = setup();
 

--- a/client/test/app/queue/NotificationTable.test.js
+++ b/client/test/app/queue/NotificationTable.test.js
@@ -78,18 +78,32 @@ describe('NotificationTable', () => {
     expect(row[8].textContent).toBe('2468012345');
   });
 
-  it('first status row should be not be delivered', async () => {
+  it('Sent status row should show Pending Delivery', async () => {
     setup();
     const row = await screen.findAllByRole('cell');
 
-    expect(row[4].textContent).toBe('Sent');
+    expect(row[4].textContent).toBe('Pending Delivery');
   });
 
-  it('second status row should be delivered', async () => {
+  it('Delivered status row should show delivered', async () => {
     setup();
     const row = await screen.findAllByRole('cell');
 
     expect(row[9].textContent).toBe('Delivered');
+  });
+
+  it('Temporary Failure status row should show pending delivery', async () => {
+    setup();
+    const row = await screen.findAllByRole('cell');
+
+    expect(row[14].textContent).toBe('Pending Delivery');
+  });
+
+  it('Permanent Failure status row should show failed delivery', async () => {
+    setup();
+    const row = await screen.findAllByRole('cell');
+
+    expect(row[19].textContent).toBe('Failed Delivery');
   });
 
   it('matches snapshot', () => {

--- a/client/test/data/notifications.js
+++ b/client/test/data/notifications.js
@@ -106,8 +106,8 @@ export const notifications = [
       event_type: 'Hearing scheduled',
       recipient_email: 'test2@caseflow.com',
       recipient_phone_number: '',
-      email_notification_status: 'delivered',
-      sms_notification_status: 'sent',
+      email_notification_status: 'temporary-failure',
+      sms_notification_status: 'permanent-failure',
       notification_content: 'string'
     }
   },

--- a/client/test/data/notifications.js
+++ b/client/test/data/notifications.js
@@ -8,8 +8,8 @@ export const notifications = [
       event_type: 'Appeal docketed',
       recipient_email: 'test@caseflow.com',
       recipient_phone_number: '1234567890',
-      email_notification_status: 'delivered',
-      sms_notification_status: 'delivered',
+      email_notification_status: 'permanent-failure',
+      sms_notification_status: 'technical-failure',
       notification_content: 'string'
     }
   },
@@ -36,7 +36,7 @@ export const notifications = [
       event_type: 'Hearing scheduled',
       recipient_email: 'test@caseflow.com',
       recipient_phone_number: '1234567890',
-      email_notification_status: 'failed',
+      email_notification_status: 'preferences-declined',
       sms_notification_status: 'sent',
       notification_content: 'string'
     }


### PR DESCRIPTION
Resolves APPEALS/8939

### Description
Made UI changes to status column in notification table. 

### Acceptance Criteria

- [ ] When the notification status says "Sent" The email and/or Text notification record Status column displays "Pending Delivery"
- [ ] When the notification status says "Delivered" The email and/or Text notification record Status column displays "Delivered"
- [ ] When the notification status says "Temporary-failure" The email and/or Text notification record Status column displays "Pending Delivery"
- [ ] When the notification status says "Permanent-failure" The email and/or Text notification record Status column displays "Failed Delivery"
- [ ] When the notification status says "Technical-failure" The email and/or Text notification record Status column displays "Failed Delivery"
- [ ] When the notification status says "Preferences-declined" The email and/or Text notification record Status column displays "Opted-out"

### Testing Plan
https://vajira.max.gov/browse/APPEALS-15028


### User Facing Changes


 BEFORE|AFTER
 --
<img width="1728" alt="Screen Shot 2023-01-31 at 11 21 45 AM" src="https://user-images.githubusercontent.com/121630615/215819300-6fd381eb-79b4-43da-8b2a-060ad58ee916.png">
-|---
<img width="1407" alt="Screen Shot 2023-01-31 at 11 20 30 AM" src="https://user-images.githubusercontent.com/121630615/215819334-8cd77809-4a3a-4832-a4b2-17f546534e30.png">
