### PR TITLE
HunJerBAH APPEALS-13363

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -153,7 +153,7 @@ class AppealsController < ApplicationController
     existing_contested_claim = appeal.contested_claim?
     if request_issues_update.perform!
       # if the appeal wasn't contested and now is after adding issue, create initial notif. letter task
-      if !existing_contested_claim && appeal.contested_claim?
+      if !existing_contested_claim && appeal.contested_claim? && FeatureToggle.enabled?(:cc_appeal_workflow)
         send_initial_notification_letter
       end
 

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -87,7 +87,8 @@ class InitialTasksFactory
                                           SendInitialNotificationLetterTask.create!(
                                             appeal: @appeal,
                                             parent: parent_task,
-                                            assigned_to: Organization.find_by_url("clerk-of-the-board")
+                                            assigned_to: Organization.find_by_url("clerk-of-the-board"),
+                                            assigned_by: RequestStore[:current_user]
                                           )
   end
 

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -74,10 +74,19 @@ class InitialTasksFactory
   end
 
   def send_initial_notification_letter
+    # depending on the docket type, create cooresponding task as parent task
+    case @appeal.docket_type
+    when "evidence_submission"
+      parent_task = @appeal.tasks.find_by(type: "EvidenceSubmissionWindowTask")
+    when "hearing"
+      parent_task = @appeal.tasks.find_by(type: "ScheduleHearingTask")
+    when "direct_review"
+      parent_task = distribution_task
+    end
     @send_initial_notification_letter ||= @appeal.tasks.open.find_by(type: :SendInitialNotificationLetterTask) ||
                                           SendInitialNotificationLetterTask.create!(
                                             appeal: @appeal,
-                                            parent: @appeal.tasks.find_by(status: "assigned"),
+                                            parent: parent_task,
                                             assigned_to: Organization.find_by_url("clerk-of-the-board")
                                           )
   end

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -25,7 +25,7 @@ class InitialTasksFactory
     create_vso_tracking_tasks
     ActiveRecord::Base.transaction do
       create_subtasks! if @appeal.original? || @appeal.cavc? || @appeal.appellant_substitution?
-      if @appeal.contested_claim?
+      if @appeal.contested_claim? && FeatureToggle.enabled?(:cc_appeal_workflow)
         send_initial_notification_letter
       end
     end

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -162,22 +162,7 @@ feature "Intake Add Issues Page", :all_dbs do
     end
 
     context "when adding a contested claim to an appeal" do
-      before do
-        ClerkOfTheBoard.singleton
-        FeatureToggle.enable!(:cc_appeal_workflow)
-        FeatureToggle.enable!(:indicator_for_contested_claims)
-      end
-      after do
-        FeatureToggle.disable!(:cc_appeal_workflow)
-        FeatureToggle.disable!(:indicator_for_contested_claims)
-      end
-
-      scenario "the appeal is evidence submission" do
-        start_appeal(veteran)
-        visit "/intake"
-        click_intake_continue
-        expect(page).to have_current_path("/intake/add_issues")
-
+      def add_contested_claim_issue
         click_intake_add_issue
         click_intake_no_matching_issues
 
@@ -200,6 +185,26 @@ feature "Intake Add Issues Page", :all_dbs do
         # click buttons
         click_on "Add this issue"
         click_on "Establish appeal"
+      end
+
+      before do
+        ClerkOfTheBoard.singleton
+        FeatureToggle.enable!(:cc_appeal_workflow)
+        FeatureToggle.enable!(:indicator_for_contested_claims)
+      end
+      after do
+        FeatureToggle.disable!(:cc_appeal_workflow)
+        FeatureToggle.disable!(:indicator_for_contested_claims)
+      end
+
+      scenario "the appeal is evidence submission" do
+        start_appeal(veteran)
+        visit "/intake"
+        click_intake_continue
+        expect(page).to have_current_path("/intake/add_issues")
+
+        # method to process add issues page with cc issue
+        add_contested_claim_issue
 
         appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
         appeal.reload
