### PR TITLE
[Restored] MattT/APPEALS-9105: Change VHA CAMO's Assigned Tab Description

### DIFF
--- a/app/models/queue_tabs/vha_camo_assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_camo_assigned_tasks_tab.rb
@@ -14,7 +14,7 @@ class VhaCamoAssignedTasksTab < QueueTab
   end
 
   def description
-    format(COPY::USER_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, assignee.name)
+    format(COPY::ORGANIZATIONAL_QUEUE_ASSIGNED_TO_DESCRIPTION, assignee.name)
   end
 
   def tasks

--- a/spec/models/queue_tabs/vha_camo_assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_camo_assigned_tasks_tab_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+describe VhaCamoAssignedTasksTab, :postgres do
+  let(:tab) { VhaCamoAssignedTasksTab.new(params) }
+  let(:params) { { assignee: assignee } }
+  let(:assignee) { VhaCamo.singleton }
+
+  describe ".column_names" do
+    subject { tab.column_names }
+
+    context "when only the assignee argument is passed when instantiating an VhaCamoAssignedTasksTab" do
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq(7)
+      end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TAB_TITLE
+      is_expected.to eq "Assigned (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it do
+      is_expected.to eq "Cases assigned to VHA CAMO:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.CAMO_ASSIGNED_TASKS_TAB_NAME)
+      is_expected.to eq("camo_assigned")
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+
+    context "when assignee views assigned tab" do
+      let!(:assignee_assigned_task) do
+        create_list(:vha_document_search_task, 4, :assigned, assigned_to: assignee)
+      end
+
+      it "returns a list of assigned tasks" do
+        is_expected.to match_array assignee_assigned_task
+        expect(subject.empty?).not_to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Resolves [APPEALS-9105](https://vajira.max.gov/browse/APPEALS-9105) | [Original PR](https://github.com/department-of-veterans-affairs/caseflow/pull/17456)

### Description
VHA CAMO's Assigned Tab description is currently set to the one used in individual users' queues. We would like to change it to be the same description used in other organizations' assigned tabs.

### Acceptance Criteria
- [ ] VHA CAMO's Assigned Tab description currently reads "Cases assigned to you:". This should instead read "Cases assigned to VHA CAMO:".

### Testing Plan
1. Log into Caseflow as a VHA CAMO user (ex: `CAMOUSER`)
2. Navigate to the VHA CAMO organization's queue. Go to their Assigned tab. ([/organizations/vha-camo?tab=camo_assigned](http://localhost:3000/organizations/vha-camo?tab=camo_assigned&page=1))
3. Ensure that the tab's description reads: "Cases assigned to VHA CAMO:"

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![](https://i.imgur.com/lw9eC0H.png)|<img width="833" alt="vha-camo-assigned-post-changes" src="https://user-images.githubusercontent.com/99351305/189999511-9fcaf686-38b8-4efd-966d-9718ce526e45.PNG">

### Code Coverage
<img width="324" alt="vha-camo-assigned-coverage" src="https://user-images.githubusercontent.com/99351305/190003162-edac2f57-d74c-4af6-b3a1-b4eacbcff1c8.PNG">

