### PR TITLE
Add PropTypes to All Non-Compensation Queue React Components

### DIFF
--- a/client/app/nonComp/components/Alerts.jsx
+++ b/client/app/nonComp/components/Alerts.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Alert from '../../components/Alert';
 
 export class ErrorAlert extends React.PureComponent {
@@ -18,6 +19,9 @@ export class ErrorAlert extends React.PureComponent {
   }
 }
 
+ErrorAlert.propTypes = {
+  errorCode: PropTypes.string,
+}
 export class SuccessAlert extends React.PureComponent {
   render() {
     const successObject = {
@@ -31,6 +35,11 @@ export class SuccessAlert extends React.PureComponent {
       {successObject.body}
     </Alert>;
   }
+}
+
+SuccessAlert.propTypes = {
+  claimantName: PropTypes.string,
+  successCode: PropTypes.string
 }
 
 export class FlashAlerts extends React.PureComponent {
@@ -54,4 +63,8 @@ export class FlashAlerts extends React.PureComponent {
 
     return <div className="cf-flash-messages">{alerts}</div>;
   }
+}
+
+FlashAlerts.propTypes = {
+  flash: PropTypes.array
 }

--- a/client/app/nonComp/components/Alerts.jsx
+++ b/client/app/nonComp/components/Alerts.jsx
@@ -21,7 +21,8 @@ export class ErrorAlert extends React.PureComponent {
 
 ErrorAlert.propTypes = {
   errorCode: PropTypes.string,
-}
+};
+
 export class SuccessAlert extends React.PureComponent {
   render() {
     const successObject = {
@@ -40,7 +41,7 @@ export class SuccessAlert extends React.PureComponent {
 SuccessAlert.propTypes = {
   claimantName: PropTypes.string,
   successCode: PropTypes.string
-}
+};
 
 export class FlashAlerts extends React.PureComponent {
   render() {
@@ -67,4 +68,4 @@ export class FlashAlerts extends React.PureComponent {
 
 FlashAlerts.propTypes = {
   flash: PropTypes.array
-}
+};

--- a/client/app/nonComp/components/BoardGrant.jsx
+++ b/client/app/nonComp/components/BoardGrant.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Button from '../../components/Button';
@@ -110,6 +111,13 @@ class BoardGrantUnconnected extends React.PureComponent {
       { completeDiv }
     </div>;
   }
+}
+
+BoardGrantUnconnected.propTypes = {
+  task: PropTypes.shape({
+    closed_at: PropTypes.string
+  }),
+  handleSave: PropTypes.func
 }
 
 const BoardGrant = connect(

--- a/client/app/nonComp/components/BoardGrant.jsx
+++ b/client/app/nonComp/components/BoardGrant.jsx
@@ -113,12 +113,28 @@ class BoardGrantUnconnected extends React.PureComponent {
   }
 }
 
+BoardGrantIssue.propTypes = {
+  issue: PropTypes.shape({
+    decisionIssue: PropTypes.object,
+    description: PropTypes.string
+  }),
+  index: PropTypes.number
+};
+
 BoardGrantUnconnected.propTypes = {
   task: PropTypes.shape({
-    closed_at: PropTypes.string
+    closed_at: PropTypes.string,
+    tasks_url: PropTypes.string
+  }),
+  appeal: PropTypes.shape({
+    requestIssues: PropTypes.array,
+    decisionIssues: PropTypes.array
+  }),
+  decisionIssuesStatus: PropTypes.shape({
+    update: PropTypes.string
   }),
   handleSave: PropTypes.func
-}
+};
 
 const BoardGrant = connect(
   (state) => ({

--- a/client/app/nonComp/components/RecordRequest.jsx
+++ b/client/app/nonComp/components/RecordRequest.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import Button from '../../components/Button';
 import { BOA_ADDRESS, DECISION_ISSUE_UPDATE_STATUS } from '../constants';
 import Checkbox from '../../components/Checkbox';
-import COPY from '../../../COPY.json';
+import COPY from '../../../COPY';
 
 class RecordRequestUnconnected extends React.PureComponent {
   constructor(props) {

--- a/client/app/nonComp/components/RecordRequest.jsx
+++ b/client/app/nonComp/components/RecordRequest.jsx
@@ -86,10 +86,15 @@ class RecordRequestUnconnected extends React.PureComponent {
 
 RecordRequestUnconnected.propTypes = {
   task: PropTypes.shape({
-    closed_at: PropTypes.string
+    closed_at: PropTypes.string,
+    tasks_url: PropTypes.string
   }),
+  decisionIssuesStatus: PropTypes.shape({
+    update: PropTypes.string
+  }),
+  businessLine: PropTypes.string,
   handleSave: PropTypes.func
-}
+};
 
 const RecordRequest = connect(
   (state) => ({

--- a/client/app/nonComp/components/RecordRequest.jsx
+++ b/client/app/nonComp/components/RecordRequest.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import Button from '../../components/Button';
@@ -81,6 +82,13 @@ class RecordRequestUnconnected extends React.PureComponent {
       { completeDiv }
     </div>;
   }
+}
+
+RecordRequestUnconnected.propTypes = {
+  task: PropTypes.shape({
+    closed_at: PropTypes.string
+  }),
+  handleSave: PropTypes.func
 }
 
 const RecordRequest = connect(

--- a/client/app/nonComp/pages/TaskPage.jsx
+++ b/client/app/nonComp/pages/TaskPage.jsx
@@ -97,7 +97,8 @@ TaskPageUnconnected.propTypes = {
     formType: PropTypes.string,
     sameOffice: PropTypes.bool,
     informalConference: PropTypes.bool,
-    veteranIsNotClaimant: PropTypes.bool
+    veteranIsNotClaimant: PropTypes.bool,
+    receiptDate: PropTypes.string
   }),
   task: PropTypes.shape({
     id: PropTypes.number,
@@ -106,8 +107,14 @@ TaskPageUnconnected.propTypes = {
     created_at: PropTypes.string
   }),
   businessLine: PropTypes.string,
-  decisionIssuesStatus: PropTypes.object
-}
+  decisionIssuesStatus: PropTypes.object,
+  taskUpdateDefaultPage: PropTypes.func,
+  completeTask: PropTypes.func,
+  history: PropTypes.shape({
+    push: PropTypes.func
+  }),
+  businessLineUrl: PropTypes.string
+};
 
 const TaskPage = connect(
   (state) => ({

--- a/client/app/nonComp/pages/TaskPage.jsx
+++ b/client/app/nonComp/pages/TaskPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
@@ -88,6 +89,24 @@ class TaskPageUnconnected extends React.PureComponent {
       { detailedTaskView }
     </div>;
   }
+}
+
+TaskPageUnconnected.propTypes = {
+  appeal: PropTypes.shape({
+    veteran: PropTypes.object,
+    formType: PropTypes.string,
+    sameOffice: PropTypes.bool,
+    informalConference: PropTypes.bool,
+    veteranIsNotClaimant: PropTypes.bool
+  }),
+  task: PropTypes.shape({
+    id: PropTypes.number,
+    claimant: PropTypes.object,
+    type: PropTypes.string,
+    created_at: PropTypes.string
+  }),
+  businessLine: PropTypes.string,
+  decisionIssuesStatus: PropTypes.object
 }
 
 const TaskPage = connect(


### PR DESCRIPTION
Resolves [APPEALS-14889](https://vajira.max.gov/browse/APPEALS-14889)

### Description
Adds PropTypes to noncomp components that were missing them

### Acceptance Criteria

PropTypes are added to the following NonComp components:
- TaskPage.jsx
- Alerts.jsx
- BoardGrant.jsx
- RecordRequest.jsx

### Testing Plan
1. Go to the client directory and run `yarn eslint "app/nonComp/**"` and note the reduction in eslint warnings

