### PR TITLE
Feature/appeals 77

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,16 @@ commands:
             - public/assets
             - tmp/cache/assets/sprockets
 
+  install_wkhtmltopdf:
+    description: Install wkhtmltopdf
+    steps:
+      - run:
+          name: apt install wkhtmltopdf
+          command: sudo apt install wkhtmltopdf
+      - run:
+          name: move wkhtmltopdf
+          command: sudo mv /usr/bin/wkhtmltopdf /usr/local/bin
+
   install_dockerize:
     description: "Install Dockerize"
     steps:
@@ -210,6 +220,8 @@ jobs:
           <<: *browser_versions
 
       - install_ruby_dependencies
+
+      - install_wkhtmltopdf
 
       - install_dockerize
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "browser"
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "465aff43770c285ad21419b14d92093d22ef01af"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "b9f0f74b85409df2a5f33ec3424f5cabbb5ae97f"
 gem "connect_mpi", git: "https://github.com/department-of-veterans-affairs/connect-mpi.git", ref: "a3a58c64f85b980a8b5ea6347430dd73a99ea74c"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "43654a058d5a1d3f83f9bfdb832a19b4a9adea8b"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 465aff43770c285ad21419b14d92093d22ef01af
-  ref: 465aff43770c285ad21419b14d92093d22ef01af
+  revision: b9f0f74b85409df2a5f33ec3424f5cabbb5ae97f
+  ref: b9f0f74b85409df2a5f33ec3424f5cabbb5ae97f
   specs:
     caseflow (0.4.8)
       aws-sdk (~> 2.10)

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -76,6 +76,7 @@ class AppealsController < ApplicationController
   rescue StandardError => error
     uuid = SecureRandom.uuid
     Rails.logger.error(error.to_s + "Error ID: " + uuid)
+    Raven.capture_exception(error, extra: { error_uuid: uuid })
     render json: { "errors": ["message": uuid] }, status: :internal_server_error
   end
 

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -73,6 +73,10 @@ class AppealsController < ApplicationController
         raise ActionController::ParameterMissing.new('Bad Format')
       end
     end
+  rescue StandardError => error
+    uuid = SecureRandom.uuid
+    Rails.logger.error(error.to_s + "Error ID: " + uuid)
+    render json: { "errors": ["message": uuid] }, status: :internal_server_error
   end
 
   def document_count
@@ -359,3 +363,4 @@ class AppealsController < ApplicationController
     end
   end
 end
+

--- a/app/jobs/notification_efolder_sync_job.rb
+++ b/app/jobs/notification_efolder_sync_job.rb
@@ -11,6 +11,7 @@ class NotificationEfolderSyncJob < CaseflowJob
 
   # rubocop:disable Metrics/MethodLength
   def perform
+    RequestStore[:current_store] = User.system_user
     appeals_with_notifications = "select appeals.* from appeals
     inner join (select distinct(notifications.appeals_id)
     from notifications where notifications.appeals_type = 'Appeal')

--- a/app/views/templates/notification_report_pdf_template.html.erb
+++ b/app/views/templates/notification_report_pdf_template.html.erb
@@ -18,9 +18,17 @@ end
 
 def get_notifications(appeal)
   if appeal.is_a?(Appeal)
-    Notification.where(appeals_id: appeal.uuid)
+    all_notifications = Notification.where(appeals_id: appeal.uuid)
+    allowed_notifications = all_notifications.where(email_notification_status: nil)
+      .or(all_notifications.where.not(email_notification_status: ["No Participant Id Found", "No Claimant Found", "No External Id"]))
+      .merge(all_notifications.where(sms_notification_status: nil)
+      .or(all_notifications.where.not(sms_notification_status: ["No Participant Id Found", "No Claimant Found", "No External Id"]))).order(event_date: :asc, id: :asc)
   elsif appeal.is_a?(LegacyAppeal)
-    Notification.where(appeals_id: appeal.vacols_id)
+    all_notifications = Notification.where(appeals_id: appeal.vacols_id)
+    allowed_notifications = all_notifications.where(email_notification_status: nil)
+      .or(all_notifications.where.not(email_notification_status: ["No Participant Id Found", "No Claimant Found", "No External Id"]))
+      .merge(all_notifications.where(sms_notification_status: nil)
+      .or(all_notifications.where.not(sms_notification_status: ["No Participant Id Found", "No Claimant Found", "No External Id"]))).order(event_date: :asc, id: :asc)
   end
 end
 
