### PR TITLE
fix dashboard selection basis redux

### DIFF
--- a/spec/feature/queue/cavc_dashboard_spec.rb
+++ b/spec/feature/queue/cavc_dashboard_spec.rb
@@ -195,7 +195,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
       v_and_r_section = page.all("div.usa-accordion-bordered").last
       v_and_r_section.click
-      v_and_r_section.find("span", exact_text: "AMA specific remand?").click
+      v_and_r_section.find("span", exact_text: "AMA specific remand").click
       v_and_r_section.find("span", exact_text: "Issuing a decision before 90-day window closed").click
       v_and_r_section.find("span", exact_text: "Other").click
       other_dropdown = page.find("div.cf-form-dropdown", text: "Type to search...")


### PR DESCRIPTION
### Description
- Add handler for selection basis change that also updates the checkedReasons state on the CavcDecisionReasons component to prevent it overwriting the basis on next change

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to any CAVC dashboard with either no dispositions selected OR a disposition selected that isn't 'reversed' or 'vacated and remanded'
2. On a disposition that is not one of the above two options, select one of those options.
3. In decision reasons, select at least two options that allow for a basis for selection and also select a basis for selection for each
4. Select one decision reason that does not require a basis for selection (AFTER selecting the above reasons!)
5. Save changes
6. Go back to dashboard
7. Verify that all selected decision reasons which required a basis for selection have the chosen basis for selection value
