### PR TITLE
hotfix/APPEALS-17688 Added CannotDeleteContentionRemediationJob to scheduled…

### DIFF
--- a/app/jobs/cannot_delete_contention_remediation_job.rb
+++ b/app/jobs/cannot_delete_contention_remediation_job.rb
@@ -9,6 +9,7 @@ class CannotDeleteContentionRemediationJob < CaseflowJob
   def initialize
     @logs = ["\nVBMS::CannotDeleteContention Remediation Log"]
     @remediated_request_issues_update_ids = []
+    super
   end
 
   # rubocop:disable all

--- a/app/jobs/cannot_delete_contention_remediation_job.rb
+++ b/app/jobs/cannot_delete_contention_remediation_job.rb
@@ -24,28 +24,30 @@ class CannotDeleteContentionRemediationJob < CaseflowJob
     RequestStore[:current_user] = User.system_user
     rius = find_cannot_delete_contention_request_issues_updates
     total = rius.count
+    Rails.logger.info("CannotDeleteContentionRemediationJob::Log - Found #{total} CannotDeleteContention Request Issues Updates")
     if total > 0
       contention_ids = get_contention_ids(rius)
       remediate!(rius, contention_ids, total)
-      store_logs_in_s3_bucket
       puts @logs
+      store_logs_in_s3_bucket
     end
   end
 
   # Main method to loop through and remediate all CannotDeleteContention Request Issues Updates
-  def remediate!(rius, contention_ids, total)
+  def remediate!(request_issues_updates, contention_ids, total)
     index = 0
     while index < total
       begin
-        affected_request_issue = find_removed_or_withdrawn_request_issue(rius[index], contention_ids[index])
-        reset_ri_closed_status_and_closed_at!(affected_request_issue, rius[index], index)
-        maybe_cancel_or_reprocess_request_issues_update!(affected_request_issue, rius[index], index)
-        sync_epe!(rius[index], affected_request_issue, index)
-        @remediated_request_issues_update_ids.push("RIU ID: #{rius[index].id}, RI ID: #{affected_request_issue.id}")
+        affected_request_issue = find_removed_or_withdrawn_request_issue(request_issues_updates[index], contention_ids[index])
+        reset_ri_closed_status_and_closed_at!(affected_request_issue, request_issues_updates[index], index)
+        maybe_cancel_or_reprocess_request_issues_update!(affected_request_issue, request_issues_updates[index], index)
+        sync_epe!(request_issues_updates[index], affected_request_issue, index)
+        @remediated_request_issues_update_ids.push("RIU ID: #{request_issues_updates[index].id}, RI ID: #{affected_request_issue.id}")
         index += 1
       rescue StandardError => error
         @logs.push("#{Time.zone.now} CannotDeleteContentionRemediation::Error - Number: #{index} "\
-            " RIU ID: #{rius[index].id}.  RI ID: #{affected_request_issue&.id}.  #{error.message}.")
+            " RIU ID: #{request_issues_updates[index].id}.  RI ID: #{affected_request_issue&.id}.  #{error.message}.")
+        log_error(error)
         index += 1
         next
       end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -41,5 +41,6 @@ SCHEDULED_JOBS = {
     "retrieve_and_cache_reader_documents_job" => RetrieveAndCacheReaderDocumentsJob,
     "travel_board_hearing_sync_job" => Hearings::TravelBoardHearingSyncJob,
     "notification_efolder_sync_job" => NotificationEfolderSyncJob,
-    "change_hearing_request_type_task_cancellation_job" => ChangeHearingRequestTypeTaskCancellationJob
+    "change_hearing_request_type_task_cancellation_job" => ChangeHearingRequestTypeTaskCancellationJob,
+    "cannot_delete_contention_remediation_job" => CannotDeleteContentionRemediationJob
 }.freeze


### PR DESCRIPTION
#APPEALS-17688

### Description

Create a job that will automatically remediate Stuck Jobs with the CannotDeleteContention Error.

### Acceptance Criteria

 - [x] Job needs to locate all RequestIssuesUpdates with the CannotDeleteContention Error
 - [x] Job needs to reset closed_at and closed_status of Request Issue that is causing the job to get stuck and then reset and re-sync correlated End Product Establishment so that job is able to finish and create appropriate decision issue.
 - [x] Job needs to create informative and concise logs that detail what the job is doing to remediate each record.
 - [x] Logs need to be stored in data-remediation-output S3 bucket within a sub-bucket called cannot-delete-contention-remediation-logs.
 - [x] Each Log saved within S3 needs to be titled 'cdc-remediation-log' and include the date/time in the file name.
- [x] Job needs to be added to scheduled_jobs file
### Testing Plan
1. Go to: https://vajira.max.gov/browse/APPEALS-19627

### Test Execution XRAY
1. Go to: https://vajira.max.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-19649&testIssueKey=APPEALS-19627

### Test Execution
1. Go to: https://vajira.max.gov/browse/APPEALS-19649
