### PR TITLE
HunJerBAH/APPEALS-13377

### DIFF
--- a/app/models/tasks/post_send_initial_notification_letter_holding_task.rb
+++ b/app/models/tasks/post_send_initial_notification_letter_holding_task.rb
@@ -31,6 +31,7 @@ class PostSendInitialNotificationLetterHoldingTask < LetterTask
   # Function to set the end time for the related TaskTimer when this class is instantiated.
   def timer_ends_at
     return @end_date if @end_date
+
     # Check for last existing associated TaskTimer
     task_timer = TaskTimer.find_by(task: self)
     return task_timer.submitted_at if task_timer

--- a/lib/tasks/letter_tasks.rake
+++ b/lib/tasks/letter_tasks.rake
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+namespace :letter_tasks do
+  desc "create 10 appeals with post initial letter tasks that will expire in 2 days"
+  task :create_post_task_appeals => :environment do
+    cob = Organization.find_by_url("clerk-of-the-board")
+    cob_user = User.find_by_css_id("COB_USER")
+    RequestStore[:current_user] = cob_user
+
+    # travel backwards to 44 days
+    Timecop.travel(Time.zone.now - 44.days)
+
+    # create appeals with root, distribution, and evidence submission tasks
+    factory_appeals = 10.times.map do
+      FactoryBot.create(
+        :appeal,
+        :ready_for_distribution,
+        docket_type: Constants.AMA_DOCKETS.evidence_submission
+      )
+    end
+
+    # create initial letter task for each appeal
+    factory_appeals.each do |a|
+      SendInitialNotificationLetterTask.create!(
+        appeal: a,
+        parent: a.tasks.find_by(type: "EvidenceSubmissionWindowTask"),
+        assigned_to: cob,
+        assigned_by: cob_user
+      )
+    end
+
+    # create post letter for each appeal
+    factory_appeals.each do |a|
+      task = a.tasks.find_by(type: "SendInitialNotificationLetterTask")
+      psi = PostSendInitialNotificationLetterHoldingTask.create!(
+        appeal: a,
+        parent: task.parent,
+        assigned_to: cob,
+        assigned_by: cob_user,
+        end_date: Time.zone.now + 45.days
+      )
+      task.completed!
+      TimedHoldTask.create_from_parent(psi, days_on_hold: 45, instructions: "instructions")
+    end
+
+    # return timecop to normal
+    Timecop.return
+  end
+
+  desc "create 10 appeals with final letter tasks for demo testing."
+  task :create_final_letter_task_appeals => :environment do
+    cob = Organization.find_by_url("clerk-of-the-board")
+    cob_user = User.find_by_css_id("COB_USER")
+    RequestStore[:current_user] = cob_user
+
+    # create appeals with root, distribution, and evidence submission tasks
+    factory_appeals = 10.times.map do
+      FactoryBot.create(
+        :appeal,
+        :ready_for_distribution,
+        docket_type: Constants.AMA_DOCKETS.evidence_submission
+      )
+    end
+
+    # create initial and final letter task for each appeal
+    factory_appeals.each do |a|
+      sit = SendInitialNotificationLetterTask.create!(
+        appeal: a,
+        parent: a.tasks.find_by(type: "EvidenceSubmissionWindowTask"),
+        assigned_to: cob,
+        assigned_by: cob_user
+      )
+      sit.completed!
+      SendFinalNotificationLetterTask.create!(
+        appeal: a,
+        parent: a.tasks.find_by(type: "EvidenceSubmissionWindowTask"),
+        assigned_to: cob,
+        assigned_by: cob_user
+      )
+    end
+  end
+end


### PR DESCRIPTION
Resolves [APPEALS-13377](https://vajira.max.gov/browse/APPEALS-13377)

### Description
Created a rake task with 2 commands: one command generates 10 appeals with the post initial letter task 2 days away from expiration, and the other command creates 10 appeals with the final letter task. These appeals will be used to seed our demo environment for testing.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] First command generates 10 appeals with the post initial letter task with a timer of 43/45 days.
- [ ] Second command generates 10 appeals with the final letter task.

### Testing Plan
1. Go to the rails console.
2. To load the new task, run `Rails.application.load_tasks` in the terminal
3. To create 10 appeals with post initial tasks, run `Rake::Task['letter_tasks:create_post_task_appeals'].invoke`
4. To create 10 appeals with final letter tasks, run `Rake::Task['letter_tasks:create_final_letter_task_appeals'].invoke`. If the command fails, you might need to run ` Rake::Task['letter_tasks:create_final_letter_task_appeals'].reenable` followed by `Rake::Task['letter_tasks:create_final_letter_task_appeals'].invoke`
5. Navigate to the Caseflow and sign in as a **COB_USER**. 
6. Navigate to the Queue app.
7. Get to the Organization page by clicking **switch views** followed by **Clerk of the Board team cases**.
![image](https://user-images.githubusercontent.com/99915461/222829993-ff4eaa4c-8558-4c14-9ab3-debe7b4e90c7.png)

8. You should see an additional 10 post initial letter holding task appeals are in the **on hold** tab. The tasks should show 43/45 days. You should also see 10 appeals with final letter tasks under the **unassigned** tab.
![image](https://user-images.githubusercontent.com/99915461/222830167-7fa22a83-b487-4ed6-bae6-ef15976b5ebd.png)
![image](https://user-images.githubusercontent.com/99915461/222830286-a4bcb9b7-425c-4780-8b3e-1a5c328cf15e.png)
