### PR TITLE
hotfix/APPEALS-15450 Caseflow VSO Conversion to Virtual Hearing is changing hearing time to incorrect time

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,6 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   # If RO is ambiguous from station_office, use the user-defined RO. Otherwise, use the unambigous RO.
   def regional_office
     upcase = ->(str) { str ? str.upcase : str }
-
     ro_is_ambiguous_from_station_office? ? upcase.call(@regional_office) : station_offices
   end
 
@@ -199,7 +198,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def timezone
-    (RegionalOffice::CITIES[regional_office] || {})[:timezone] || "America/Chicago"
+    RegionalOffice::CITIES[users_regional_office][:timezone]
   end
 
   # If user has never logged in, we might not have their full name in Caseflow DB.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -215,10 +215,15 @@ describe User, :all_dbs do
       it { is_expected.to eq("America/New_York") }
     end
 
+    # for VSO users with multiple RO's
+    # regional_office will default to nil, but selected_regional_office will not
     context "when ro isn't set" do
       subject { user.timezone }
-      before { user.regional_office = nil }
-      it { is_expected.to eq("America/Chicago") }
+      before do
+        user.regional_office = nil
+        user.selected_regional_office = "RO27"
+      end
+      it { is_expected.to eq("America/Kentucky/Louisville") }
     end
   end
 


### PR DESCRIPTION
Resolves [APPEALS-15450](https://vajira.max.gov/browse/APPEALS-15450)

### Description
Virtual Hearings which have undergone VSO Conversion by VSO Users are having their Hearings time adjusted to align to the time zone of the VSO User rather than the Veteran and Coordinators. 
Some VSO users had multiple RO's assigned to their station. This made their `regional office` nil, and forced the timezone to default to Chicago time. 

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-18745