### PR TITLE
disable tests checking DateSelector future date validations

### DIFF
--- a/spec/feature/intake/appeal_spec.rb
+++ b/spec/feature/intake/appeal_spec.rb
@@ -75,11 +75,11 @@ feature "Appeal Intake", :all_dbs do
     click_on "Search"
     expect(page).to have_current_path("/intake/review_request")
 
-    fill_in "What is the Receipt Date of this form?", with: future_date.mdY
-    click_intake_continue
-
-    expect(page).to have_content("Receipt date cannot be in the future.")
-    expect(page).to have_content("Please select an option.")
+    # DateSelector component has been updated to not allow future dates to be selected at all
+    # fill_in "What is the Receipt Date of this form?", with: future_date.mdY
+    # click_intake_continue
+    # expect(page).to have_content("Receipt date cannot be in the future.")
+    #expect(page).to have_content("Please select an option.")
 
     fill_in "What is the Receipt Date of this form?", with: receipt_date.mdY
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -175,13 +175,12 @@ feature "Higher-Level Review", :all_dbs do
 
     select_agree_to_withdraw_legacy_issues(false)
 
-    fill_in "What is the Receipt Date of this form?", with: Time.zone.tomorrow.mdY
-
-    click_intake_continue
-
-    expect(page).to have_content(
-      "Receipt date cannot be in the future."
-    )
+    # DateSelector component has been updated to not allow future dates to be selected at all
+    # fill_in "What is the Receipt Date of this form?", with: Time.zone.tomorrow.mdY
+    # click_intake_continue
+    # expect(page).to have_content(
+    #   "Receipt date cannot be in the future."
+    # )
 
     fill_in "What is the Receipt Date of this form?", with: receipt_date.mdY
 

--- a/spec/feature/intake/review_page_spec.rb
+++ b/spec/feature/intake/review_page_spec.rb
@@ -664,14 +664,15 @@ def check_pension_and_compensation_payee_code
     find("label", text: "Compensation", match: :prefer_exact).click
   end
 
-  fill_in "What is the Receipt Date of this form?", with: Time.zone.tomorrow.mdY
   find("label", text: "Blake Vance, Other", match: :prefer_exact).click
-  click_intake_continue
 
-  # check that other validation still works
-  expect(page).to have_content(
-    "Receipt date cannot be in the future."
-  )
+  # DateSelector component has been updated to not allow future dates to be selected at all
+  # fill_in "What is the Receipt Date of this form?", with: Time.zone.tomorrow.mdY
+  # click_intake_continue
+  # # check that other validation still works
+  # expect(page).to have_content(
+  #   "Receipt date cannot be in the future."
+  # )
 
   fill_in "What is the Receipt Date of this form?", with: Time.zone.today.mdY
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -136,11 +136,12 @@ feature "Supplemental Claim Intake", :all_dbs do
 
     select_agree_to_withdraw_legacy_issues(false)
 
-    fill_in "What is the Receipt Date of this form?", with: (Time.zone.today + 1.day).mdY
-    click_intake_continue
-    expect(page).to have_content(
-      "Receipt date cannot be in the future."
-    )
+    # DateSelector component has been updated to not allow future dates to be selected at all
+    # fill_in "What is the Receipt Date of this form?", with: (Time.zone.today + 1.day).mdY
+    # click_intake_continue
+    # expect(page).to have_content(
+    #   "Receipt date cannot be in the future."
+    # )
     fill_in "What is the Receipt Date of this form?", with: receipt_date.mdY
 
     click_intake_continue


### PR DESCRIPTION
### Description
- Disable RSpec tests that check the DateSelector component's validation for future dates due to the component being modified to not allow them at all

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass