### PR TITLE
hotfix/APPEALS-9503

### DIFF
--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -162,6 +162,8 @@ class BodyRows extends React.PureComponent {
         const key = getKeyForRow(rowNumber, object);
 
         return <Row
+          tabIndex={-1}
+          role="gridcell"
           rowObject={object}
           columns={columns}
           rowClassNames={rowClassNames}

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -213,7 +213,8 @@ export class Row extends React.PureComponent {
           filter((column) => getCellSpan(props.rowObject, column) > 0).
           map((column, columnNumber) => (
             <td
-              role="cell"
+              tabIndex={-1}
+              role="gridcell"
               key={columnNumber}
               className={cellClasses(column)}
               colSpan={getCellSpan(props.rowObject, column)}
@@ -656,7 +657,7 @@ export default class QueueTable extends React.PureComponent {
       <table
         aria-label={COPY.CASE_LIST_TABLE_TITLE}
         aria-describedby="case-table-description"
-        role="table"
+        role="grid"
         id={id ?? 'case-table-description'}
         className={`usa-table-borderless ${this.props.className}`}
         {...styling}


### PR DESCRIPTION
Resolves [APPEALS-9503](https://vajira.max.gov/browse/APPEALS-9503)

### Description
508: Software disrupts platform features that are defined in the platform documentation as accessibility features

Make sure software does not disrupt platform features that are defined in the platform documentation as accessibility features. The following is an example:
On the Review Cases | Caseflow Screen (Caseflow), when reading cell (1,1), assistive technology table commands cannot be used to read the rest of the table.
For example, when reading the first row, table commands cannot be used to read the table after moving from the second column to the first column.

Tests for this 508 have been completed successfully:
[Test Link](https://vajira.max.gov/browse/APPEALS-18087)