@@ -222,28 +227,8 @@ feature "Intake Add Issues Page", :all_dbs do
         click_intake_continue
         expect(page).to have_current_path("/intake/add_issues")
 
-        click_intake_add_issue
-        click_intake_no_matching_issues
-
-        # add the cc issue
-        dropdown_select_string = "Select or enter..."
-        benefit_text = "Insurance"
-
-        # Select the benefit type
-        all(".cf-select__control", text: dropdown_select_string).first.click
-        find("div", class: "cf-select__option", text: benefit_text).click
-
-        # Select the issue category
-        find(".cf-select__control", text: dropdown_select_string).click
-        find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
-
-        # fill in date and issue description
-        fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
-        fill_in "Issue description", with: "CC Instructions"
-
-        # click buttons
-        click_on "Add this issue"
-        click_on "Establish appeal"
+        # method to process add issues page with cc issue
+        add_contested_claim_issue
 
         appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
         appeal.reload
@@ -266,28 +251,8 @@ feature "Intake Add Issues Page", :all_dbs do
         click_intake_continue
         expect(page).to have_current_path("/intake/add_issues")
 
-        click_intake_add_issue
-        click_intake_no_matching_issues
-
-        # add the cc issue
-        dropdown_select_string = "Select or enter..."
-        benefit_text = "Insurance"
-
-        # Select the benefit type
-        all(".cf-select__control", text: dropdown_select_string).first.click
-        find("div", class: "cf-select__option", text: benefit_text).click
-
-        # Select the issue category
-        find(".cf-select__control", text: dropdown_select_string).click
-        find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
-
-        # fill in date and issue description
-        fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
-        fill_in "Issue description", with: "CC Instructions"
-
-        # click buttons
-        click_on "Add this issue"
-        click_on "Establish appeal"
+        # method to process add issues page with cc issue
+        add_contested_claim_issue
 
         appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
         appeal.reload

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -160,6 +160,149 @@ feature "Intake Add Issues Page", :all_dbs do
         end
       end
     end
