### PR TITLE
Hotfix/appeals 15451

### DIFF
--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -109,7 +109,7 @@ class SendNotificationJob < CaseflowJob
     sms_template_id = event.sms_template_id
     quarterly_sms_template_id = NotificationEvent.find_by(event_type: "Quarterly Notification").sms_template_id
     appeal = Appeal.find_by_uuid(message.appeal_id) || LegacyAppeal.find_by(vacols_id: message.appeal_id)
-    first_name = appeal.appellant_or_veteran_name.split(" ").first
+    first_name = appeal&.appellant_or_veteran_name&.split(" ")&.first || "Appellant"
     status = message.appeal_status || ""
     docket_number = appeal.docket_number
 

--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -109,7 +109,7 @@ class SendNotificationJob < CaseflowJob
     sms_template_id = event.sms_template_id
     quarterly_sms_template_id = NotificationEvent.find_by(event_type: "Quarterly Notification").sms_template_id
     appeal = Appeal.find_by_uuid(message.appeal_id) || LegacyAppeal.find_by(vacols_id: message.appeal_id)
-    first_name = appeal&.appellant_first_name || "Appellant"
+    first_name = appeal.appellant_or_veteran_name.split(" ").first
     status = message.appeal_status || ""
     docket_number = appeal.docket_number
 


### PR DESCRIPTION
Resolves #APPEALS-15451

Description: VANotify messages from Caseflow are not accurately capturing Veteran/Appellant first name
