### PR TITLE
Hotfix/appeals 17688

### DIFF
--- a/app/jobs/cannot_delete_contention_remediation_job.rb
+++ b/app/jobs/cannot_delete_contention_remediation_job.rb
@@ -27,7 +27,7 @@ class CannotDeleteContentionRemediationJob < CaseflowJob
     if total > 0
       contention_ids = get_contention_ids(rius)
       remediate!(rius, contention_ids, total)
-      #store_logs_in_s3_bucket
+      store_logs_in_s3_bucket
       puts @logs
     end
   end


### PR DESCRIPTION
#APPEALS-17688

Description

Create a job that will automatically remediate Stuck Jobs with the CannotDeleteContention Error.

Acceptance Criteria

 Job needs to locate all RequestIssuesUpdates with the CannotDeleteContention Error
 Job needs to reset closed_at and closed_status of Request Issue that is causing the job to get stuck and then reset and re-sync correlated End Product Establishment so that job is able to finish and create appropriate decision issue.
 Job needs to create informative and concise logs that detail what the job is doing to remediate each record.
 Logs need to be stored in data-remediation-output S3 bucket within a sub-bucket called cannot-delete-contention-remediation-logs.
 Each Log saved within S3 needs to be titled 'cdc-remediation-log' and include the date/time in the file name.