### PR TITLE
APPEALS-13128 Generalize uploading documents to VBMS

### DIFF
--- a/app/jobs/upload_document_to_vbms_job.rb
+++ b/app/jobs/upload_document_to_vbms_job.rb
@@ -2,10 +2,11 @@
 
 class UploadDocumentToVbmsJob < CaseflowJob
   queue_with_priority :low_priority
-  application_attr :idt
+  # application_attr application.to_sym
+  # application_attr :idt
 
-  def perform(document_id:, initiator_css_id:)
-    RequestStore.store[:application] = "idt"
+  def perform(document_id:, initiator_css_id:, application: "idt")
+    RequestStore.store[:application] = application
     RequestStore.store[:current_user] = User.system_user
 
     @document = VbmsUploadedDocument.find_by(id: document_id)

--- a/app/jobs/upload_document_to_vbms_job.rb
+++ b/app/jobs/upload_document_to_vbms_job.rb
@@ -2,9 +2,15 @@
 
 class UploadDocumentToVbmsJob < CaseflowJob
   queue_with_priority :low_priority
-  # application_attr application.to_sym
   # application_attr :idt
 
+  # Purpose: Calls the UploadDocumentToVbms workflow to upload the given document to VBMS
+  #
+  # Params: document_id - integer to search for VbmsUploadedDocument
+  #         initiator_css_id - string to find a user by css_id
+  #         application - string with a default value of "idt" but can be overwritten
+  #
+  # Return: nil
   def perform(document_id:, initiator_css_id:, application: "idt")
     RequestStore.store[:application] = application
     RequestStore.store[:current_user] = User.system_user

--- a/app/jobs/upload_document_to_vbms_job.rb
+++ b/app/jobs/upload_document_to_vbms_job.rb
@@ -2,7 +2,6 @@
 
 class UploadDocumentToVbmsJob < CaseflowJob
   queue_with_priority :low_priority
-  # application_attr :idt
 
   # Purpose: Calls the UploadDocumentToVbms workflow to upload the given document to VBMS
   #

--- a/app/workflows/prepare_document_upload_to_vbms.rb
+++ b/app/workflows/prepare_document_upload_to_vbms.rb
@@ -6,9 +6,9 @@ class PrepareDocumentUploadToVbms
   validates :veteran_file_number, :file, presence: true
   validate :valid_document_type
 
-  # Params: params - hash containing veteran_file_number, file, and document_type at minimum
+  # Params: params - hash containing file and document_type at minimum
   #         user - current user that is preparing the document for upload
-  #         appeal - Appeal object (optional)
+  #         appeal - Appeal object (optional if ssn or file number are passed into params)
   def initialize(params, user, appeal = nil)
     @params = params.slice(:veteran_file_number, :document_type, :document_subject, :document_name, :file, :application)
     @document_type = @params[:document_type]

--- a/app/workflows/prepare_document_upload_to_vbms.rb
+++ b/app/workflows/prepare_document_upload_to_vbms.rb
@@ -16,7 +16,7 @@ class PrepareDocumentUploadToVbms
     @appeal = appeal
   end
 
-  # Purpose: Starts the chain to upload a document to vbms
+  # Purpose: Queues a job to upload a document to vbms
   #
   # Params: See initialize
   #

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -5,9 +5,9 @@ class UploadDocumentToVbms
 
   delegate :document_type, :document_subject, :document_name, to: :document
 
-  def initialize(document:, s3_sub_bucket: "idt-uploaded-documents")
+  def initialize(document:, document_source: "idt-uploaded-documents")
     @document = document
-    @s3_sub_bucket = s3_sub_bucket
+    @document_source = document_source
   end
 
   def call
@@ -72,7 +72,7 @@ class UploadDocumentToVbms
 
   def s3_location
     # UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
-    s3_sub_bucket + "/" + pdf_name
+    document_source + "/" + pdf_name
   end
 
   def output_location

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -90,7 +90,8 @@ class UploadDocumentToVbms
   #
   # Return: string for the sub-bucket
   def s3_bucket_by_doc_type
