### PR TITLE
Hotfix/appeals 15450 updated

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,7 +52,6 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   # If RO is ambiguous from station_office, use the user-defined RO. Otherwise, use the unambigous RO.
   def regional_office
     upcase = ->(str) { str ? str.upcase : str }
-
     ro_is_ambiguous_from_station_office? ? upcase.call(@regional_office) : station_offices
   end
 
@@ -199,7 +198,7 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def timezone
-    (RegionalOffice::CITIES[regional_office] || {})[:timezone] || "America/Chicago"
+    RegionalOffice::CITIES[users_regional_office][:timezone]
   end
 
   # If user has never logged in, we might not have their full name in Caseflow DB.

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -198,7 +198,11 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
   end
 
   def timezone
-    RegionalOffice::CITIES[users_regional_office][:timezone]
+    if vso_employee?
+      RegionalOffice::CITIES[users_regional_office][:timezone]
+    else
+      (RegionalOffice::CITIES[regional_office] || {})[:timezone] || "America/Chicago"
+    end
   end
 
   # If user has never logged in, we might not have their full name in Caseflow DB.

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -215,10 +215,15 @@ describe User, :all_dbs do
       it { is_expected.to eq("America/New_York") }
     end
 
+    # for VSO users with multiple RO's
+    # regional_office will default to nil, but selected_regional_office will not
     context "when ro isn't set" do
       subject { user.timezone }
-      before { user.regional_office = nil }
-      it { is_expected.to eq("America/Chicago") }
+      before do
+        user.regional_office = nil
+        user.selected_regional_office = "RO27"
+      end
+      it { is_expected.to eq("America/Kentucky/Louisville") }
     end
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,7 +209,6 @@ describe User, :all_dbs do
   end
 
   context "#timezone" do
-    let!(:vso_user) { create(:user, :vso_role) }
     context "when ro is set" do
       subject { user.timezone }
       before { user.regional_office = "RO84" }
@@ -218,19 +217,17 @@ describe User, :all_dbs do
 
     context "when ro isn't set" do
       subject { user.timezone }
-      before do
-        user.regional_office = nil
-      end
+      before { user.regional_office = nil }
       it { is_expected.to eq("America/Chicago") }
     end
 
     # for VSO users with multiple RO's
     # regional_office will default to nil, but selected_regional_office will not
     context "when ro isn't set for VSO user" do
-      subject { user.timezone }
+      let!(:vso_user) { create(:user, :vso_role, station_id: "327", selected_regional_office: "RO27") }
+      subject { vso_user.timezone }
       before do
         user.regional_office = nil
-        user.selected_regional_office = "RO27"
       end
       it { is_expected.to eq("America/Kentucky/Louisville") }
     end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -209,15 +209,24 @@ describe User, :all_dbs do
   end
 
   context "#timezone" do
+    let!(:vso_user) { create(:user, :vso_role) }
     context "when ro is set" do
       subject { user.timezone }
       before { user.regional_office = "RO84" }
       it { is_expected.to eq("America/New_York") }
     end
 
+    context "when ro isn't set" do
+      subject { user.timezone }
+      before do
+        user.regional_office = nil
+      end
+      it { is_expected.to eq("America/Chicago") }
+    end
+
     # for VSO users with multiple RO's
     # regional_office will default to nil, but selected_regional_office will not
-    context "when ro isn't set" do
+    context "when ro isn't set for VSO user" do
       subject { user.timezone }
       before do
         user.regional_office = nil


### PR DESCRIPTION
Resolves #APPEALS-15450

Description
Virtual Hearings which have undergone VSO Conversion by VSO Users are having their Hearings time adjusted to align to the time zone of the VSO User rather than the Veteran and Coordinators