### PR TITLE
HunJerBAH/ BGS Fakes POA seed data fix

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -707,17 +707,36 @@ class Fakes::BGSService
     RequestStore[:current_user]
   end
 
+  def generate_random_file_number
+    Kernel.srand(1)
+    value = rand(700_000_000...733_792_224).to_s
+
+    # make sure the value is unique for both file number and participant id
+    while BgsPowerOfAttorney.find_by(file_number: value).nil? == false &&
+          BgsPowerOfAttorney.find_by(participant_id: value).nil? == false
+
+      value = rand(700_000_000...733_792_224).to_s
+    end
+    # return the value
+    value
+  end
+
   def default_power_of_attorney_record
+    # generate random file number and participant id to prevent unique id collisions
+    # with test data
+    file_number = generate_random_file_number
+    ptcpnt_id = generate_random_file_number
+
     {
-      file_number: "633792224",
+      file_number: file_number,
       power_of_attorney:
         {
           legacy_poa_cd: "3QQ",
           nm: FakeConstants.BGS_SERVICE.DEFAULT_POA_NAME,
           org_type_nm: "POA Attorney",
-          ptcpnt_id: "600153863"
+          ptcpnt_id: ptcpnt_id
         },
-      ptcpnt_id: "600085544"
+      ptcpnt_id: ptcpnt_id
     }
   end
 


### PR DESCRIPTION
### Description
Refactored fakes bgs service to prevent BGS POA duplicate errors in Caseflow test data. 

### Acceptance Criteria and Testing Plan
Testing plan and AC is found on [this previous PR](https://github.com/department-of-veterans-affairs/caseflow/pull/17908)
