### PR TITLE
Hotfix/APPEALS-15399

### DIFF
--- a/client/app/styles/_noncomp.scss
+++ b/client/app/styles/_noncomp.scss
@@ -76,7 +76,6 @@
     .cf-search-input-with-close {
       width: 100%;
       max-width: 55rem;
-      margin-top: 1rem;
     }
   }
 }
@@ -122,6 +121,9 @@
 
 .usa-search-small {
   max-width: none;
+  label {
+    margin-bottom: 1rem;
+  }
 }
 
 .cf-pagination-pages {

--- a/client/app/styles/reader/_reviewer.scss
+++ b/client/app/styles/reader/_reviewer.scss
@@ -494,7 +494,6 @@ input[type="search"].cf-search-input-with-close {
 .usa-search-small {
   [type="button"].cf-search-close-icon {
     margin-left: -20px;
-    margin-top: 2px;
     position: absolute;
   }
 }


### PR DESCRIPTION
Resolves APPEALS-15399

### Description
Fixed the vertical alignment for the 'X' button in the search box on the decision_reviews page, so that it is vertically centered within the search box.

### Acceptance Criteria
- [x] Code compiles correctly
- [x]  'X' button is vertically centered within the search box
- [x]  'X' button is correctly placed at any screen resolution
- [x] Doesn't break layout of any other pages

### Testing Plan
1. Go to /decision_reviews/vha page
2. Type anything into the search box

### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
<img width="428" alt="image-2023-02-10-14-50-51-627" src="https://user-images.githubusercontent.com/110493538/219072789-e070ff2c-a53d-4ea3-ba7c-c1a1f759a6e6.png">|![Screen Shot 2023-02-14 at 12 21 44 PM](https://user-images.githubusercontent.com/110493538/219072822-061148c0-cbc0-4824-9f34-5a5aaed8e430.png)

