### PR TITLE
msteele/APPEALS-13128-v2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "browser"
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "fb6fa9658825c143eb8d202b87128f34ca7e210b"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "465aff43770c285ad21419b14d92093d22ef01af"
 gem "connect_mpi", git: "https://github.com/department-of-veterans-affairs/connect-mpi.git", ref: "a3a58c64f85b980a8b5ea6347430dd73a99ea74c"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "ac1ae63ffb04a2ab4d2d5469262981acab162e94"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"


### PR DESCRIPTION
Resolves APPEALS-13128

### Description
Updated commit hash to match caseflow-commons repo and include BVA Case Notifications document type.

### Acceptance Criteria
- [x] Code compiles correctly

### Testing Plan
- Updated https://vajira.max.gov/browse/APPEALS-15516 to reflect changes to document type accepted list.