-    if document_type == "BVA Case Notifications"
+    case document_type
+    when "BVA Case Notifications"
       "notification-reports"
     else
       "idt-uploaded-documents"

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -4,10 +4,11 @@ class UploadDocumentToVbms
   # S3_SUB_BUCKET = "idt-uploaded-documents"
 
   delegate :document_type, :document_subject, :document_name, to: :document
+  attr_reader :s3_sub_bucket
 
-  def initialize(document:, document_source: "idt-uploaded-documents")
+  def initialize(document:, s3_sub_bucket: "idt-uploaded-documents")
     @document = document
-    @document_source = document_source
+    @s3_sub_bucket = s3_sub_bucket
   end
 
   def call
@@ -72,7 +73,7 @@ class UploadDocumentToVbms
 
   def s3_location
     # UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
-    document_source + "/" + pdf_name
+    s3_sub_bucket + "/" + pdf_name
   end
 
   def output_location

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -2,14 +2,9 @@
 
 class UploadDocumentToVbms
   delegate :document_type, :document_subject, :document_name, to: :document
-  attr_reader :s3_sub_bucket
 
-  # s3_sub_bucket was previously a constant defined for this class.
-  # It was added to a variable in the initialize method to allow for different sub buckets
-  # to be passed in, while maintaining the original constant as the default.
-  def initialize(document:, s3_sub_bucket: "idt-uploaded-documents")
+  def initialize(document:)
     @document = document
-    @s3_sub_bucket = s3_sub_bucket
   end
 
   def call
@@ -73,7 +68,7 @@ class UploadDocumentToVbms
   end
 
   def s3_location
-    s3_sub_bucket + "/" + pdf_name
+    s3_bucket_by_doc_type + "/" + pdf_name
   end
 
   def output_location
@@ -86,5 +81,19 @@ class UploadDocumentToVbms
 
   def file_number
     document.veteran_file_number
+  end
+
+  # Purpose: Get the s3_sub_bucket based on the document type
+  # S3_SUB_BUCKET was previously a constant defined for this class.
+  #
+  # Params: None
+  #
+  # Return: string for the sub-bucket
+  def s3_bucket_by_doc_type
+    if document_type == "BVA Case Notifications"
+      "notification-reports"
+    else
+      "idt-uploaded-documents"
+    end
   end
 end

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 class UploadDocumentToVbms
-  S3_SUB_BUCKET = "idt-uploaded-documents"
+  # S3_SUB_BUCKET = "idt-uploaded-documents"
 
   delegate :document_type, :document_subject, :document_name, to: :document
 
-  def initialize(document:)
+  def initialize(document:, s3_sub_bucket: "idt-uploaded-documents")
     @document = document
+    @s3_sub_bucket = s3_sub_bucket
   end
 
   def call
@@ -70,7 +71,8 @@ class UploadDocumentToVbms
   end
 
   def s3_location
-    UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
+    # UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
+    s3_sub_bucket + "/" + pdf_name
   end
 
   def output_location

--- a/app/workflows/upload_document_to_vbms.rb
+++ b/app/workflows/upload_document_to_vbms.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
 class UploadDocumentToVbms
-  # S3_SUB_BUCKET = "idt-uploaded-documents"
-
   delegate :document_type, :document_subject, :document_name, to: :document
   attr_reader :s3_sub_bucket
 
+  # s3_sub_bucket was previously a constant defined for this class.
+  # It was added to a variable in the initialize method to allow for different sub buckets
+  # to be passed in, while maintaining the original constant as the default.
   def initialize(document:, s3_sub_bucket: "idt-uploaded-documents")
     @document = document
     @s3_sub_bucket = s3_sub_bucket
@@ -72,7 +73,6 @@ class UploadDocumentToVbms
   end
 
   def s3_location
