### PR TITLE
[Restored] BillyS/APPEALS-9206: Adjust VHA Program Office Ready for review Radio Fieldset Label 

### DIFF
--- a/app/models/tasks/pre_docket/assess_documentation_task.rb
+++ b/app/models/tasks/pre_docket/assess_documentation_task.rb
@@ -11,7 +11,7 @@ class AssessDocumentationTask < Task
 
   # Actions that can be taken on both organization and user tasks
   DEFAULT_ACTIONS = [
-    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h    
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h
   ].freeze
 
   PO_ACTIONS = [

--- a/app/models/tasks/pre_docket/assess_documentation_task.rb
+++ b/app/models/tasks/pre_docket/assess_documentation_task.rb
@@ -11,16 +11,17 @@ class AssessDocumentationTask < Task
 
   # Actions that can be taken on both organization and user tasks
   DEFAULT_ACTIONS = [
-    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-    Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h
+    Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h    
   ].freeze
 
   PO_ACTIONS = [
-    Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h
+    Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h,
+    Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h
   ].freeze
 
   RO_ACTIONS = [
-    Constants.TASK_ACTIONS.VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE.to_h
+    Constants.TASK_ACTIONS.VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE.to_h,
+    Constants.TASK_ACTIONS.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.to_h
   ].freeze
 
   def available_actions(user)

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -319,10 +319,12 @@ class TaskActionRepository
 
     def vha_complete_data(task, _user)
       org = Organization.find(task.assigned_to_id)
+      org_to_receive = org.is_a?(VhaProgramOffice) ? "VHA CAMO" : "VHA Program Office"
       queue_url = org.url
       {
-        modal_title: COPY::VHA_COMPLETE_TASK_MODAL_TITLE,
+        modal_title: COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE,      
         modal_button_text: COPY::MODAL_SEND_BUTTON,
+        radio_field_label: format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, org_to_receive),        
         instructions: [],
         type: AssessDocumentationTask.name,
         redirect_after: "/organizations/#{queue_url}"

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -322,9 +322,9 @@ class TaskActionRepository
       org_to_receive = org.is_a?(VhaProgramOffice) ? "VHA CAMO" : "VHA Program Office"
       queue_url = org.url
       {
-        modal_title: COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE,      
+        modal_title: COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE,
         modal_button_text: COPY::MODAL_SEND_BUTTON,
-        radio_field_label: format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, org_to_receive),        
+        radio_field_label: format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, org_to_receive),
         instructions: [],
         type: AssessDocumentationTask.name,
         redirect_after: "/organizations/#{queue_url}"

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1287,6 +1287,7 @@
   "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_MODAL_BODY": "By marking task as in progress, you are confirming that you are actively working on collecting documents for this appeal.\n\nOnce marked, other members of your organization will no longer be able to mark this task as in progress.",
   "VHA_CAREGIVER_SUPPORT_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE": "You have successfully marked %s's case as in progress",
   "VHA_CAREGIVER_SUPPORT_DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_CONFIRMATION_TITLE": "You have successfully sent %s's case to Board Intake for review",
+  "DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY": "This appeal will be sent to %s for review.\n\nPlease select where the documents for this appeal are stored",
   "DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_BODY": "This appeal will be sent to Board Intake for review.\n\nPlease select where the documents for this appeal are stored",
   "DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE": "Ready for review",
   "BVA_INTAKE_RETURN_TO_CAMO_MODAL_TITLE": "Return appeal to VHA CAMO",

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -615,7 +615,7 @@ class CompleteTaskModal extends React.Component {
         title={taskData.modal_title || (modalAttributes.title && modalAttributes.title(this.getContentArgs()))}
         /* eslint-disable-next-line camelcase */
         button={taskData?.modal_button_text}
-        submitDisabled={this.validateForm()}
+        submitDisabled={!this.validateForm()}
         validateForm={this.validateForm}
         submit={this.submit}
         pathAfterSubmit={taskData.redirect_after || '/queue'}

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -356,8 +356,6 @@ const MODAL_TYPE_ATTRS = {
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_PO, appeal.veteranFullName) :
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_VISN, appeal.veteranFullName)
     }),
-    // Title is obtained via taskActionData instead.
-    title: () => null,
     getContent: ReadyForReviewModal
   },
   send_colocated_task: {
@@ -614,7 +612,7 @@ class CompleteTaskModal extends React.Component {
 
     return (
       <QueueFlowModal
-        title={taskData.modal_title || modalAttributes.title(this.getContentArgs())}
+        title={taskData.modal_title || (modalAttributes.title && modalAttributes.title(this.getContentArgs()))}
         /* eslint-disable-next-line camelcase */
         button={taskData?.modal_button_text}
         submitDisabled={modalAttributes.submitDisabled?.(this.getContentArgs())}

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -356,6 +356,8 @@ const MODAL_TYPE_ATTRS = {
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_PO, appeal.veteranFullName) :
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_VISN, appeal.veteranFullName)
     }),