+
+    context "when adding a contested claim to an appeal" do
+      before do
+        ClerkOfTheBoard.singleton
+        FeatureToggle.enable!(:cc_appeal_workflow)
+        FeatureToggle.enable!(:indicator_for_contested_claims)
+      end
+      after do
+        FeatureToggle.disable!(:cc_appeal_workflow)
+        FeatureToggle.disable!(:indicator_for_contested_claims)
+      end
+
+      scenario "the appeal is evidence submission" do
+        start_appeal(veteran)
+        visit "/intake"
+        click_intake_continue
+        expect(page).to have_current_path("/intake/add_issues")
+
+        click_intake_add_issue
+        click_intake_no_matching_issues
+
+        # add the cc issue
+        dropdown_select_string = "Select or enter..."
+        benefit_text = "Insurance"
+
+        # Select the benefit type
+        all(".cf-select__control", text: dropdown_select_string).first.click
+        find("div", class: "cf-select__option", text: benefit_text).click
+
+        # Select the issue category
+        find(".cf-select__control", text: dropdown_select_string).click
+        find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
+
+        # fill in date and issue description
+        fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
+        fill_in "Issue description", with: "CC Instructions"
+
+        # click buttons
+        click_on "Add this issue"
+        click_on "Establish appeal"
+
+        appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
+        appeal.reload
+
+        # expect the SendInitialNotificationLetterHoldingTask to be created and assigned to COB
+        expect(page).to have_content("Intake completed")
+        expect(appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+        ).to eql(appeal.tasks.find_by(type: "EvidenceSubmissionWindowTask"))
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+        ).to eql(ClerkOfTheBoard.singleton)
+      end
+
+      scenario "the appeal is direct review" do
+        start_appeal(veteran)
+        visit "/intake"
+        find("label", text: "Direct Review").click
+        click_intake_continue
+        expect(page).to have_current_path("/intake/add_issues")
+
+        click_intake_add_issue
+        click_intake_no_matching_issues
+
+        # add the cc issue
+        dropdown_select_string = "Select or enter..."
+        benefit_text = "Insurance"
+
+        # Select the benefit type
+        all(".cf-select__control", text: dropdown_select_string).first.click
+        find("div", class: "cf-select__option", text: benefit_text).click
+
+        # Select the issue category
+        find(".cf-select__control", text: dropdown_select_string).click
+        find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
+
+        # fill in date and issue description
+        fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
+        fill_in "Issue description", with: "CC Instructions"
+
+        # click buttons
+        click_on "Add this issue"
+        click_on "Establish appeal"
+
+        appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
+        appeal.reload
+
+        # expect the SendInitialNotificationLetterHoldingTask to be created and assigned to COB
+        expect(page).to have_content("Intake completed")
+        expect(appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+        ).to eql(appeal.tasks.find_by(type: "DistributionTask"))
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+        ).to eql(ClerkOfTheBoard.singleton)
+      end
+
+      scenario "the appeal is a hearing request" do
+        start_appeal(veteran)
+        visit "/intake"
+        find("label", text: "Hearing").click
+        click_intake_continue
+        expect(page).to have_current_path("/intake/add_issues")
+
+        click_intake_add_issue
+        click_intake_no_matching_issues
+
+        # add the cc issue
+        dropdown_select_string = "Select or enter..."
+        benefit_text = "Insurance"
+
+        # Select the benefit type
+        all(".cf-select__control", text: dropdown_select_string).first.click
+        find("div", class: "cf-select__option", text: benefit_text).click
+
+        # Select the issue category
+        find(".cf-select__control", text: dropdown_select_string).click
+        find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
+
+        # fill in date and issue description
+        fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
+        fill_in "Issue description", with: "CC Instructions"
+
+        # click buttons
+        click_on "Add this issue"
+        click_on "Establish appeal"
+
+        appeal = Appeal.find_by(veteran_file_number: veteran.file_number)
+        appeal.reload
+
+        # expect the SendInitialNotificationLetterHoldingTask to be created and assigned to COB
+        expect(page).to have_content("Intake completed")
+        expect(appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+        ).to eql(appeal.tasks.find_by(type: "ScheduleHearingTask"))
+        expect(
+          appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+        ).to eql(ClerkOfTheBoard.singleton)
+      end
+    end
   end
 
   context "when edit contention text feature is enabled" do

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -347,6 +347,182 @@ feature "Appeal Edit issues", :all_dbs do
     end
   end
 
