### PR TITLE
akonhilas/APPEALS-8938-V3

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -73,6 +73,10 @@ class AppealsController < ApplicationController
         raise ActionController::ParameterMissing.new('Bad Format')
       end
     end
+  rescue StandardError => error
+    uuid = SecureRandom.uuid
+    Rails.logger.error(error.to_s + "Error ID: " + uuid)
+    render json: { "errors": ["message": uuid] }, status: :internal_server_error
   end
 
   def document_count
@@ -359,3 +363,4 @@ class AppealsController < ApplicationController
     end
   end
 end
+

--- a/client/app/queue/NotificationsView.jsx
+++ b/client/app/queue/NotificationsView.jsx
@@ -37,7 +37,10 @@ export const NotificationsView = (props) => {
     setModalState(false);
   };
 
-  const [alert, setAlert] = useState(false);
+  const [alert, setAlert] = useState([{
+    alertState: false,
+    alertMessage: ''
+  }]);
   const [loading, setLoading] = useState(false);
 
   const { push } = useHistory();
@@ -67,6 +70,7 @@ export const NotificationsView = (props) => {
 
   const errorCode = 'Error Code: ';
   const pdfURL = `/appeals/${appealId}/notifications.pdf`;
+  let errorUuid = '';
 
   //  Error handling to add alert message for PDF generation
   const generatePDF = () => {
@@ -76,8 +80,10 @@ export const NotificationsView = (props) => {
       setLoading(false);
     }).
       catch((error) => {
+
         if (error.status > 299 || error.status < 200) {
-          setAlert(true);
+          errorUuid = JSON.parse(error.response.text).errors[0].message;
+          setAlert({ alertState: true, alertMessage: errorUuid });
         }
         setLoading(false);
       });
@@ -89,7 +95,7 @@ export const NotificationsView = (props) => {
     <React.Fragment>
       <AppSegment filledBackground>
         <CaseTitle titleHeader = {`Case notifications for ${appeal.veteranFullName}`} appeal={appeal} hideCaseView />
-        {alert && <Alert type="error" title={COPY.PDF_GENERATION_ERROR_TITLE} styling={alertStyle}>{COPY.PDF_GENERATION_ERROR_MESSAGE}<br />{errorCode}{appealId}</Alert>}
+        {alert.alertState && <Alert type="error" title={COPY.PDF_GENERATION_ERROR_TITLE} styling={alertStyle}>{COPY.PDF_GENERATION_ERROR_MESSAGE}<br />{errorCode}{alert.alertMessage}</Alert>}
         {supportPendingAppealSubstitution && (
           <div {...sectionGap}>
             <Button
@@ -187,3 +193,4 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(NotificationsView);
+


### PR DESCRIPTION
Resolves #APPEALS-8938
https://vajira.max.gov/browse/APPEALS-8938

### Description
Updated appeals_controller.rb to send specific error uuid on pdf generation error and updated NotificationsView.jsx to show the specific error uuid on the alert banner.

### Acceptance Criteria
Case notification page has a Download button
Button has a blue outline and blue letters with a white background (see wireframe)
Button displays: "Download"
Button is placed below the right hand side of the title/header section (see wireframe)
When the download button is clicked
A download of the pdf is started in the browser
If there is an error when trying to get the PDF a red error alert appears under the case title and above the case title details components (see wireframe)
Download button is visible for all users who can see the notifications screen
REVISION-BA Approved (03/02/2023) Download button will become disabled and show loading state while waiting for PDF generation and download then return to regular state after download is complete.

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-16067