@@ -35,7 +43,16 @@ def generate_table_notifications(notifications)
   notifications.each do |notification|
 
     email_notification = {
-      status: notification.email_notification_status == 'Success' ? 'Sent' : notification.email_notification_status,
+      status: case notification.email_notification_status.downcase
+        when 'sent' , 'temporary-failure'
+          'Pending Delivery'
+        when 'permanent-failure' , 'technical-failure'
+          'Failed Delivery'
+        when 'preferences-declined'
+          'Opted-out'
+        else
+          notification.email_notification_status
+        end,
       content: notification.email_notification_content,
       notification_type: 'Email',
       recipient_information: notification.recipient_email == nil ? '—' : notification.recipient_email,
@@ -44,7 +61,16 @@ def generate_table_notifications(notifications)
     }
 
     sms_notification = {
-      status: notification.sms_notification_status == 'Success' ? 'Sent' : notification.sms_notification_status,
+      status: case notification.sms_notification_status.downcase
+        when 'sent' , 'temporary-failure'
+          'Pending Delivery'
+        when 'permanent-failure' , 'technical-failure'
+          'Failed Delivery'
+        when 'preferences-declined'
+          'Opted-out'
+        else
+          notification.sms_notification_status
+        end,
       content: notification.sms_notification_content,
       notification_type: 'Text',
       recipient_information: notification.recipient_phone_number == nil ? '—' : notification.recipient_phone_number,
@@ -207,4 +233,5 @@ end
   </style>
 
 </html>
+
 

--- a/client/app/queue/NotificationsView.jsx
+++ b/client/app/queue/NotificationsView.jsx
@@ -37,7 +37,10 @@ export const NotificationsView = (props) => {
     setModalState(false);
   };
 
-  const [alert, setAlert] = useState(false);
+  const [alert, setAlert] = useState([{
+    alertState: false,
+    alertMessage: ''
+  }]);
   const [loading, setLoading] = useState(false);
 
   const { push } = useHistory();
@@ -67,6 +70,7 @@ export const NotificationsView = (props) => {
 
   const errorCode = 'Error Code: ';
   const pdfURL = `/appeals/${appealId}/notifications.pdf`;
+  let errorUuid = '';
 
   //  Error handling to add alert message for PDF generation
   const generatePDF = () => {
@@ -76,8 +80,10 @@ export const NotificationsView = (props) => {
       setLoading(false);
     }).
       catch((error) => {
+
         if (error.status > 299 || error.status < 200) {
-          setAlert(true);
+          errorUuid = JSON.parse(error.response.text).errors[0].message;
+          setAlert({ alertState: true, alertMessage: errorUuid });
         }
         setLoading(false);
       });
@@ -89,7 +95,7 @@ export const NotificationsView = (props) => {
     <React.Fragment>
       <AppSegment filledBackground>
         <CaseTitle titleHeader = {`Case notifications for ${appeal.veteranFullName}`} appeal={appeal} hideCaseView />
-        {alert && <Alert type="error" title={COPY.PDF_GENERATION_ERROR_TITLE} styling={alertStyle}>{COPY.PDF_GENERATION_ERROR_MESSAGE}<br />{errorCode}{appealId}</Alert>}
+        {alert.alertState && <Alert type="error" title={COPY.PDF_GENERATION_ERROR_TITLE} styling={alertStyle}>{COPY.PDF_GENERATION_ERROR_MESSAGE}<br />{errorCode}{alert.alertMessage}</Alert>}
         {supportPendingAppealSubstitution && (
           <div {...sectionGap}>
             <Button
@@ -187,3 +193,4 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(NotificationsView);
+

--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,3 +1,3 @@
 PDFKit.configure do |config|
-  config.wkhtmltopdf = '/usr/bin/wkhtmltopdf'
+  config.wkhtmltopdf = '/usr/local/bin/wkhtmltopdf'
 end

--- a/config/initializers/pdfkit.rb
+++ b/config/initializers/pdfkit.rb
@@ -1,3 +1,3 @@
 PDFKit.configure do |config|
-  config.wkhtmltopdf = '/usr/local/bin/wkhtmltopdf'
+  config.wkhtmltopdf = '/usr/bin/wkhtmltopdf'
 end

--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -929,11 +929,10 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         subject do
           get :fetch_notification_list, params: { appeals_id: bad_appeals_id, format: request_format }
         end
-        it "should raise an error" do
-          expect { subject }.to raise_error do |error|
-            expect(error).to be_a(ActionController::RoutingError)
-            expect(error.to_s).to include("Appeal Not Found")
-          end
+        it "should send error uuid and 500 status" do
+          subject
+          expect(subject.status).to eq 500
+          expect(subject.body).to include("errors" && "message")
         end
       end
     end


### PR DESCRIPTION
Resolves UAT issues
https://vajira.max.gov/browse/APPEALS-8939
Description

Updates statuses in PDF template to display properly
Updates commit hash for caseflow gem
Acceptance Criteria

When the notification status says "Sent" The email and/or Text notification record Status column displays "Pending Delivery"
When the notification status says "Delivered" The email and/or Text notification record Status column displays "Delivered"
When the notification status says "Temporary-failure" The email and/or Text notification record Status column displays "Pending Delivery"
When the notification status says "Permanent-failure" The email and/or Text notification record Status column displays "Failed Delivery"
When the notification status says "Technical-failure" The email and/or Text notification record Status column displays "Failed Delivery"
When the notification status says "Preferences-declined" The email and/or Text notification record Status column displays "Opted-out"
