### PR TITLE
updated query for cavc dashboard button check

### DIFF
--- a/app/models/serializers/work_queue/appeal_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_serializer.rb
@@ -283,11 +283,6 @@ class WorkQueue::AppealSerializer
   end
 
   attribute :cavc_remands_with_dashboard do |appeal|
-    @remands_with_dashboard = CavcRemand.where(source_appeal_id: appeal.id, cavc_decision_type:
-    [
-      Constants.CAVC_DECISION_TYPES.other_dismissal,
-      Constants.CAVC_DECISION_TYPES.affirmed,
-      Constants.CAVC_DECISION_TYPES.settlement
-    ]).count
+    @remands_with_dashboard = CavcRemand.where(source_appeal_id: appeal.id).count
   end
 end


### PR DESCRIPTION
Resolves [16195](https://vajira.max.gov/browse/APPEALS-16195?workflowName=VA+Caseflow+Sandbox+Story+Enabler+Workflow&stepId=20)

### Description
Modified query in appeal_serializer for cavc_remands_with_dashboard to allow cavc dashboard button to appear on post dispatch if any appeal has cavc remands tied to it.

### Acceptance Criteria
When on the source appeal for a CAVC Remand in the Post Dispatch Actions a CAVC Dashboard button is visible:
The Post-Dispatch Actions section on the original appeal stream

### Testing Plan
1. Go to an appeal that is Dispatched and has CAVC remands. (OCC/OAI user)
2. On the case details page, there should be a CAVC Dashboard button displayed within the Post-dispatch actions section.
3. Click the CAVC Dashboard button and observe that it takes you to the CAVC dashboard page.