### PR TITLE
hotfix/APPEALS-19640

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,6 +52,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   # If RO is ambiguous from station_office, use the user-defined RO. Otherwise, use the unambigous RO.
   def regional_office
     upcase = ->(str) { str ? str.upcase : str }
+
     ro_is_ambiguous_from_station_office? ? upcase.call(@regional_office) : station_offices
   end
 
@@ -206,7 +207,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def timezone
-    RegionalOffice::CITIES[users_regional_office][:timezone]
+    (RegionalOffice::CITIES[regional_office] || {})[:timezone] || "America/Chicago"
   end
 
   # If user has never logged in, we might not have their full name in Caseflow DB.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -215,15 +215,10 @@ describe User, :all_dbs do
       it { is_expected.to eq("America/New_York") }
     end
 
-    # for VSO users with multiple RO's
-    # regional_office will default to nil, but selected_regional_office will not
     context "when ro isn't set" do
       subject { user.timezone }
-      before do
-        user.regional_office = nil
-        user.selected_regional_office = "RO27"
-      end
-      it { is_expected.to eq("America/Kentucky/Louisville") }
+      before { user.regional_office = nil }
+      it { is_expected.to eq("America/Chicago") }
     end
   end
 


### PR DESCRIPTION
Resolves https://vajira.max.gov/browse/APPEALS-19640 

### Description
Code was merged into master before it was ready causing issues with some uses being able to to have their timezones calculated leading to some UI pages being unable to load.

1. VAH User with multiple RO's logs into casefow and does not set a set a current RO to be working from
2. Navigate to Caseflow Queue and get a 500 error

Expected Results: User is able to navigate to Queue
Actual Result: User in unable to navigate to Queue

### Test Links
Local: https://vajira.max.gov/browse/APPEALS-19641 
UAT: https://vajira.max.gov/browse/APPEALS-19642