### PR TITLE
[Restored] TYLERB/APPEALS-9156: Standardize "Mark task in progress" Task Action Labels

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1277,7 +1277,7 @@
   "VHA_PROGRAM_OFFICE_RETURN_TO_CAMO_MODAL_TITLE": "Return to CAMO team",
   "VHA_PROGRAM_OFFICE_RETURN_TO_CAMO_CONFIRMATION_TITLE": "You have successfully returned this appeal to the CAMO team",
   "VHA_PROGRAM_OFFICE_RETURN_TO_CAMO_CONFIRMATION_DETAIL": "This appeal will be removed from your Queue and placed in the CAMO team's Queue",
-  "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_MODAL_TITLE": "Mark task as in progress",
+  "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_MODAL_TITLE": "Mark task in progress",
   "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_MODAL_BODY": "By marking task as in progress, you are confirming that you are actively working on collecting documents for this appeal.\n\nOnce marked, other members of your organization will no longer be able to mark this task as in progress.",
   "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE": "You have successfully marked %s's case as in progress",
   "VHA_CAREGIVER_SUPPORT_DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_CONFIRMATION_TITLE": "You have successfully sent %s's case to Board Intake for review",

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -415,7 +415,7 @@
     "func": "vha_mark_task_in_progress"
   },
   "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS": {
-    "label": "Mark task as in progress",
+    "label": "Mark task in progress",
     "value": "modal/mark_task_in_progress",
     "func": "vha_caregiver_support_mark_task_in_progress"
   },

--- a/client/test/data/queue/taskActionModals/completeTaskActionModalData.js
+++ b/client/test/data/queue/taskActionModals/completeTaskActionModalData.js
@@ -17,7 +17,7 @@ const uiData = {
 const caregiverActions = [
   {
     func: 'vha_caregiver_support_mark_task_in_progress',
-    label: 'Mark task as in progress',
+    label: 'Mark task in progress',
     value: 'modal/mark_task_in_progress',
     data: {
       modal_title: 'Mark task as in progress',

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           end
         end
 
-        step "enacting the 'Mark task as in progress' task action updates
+        step "enacting the 'Mark task in progress' task action updates
           the VhaDocumentSearchTask's status to in_progress" do
           User.authenticate!(user: vha_caregiver_user)
 


### PR DESCRIPTION
## Resolves [APPEALS-9156](https://vajira.max.gov/browse/APPEALS-9156) | [Original PR](https://github.com/department-of-veterans-affairs/caseflow/pull/17477)

### Description
Updated all modal titles and task actions that used the wording "Mark task as in progress" to "Mark task in progress" in the vha caregiver support files.

### Acceptance Criteria
- [x] VHA Caregiver Support task action changed from Mark task as in progress to Mark task in progress
- [x] VHA Caregiver Support in progress modal title changed from Mark task as in progress to Mark task in progress 

### Testing Plan
1. Create an appeal assigned to the CSP:
```ruby
appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
parent_task = appeal.tasks.last
csp_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCaregiverSupport.singleton )
```
2. Sign into Caseflow as a CSP user (ex: `CAREGIVERUSER`)
3. Navigate to the Case Details page for the appeal created in step 1. You can either find it listed on the CSP's Unassigned queue tab, or navigate to it directly using the appeal's UUID.
```ruby
appeal.uuid
```
`/queue/appeals/<appeal.uuid>`
4. Click on the Actions dropdown, and make sure one of the options read "Mark task in progress". 
5. Click on this option, and ensure that the modal title is "Mark task in progress" as well, and that the submission button has the text "Mark in progress".