-    # UploadDocumentToVbms::S3_SUB_BUCKET + "/" + pdf_name
     s3_sub_bucket + "/" + pdf_name
   end
 

--- a/spec/controllers/idt/api/v1/upload_vbms_document_controller_spec.rb
+++ b/spec/controllers/idt/api/v1/upload_vbms_document_controller_spec.rb
@@ -141,7 +141,8 @@ RSpec.describe Idt::Api::V1::UploadVbmsDocumentController, :all_dbs, type: :cont
             expect(VbmsUploadedDocument).to receive(:create).with(document_params).and_return(uploaded_document)
             expect(UploadDocumentToVbmsJob).to receive(:perform_later).with(
               document_id: uploaded_document.id,
-              initiator_css_id: user.css_id
+              initiator_css_id: user.css_id,
+              application: anything
             )
             expect(uploaded_document).to receive(:cache_file)
 

--- a/spec/workflows/upload_document_to_vbms_spec.rb
+++ b/spec/workflows/upload_document_to_vbms_spec.rb
@@ -21,6 +21,7 @@ describe UploadDocumentToVbms, :postgres do
   let(:uploaded_to_vbms_at) { nil }
   let(:processed_at) { nil }
   let!(:doc_to_upload) { UploadDocumentToVbms.new(document: document) }
+  let(:doc_with_s3) { UploadDocumentToVbms.new(document: document, s3_sub_bucket: "test") }
 
   describe "#pdf_location" do
     it "fetches file from s3 and returns temporary location" do
@@ -46,6 +47,20 @@ describe UploadDocumentToVbms, :postgres do
   describe "#document_type" do
     it "reads it from the document instance" do
       expect(doc_to_upload.document_type).to eq document.document_type
+    end
+  end
+
+  describe "#s3_location" do
+    context "with default argument" do
+      it "defaults to idt-uploaded-documents" do
+        expect(doc_to_upload.s3_sub_bucket).to eq "idt-uploaded-documents"
+      end
+    end
+
+    context "with passed in argument" do
+      it "uses what was passed in" do
+        expect(doc_with_s3.send(:s3_location)).to include(doc_with_s3.s3_sub_bucket)
+      end
     end
   end
 

--- a/spec/workflows/upload_document_to_vbms_spec.rb
+++ b/spec/workflows/upload_document_to_vbms_spec.rb
@@ -21,7 +21,6 @@ describe UploadDocumentToVbms, :postgres do
   let(:uploaded_to_vbms_at) { nil }
   let(:processed_at) { nil }
   let!(:doc_to_upload) { UploadDocumentToVbms.new(document: document) }
-  let(:doc_with_s3) { UploadDocumentToVbms.new(document: document, s3_sub_bucket: "test") }
 
   describe "#pdf_location" do
     it "fetches file from s3 and returns temporary location" do
@@ -51,15 +50,13 @@ describe UploadDocumentToVbms, :postgres do
   end
 
   describe "#s3_location" do
-    context "with default argument" do
-      it "defaults to idt-uploaded-documents" do
-        expect(doc_to_upload.s3_sub_bucket).to eq "idt-uploaded-documents"
+    context "fetches a bucket name based on document type" do
+      it "changes based on specific document types" do
+        document.document_type = "BVA Case Notifications"
+        expect(doc_to_upload.send(:s3_location)).to include("notification-reports")
       end
-    end
-
-    context "with passed in argument" do
-      it "uses what was passed in" do
-        expect(doc_with_s3.send(:s3_location)).to include(doc_with_s3.s3_sub_bucket)
+      it "defaults to idt-uploaded-documents" do
+        expect(doc_to_upload.send(:s3_location)).to include("idt-uploaded-documents")
       end
     end
   end


### PR DESCRIPTION
Resolves APPEALS-13128

### Description
Updated UploadDocumentToVbms workflow and UploadDocumentToVbmsJob to allow for Notification PDF report to use the same process as IDT document upload while maintaining IDT functionality

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-15516

### Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.