### PR TITLE
Only Active Request Issues show on CAVC Dashboard

### DIFF
--- a/app/models/cavc_dashboard.rb
+++ b/app/models/cavc_dashboard.rb
@@ -26,7 +26,8 @@ class CavcDashboard < CaseflowRecord
   end
 
   def remand_request_issues
-    cavc_remand.remand_appeal&.request_issues
+    return cavc_remand.remand_appeal&.request_issues.active.order(:id) if cavc_remand.remand_appeal
+    cavc_remand.source_appeal&.request_issues.active.order(:id)
   end
 
   def create_dispositions_for_remand_request_issues

--- a/app/models/cavc_dashboard.rb
+++ b/app/models/cavc_dashboard.rb
@@ -27,6 +27,7 @@ class CavcDashboard < CaseflowRecord
 
   def remand_request_issues
     return cavc_remand.remand_appeal&.request_issues.active.order(:id) if cavc_remand.remand_appeal
+
     cavc_remand.source_appeal&.request_issues.active.order(:id)
   end
 

--- a/app/models/serializers/work_queue/cavc_dashboard_serializer.rb
+++ b/app/models/serializers/work_queue/cavc_dashboard_serializer.rb
@@ -11,11 +11,21 @@ class WorkQueue::CavcDashboardSerializer
       WorkQueue::CavcDashboardDispositionSerializer.new(cdd).serializable_hash[:data][:attributes]
     end
   end
-  attribute :cavc_dashboard_issues
+  attribute :cavc_dashboard_issues do |object|
+    object.cavc_dashboard_issues.order(:id)
+  end
   attribute :cavc_decision_date
   attribute :cavc_docket_number
   attribute :cavc_remand
   attribute :joint_motion_for_remand
 
-  attribute :remand_request_issues
+  attribute :remand_request_issues do |object|
+    object.remand_request_issues.map do |issue|
+      {
+        id: issue.id,
+        benefit_type: issue.benefit_type,
+        description: issue.description,
+      }
+    end
+  end
 end

--- a/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
+++ b/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
@@ -120,12 +120,8 @@ const CavcDashboardIssue = (props) => {
     return false;
   };
 
-  if (issue.decision_review_type && !addedIssueSection) {
-    if (issue.contested_issue_description) {
-      issueType = `${issue.decision_review_type} - ${issue.contested_issue_description}`;
-    } else {
-      issueType = `${issue.decision_review_type}`;
-    }
+  if (!addedIssueSection) {
+    issueType = issue.description;
   } else {
     issueType = issue.issue_category;
   }
@@ -294,9 +290,7 @@ CavcDashboardIssue.propTypes = {
   index: PropTypes.number,
   issue: PropTypes.shape({
     benefit_type: PropTypes.string,
-    decision_review_type: PropTypes.string,
-    contested_issue_description: PropTypes.string,
-    issue_category: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    description: PropTypes.string,
     id: PropTypes.number,
   }),
   dispositions: PropTypes.array,

--- a/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
+++ b/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
@@ -17,13 +17,12 @@ const createDashboardProp = (hasIssues) => {
       remand_request_issues: [{
         id: 1000,
         benefit_type: 'compensation',
-        decision_review_type: 'Appeal',
-        contested_issue_description: 'A description of issue',
+        description: 'Appeal - A description of issue'
       }],
       cavc_dashboard_issues: [{
         benefit_type: 'education',
         issue_category: 'Service Connection',
-        disposition: 'Reversed'
+        disposition: 'Reversed',
       }],
       cavc_dashboard_dispositions: [{
         request_issue_id: 1000,
@@ -54,10 +53,7 @@ describe('CavcDashboardIssuesSection', () => {
     const Issues = [...document.querySelectorAll('li')];
 
     expect(screen.getAllByText(dashboard.remand_request_issues[0].benefit_type, { exact: false })).toBeTruthy();
-    expect(screen.getAllByText(
-      // eslint-disable-next-line max-len
-      `${dashboard.remand_request_issues[0].decision_review_type } - ${ dashboard.remand_request_issues[0].contested_issue_description}`
-    )).toBeTruthy();
+    expect(screen.getAllByText(dashboard.remand_request_issues[0].description)).toBeTruthy();
     expect(Issues.length).toBe(2);
 
   });

--- a/spec/controllers/cavc_dashboard_controller_spec.rb
+++ b/spec/controllers/cavc_dashboard_controller_spec.rb
@@ -215,7 +215,7 @@ RSpec.describe CavcDashboardController, type: :controller do
       get :index, params: { format: :json, appeal_id: cavc_remand.source_appeal.uuid }
       response_body = JSON.parse(response.body)
       expect(response_body.key?("cavc_dashboards")).to be true
-      expect(response_body["cavc_dashboards"][0]["remand_request_issues"]&.count).to be nil
+      expect(response_body["cavc_dashboards"][0]["remand_request_issues"]&.count).to be 1
     end
   end
 end


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/APPEALS-16338

### Description
If remand does not have a remand appeal use Source appeal's request issues. This allows for the Source Appeal's request issues to be displayed on its CAVC Dashboard Tab. Also ensures display order matches Case Details.

Match Request Issue displayed information to what is used on Case Details page.
- https://github.com/department-of-veterans-affairs/caseflow/blob/feature/APPEALS-94/client/app/components/AmaIssueList.jsx#L39
- https://github.com/department-of-veterans-affairs/caseflow/blob/feature/APPEALS-94/app/models/serializers/work_queue/appeal_serializer.rb#L36
- https://github.com/department-of-veterans-affairs/caseflow/blob/feature/APPEALS-94/app/models/request_issue.rb#L307


### Acceptance Criteria
- [ ] Code compiles correctly