+  def add_contested_claim_issue
+    click_intake_add_issue
+    click_intake_no_matching_issues
+
+    # add the cc issue
+    dropdown_select_string = "Select or enter..."
+    benefit_text = "Insurance"
+
+    # Select the benefit type
+    all(".cf-select__control", text: dropdown_select_string).first.click
+    find("div", class: "cf-select__option", text: benefit_text).click
+
+    # Select the issue category
+    find(".cf-select__control", text: dropdown_select_string).click
+    find("div", class: "cf-select__option", text: "Contested Death Claim | Intent of Insured").click
+
+    # fill in date and issue description
+    fill_in "Decision date", with: 1.day.ago.to_date.mdY.to_s
+    fill_in "Issue description", with: "CC Instructions"
+
+    # click buttons
+    click_on "Add this issue"
+    click_on "Save"
+    click_on "Yes, save"
+  end
+
+  context "A contested claim is added to an evidence submission appeal" do
+    let!(:cc_appeal) do
+      create(:appeal,
+             veteran_file_number: veteran.file_number,
+             receipt_date: receipt_date,
+             docket_type: Constants.AMA_DOCKETS.evidence_submission,
+             veteran_is_not_claimant: false,
+             legacy_opt_in_approved: legacy_opt_in_approved).tap(&:create_tasks_on_intake_success!)
+    end
+
+    before do
+      User.authenticate!(user: current_user)
+      FeatureToggle.enable!(:cc_appeal_workflow)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      ClerkOfTheBoard.singleton
+    end
+
+    scenario "the cc_appeal_workflow feature toggle is not enabled" do
+      FeatureToggle.disable!(:cc_appeal_workflow)
+      visit("/appeals/#{cc_appeal.uuid}/edit")
+      add_contested_claim_issue
+      # wait for page to load
+      sleep(4)
+      expect(page).to have_content("You have successfully added 1 issue")
+      expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be true
+    end
+
+    scenario "a cc issue is assigned to an evidence submission appeal" do
+      visit("/appeals/#{cc_appeal.uuid}/edit")
+      add_contested_claim_issue
+
+      # wait for page to load
+      sleep(4)
+      expect(page).to have_content("You have successfully added 1 issue")
+      expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+      ).to eql(cc_appeal.tasks.find_by(type: "EvidenceSubmissionWindowTask"))
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+      ).to eql(ClerkOfTheBoard.singleton)
+    end
+  end
+
+  context "A contested claim is added to an hearing appeal" do
+    let!(:cc_appeal) do
+      create(:appeal,
+             veteran_file_number: veteran.file_number,
+             receipt_date: receipt_date,
+             docket_type: Constants.AMA_DOCKETS.hearing,
+             veteran_is_not_claimant: false,
+             legacy_opt_in_approved: legacy_opt_in_approved).tap(&:create_tasks_on_intake_success!)
+    end
+
+    before do
+      User.authenticate!(user: current_user)
+      FeatureToggle.enable!(:cc_appeal_workflow)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      ClerkOfTheBoard.singleton
+    end
+
+    scenario "a cc issue is assigned to a hearing appeal" do
+      visit("/appeals/#{cc_appeal.uuid}/edit")
+      add_contested_claim_issue
+
+      # wait for page to load
+      sleep(4)
+      expect(page).to have_content("You have successfully added 1 issue")
+      expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+      ).to eql(cc_appeal.tasks.find_by(type: "ScheduleHearingTask"))
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+      ).to eql(ClerkOfTheBoard.singleton)
+    end
+  end
+
+  context "A contested claim is added to an hearing appeal" do
+    let!(:cc_appeal) do
+      create(:appeal,
+             veteran_file_number: veteran.file_number,
+             receipt_date: receipt_date,
+             docket_type: Constants.AMA_DOCKETS.hearing,
+             veteran_is_not_claimant: false,
+             legacy_opt_in_approved: legacy_opt_in_approved).tap(&:create_tasks_on_intake_success!)
+    end
+
+    before do
+      User.authenticate!(user: current_user)
+      FeatureToggle.enable!(:cc_appeal_workflow)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      ClerkOfTheBoard.singleton
+    end
+
+    scenario "a cc issue is assigned to a hearing appeal" do
+      visit("/appeals/#{cc_appeal.uuid}/edit")
+      add_contested_claim_issue
+
+      # wait for page to load
+      sleep(4)
+      expect(page).to have_content("You have successfully added 1 issue")
+      expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+      ).to eql(cc_appeal.tasks.find_by(type: "ScheduleHearingTask"))
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+      ).to eql(ClerkOfTheBoard.singleton)
+    end
+  end
+
+  context "A contested claim is added to a direct review appeal" do
+    let!(:cc_appeal) do
+      create(:appeal,
+             veteran_file_number: veteran.file_number,
+             receipt_date: receipt_date,
+             docket_type: Constants.AMA_DOCKETS.direct_review,
+             veteran_is_not_claimant: false,
+             legacy_opt_in_approved: legacy_opt_in_approved).tap(&:create_tasks_on_intake_success!)
+    end
+
+    before do
+      User.authenticate!(user: current_user)
+      FeatureToggle.enable!(:cc_appeal_workflow)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      FeatureToggle.enable!(:indicator_for_contested_claims)
+      ClerkOfTheBoard.singleton
+    end
+
+    scenario "a cc issue is assigned to a hearing appeal" do
+      visit("/appeals/#{cc_appeal.uuid}/edit")
+      add_contested_claim_issue
+
+      # wait for page to load
+      sleep(4)
+      expect(page).to have_content("You have successfully added 1 issue")
+      expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
+      ).to eql(cc_appeal.tasks.find_by(type: "DistributionTask"))
+      expect(
+        cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").assigned_to
+      ).to eql(ClerkOfTheBoard.singleton)
+    end
+  end
+
   context "User is a member of the Supervisory Senior Council" do
     let!(:organization) { SupervisorySeniorCouncil.singleton }
     let!(:current_user) { create(:user, roles: ["Mail Intake"]) }

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -395,9 +395,8 @@ feature "Appeal Edit issues", :all_dbs do
       FeatureToggle.disable!(:cc_appeal_workflow)
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be true
     end
 
