### PR TITLE
[Restored] MattT/APPEALS-9109: Change BVA Intake's Completed Tab Description

### DIFF
--- a/app/models/queue_tabs/bva_intake_completed_tab.rb
+++ b/app/models/queue_tabs/bva_intake_completed_tab.rb
@@ -14,7 +14,7 @@ class BvaIntakeCompletedTab < QueueTab
   end
 
   def description
-    format(COPY::ORGANIZATIONAL_QUEUE_PAGE_BVA_COMPLETED_TASKS_DESCRIPTION, assignee.name)
+    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/completed_tasks_tab.rb
+++ b/app/models/queue_tabs/completed_tasks_tab.rb
@@ -12,7 +12,7 @@ class CompletedTasksTab < QueueTab
   end
 
   def description
-    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+    COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/organization_completed_tasks_tab.rb
+++ b/app/models/queue_tabs/organization_completed_tasks_tab.rb
@@ -12,7 +12,7 @@ class OrganizationCompletedTasksTab < QueueTab
   end
 
   def description
-    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+    COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/vha_caregiver_support_completed_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_caregiver_support_completed_tasks_tab.rb
@@ -12,7 +12,7 @@ class VhaCaregiverSupportCompletedTasksTab < QueueTab
   end
 
   def description
-    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+    COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION
   end
 
   def tasks

--- a/app/models/queue_tabs/vha_program_office_completed_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_program_office_completed_tasks_tab.rb
@@ -12,7 +12,7 @@ class VhaProgramOfficeCompletedTasksTab < QueueTab
   end
 
   def description
-    COPY::VHA_QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
   end
 
   def parent_ids_with_cancelled_assess_documentation_task

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -314,7 +314,6 @@
   "ORGANIZATIONAL_QUEUE_PAGE_UNASSIGNED_TASKS_DESCRIPTION": "Cases owned by the %s team that are unassigned to a person.",
   "ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to a member of the %s team:",
   "ORGANIZATIONAL_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold in a %s team member's queue.",
-  "ORGANIZATIONAL_QUEUE_PAGE_BVA_COMPLETED_TASKS_DESCRIPTION": "Cases that are complete:",
   "ORGANIZATIONAL_QUEUE_PAGE_BVA_PENDING_TASKS_DESCRIPTION": "Appeals in Pre-Docket streams:",
   "ORGANIZATIONAL_QUEUE_PAGE_BVA_READY_FOR_REVIEW_TASKS_DESCRIPTION": "Cases assigned to Board Intake:",
   "ORGANIZATIONAL_QUEUE_EMPTY_STATE_MESSAGE": "This queue is empty. You can ",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -287,8 +287,8 @@
   "USER_QUEUE_PAGE_TABLE_TITLE": "Your cases",
   "USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to you:",
   "USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION": "Cases on hold (will return to \"Assigned\" tab when hold is completed):",
-  "QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed (last 7 days):",
-  "VHA_QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed:",
+  "QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION": "Cases completed (last 7 days):",
+  "QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION": "Cases completed:",
 
   "EDUCATION_EMO_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION": "Cases assigned to a member of a Regional Processing Office team or Board Intake:",
   "EDUCATION_EMO_QUEUE_PAGE_COMPLETED_TASKS_DESCRIPTION": "Cases completed:",

--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -44,7 +44,7 @@ class NonCompTabsUnconnected extends React.PureComponent {
         baseTasksUrl={`${this.props.baseTasksUrl}?${QUEUE_CONFIG.TAB_NAME_REQUEST_PARAM}=completed`}
         tabPaginationOptions={tabPaginationOptions}
         filterableTaskTypes={this.props.taskFilterDetails.completed}
-        description={COPY.QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION}
+        description={COPY.QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION}
         predefinedColumns={{ includeCompletedDate: true,
           defaultSortIdx: 3 }} />
     }];

--- a/spec/models/queue_config_spec.rb
+++ b/spec/models/queue_config_spec.rb
@@ -250,7 +250,7 @@ describe QueueConfig, :postgres do
 
           expect(tabs[0][:description]).to eq(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION)
           expect(tabs[1][:description]).to eq(COPY::USER_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION)
-          expect(tabs[2][:description]).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
+          expect(tabs[2][:description]).to eq(COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION)
         end
 
         context "when the user does not use the task pages API" do

--- a/spec/models/queue_tabs/bva_intake_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/bva_intake_completed_tasks_tab_spec.rb
@@ -21,6 +21,33 @@ describe BvaIntakeCompletedTab, :postgres do
     end
   end
 
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_COMPLETED_TAB_TITLE
+      is_expected.to eq "Completed"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+      is_expected.to eq "Cases completed:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.BVA_INTAKE_COMPLETED_TAB_NAME)
+      is_expected.to eq("bvaIntakeCompletedTab")
+    end
+  end
+
   describe ".tasks" do
     subject { tab.tasks }
 

--- a/spec/models/queue_tabs/organization_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/organization_completed_tasks_tab_spec.rb
@@ -40,7 +40,7 @@ describe OrganizationCompletedTasksTab, :postgres do
 
     context "when we want to show the amount of cases completed in the last 7 days" do
       it "has the correct description for each tab" do
-        expect(subject).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
+        expect(subject).to eq(COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION)
       end
     end
   end

--- a/spec/models/queue_tabs/vha_caregiver_support_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_caregiver_support_completed_tasks_tab_spec.rb
@@ -36,7 +36,7 @@ describe VhaCaregiverSupportCompletedTasksTab, :postgres do
 
     context "the description should be appropriately reflected" do
       it "matches what is defined in the Copy.json file" do
-        expect(subject).to eq(COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION)
+        expect(subject).to eq(COPY::QUEUE_PAGE_COMPLETE_LAST_SEVEN_DAYS_TASKS_DESCRIPTION)
         expect(subject).to eq("Cases completed (last 7 days):")
       end
     end


### PR DESCRIPTION
## Resolves [APPEALS-9109](https://vajira.max.gov/browse/APPEALS-9109) | [Original PR](https://github.com/department-of-veterans-affairs/caseflow/pull/17459)

### Description
In order to promote uniformity across all of our pre-docket queues, we would like for BVA Intake's completed tab to have the same description as the completed tab for EMO in the education business line.

### Acceptance Criteria
- [ ] The description for the tab currently reads "Cases that are complete:". It should be changed to "Cases completed:"

### Testing Plan
1. Log into Caseflow as a BVA Intake user (ex: BVADWISE)
2. Navigate to the BVA Intake organization's queue. Go to their Completed tab. ([/organizations/bva-intake?tab=bvaIntakeCompletedTab](http://localhost:3000/organizations/bva-intake?tab=bvaIntakeCompletedTab))
3. Ensure that the tab's description reads: "Cases completed:"

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
 ![](https://i.imgur.com/Djd5jER.png)|<img width="814" alt="bva-completed-tab-post-fix" src="https://user-images.githubusercontent.com/99351305/190034434-67641ad6-2b90-4325-88b3-fdd86b0f5e61.PNG">
 
### Code Coverage
<img width="378" alt="bva-completed-coverage" src="https://user-images.githubusercontent.com/99351305/190034886-2869fed0-8f47-42f9-bdfe-44531f8d3aff.PNG">

