### PR TITLE
Craig/dashboard enable minimum basis length

### DIFF
--- a/client/app/queue/cavcDashboard/CavcDecisionReasons.jsx
+++ b/client/app/queue/cavcDashboard/CavcDecisionReasons.jsx
@@ -386,7 +386,6 @@ const CavcDecisionReasons = (props) => {
             }
             }
             placeholder="Type to search..."
-            creatable
             noOptionsMessage={noOptionsMessage}
             styling={basisForSelectionStylingNoChild}
             readOnly={!userCanEdit}

--- a/client/app/queue/cavcDashboard/CavcDecisionReasons.jsx
+++ b/client/app/queue/cavcDashboard/CavcDecisionReasons.jsx
@@ -14,7 +14,7 @@ import { setCheckedDecisionReasons,
   setSelectionBasisForReasonCheckbox,
   updateOtherFieldTextValue } from './cavcDashboardActions';
 import SearchableDropdown from '../../components/SearchableDropdown';
-// import { createFilter } from 'react-select';
+import { createFilter } from 'react-select';
 import { CheckIcon } from '../../components/icons/fontAwesome/CheckIcon';
 
 const CavcDecisionReasons = (props) => {
@@ -250,14 +250,14 @@ const CavcDecisionReasons = (props) => {
     input.length >= MIN_INPUT_LENGTH ?
       'No options' :
       'Search input must be at least 3 characters';
-  // const filterOption = (candidate, input) => {
-  //   return (
-  //     // Min input length
-  //     input.length >= MIN_INPUT_LENGTH &&
-  //     // Use Select's default filtering for string matching by creating filter
-  //     createFilter({})(candidate, input)
-  //   );
-  // };
+  const filterOption = (candidate, input) => {
+    return (
+      // Min input length
+      input.length >= MIN_INPUT_LENGTH &&
+      // Use Select's default filtering for string matching by creating filter
+      createFilter({})(candidate, input)
+    );
+  };
 
   const [otherBasisSelectedByCheckboxId, setOtherBasisSelectedByCheckboxId] = useState(decisionReasons.map((reason) => {
     return { checkboxId: reason.id, checked: false };
@@ -281,7 +281,7 @@ const CavcDecisionReasons = (props) => {
         <div>
           <SearchableDropdown
             name={`decision-reason-basis-${child.id}`}
-            // filterOption={filterOption}
+            filterOption={filterOption}
             label={DECISION_REASON_LABELS.DECISION_REASON_BASIS_LABEL}
             placeholder="Type to search..."
             noOptionsMessage={noOptionsMessage}
@@ -354,7 +354,7 @@ const CavcDecisionReasons = (props) => {
           <SearchableDropdown
             name={`decision-reason-basis-${parent.id}`}
             label={DECISION_REASON_LABELS.DECISION_REASON_BASIS_LABEL}
-            // filterOption={filterOption}
+            filterOption={filterOption}
             options={selectionBases.
               filter((selection) => selection.category === parent.basis_for_selection_category).
               map((selection) => ({

--- a/spec/feature/queue/cavc_dashboard_spec.rb
+++ b/spec/feature/queue/cavc_dashboard_spec.rb
@@ -200,6 +200,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
       v_and_r_section.find("span", exact_text: "Other").click
       other_dropdown = page.find("div.cf-form-dropdown", text: "Type to search...")
       other_dropdown.find("div.cf-select").click
+      other_dropdown.find("input").send_keys "oth"
       other_dropdown.find("div.cf-select__menu").all("div", exact_text: "Other").last.click
       v_and_r_section.find("input.cf-form-textinput").click.send_keys "Test New Basis"
 


### PR DESCRIPTION
### Description
- Uncomment filter option code to enable minimum character length for Basis for Selection dropdown
- Fix parent reason dropdown to not have "createable" prop so that it functions properly

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Minimum character length is required to show search results in dropdown
