### PR TITLE
TYLERB/UAT-Membership-Request-Mailer-Fix: UAT email address update

### DIFF
--- a/app/controllers/help_controller.rb
+++ b/app/controllers/help_controller.rb
@@ -26,9 +26,7 @@ class HelpController < ApplicationController
   end
 
   def user_logged_in?(user = current_user)
-    return false unless user
-
-    user.authenticated?
+    user&.authenticated? || false
   end
 
   helper_method :feature_toggle_ui_hash, :user_organizations, :pending_membership_requests, :user_logged_in?

--- a/app/jobs/memberships/send_membership_request_mailer_job.rb
+++ b/app/jobs/memberships/send_membership_request_mailer_job.rb
@@ -59,7 +59,7 @@ class Memberships::SendMembershipRequestMailerJob < CaseflowJob
   end
 
   def email_nil?(email)
-    if email.nil?
+    if email.try(:to).nil?
       message = "No #{TYPE_LABEL} was sent because no email address is defined"
       log = log_message(mailer_parameters).merge(
         status: "error", message: message

--- a/app/jobs/memberships/send_membership_request_mailer_job.rb
+++ b/app/jobs/memberships/send_membership_request_mailer_job.rb
@@ -60,11 +60,12 @@ class Memberships::SendMembershipRequestMailerJob < CaseflowJob
 
   def email_nil?(email)
     if email.nil?
+      message = "No #{TYPE_LABEL} was sent because no email address is defined"
       log = log_message(mailer_parameters).merge(
-        status: "error", message: "No #{TYPE_LABEL} was sent because no email address is defined"
+        status: "error", message: message
       )
       Rails.logger.info("#{LOG_PREFIX} #{log}")
-      false
+      fail Caseflow::Error::InvalidEmailError, message: message
     else
       true
     end

--- a/app/mailers/membership_request_mailer.rb
+++ b/app/mailers/membership_request_mailer.rb
@@ -19,7 +19,14 @@ class MembershipRequestMailer < ActionMailer::Base
     @requests = params[:requests]
     @requesting_org_names = @requests&.map { |request| request.organization.name }
     @subject = params[:subject]
-    mail(to: @recipient&.email, subject: @subject)
+    # This has to be set here rather than changing the users email address in the database for UAT
+    # Because the email address is automatically updated on user login.
+    email_address = if Rails.deploy_env?(:uat)
+                      "BID_Appeals_UAT@bah.com"
+                    else
+                      @recipient&.email
+                    end
+    mail(to: email_address, subject: @subject)
   end
 
   def admin_request_made

--- a/app/models/membership_request.rb
+++ b/app/models/membership_request.rb
@@ -36,7 +36,10 @@ class MembershipRequest < CaseflowRecord
 
     def create_many_from_params_and_send_creation_emails(organizations, params, user)
       created_requests = create_many_from_orgs(organizations, params, user)
-      send_creation_emails(created_requests)
+      # Only send emails if there are created requests.
+      if created_requests.present?
+        send_creation_emails(created_requests)
+      end
       created_requests
     end
 

--- a/spec/controllers/membership_requests_controller_spec.rb
+++ b/spec/controllers/membership_requests_controller_spec.rb
@@ -228,8 +228,8 @@ describe MembershipRequestsController, :postgres, type: :controller do
   private
 
   def create_vha_orgs
-    create(:business_line, name: "Veterans Health Administration", url: "vha")
     VhaCamo.singleton
+    create(:business_line, name: "Veterans Health Administration", url: "vha")
     VhaCaregiverSupport.singleton
     create(:vha_program_office,
            name: "Community Care - Veteran and Family Members Program",


### PR DESCRIPTION
Resolves #{github issue number}

### Description
Added a couple of conditionals to the membership request mailer and the send membership request mailer job to avoid trying to send emails if there were no created memberhip requests. Also added a specific UAT environment check to always send the membership_request created email to the same email address since it is automatically updated on user login in the UAT environment.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The user email is sent successfully in UAT to the "BID_Appeals_UAT@bah.com" email address for the user on successful membership request(s) creation.
- [ ] It should prevent sending the emails for blank email addresses
- [ ] It should not try to send emails if there are no created requests

### Testing Plan
1. Create a membership request in UAT via the Vha membership request form.
2. Verify that the appropriate email was sent to the requestor at the "BID_Appeals_UAT@bah.com" email address
3. Create a user without an email address
4. Create a membership request in UAT via the Vha membership request form.
5. Verify that the email did not try to send.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
