### PR TITLE
fix bug causing dashboards to not create for new decision types

### DIFF
--- a/app/models/cavc_dashboard.rb
+++ b/app/models/cavc_dashboard.rb
@@ -26,11 +26,11 @@ class CavcDashboard < CaseflowRecord
   end
 
   def remand_request_issues
-    cavc_remand.remand_appeal.request_issues
+    cavc_remand.remand_appeal&.request_issues
   end
 
   def create_dispositions_for_remand_request_issues
-    remand_request_issues.map do |issue|
+    remand_request_issues&.map do |issue|
       CavcDashboardDisposition.create(cavc_dashboard: self, request_issue: issue)
     end
   end

--- a/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
+++ b/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
@@ -235,7 +235,7 @@ const CavcDashboardIssuesSection = (props) => {
         <hr />
       </div>
       <ol {...olStyling}>
-        {issues.map((issue, i) => {
+        {issues?.map((issue, i) => {
           const issueDisposition = dashboardDispositions.filter((dis) => {
             return dis.request_issue_id === issue.id;
           });

--- a/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
+++ b/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
@@ -11,23 +11,31 @@ jest.mock('react-redux', () => ({
   useDispatch: () => jest.fn().mockImplementation(() => Promise.resolve(true))
 }));
 
-const createDashboardProp = () => {
+const createDashboardProp = (hasIssues) => {
+  if (hasIssues) {
+    return {
+      remand_request_issues: [{
+        id: 1000,
+        benefit_type: 'compensation',
+        decision_review_type: 'Appeal',
+        contested_issue_description: 'A description of issue',
+      }],
+      cavc_dashboard_issues: [{
+        benefit_type: 'education',
+        issue_category: 'Service Connection',
+        disposition: 'Reversed'
+      }],
+      cavc_dashboard_dispositions: [{
+        request_issue_id: 1000,
+        disposition: 'Reversed',
+      }]
+    };
+  }
+
   return {
-    remand_request_issues: [{
-      id: 1000,
-      benefit_type: 'compensation',
-      decision_review_type: 'Appeal',
-      contested_issue_description: 'A description of issue',
-    }],
-    cavc_dashboard_issues: [{
-      benefit_type: 'education',
-      issue_category: 'Service Connection',
-      disposition: 'Reversed'
-    }],
-    cavc_dashboard_dispositions: [{
-      request_issue_id: 1000,
-      disposition: 'Reversed',
-    }]
+    remand_request_issues: [],
+    cavc_dashboard_issues: [],
+    cavc_dashboard_dispositions: []
   };
 };
 
@@ -40,7 +48,7 @@ const renderCavcDashboardIssuesSection = async (dashboard, userCanEdit = true) =
 describe('CavcDashboardIssuesSection', () => {
 
   it('displays correct values with remand_request_issues', async () => {
-    const dashboard = createDashboardProp();
+    const dashboard = createDashboardProp(true);
 
     await renderCavcDashboardIssuesSection(dashboard);
     const Issues = [...document.querySelectorAll('li')];
@@ -55,7 +63,7 @@ describe('CavcDashboardIssuesSection', () => {
   });
 
   it('displays correct values with cavc_dashboard_issues', async () => {
-    const dashboard = createDashboardProp();
+    const dashboard = createDashboardProp(true);
 
     await renderCavcDashboardIssuesSection(dashboard);
     const Issues = [...document.querySelectorAll('li')];
@@ -63,5 +71,15 @@ describe('CavcDashboardIssuesSection', () => {
     expect(screen.getByText(dashboard.cavc_dashboard_issues[0].benefit_type, { exact: false })).toBeTruthy();
     expect(screen.getByText(dashboard.cavc_dashboard_issues[0].issue_category)).toBeTruthy();
     expect(Issues.length).toBe(2);
+  });
+
+  it('renders with no remand_request_issues present', async () => {
+    const dashboard = createDashboardProp(false);
+
+    await renderCavcDashboardIssuesSection(dashboard);
+
+    expect(screen.getByText('Issues')).toBeTruthy();
+    expect(screen.getByText('Dispositions')).toBeTruthy();
+    expect(document.querySelector('ol').childElementCount).toBe(0);
   });
 });

--- a/spec/controllers/cavc_dashboard_controller_spec.rb
+++ b/spec/controllers/cavc_dashboard_controller_spec.rb
@@ -180,10 +180,8 @@ RSpec.describe CavcDashboardController, type: :controller do
     end
 
     it "#index creates new dashboard and returns index data from format.json" do
-      Seeds::CavcDashboardData.new.seed!
-
-      remand = CavcRemand.last
-      appeal_uuid = Appeal.find(remand.remand_appeal_id).uuid
+      remand = create(:cavc_remand)
+      appeal_uuid = remand.remand_appeal.uuid
 
       get :index, params: { format: :json, appeal_id: appeal_uuid }
       response_body = JSON.parse(response.body)
@@ -192,6 +190,32 @@ RSpec.describe CavcDashboardController, type: :controller do
       expect(response_body.key?("cavc_dashboards")).to be true
       expect(response_body["cavc_dashboards"][0]["cavc_dashboard_dispositions"].count)
         .to eq CavcDashboardDisposition.where(cavc_dashboard: dashboard).count
+    end
+
+    it "#index creates a new dashboard for a decision that doesn't create a remand appeal stream" do
+      appeal = create(:appeal, :dispatched, :with_decision_issue)
+
+      creation_params = {
+        source_appeal_id: appeal.id,
+        cavc_decision_type: Constants::CAVC_DECISION_TYPES["affirmed"],
+        cavc_docket_number: "12-3456",
+        cavc_judge_full_name: "Clerk",
+        created_by_id: authorized_user.id,
+        decision_date: 1.week.ago,
+        decision_issue_ids: appeal.decision_issue_ids,
+        instructions: "Seed remand for testing",
+        represented_by_attorney: true,
+        updated_by_id: authorized_user.id,
+        remand_subtype: nil,
+        judgement_date: 1.week.ago,
+        mandate_date: 1.week.ago
+      }
+      cavc_remand = CavcRemand.create!(creation_params)
+
+      get :index, params: { format: :json, appeal_id: cavc_remand.source_appeal.uuid }
+      response_body = JSON.parse(response.body)
+      expect(response_body.key?("cavc_dashboards")).to be true
+      expect(response_body["cavc_dashboards"][0]["remand_request_issues"]&.count).to be nil
     end
   end
 end


### PR DESCRIPTION
Resolves [APPEALS-16188](https://vajira.max.gov/browse/APPEALS-16188)

### Description
- Add safe operators to cavc_dashboard model and CavcDashboardIssuesSection component so that dashboards are created and displayed properly if no remand_request_issues exist (ie. remand was created with one of the new decision types)
- Updated/added tests for this scenario

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
See original PR [18158](https://github.com/department-of-veterans-affairs/caseflow/pull/18158)
