### PR TITLE
fix cavc dashboard reducer initial state

### DIFF
--- a/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
+++ b/client/app/queue/cavcDashboard/CavcDashboardIssuesSection.jsx
@@ -10,7 +10,7 @@ import CavcDecisionReasons from './CavcDecisionReasons';
 import Button from '../../components/Button';
 import CAVC_DASHBOARD_DISPOSITIONS from '../../../constants/CAVC_DASHBOARD_DISPOSITIONS';
 import RemoveCavcDashboardIssueModal from './RemoveCavcDashboardIssueModal';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { removeCheckedDecisionReason, setDispositionValue } from './cavcDashboardActions';
 
 const singleIssueStyling = (userCanEdit) => {
@@ -84,6 +84,7 @@ const CavcDashboardIssue = (props) => {
   } = props;
 
   const [removeModalIsOpen, setRemoveModalIsOpen] = useState(false);
+  const selectionBases = useSelector((state) => state.cavcDashboard.selection_bases);
 
   const disposition = dispositions?.find(
     (dis) => dis.request_issue_id === issue.id ||
@@ -179,7 +180,7 @@ const CavcDashboardIssue = (props) => {
         </div>
         <div />
       </div>
-      {requireDecisionReason() && (
+      {requireDecisionReason() && selectionBases.length > 0 &&
         <CavcDecisionReasons
           uniqueId={issue.id}
           initialDispositionRequiresReasons={dispositionsRequiringReasons.includes(disposition)}
@@ -187,7 +188,7 @@ const CavcDashboardIssue = (props) => {
           loadCheckedBoxes={loadCheckedBoxes}
           userCanEdit={userCanEdit}
         />
-      )}
+      }
       {addedIssueSection && userCanEdit &&
         <>
           <Button

--- a/client/app/queue/cavcDashboard/cavcDashboardReducer.js
+++ b/client/app/queue/cavcDashboard/cavcDashboardReducer.js
@@ -2,8 +2,8 @@ import { update } from '../../util/ReducerUtil';
 import { ACTIONS } from './cavcDashboardConstants';
 
 export const initialState = {
-  decision_reasons: {},
-  selection_bases: {},
+  decision_reasons: [],
+  selection_bases: [],
   initial_state: {
     cavc_dashboards: [],
     checked_boxes: {}

--- a/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
+++ b/client/test/app/queue/cavcDashboard/CavcDashboardIssuesSection.test.js
@@ -8,7 +8,9 @@ jest.mock('../../../../app/queue/cavcDashboard/CavcDecisionReasons',
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
-  useDispatch: () => jest.fn().mockImplementation(() => Promise.resolve(true))
+  useDispatch: () => jest.fn().mockImplementation(() => Promise.resolve(true)),
+  // useSelector is only used to get state for selectionBases and see if array length is > 0
+  useSelector: () => jest.fn().mockImplementation(() => Promise.resolve([1, 2, 3]))
 }));
 
 const createDashboardProp = (hasIssues) => {


### PR DESCRIPTION
### Description
- Change dashboard reducer initial state for decision reasons and selection bases to empty arrays instead of objects
- Add conditional rendering for CavcDecisionReasons to only load if selectionBases have been loaded and dispatched in redux; this prevents the below error while maintaining current save state functionality

### Acceptance Criteria
- [ ] Code compiles correctly

##
Error:
![image](https://user-images.githubusercontent.com/109101548/225026793-cfa62d1b-689c-47a2-b28f-cc343bfc6a67.png)
Caused by `FETCH_CAVC_SELECTION_BASES` running after `REMOVED_CHECKED_DECISION_REASON`:
![image](https://user-images.githubusercontent.com/109101548/225027711-6a01d662-86b5-47a7-9ff0-421816716f87.png)