@@ -405,9 +404,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
       expect(
         cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
@@ -443,9 +440,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
       expect(
         cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
@@ -481,9 +476,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").nil?).to be false
       expect(
         cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask").parent
@@ -528,9 +521,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.where(type: "SendInitialNotificationLetterTask").count).to eq 1
       # expect(cc_appeal.reload.tasks.find_by(type: "SendInitialNotificationLetterTask")).to be initial_letter_task
     end
@@ -541,9 +532,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.where(type: "SendInitialNotificationLetterTask").count).to eq 2
       expect(cc_appeal.reload.tasks.where(
         type: "SendInitialNotificationLetterTask"
@@ -556,9 +545,7 @@ feature "Appeal Edit issues", :all_dbs do
       visit("/appeals/#{cc_appeal.uuid}/edit")
       add_contested_claim_issue
 
-      # wait for page to load
-      sleep(4)
-      expect(page).to have_content("You have successfully added 1 issue")
+      assert page.has_content?("You have successfully added 1 issue")
       expect(cc_appeal.reload.tasks.where(type: "SendInitialNotificationLetterTask").count).to eq 2
       expect(cc_appeal.reload.tasks.where(
         type: "SendInitialNotificationLetterTask"


### PR DESCRIPTION
Resolves [APPEALS-13363](https://vajira.max.gov/browse/APPEALS-13363)

### Description
When a contested claim appeal is created within Intake, or a contested issue is added to an appeal, a Send Initial Notification Letter Task is created. This task is assigned to the COB organization. 

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] An appeal with a CC issue creates a SendInitialNotificationLetterTask at the end of the Intake process that blocks the DistributionTask
- [ ] An appeal with a CC issue creates a SendInitialNotificationLetterTask at the end of the Intake process that blocks the EvidenceSubmissionWindowTask
- [ ] An appeal with a CC issue creates a SendInitialNotificationLetterTask at the end of the Intake process that blocks the ScheduleHearingTask.
- [ ] An appeal with a CC issue added to it in Queue creates a SendInitialNotificationLetterTask.
- [ ] If an appeal already has an open SendInitialNotificationLetterTask, a new task is not created

### Testing Plan
### TESTING INTAKE
1. Go to the login page and sign in as a BVA Intake user (BVADWISE). 
2. Navigate to the Intake app.
3. Select the first option on the dropdown and click Continue to Search
![image](https://user-images.githubusercontent.com/99915461/217073825-546eac10-79e4-4e28-903b-1c9a8db6f831.png)

4. Enter a veteran's file number and click the magnifying glass to search. I used 484190018.
![image](https://user-images.githubusercontent.com/99915461/217073955-1feea08f-d132-427d-9d59-1c04616f0aff.png)

5. Fill out the form. For the first run through, select "Direct Review" for the review option, and click the button to continue. Future tests in this plan will go through creating appeals with the evidence, and hearing options. 
![image](https://user-images.githubusercontent.com/99915461/217074451-ebc22a1c-a9ef-411e-92a9-7de0209dd9ab.png)

6. Click the **Add issues** button and fill out the form with a **contested claim issue**. Click **add this issue** to close out of the form and **establish appeal** to finish the appeal. 
![image](https://user-images.githubusercontent.com/99915461/217074870-efc073e9-ce24-4b48-a7dc-8d0c03a8b3b2.png)

7. You should be greeted by a success message. Save the veteran's file number to search for the appeal later. Click **Begin next intake**. Repeat steps 3-6, but for the other two review types (Evidence Submission and Hearing).
![image](https://user-images.githubusercontent.com/99915461/217075457-70ca1878-7210-410b-b904-9aa67b28af3a.png)
![image](https://user-images.githubusercontent.com/99915461/217075695-0910135b-fd81-4343-984c-bd2f9a95355c.png)

8. When you are finished creating the 3 different types of appeal, navigate back to the login screen. Sign in as a COB member (I used COB_USER).
![image](https://user-images.githubusercontent.com/99915461/217076105-5a9e7e81-3c79-47dc-b6c6-78e062440588.png)

9. Enter the Queue app and click **search cases** in the top right of the screen. At the search bar, enter the veteran's file number that you used to intake the appeals. 
![image](https://user-images.githubusercontent.com/99915461/217076302-2c471020-ce23-4905-b4bc-37615ebfe73d.png)

10. Select each appeal and make sure that the active task is a **Send Initial Notification Letter** task. Make sure the task **assigned to** is the **COB organization** and **assigned by** is the BVA Intake user you were signed in as.
![image](https://user-images.githubusercontent.com/99915461/217076636-f44a7523-017b-4768-95c4-78528bd5746d.png)

### TESTING QUEUE
1. Go back to the case details page and sign in as BVADWISE or another intake user. 
2. Intake another appeal following steps 3-6 above **except do not select a CC issue on the appeal**. If you have another appeal available that doesn't have a contested claim issue on it, that would work as well. When the intake process is complete, save the veteran file number to search for it in Queue. 
![image](https://user-images.githubusercontent.com/99915461/217078005-7bc3acff-b52f-477e-8d83-5aef9e065b28.png)
![image](https://user-images.githubusercontent.com/99915461/217078043-c95482d8-7211-46b0-9383-29e23d4311b6.png)

3. Navigate to the Queue app by clicking the **search cases** link in the top right of the screen. 
4. Enter the veteran's file number to find the non-contested claim appeal. Click on the docket number link to navigate to the Case Details Screen
![image](https://user-images.githubusercontent.com/99915461/217078339-1fa52066-c72f-4035-853d-5e781e08697f.png)

5. Click on the **Correct issues** link on the case details page
![image](https://user-images.githubusercontent.com/99915461/217078536-250486c3-1f28-4b21-bb67-18c71f736e47.png)

6. Click **add issue** and fill out the form with a contested claim issue. Click **add this issue** to close out of the form, **save** to save the new issue to the appeal, and **yes, save** to finish adding the issue to the appeal.
![image](https://user-images.githubusercontent.com/99915461/217078735-1051da93-a27d-48f1-958a-923694d46f07.png)
![image](https://user-images.githubusercontent.com/99915461/217078850-b5dffa57-6154-49ba-9c95-6da38067018e.png)

7. You should be greeted by a green success banner and the **Send Initial Notification Letter** task should show in the **current active tasks**.
![image](https://user-images.githubusercontent.com/99915461/217078956-e3599b75-fe28-4188-bbd7-6d79a5483cca.png)


### TESTING EDGE CASES IN QUEUE
1. Sign in as a COB user. Navigate back to Queue and search for the veteran file number of one of the appeals you created (preferably, select one that has not been edited). Click on the docket number link to get to the case details page.
![image](https://user-images.githubusercontent.com/99915461/217079799-ccae72ec-27de-4fea-ba4f-c790908ab877.png)

2. Save the **Steam Docket Number** of the appeal. Click the **Actions** dropdown and select **cancel task**. Fill out the instructions and click **submit**
![image](https://user-images.githubusercontent.com/99915461/217080148-bc379cf3-9435-45d8-970b-8dfc0f1aef4f.png)
![image](https://user-images.githubusercontent.com/99915461/217080200-5cab4946-388d-4186-a7cf-c1679d5b79e5.png)

3. Sign in as a BVA Intake user. Navigate to Queue search again and use the stream docket number to find the appeal (you might also be able to use the back button if you didn't save the vet file number or stream docket number). 
4. Once on the Case Details page for the appeal, you will see at the bottom that the **Send Initial Notification Letter **task is cancelled. Click the **correct issues** link to get to the add issues page.
![image](https://user-images.githubusercontent.com/99915461/217080838-3903581c-a353-4236-9642-aeb2a9325f64.png)

5. Add another contested claim issue to the appeal (step 6 of **Queue testing plan above**). 
6. You should be greeted by a green success banner and a new **Send Initial Notification Letter** task should be created. 
![image](https://user-images.githubusercontent.com/99915461/217081189-ee0d4c39-69b5-4e29-bf3a-3ee2f34a2db3.png)

7. To test the final edge case, copy the veteran's file number. Click **search cases** and enter the veteran's file number to find the appeals you created during the intake process. You should still be signed in as BVADWISE or another intake user. 
![image](https://user-images.githubusercontent.com/99915461/217081734-9a050019-e6f4-4f61-9283-4e402871755d.png)

8. Select one of the contested claims appeals that you have not added an issue to. 
![image](https://user-images.githubusercontent.com/99915461/217081988-5f3cc959-4968-4e8a-b5ba-08c399212a6f.png)

9. Click the **Correct issues** link.
10. Add a 2nd Contested Claim issue to the appeal by clicking the **add issue** button, filling out the form, and clicking **add this issue**, **save**, and then the **yes, save** buttons. 
![image](https://user-images.githubusercontent.com/99915461/217082738-8379f305-8fba-4beb-9d80-45f0edc43be9.png)

11. You should be greeted by a green success banner. A 2nd **Send Initial Notification Letter** task should **not** have been created (only 1 visible). If you want, you can copy the docket number, sign in as a COB user, search the docket number, and confirm that there is no 2nd task dropdown (2nd image below). 
![image](https://user-images.githubusercontent.com/99915461/217082992-8fc1d72a-7a44-4219-b0b3-42c1e2e7d82f.png)
![image](https://user-images.githubusercontent.com/99915461/217083240-b6dfd8e1-f806-4097-9bfd-0db440eb5416.png)

12 **bonus**. I'm not sure if this works in the demo environment, but if you remove **queue** from the appeal hyperlink and replace it with **explain**, it will lead you to a view that gives more details about the appeal. You can click **task tree** to see the detailed task tree to get confirmation that only 1 **SendInitialNotificationLetterTask** was created.
![image](https://user-images.githubusercontent.com/99915461/217083422-1132240d-dc95-4175-b3b4-c6ca4f4d5a0f.png)
![image](https://user-images.githubusercontent.com/99915461/217083469-1c69971c-c213-42ea-80e9-ab6f9bc72e2e.png)
![image](https://user-images.githubusercontent.com/99915461/217083514-53cc9682-9d54-4031-b9ec-bc842b642702.png)
![image](https://user-images.githubusercontent.com/99915461/217083562-749af7c6-5711-4f7e-a1db-b15ca307f28c.png)
