### PR TITLE
Craig/appeals 13263 fix jmr bool

### DIFF
--- a/app/models/serializers/work_queue/cavc_dashboard_serializer.rb
+++ b/app/models/serializers/work_queue/cavc_dashboard_serializer.rb
@@ -11,9 +11,7 @@ class WorkQueue::CavcDashboardSerializer
   attribute :cavc_decision_date
   attribute :cavc_docket_number
   attribute :cavc_remand
-  attribute :joint_motion_for_remand do |object|
-    object.joint_motion_for_remand.to_s
-  end
+  attribute :joint_motion_for_remand
 
   attribute :source_request_issues
 end


### PR DESCRIPTION
Resolves [APPEALS-13263](https://vajira.max.gov/browse/APPEALS-13263)

### Description
- Modified cavc_dashboard_serializer to return joint_motion_for_remand boolean instead of string

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Verify that the Joint Motion For Remand? column on a CAVC Dashboard displays "No" for a non-JMR/JMPR remand