+    // Title is obtained via taskActionData instead.
+    title: () => null,
     getContent: ReadyForReviewModal
   },
   send_colocated_task: {

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -90,7 +90,7 @@ const ReadyForReviewModal = ({ props, state, setState }) => {
   };
   const modalLabel = () => {
     if (getTaskType() === 'AssessDocumentationTask') {
-      return COPY.VHA_COMPLETE_TASK_MODAL_TITLE;
+      return StringUtil.nl2br(taskConfiguration.radio_field_label);
     } else if ((getTaskType() === 'VhaDocumentSearchTask') || (getTaskType()?.includes('Education'))) {
       return StringUtil.nl2br(COPY.DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_BODY);
     }
@@ -100,7 +100,7 @@ const ReadyForReviewModal = ({ props, state, setState }) => {
 
   return (
     <React.Fragment>
-      {taskConfiguration && taskConfiguration.modal_body}
+      {taskConfiguration && StringUtil.nl2br(taskConfiguration.modal_body)}
       {(!taskConfiguration || !taskConfiguration.modal_hide_instructions) && (
         <div style= {{ marginTop: '1.25rem' }}>
           <RadioField
@@ -356,7 +356,6 @@ const MODAL_TYPE_ATTRS = {
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_PO, appeal.veteranFullName) :
         sprintf(COPY.VHA_COMPLETE_TASK_CONFIRMATION_VISN, appeal.veteranFullName)
     }),
-    title: () => COPY.DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE,
     getContent: ReadyForReviewModal
   },
   send_colocated_task: {
@@ -613,9 +612,10 @@ class CompleteTaskModal extends React.Component {
 
     return (
       <QueueFlowModal
-        title={modalAttributes.title(this.getContentArgs())}
-        button={taskData.modal_button_text}
-        submitDisabled={!this.validateForm()}
+        title={taskData.modal_title || modalAttributes.title(this.getContentArgs())}
+        /* eslint-disable-next-line camelcase */
+        button={taskData?.modal_button_text}
+        submitDisabled={modalAttributes.submitDisabled?.(this.getContentArgs())}
         validateForm={this.validateForm}
         submit={this.submit}
         pathAfterSubmit={taskData.redirect_after || '/queue'}

--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -615,7 +615,7 @@ class CompleteTaskModal extends React.Component {
         title={taskData.modal_title || (modalAttributes.title && modalAttributes.title(this.getContentArgs()))}
         /* eslint-disable-next-line camelcase */
         button={taskData?.modal_button_text}
-        submitDisabled={modalAttributes.submitDisabled?.(this.getContentArgs())}
+        submitDisabled={this.validateForm()}
         validateForm={this.validateForm}
         submit={this.submit}
         pathAfterSubmit={taskData.redirect_after || '/queue'}

--- a/client/app/queue/components/CompleteTaskModal.stories.js
+++ b/client/app/queue/components/CompleteTaskModal.stories.js
@@ -15,7 +15,8 @@ import {
   caregiverToIntakeData,
   emoToBvaIntakeData,
   rpoToBvaIntakeData,
-  vhaPOToCAMOData
+  vhaPOToCAMOData,
+  visnData
 } from '../../../test/data/queue/taskActionModals/taskActionModalData';
 import TASK_ACTIONS from '../../../constants/TASK_ACTIONS';
 import CompleteTaskModal from './CompleteTaskModal';
@@ -68,6 +69,13 @@ VhaPoToVhaCamo.args = {
   storeValues: vhaPOToCAMOData,
   taskType: 'AssessDocumentationTask',
   modalType: trimTaskActionValue(TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.value)
+};
+
+export const VhaRoToVhaPo = Template.bind({});
+VhaRoToVhaPo.args = {
+  storeValues: visnData,
+  taskType: 'AssessDocumentationTask',
+  modalType: trimTaskActionValue(TASK_ACTIONS.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.value)
 };
 
 export const VhaCaregiverSupportProgramToBoardIntakeForReview = Template.bind({});

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -208,6 +208,11 @@
     "value": "modal/ready_for_review",
     "func": "vha_complete_data"
   },
+  "VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW": {
+    "label": "Documents ready for VHA Program Office team review",
+    "value": "modal/ready_for_review",
+    "func": "vha_complete_data"
+  },
   "PLACE_TIMED_HOLD": {
     "label": "Put task on hold",
     "value": "modal/place_timed_hold"

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -408,7 +408,7 @@
     "func": "vha_program_office_return_to_camo"
   },
   "VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE": {
-    "label": "Return to Program Office",
+    "label": "Return to VHA Program Office team",
     "value": "modal/return_to_program_office",
     "func": "vha_regional_office_return_to_program_office"
   },

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -163,7 +163,7 @@ describe('CompleteTaskModal', () => {
     });
   });
 
-  describe('ready_for_review', () => {
+  describe('Vha Po send to Vha Camo for review', () => {
     const taskType = 'AssessDocumentationTask';
     const buttonText = COPY.MODAL_SEND_BUTTON;
     const modalType = 'ready_for_review';
@@ -171,6 +171,10 @@ describe('CompleteTaskModal', () => {
     test('modal title is Ready for review', () => {
       renderCompleteTaskModal(modalType, vhaPOToCAMOData, taskType);
       expect(screen.getByText('Ready for review')).toBeTruthy();
+    });
+
+    test('modal text indicates appeal will be sent to VHA CAMO', () => {
+      renderCompleteTaskModal(modalType, vhaPOToCAMOData, taskType);
       expect(screen.getByText('This appeal will be sent to VHA CAMO for review.Please select where the documents for this appeal are stored')).toBeTruthy();
     });
 
@@ -235,7 +239,7 @@ describe('CompleteTaskModal', () => {
     });
   });
 
-  describe('ready_for_review2', () => {
+  describe('Vha Ro send to Vha Po for review', () => {
     const taskType = 'AssessDocumentationTask';
     const buttonText = COPY.MODAL_SEND_BUTTON;
     const modalType = 'ready_for_review';
@@ -243,6 +247,10 @@ describe('CompleteTaskModal', () => {
     test('modal title is Ready for review', () => {
       renderCompleteTaskModal(modalType, visnData, taskType);
       expect(screen.getByText('Ready for review')).toBeTruthy();
+    });
+
+    test('modal text indicates appeal will be sent to VHA Program Office', () => {
+      renderCompleteTaskModal(modalType, visnData, taskType);
       expect(screen.getByText('This appeal will be sent to VHA Program Office for review.Please select where the documents for this appeal are stored')).toBeTruthy();
     });
 

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -22,7 +22,8 @@ import {
   caregiverToIntakeData,
   emoToBvaIntakeData,
   rpoToBvaIntakeData,
-  vhaPOToCAMOData
+  vhaPOToCAMOData,
+  visnData
 } from '../../../data/queue/taskActionModals/taskActionModalData';
 import * as uiActions from 'app/queue/uiReducer/uiActions';
 import CompleteTaskModal from 'app/queue/components/CompleteTaskModal';
@@ -32,7 +33,7 @@ let requestPatchSpy;
 const renderCompleteTaskModal = (modalType, storeValues, taskType) => {
   const appealId = getAppealId(storeValues);
   const taskId = getTaskId(storeValues, taskType);
-
+  
   const queueReducer = createQueueReducer(storeValues);
   const store = createStore(
     queueReducer,
@@ -170,6 +171,7 @@ describe('CompleteTaskModal', () => {
     test('modal title is Ready for review', () => {
       renderCompleteTaskModal(modalType, vhaPOToCAMOData, taskType);
       expect(screen.getByText('Ready for review')).toBeTruthy();
+      expect(screen.getByText('This appeal will be sent to VHA CAMO for review.Please select where the documents for this appeal are stored')).toBeTruthy();
     });
 
     test('Before Radio button is Chosen, button should be disabled', () => {
@@ -232,6 +234,79 @@ describe('CompleteTaskModal', () => {
       );
     });
   });
+
+  describe('ready_for_review2', () => {
+    const taskType = 'AssessDocumentationTask';
+    const buttonText = COPY.MODAL_SEND_BUTTON;
+    const modalType = 'ready_for_review';
+
+    test('modal title is Ready for review', () => {
+      renderCompleteTaskModal(modalType, visnData, taskType);
+      expect(screen.getByText('Ready for review')).toBeTruthy();
+      expect(screen.getByText('This appeal will be sent to VHA Program Office for review.Please select where the documents for this appeal are stored')).toBeTruthy();
+    });
+
+    test('Before Radio button is Chosen, button should be disabled', () => {
+      renderCompleteTaskModal(modalType, visnData, taskType);
+      expect(screen.getByText(buttonText).closest('button')).toBeDisabled();
+    });
+
+    test('When Centralized Mail Portal is chosen in Modal', () => {
+      renderCompleteTaskModal(modalType, visnData, taskType);
+
+      enterModalRadioOptions(
+        'Centralized Mail Portal'
+      );
+
+      expect(screen.getByText(buttonText).closest('button')).toBeDisabled();
+
+      enterTextFieldOptions(
+        'Provide details such as file structure or file path',
+        'VHA PO -> BVA Intake'
+      );
+
+      expect(screen.getByText(buttonText).closest('button')).not.toBeDisabled();
+
+      clickSubmissionButton(buttonText);
+
+      expect(getReceivedInstructions()).toBe(
+        'Documents for this appeal are stored in Centralized Mail Portal.' +
+        '\n\n**Detail:**\n\nVHA PO -> BVA Intake\n'
+      );
+    });
+
+    test('When Other is Chosen in Modal', () => {
+      renderCompleteTaskModal(modalType, visnData, taskType);
+
+      enterModalRadioOptions(
+        'Other'
+      );
+
+      expect(screen.getByText(buttonText).closest('button')).toBeDisabled();
+
+      enterTextFieldOptions(
+        'Provide details such as file structure or file path',
+        'PO -> CAMO'
+      );
+
+      expect(screen.getByText(buttonText).closest('button')).toBeDisabled();
+
+      enterTextFieldOptions(
+        'Please indicate the source',
+        'Other Source'
+      );
+
+      expect(screen.getByText(buttonText).closest('button')).not.toBeDisabled();
+
+      clickSubmissionButton(buttonText);
+
+      expect(getReceivedInstructions()).toBe(
+        'Documents for this appeal are stored in Other Source.' +
+        '\n\n**Detail:**\n\nPO -> CAMO\n'
+      );
+    });
+  });
+
 
   describe('vha_caregiver_support_send_to_board_intake_for_review', () => {
     const taskType = 'VhaDocumentSearchTask';

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -33,7 +33,7 @@ let requestPatchSpy;
 const renderCompleteTaskModal = (modalType, storeValues, taskType) => {
   const appealId = getAppealId(storeValues);
   const taskId = getTaskId(storeValues, taskType);
-  
+
   const queueReducer = createQueueReducer(storeValues);
   const store = createStore(
     queueReducer,
@@ -147,7 +147,7 @@ describe('CompleteTaskModal', () => {
       enterModalRadioOptions('Correct documents have been successfully added');
 
       enterTextFieldOptions(
-        'Provide additional context and/or documents:',
+        'Provide additional context and/or documents',
         'Null test'
       );
 

--- a/client/test/data/queue/taskActionModals/taskActionModalData.js
+++ b/client/test/data/queue/taskActionModals/taskActionModalData.js
@@ -160,7 +160,7 @@ const vhaDocumentSearchTaskData = {
             }
           ],
           modal_title: 'Assign to Program Office',
-          modal_body: 'Provide instructions and context for this action',
+          modal_body: 'Provide instructions and context for this action:',
           modal_button_text: 'Assign',
           modal_selector_placeholder: 'Select Program Office',
           type: 'AssessDocumentationTask',
@@ -252,7 +252,7 @@ const educationDocumentSearchTaskData = {
             }
           ],
           modal_title: 'Assign to RPO',
-          modal_body: 'Provide instructions and context for this action',
+          modal_body: 'Provide instructions and context for this action:',
           modal_selector_placeholder: 'Select RPO',
           modal_button_text: 'Assign',
           type: 'EducationAssessDocumentationTask',
@@ -267,7 +267,6 @@ const educationDocumentSearchTaskData = {
         data: {
           modal_title: 'Return to Board Intake',
           modal_button_text: 'Return',
-          instructions_label: 'Provide instructions and context for this action',
           type: 'EducationDocumentSearchTask',
           redirect_after: '/organizations/edu-emo'
         }
@@ -354,7 +353,7 @@ const preDocketTaskData = {
           modal_title: 'Docket appeal',
           modal_body: 'Please confirm that the documents provided by VHA are available in VBMS before docketing this appeal.',
           modal_alert: 'Once you confirm, the appeal will be established. Please remember to send the docketing letter out to all parties and representatives.',
-          instructions_label: 'Provide instructions and context for this action',
+          instructions_label: 'Provide instructions and context for this action:',
           redirect_after: '/organizations/bva-intake'
         }
       },
@@ -617,7 +616,7 @@ const assessDocumentationTaskData = {
             }
           ],
           modal_title: 'Assign to VISN/VA Medical Center',
-          modal_body: 'Provide instructions and context for this action',
+          modal_body: 'Provide instructions and context for this action:',
           modal_button_text: 'Assign',
           modal_selector_placeholder: 'Select VISN/VA Medical Center',
           instructions: [],
@@ -835,7 +834,7 @@ const educationAssessDocumentationTaskData = {
           modal_button_text: 'Send',
           type: 'EducationAssessDocumentationTask',
           body_optional: true,
-          redirect_after: '/organizations/buffalo-rpo'
+          redirect_after: '/organizations/buffalo-rpo',
         }
       },
       {

--- a/client/test/data/queue/taskActionModals/taskActionModalData.js
+++ b/client/test/data/queue/taskActionModals/taskActionModalData.js
@@ -36,7 +36,7 @@ const caregiverActions = [
     label: 'Documents ready for Board Intake review',
     value: 'modal/vha_caregiver_support_send_to_board_intake_for_review',
     data: {
-      modal_title: 'Ready for Review',
+      modal_title: 'Ready for review',
       modal_button_text: 'Send',
       message_title: 'You have successfully sent Bob Smithswift\'s case to Board Intake for Review',
       type: 'VhaDocumentSearchTask',
@@ -277,7 +277,7 @@ const educationDocumentSearchTaskData = {
         label: 'Ready for Review',
         value: 'modal/emo_send_to_board_intake_for_review',
         data: {
-          modal_title: 'Ready for Review',
+          modal_title: 'Ready for review',
           modal_button_text: 'Send',
           type: 'EducationDocumentSearchTask',
           redirect_after: '/organizations/edu-emo',
@@ -529,8 +529,9 @@ const assessDocumentationTaskData = {
         label: 'Ready for Review',
         value: 'modal/ready_for_review',
         data: {
-          modal_title: 'Where were documents regarding this appeal stored?',
+          modal_title: 'Ready for review',
           modal_button_text: 'Send',
+          radio_field_label: 'This appeal will be sent to VHA CAMO for review.\n\nPlease select where the documents for this appeal are stored',
           instructions: [],
           type: 'AssessDocumentationTask',
           redirect_after: '/organizations/prosthetics'
@@ -660,7 +661,106 @@ const assessDocumentationTaskData = {
     canMoveOnDocketSwitch: true,
     timerEndsAt: null,
     unscheduledHearingNotes: {}
-  }
+  },
+};
+
+const assessVISNData = {
+  7217: {
+    uniqueId: '7217',
+    isLegacy: false,
+    type: 'AssessDocumentationTask',
+    appealType: 'Appeal',
+    addedByCssId: null,
+    appealId: 1657,
+    externalAppealId: 'b41145a6-6c8b-4e02-a4d9-0963ae61c15a',
+    assignedOn: '2022-09-23T15:55:28.334-04:00',
+    closestRegionalOffice: null,
+    createdAt: '2022-09-23T15:55:28.334-04:00',
+    closedAt: null,
+    startedAt: null,
+    assigneeName: 'Sierra Pacific Network',
+    assignedTo: {
+      cssId: null,
+      name: 'Sierra Pacific Network',
+      id: 53,
+      isOrganization: true,
+      type: 'VhaRegionalOffice'
+    },
+    assignedBy: {
+      firstName: 'Channing',
+      lastName: 'Katz',
+      cssId: 'VHAPOADMIN',
+      pgId: 4206
+    },
+    cancelledBy: {
+      cssId: null
+    },
+    cancelReason: null,
+    convertedBy: {
+      cssId: null
+    },
+    convertedOn: null,
+    taskId: '7217',
+    parentId: 7216,
+    label: 'Assess Documentation',
+    documentId: null,
+    externalHearingId: null,
+    workProduct: null,
+    previousTaskAssignedOn: null,
+    placedOnHoldAt: null,
+    status: 'assigned',
+    onHoldDuration: null,
+    instructions: [
+      'Assign to Sierra Pacific'
+    ],
+    decisionPreparedBy: null,
+    availableActions: [
+      {
+        label: 'Put task on hold',
+        value: 'modal/place_timed_hold'
+      },
+      {
+        func: 'vha_regional_office_return_to_program_office',
+        label: 'Return to Program Office',
+        value: 'modal/return_to_program_office',
+        data: {
+          modal_title: 'Return to Program Office',
+          message_title: 'You have successfully returned this appeal to the Program Office',
+          message_detail: 'This appeal will be removed from your Queue and placed in the Program Office\'s Queue',
+          modal_button_text: 'Return',
+          type: 'AssessDocumentationTask',
+          redirect_after: '/organizations/sierra-pacific-network'
+        }
+      },
+      {
+        func: 'vha_complete_data',
+        label: 'Documents ready for VHA Program Office team review',
+        value: 'modal/ready_for_review',
+        data: {
+          modal_title: 'Ready for review',
+          modal_button_text: 'Send',
+          radio_field_label: 'This appeal will be sent to VHA Program Office for review.\n\nPlease select where the documents for this appeal are stored',
+          instructions: [],
+          type: 'AssessDocumentationTask',
+          redirect_after: '/organizations/sierra-pacific-network'
+        }
+      },
+      {
+        func: 'vha_mark_task_in_progress',
+        label: 'Mark task in progress',
+        value: 'modal/mark_task_in_progress',
+        data: {
+          modal_title: 'Mark task in progress',
+          modal_body: 'Please confirm that you are actively working on collecting documents for this appeal.  Once confirmed, other members of your organization will no longer be able to mark this task in progress.',
+          message_title: 'You have successfully marked your task as in progress',
+          message_detail: 'This appeal will be visible in the "In Progress" tab of your Queue',
+          modal_button_text: 'Mark in progress',
+          type: 'AssessDocumentationTask',
+          redirect_after: '/organizations/sierra-pacific-network'
+        }
+      }
+    ]
+  },
 };
 
 const educationAssessDocumentationTaskData = {
@@ -731,7 +831,7 @@ const educationAssessDocumentationTaskData = {
         label: 'Ready for Review',
         value: 'modal/rpo_send_to_board_intake_for_review',
         data: {
-          modal_title: 'Ready for Review',
+          modal_title: 'Ready for review',
           modal_button_text: 'Send',
           type: 'EducationAssessDocumentationTask',
           body_optional: true,
@@ -785,6 +885,21 @@ export const returnToOrgData = {
   queue: {
     amaTasks: {
       ...preDocketTaskData
+    },
+    appeals: {
+      '419ce568-387c-4ac6-a5f5-00a1554cea36': {
+        id: '1632',
+        externalId: '419ce568-387c-4ac6-a5f5-00a1554cea36'
+      }
+    }
+  },
+  ...uiData
+};
+
+export const visnData = {
+  queue: {
+    amaTasks: {
+      ...assessVISNData
     },
     appeals: {
       '419ce568-387c-4ac6-a5f5-00a1554cea36': {

--- a/client/test/data/queue/taskActionModals/taskActionModalData.js
+++ b/client/test/data/queue/taskActionModals/taskActionModalData.js
@@ -268,6 +268,7 @@ const educationDocumentSearchTaskData = {
           modal_title: 'Return to Board Intake',
           modal_button_text: 'Return',
           type: 'EducationDocumentSearchTask',
+          instructions_label: 'Provide instructions and context for this action',
           redirect_after: '/organizations/edu-emo'
         }
       },

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -507,7 +507,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           find(
             "div",
             class: "cf-select__option",
-            text: Constants.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.label
+            text: Constants.TASK_ACTIONS.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.label
           ).click
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -459,7 +459,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
           find("label", text: "VBMS").click
-          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: po_instructions)
+          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: "test")
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
 

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -446,6 +446,30 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::ORGANIZATION_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE)
         end
 
+        step "Regional Program can send appeal to VHA CAMO as Ready for Review" do
+          appeal = Appeal.last
+          visit "/queue/appeals/#{appeal.external_id}"
+
+          find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+          find(
+            "div",
+            class: "cf-select__option",
+            text: Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.label
+          ).click
+          expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
+          expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
+          find("label", text: "VBMS").click
+          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: po_review_instructions)
+          find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
+          expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
+
+          appeal = Appeal.last
+          visit "/queue/appeals/#{appeal.external_id}"
+          find_all("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).first.click
+          expect(page).to have_content("Documents for this appeal are stored in VBMS")
+          expect(page).to have_content(po_review_instructions)
+        end
+
         step "Program Office can assign AssessDocumentationTask to Regional Office" do
           appeal = Appeal.last
           visit "/queue/appeals/#{appeal.external_id}"
@@ -499,7 +523,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::ORGANIZATION_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE)
         end
 
-        step "Regional Office can mark AssessDocumentationTask as Ready for Review" do
+        step "Regional Office can send appeal to Program Office as Ready for Review" do
           appeal = Appeal.last
           visit "/queue/appeals/#{appeal.external_id}"
 
@@ -507,12 +531,12 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           find(
             "div",
             class: "cf-select__option",
-            text: Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.label
+            text: Constants.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.label
           ).click
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
-          expect(page).to have_content(COPY::VHA_COMPLETE_TASK_MODAL_BODY)
+          expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
           find("label", text: "VBMS").click
-          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: ro_review_instructions)
+          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: ro_review_instructions)
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_VISN)
 

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -446,30 +446,6 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::ORGANIZATION_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE)
         end
 
-        step "Program Office can send appeal to VHA CAMO as Ready for Review" do
-          appeal = Appeal.last
-          sleep(10)
-          visit "/queue/appeals/#{appeal.external_id}"
-
-          find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
-          find(
-            "div",
-            class: "cf-select__option",
-            text: Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.label
-          ).click
-          expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
-          expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
-          find("label", text: "VBMS").click
-          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: po_instructions)
-          find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
-          expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
-
-          visit "/queue/appeals/#{appeal.external_id}"
-          find_all("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).first.click
-          expect(page).to have_content("Documents for this appeal are stored in VBMS")
-          expect(page).to have_content(po_instructions)
-        end
-
         step "Program Office can assign AssessDocumentationTask to Regional Office" do
           appeal = Appeal.last
           visit "/queue/appeals/#{appeal.external_id}"
@@ -557,6 +533,29 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(format(COPY::ORGANIZATIONAL_QUEUE_ON_HOLD_TAB_TITLE, 0))
           expect(page).to have_content(format(COPY::ORGANIZATIONAL_QUEUE_PAGE_READY_FOR_REVIEW_TAB_TITLE, 1))
           expect(page).to have_content("#{appeal.veteran.name} (#{appeal.veteran.file_number})")
+        end
+
+        step "Program Office can send appeal to VHA CAMO as Ready for Review" do
+          appeal = Appeal.last
+          visit "/queue/appeals/#{appeal.external_id}"
+
+          find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+          find(
+            "div",
+            class: "cf-select__option",
+            text: Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.label
+          ).click
+          expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
+          expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
+          find("label", text: "VBMS").click
+          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: po_instructions)
+          find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
+          expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
+
+          visit "/queue/appeals/#{appeal.external_id}"
+          find_all("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).first.click
+          expect(page).to have_content("Documents for this appeal are stored in VBMS")
+          expect(page).to have_content(po_instructions)
         end
 
         step "CAMO can return the appeal to BVA Intake" do

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -448,8 +448,9 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
 
         step "Program Office can send appeal to VHA CAMO as Ready for Review" do
           appeal = Appeal.last
+          sleep(10)
           visit "/queue/appeals/#{appeal.external_id}"
-          
+
           find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
           find(
             "div",
@@ -463,7 +464,6 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
 
-          appeal = Appeal.last
           visit "/queue/appeals/#{appeal.external_id}"
           find_all("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).first.click
           expect(page).to have_content("Documents for this appeal are stored in VBMS")

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -447,6 +447,9 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         end
 
         step "Program Office can send appeal to VHA CAMO as Ready for Review" do
+          appeal = Appeal.last
+          visit "/queue/appeals/#{appeal.external_id}"
+          
           find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
           find(
             "div",

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -447,9 +447,6 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
         end
 
         step "Program Office can send appeal to VHA CAMO as Ready for Review" do
-          appeal = Appeal.last
-          visit "/queue/appeals/#{appeal.external_id}"
-
           find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
           find(
             "div",
@@ -459,7 +456,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
           find("label", text: "VBMS").click
-          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: "test")
+          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: po_instructions)
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
 

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -446,7 +446,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::ORGANIZATION_MARK_TASK_IN_PROGRESS_CONFIRMATION_TITLE)
         end
 
-        step "Regional Program can send appeal to VHA CAMO as Ready for Review" do
+        step "Program Office can send appeal to VHA CAMO as Ready for Review" do
           appeal = Appeal.last
           visit "/queue/appeals/#{appeal.external_id}"
 
@@ -459,7 +459,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
           find("label", text: "VBMS").click
-          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: po_review_instructions)
+          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: po_instructions)
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
 
@@ -467,7 +467,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           visit "/queue/appeals/#{appeal.external_id}"
           find_all("button", text: COPY::TASK_SNAPSHOT_VIEW_TASK_INSTRUCTIONS_LABEL).first.click
           expect(page).to have_content("Documents for this appeal are stored in VBMS")
-          expect(page).to have_content(po_review_instructions)
+          expect(page).to have_content(po_instructions)
         end
 
         step "Program Office can assign AssessDocumentationTask to Regional Office" do

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -459,7 +459,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
           find("label", text: "VBMS").click
-          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: po_instructions)
+          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: po_instructions)
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_PO)
 
@@ -536,7 +536,7 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
           find("label", text: "VBMS").click
-          fill_in(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, with: ro_review_instructions)
+          fill_in(COPY::VHA_COMPLETE_TASK_MODAL_BODY, with: ro_review_instructions)
           find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
           expect(page).to have_content(COPY::VHA_COMPLETE_TASK_CONFIRMATION_VISN)
 

--- a/spec/models/tasks/assess_documentation_task_spec.rb
+++ b/spec/models/tasks/assess_documentation_task_spec.rb
@@ -22,9 +22,9 @@ describe AssessDocumentationTask, :postgres do
 
       available_actions = [
         Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-        Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h,
         Constants.TASK_ACTIONS.VHA_ASSIGN_TO_REGIONAL_OFFICE.to_h,
-        Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h,
+        Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h, 
+        Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h,
         Constants.TASK_ACTIONS.VHA_MARK_TASK_IN_PROGRESS.to_h
       ]
 
@@ -40,9 +40,9 @@ describe AssessDocumentationTask, :postgres do
       subject { regional_office_task.available_actions(user) }
 
       available_actions = [
-        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
-        Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h,
+        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,        
         Constants.TASK_ACTIONS.VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE.to_h,
+        Constants.TASK_ACTIONS.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.to_h,
         Constants.TASK_ACTIONS.VHA_MARK_TASK_IN_PROGRESS.to_h
       ]
 

--- a/spec/models/tasks/assess_documentation_task_spec.rb
+++ b/spec/models/tasks/assess_documentation_task_spec.rb
@@ -23,7 +23,7 @@ describe AssessDocumentationTask, :postgres do
       available_actions = [
         Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
         Constants.TASK_ACTIONS.VHA_ASSIGN_TO_REGIONAL_OFFICE.to_h,
-        Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h, 
+        Constants.TASK_ACTIONS.VHA_PROGRAM_OFFICE_RETURN_TO_CAMO.to_h,
         Constants.TASK_ACTIONS.VHA_PO_SEND_TO_CAMO_FOR_REVIEW.to_h,
         Constants.TASK_ACTIONS.VHA_MARK_TASK_IN_PROGRESS.to_h
       ]
@@ -40,7 +40,7 @@ describe AssessDocumentationTask, :postgres do
       subject { regional_office_task.available_actions(user) }
 
       available_actions = [
-        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,        
+        Constants.TASK_ACTIONS.TOGGLE_TIMED_HOLD.to_h,
         Constants.TASK_ACTIONS.VHA_REGIONAL_OFFICE_RETURN_TO_PROGRAM_OFFICE.to_h,
         Constants.TASK_ACTIONS.VHA_VISN_SEND_TO_VHA_PO_FOR_REVIEW.to_h,
         Constants.TASK_ACTIONS.VHA_MARK_TASK_IN_PROGRESS.to_h

--- a/spec/repositories/task_action_repository_spec.rb
+++ b/spec/repositories/task_action_repository_spec.rb
@@ -180,8 +180,6 @@ describe TaskActionRepository, :all_dbs do
     end
 
     describe "#vha_po_send_to_vha_camo_for_review" do
-      let(:assigned_tab_name) { VhaProgramOfficeAssignedTasksTab.tab_name }
-      let(:redirect_url) { "/organizations/#{VhaProgramOffice.url}?tab=#{assigned_tab_name}" }
       let(:program_office) { VhaProgramOffice.create!(name: "Program Office", url: "Program Office") }
       let(:program_office_task) { create(:assess_documentation_task, assigned_to: program_office) }
 
@@ -196,8 +194,6 @@ describe TaskActionRepository, :all_dbs do
     end
 
     describe "#vha_ro_send_to_vha_po_for_review" do
-      # let(:completed_tab_name) { VhaProgramOfficeCompletedTasksTab.tab_name }
-      # let(:redirect_url) { "/organizations/#{VhaProgramOffice.url}?tab=#{completed_tab_name}" }
       let(:regional_office) { VhaRegionalOffice.create!(name: "Regional Office", url: "Regional Office") }
       let(:regional_office_task) { create(:assess_documentation_task, assigned_to: regional_office) }
 

--- a/spec/repositories/task_action_repository_spec.rb
+++ b/spec/repositories/task_action_repository_spec.rb
@@ -190,8 +190,8 @@ describe TaskActionRepository, :all_dbs do
       subject { TaskActionRepository.vha_complete_data(program_office_task, user) }
 
       it "the modal body includes the text This appeal will be sent to VHA CAMO for review" do
-        expect(subject[:radio_field_label]).
-        to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
+        expect(subject[:radio_field_label])
+          .to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
       end
     end
 
@@ -206,8 +206,8 @@ describe TaskActionRepository, :all_dbs do
       subject { TaskActionRepository.vha_complete_data(regional_office_task, user) }
 
       it "the modal body includes the text This appeal will be sent to VHA Program Office for review" do
-        expect(subject[:radio_field_label]).
-        to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
+        expect(subject[:radio_field_label])
+          .to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
       end
     end
   end

--- a/spec/repositories/task_action_repository_spec.rb
+++ b/spec/repositories/task_action_repository_spec.rb
@@ -168,4 +168,45 @@ describe TaskActionRepository, :all_dbs do
       end
     end
   end
+
+  context "#vha po and vha ro ready for review" do
+    let(:user) { create(:user) }
+    before do
+      FeatureToggle.enable!(:visn_predocket_workflow)
+    end
+  
+    after do
+      FeatureToggle.disable!(:visn_predocket_workflow)
+    end    
+
+    describe "#vha_po_send_to_vha_camo_for_review" do
+      let(:assigned_tab_name) { VhaProgramOfficeAssignedTasksTab.tab_name }
+      let(:redirect_url) { "/organizations/#{VhaProgramOffice.url}?tab=#{assigned_tab_name}" }
+      let(:program_office) { VhaProgramOffice.create!(name: "Program Office", url: "Program Office") }
+      let(:program_office_task) { create(:assess_documentation_task, assigned_to: program_office) }
+
+      before { program_office.add_user(user) }
+
+      subject { TaskActionRepository.vha_complete_data(program_office_task, user) }
+
+      it "the modal body includes the text This appeal will be sent to VHA CAMO for review" do
+        expect(subject[:radio_field_label]).to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
+      end
+    end
+
+    describe "#vha_ro_send_to_vha_po_for_review" do
+      # let(:completed_tab_name) { VhaProgramOfficeCompletedTasksTab.tab_name }
+      # let(:redirect_url) { "/organizations/#{VhaProgramOffice.url}?tab=#{completed_tab_name}" }
+      let(:regional_office) { VhaRegionalOffice.create!(name: "Regional Office", url: "Regional Office") }
+      let(:regional_office_task) { create(:assess_documentation_task, assigned_to: regional_office) }
+
+      before { regional_office.add_user(user) }
+
+      subject { TaskActionRepository.vha_complete_data(regional_office_task, user) }
+
+      it "the modal body includes the text This appeal will be sent to VHA Program Office for review" do
+        expect(subject[:radio_field_label]).to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
+      end
+    end
+  end
 end

--- a/spec/repositories/task_action_repository_spec.rb
+++ b/spec/repositories/task_action_repository_spec.rb
@@ -174,10 +174,10 @@ describe TaskActionRepository, :all_dbs do
     before do
       FeatureToggle.enable!(:visn_predocket_workflow)
     end
-  
+
     after do
       FeatureToggle.disable!(:visn_predocket_workflow)
-    end    
+    end
 
     describe "#vha_po_send_to_vha_camo_for_review" do
       let(:assigned_tab_name) { VhaProgramOfficeAssignedTasksTab.tab_name }

--- a/spec/repositories/task_action_repository_spec.rb
+++ b/spec/repositories/task_action_repository_spec.rb
@@ -190,7 +190,8 @@ describe TaskActionRepository, :all_dbs do
       subject { TaskActionRepository.vha_complete_data(program_office_task, user) }
 
       it "the modal body includes the text This appeal will be sent to VHA CAMO for review" do
-        expect(subject[:radio_field_label]).to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
+        expect(subject[:radio_field_label]).
+        to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA CAMO"))
       end
     end
 
@@ -205,7 +206,8 @@ describe TaskActionRepository, :all_dbs do
       subject { TaskActionRepository.vha_complete_data(regional_office_task, user) }
 
       it "the modal body includes the text This appeal will be sent to VHA Program Office for review" do
-        expect(subject[:radio_field_label]).to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
+        expect(subject[:radio_field_label]).
+        to eq(format(COPY::DOCUMENTS_READY_FOR_ORG_REVIEW_MODAL_BODY, "VHA Program Office"))
       end
     end
   end


### PR DESCRIPTION
## Resolves [APPEALS-9206](https://vajira.max.gov/browse/APPEALS-9206) | [Original PR](https://github.com/department-of-veterans-affairs/caseflow/pull/17534)

### Description
We would like for the radio fieldset label text on the "Ready for review" modal used by VHA Program Offices to be consistent with the text used on the "Ready for review" modals used by all of the other organizations that participate in pre-docket workflows.

*Note:* This string in use by other organizations can be found [here](https://github.com/department-of-veterans-affairs/caseflow/blob/9f5b20ee94ff2fa5d648a39bdbbf8b99a37b9c5a/client/COPY.json#L1266).

See this section of our research document for more information: https://hackmd.io/RnTH0BcnQ5Cxd_PulUWyyg?view#%E2%9C%85-Ready-for-Review-R4R

In the process of researching this story, it was discovered that the Regional Office Ready for review modal/task action needed to be updated as well to reflect that the appeal was being sent to Program Office for Review

### Acceptance Criteria
- [ ] The VHA Program Office Ready for review Radio Field Label should be: "This appeal we be sent to VHA CAMO for review.\n\nPlease select where the documents for this appeal are stored"
- [ ] The VISN Ready for review Radio Field Label should be: "This appeal we be sent to VHA Program Office for review.\n\nPlease select where the documents for this appeal are stored"
- [ ] Correct the VISN-to-VHA PO task action labels and accompanying modal titles to be "Documents ready for VHA Program Office team review" and "Return to VHA Program Office team".

### Testing Plan
1. In the Rails console, stage 2 appeals that will be in a VHA PO's queue with veteran file numbers 500001000 and 500002000
```ruby

appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
parent_task = appeal.tasks.last
camo_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCamo.singleton )
po_task = AssessDocumentationTask.create!( parent: camo_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaProgramOffice.first )
appeal.last.update( veteran_file_number: "500001000" )
end

appeal = FactoryBot.create(:appeal, :with_pre_docket_task)
parent_task = appeal.tasks.last
camo_task = VhaDocumentSearchTask.create!( parent: parent_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaCamo.singleton )
po_task = AssessDocumentationTask.create!( parent: camo_task, appeal: appeal, assigned_at: Time.zone.now, assigned_to: VhaProgramOffice.first )
appeal.last.update( veteran_file_number: "500002000" )
end
```
2. Log into Caseflow as a VHA PO user (ex: `VHAPOUSER`)
3. Navigate to the queue for the VHA Program Office where the appeals currently reside:
```ruby
# It should be the "Community Care - Payment Operations Management" office, but just in case here is
# how you can locate the URL:
"/organizations/#{VhaProgramOffice.first.url}/"
```
4. Assign the 2nd appeal (veteran file number: 500002000) to a VISN/RO):
You can go to the Case Details for the appeal and use the actions dropdown. Select "Assign to VISN" and take note of which RO was selected for later use:
<img width="307" alt="assign_to_visn" src="https://user-images.githubusercontent.com/99351305/190537458-fc1a07c0-68a6-4522-93e6-c309e6d15203.PNG">

5. Navigate back to the queue for the VHA Program Office and select 1st appeal (veteran file number: 500001000) to visit the case details page.

6. In the task action dropdown, select the task action "Documents ready for VHA CAMO team review 
![image](https://user-images.githubusercontent.com/98414141/193147652-86343971-913a-4042-aa3f-f79f189291a6.png)

7. Please note the updated text in the modal which is represented below in the "After" screenshot

**Before** | **After** 
--- | ---
![VHAPO Before](https://user-images.githubusercontent.com/98414141/193152362-bf90ad2f-e255-4d0a-90a9-e37711c4be36.PNG)|![VHARO After](https://user-images.githubusercontent.com/98414141/193152390-ee85dbdf-5172-4b4f-97f7-cc6035168ad5.PNG)

8. Switch user to Regional Office user (ex: `VISNUSER`)

9. Navigate to the queue for the Regional Office where the appeals currently reside and select 2nd appeal (veteran file number: 500002000) to visit the case details page.

10. In the task action dropdown, please note the new task action and select it "Documents ready for VHA Program Office team review.  Also note the updated Task Action text, "Return to VHA Program Office team"  
![Ready for VHAPO dropdown](https://user-images.githubusercontent.com/98414141/193588337-53c75c6f-48b5-4597-8346-8fb0d515fb72.PNG)

11. Please note the updated text in the modal which is represented below in the "After" screenshot

**Before** | **After** 
--- | ---
![VHAPO Before](https://user-images.githubusercontent.com/98414141/193152362-bf90ad2f-e255-4d0a-90a9-e37711c4be36.PNG)|![VHARO After](https://user-images.githubusercontent.com/98414141/193154351-d1340bf4-1716-4dcb-ae92-97591914283f.PNG)



