### PR TITLE
Pamatya/appeals 17255

### DIFF
--- a/app/models/organizations/vha_regional_office.rb
+++ b/app/models/organizations/vha_regional_office.rb
@@ -4,4 +4,39 @@ class VhaRegionalOffice < Organization
   def can_receive_task?(_task)
     false
   end
+
+  def queue_tabs
+    [
+      assigned_tasks_tab,
+      in_progress_tasks_tab,
+      on_hold_tasks_tab,
+      completed_tasks_tab
+    ]
+  end
+
+  def assigned_tasks_tab
+    ::VhaRegionalOfficeAssignedTasksTab.new(assignee: self)
+  end
+
+  def in_progress_tasks_tab
+    ::VhaRegionalOfficeInProgressTasksTab.new(assignee: self)
+  end
+
+  def on_hold_tasks_tab
+    ::VhaRegionalOfficeOnHoldTasksTab.new(assignee: self)
+  end
+
+  def completed_tasks_tab
+    ::VhaRegionalOfficeCompletedTasksTab.new(assignee: self)
+  end
+
+  COLUMN_NAMES = [
+    Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+    Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+    Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+    Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+    Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_ID.name
+  ].compact
 end

--- a/app/models/organizations/vha_regional_office.rb
+++ b/app/models/organizations/vha_regional_office.rb
@@ -35,8 +35,9 @@ class VhaRegionalOffice < Organization
     Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
     Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+    Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
     Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
     Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
-    Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_ID.name
+    Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
   ].compact
 end

--- a/app/models/queue_tabs/vha_regional_office_assigned_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_regional_office_assigned_tasks_tab.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class VhaRegionalOfficeAssignedTasksTab < QueueTab
+  validate :assignee_is_organization
+
+  def label
+    COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TAB_TITLE
+  end
+
+  def self.tab_name
+    Constants.QUEUE_CONFIG.VHA_PO_ASSIGNED_TASKS_TAB_NAME
+  end
+
+  def description
+    format(COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TASKS_DESCRIPTION, assignee.name)
+  end
+
+  def parent_ids_with_completed_child_assess_documentation_task
+    assigned_task_children.where(type: :AssessDocumentationTask)
+      .completed
+      .pluck(:parent_id).uniq
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(
+      id: assigned_tasks.map(&:id) - parent_ids_with_completed_child_assess_documentation_task
+    )
+  end
+
+  def column_names
+    VhaRegionalOffice::COLUMN_NAMES
+  end
+end

--- a/app/models/queue_tabs/vha_regional_office_completed_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_regional_office_completed_tasks_tab.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class VhaRegionalOfficeCompletedTasksTab < QueueTab
+  validate :assignee_is_organization
+
+  def label
+    COPY::ORGANIZATIONAL_QUEUE_COMPLETED_TAB_TITLE
+  end
+
+  def self.tab_name
+    Constants.QUEUE_CONFIG.VHA_PO_COMPLETED_TASKS_TAB_NAME
+  end
+
+  def description
+    COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+  end
+
+  def parent_ids_with_cancelled_assess_documentation_task
+    Task.where(type: :AssessDocumentationTask, assigned_to: assignee)
+      .cancelled
+      .pluck(:id).uniq
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(
+      id: closed_tasks.map(&:id)
+    )
+  end
+
+  def column_names
+    VhaRegionalOffice::COLUMN_NAMES
+  end
+end

--- a/app/models/queue_tabs/vha_regional_office_in_progress_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_regional_office_in_progress_tasks_tab.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class VhaRegionalOfficeInProgressTasksTab < QueueTab
+  validate :assignee_is_organization
+
+  def label
+    COPY::ORGANIZATIONAL_QUEUE_PAGE_IN_PROGRESS_TAB_TITLE
+  end
+
+  def self.tab_name
+    Constants.QUEUE_CONFIG.VHA_PO_IN_PROGRESS_TASKS_TAB_NAME
+  end
+
+  def description
+    format(COPY::ORGANIZATIONAL_QUEUE_PAGE_IN_PROGRESS_TASKS_DESCRIPTION, assignee.name)
+  end
+
+  def tasks
+    in_progress_tasks
+  end
+
+  def column_names
+    VhaRegionalOffice::COLUMN_NAMES
+  end
+end

--- a/app/models/queue_tabs/vha_regional_office_on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_regional_office_on_hold_tasks_tab.rb
@@ -20,7 +20,7 @@ class VhaRegionalOfficeOnHoldTasksTab < QueueTab
   end
 
   def parents_with_child_assess_documentation_task_ids
-    on_hold_task_children.where(type: AssessDocumentationTask.name)
+    on_hold_task_children.where(type: :AssessDocumentationTask)
       .pluck(:parent_id).uniq
   end
 

--- a/app/models/queue_tabs/vha_regional_office_on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/vha_regional_office_on_hold_tasks_tab.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class VhaRegionalOfficeOnHoldTasksTab < QueueTab
+  validate :assignee_is_organization
+
+  def label
+    COPY::ORGANIZATIONAL_QUEUE_ON_HOLD_TAB_TITLE
+  end
+
+  def self.tab_name
+    Constants.QUEUE_CONFIG.VHA_PO_ON_HOLD_TASKS_TAB_NAME
+  end
+
+  def description
+    format(COPY::ORGANIZATIONAL_QUEUE_PAGE_ON_HOLD_TASKS_DESCRIPTION, assignee.name)
+  end
+
+  def po_on_hold_tasks
+    on_hold_tasks.where(type: :AssessDocumentationTask)
+  end
+
+  def parents_with_child_assess_documentation_task_ids
+    on_hold_task_children.where(type: AssessDocumentationTask.name)
+      .pluck(:parent_id).uniq
+  end
+
+  def tasks
+    Task.includes(*task_includes).visible_in_queue_table_view.where(
+      id: (po_on_hold_tasks.map(&:id) + visible_child_task_ids) - parents_with_child_assess_documentation_task_ids
+    )
+  end
+
+  def column_names
+    VhaRegionalOffice::COLUMN_NAMES
+  end
+end

--- a/spec/feature/queue/vha_regional_queue_spec.rb
+++ b/spec/feature/queue/vha_regional_queue_spec.rb
@@ -1,99 +1,119 @@
 # frozen_string_literal: true
 
 feature "VhaRegionalQueue", :all_dbs do
+  def a_normal_tab(expected_text)
+    # a normal tab should have same column header and should also contain Paging information
+    html_table_headings = all("th").map(&:text).reject(&:empty?).compact
+    expect(html_table_headings).to eq(column_heading_names)
+    expect(page).to have_text expected_text
+  end
+
   context "Load VhaRegional Queue aka VISN" do
-    let(:csp_visn) { create(:vha_regional_office) }
-    let(:csp_user) { User.authenticate!(roles: ["VISNADMIN"]) }
-    let(:unassigned_tab_text) { "Unassigned" }
+    let(:regional_office) { create(:vha_regional_office) }
+    let(:regional_office_user) { create(:user) }
+    let(:assigned_tab_text) { "Assigned" }
     let(:in_progress_tab_text) { "In Progress" }
     let(:on_hold_tab_text) { "On Hold" }
     let(:completed_tab_text) { "Completed" }
+    let(:assigned_pagination_text) { "Viewing 1-#{num_assigned_rows} of #{num_assigned_rows} total" }
+    let(:in_progress_pagination_text) { "Viewing 1-#{num_in_progress_rows} of #{num_in_progress_rows} total" }
+    let(:completed_pagination_text) { "Viewing 1-#{num_completed_rows} of #{num_completed_rows} total" }
+    let(:on_hold_pagination_text) { "Viewing 1-#{num_on_hold_rows} of #{num_on_hold_rows} total" }
     let(:column_heading_names) do
       [
         "Case Details", "Tasks", "Assigned By", "Types", "Docket", "Days Waiting", "Veteran Documents"
       ]
     end
-    let!(:num_unassigned_rows) { 3 }
+    let!(:num_assigned_rows) { 3 }
     let!(:num_in_progress_rows) { 9 }
     let!(:num_on_hold_rows) { 4 }
     let!(:num_completed_rows) { 5 }
 
-    let!(:vha_regional_unassigned_tasks) do
-      create_list(:vha_document_search_task, num_unassigned_rows, :assigned, assigned_to: csp_visn)
+    let!(:vha_regional_assigned_tasks) do
+      create_list(:assess_documentation_task, num_assigned_rows, :assigned, assigned_to: regional_office)
     end
     let!(:vha_regional_in_progress_tasks) do
-      create_list(:vha_document_search_task, num_in_progress_rows, :in_progress, assigned_to: csp_visn)
+      create_list(:assess_documentation_task, num_in_progress_rows, :in_progress, assigned_to: regional_office)
     end
     let!(:vha_regional_on_hold_tasks) do
-      create_list(:vha_document_search_task, num_in_progress_rows, :on_hold, assigned_to: csp_visn)
+      create_list(:assess_documentation_task, num_on_hold_rows, :on_hold, assigned_to: regional_office)
     end
     let!(:vha_regional_completed_tasks) do
-      create_list(:vha_document_search_task, num_completed_rows, :completed, assigned_to: csp_visn)
+      create_list(:assess_documentation_task, num_completed_rows, :completed, assigned_to: regional_office)
     end
 
     before do
-      csp_visn.add_user(csp_user)
-      csp_user.reload
-      visit "/organizations/#{csp_visn.url}"
+      User.authenticate!(user: regional_office_user)
+      regional_office.add_user(regional_office_user)
+      regional_office_user.reload
+      visit "/organizations/#{regional_office.url}?tab=po_assigned&page=1&sort_by=typeColumn&order=asc"
     end
 
-    scenario "Vha Regional office Queue Loads" do
-      expect(find("h1")).to have_content("#{csp_visn.name} System cases")
+    scenario "Vha Regional office Queue contains appropriate header" do
+      expect(find("h1")).to have_content("#{regional_office.name} cases")
     end
 
-    # scenario "CSP Queue Has unassigned, in progress, and completed tabs" do
-    #   expect(page).to have_content unassigned_tab_text
-    #   expect(page).to have_content in_progress_tab_text
-    #   expect(page).to have_content completed_tab_text
-    # end
+    scenario "Vha Regional Organization Queue Has Assigned, in progress, on hold and completed tabs" do
+      expect(page).to have_content assigned_tab_text
+      expect(page).to have_content in_progress_tab_text
+      expect(page).to have_content on_hold_tab_text
+      expect(page).to have_content completed_tab_text
+    end
 
-    # scenario "CSP Queue Unassigned tab has the correct column Headings and description text" do
-    #   # The first tab is the unassigned tab so there is no need to navigate
-    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
-    #   expect(page).to have_content "Cases assigned to VHA Caregiver Support Program:"
-    #   expect(html_table_headings).to eq(column_heading_names)
-    # end
+    scenario "tab has the correct column Headings and description text" do
+      expect(page).to have_content "Cases assigned to a member of the #{regional_office.name} team:"
+      a_normal_tab(assigned_pagination_text)
+    end
 
-    # scenario "CSP Queue In Progress tab has the correct column Headings and description text" do
-    #   # Navigate to the In Progress Tab
-    #   click_button(in_progress_tab_text)
+    scenario "In Progress tab has the correct column Headings and description text" do
+      # Navigate to the In Progress Tab
+      click_button(in_progress_tab_text)
+      expect(page).to have_content "Cases in progress in a #{regional_office.name} team member's queue"
+      a_normal_tab(in_progress_pagination_text)
+    end
 
-    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
-    #   expect(page).to have_content "Cases assigned to VHA Caregiver Support Program:"
-    #   expect(html_table_headings).to eq(column_heading_names)
-    # end
+    scenario "On Hold tab has the correct column Headings and description text" do
+      # Navigate to the Completed Tab
+      click_button(on_hold_tab_text)
+      expect(page).to have_content "Cases on hold in a #{regional_office.name} team member's queue"
+      a_normal_tab(on_hold_pagination_text)
+    end
 
-    # scenario "CSP Queue Completed tab has the correct column Headings and description text" do
-    #   # Navigate to the Completed Tab
-    #   click_button(completed_tab_text)
+    scenario "Completed tab has the correct column Headings and description text" do
+      # Navigate to the Completed Tab
+      click_button(completed_tab_text)
+      expect(page).to have_content "Cases completed:"
+      a_normal_tab(completed_pagination_text)
+    end
 
-    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
-    #   expect(page).to have_content "Cases completed (last 7 days):"
-    #   expect(html_table_headings).to eq(column_heading_names)
-    # end
+    scenario "Assigned tab has the correct number in the tab name and the number of table rows" do
+      assigned_tab_button = find("button", text: assigned_tab_text)
+      num_table_rows = all("tbody > tr").count
+      expect(assigned_tab_button.text).to eq("#{assigned_tab_text} (#{num_assigned_rows})")
+      expect(num_table_rows).to eq(num_assigned_rows)
+    end
 
-    # scenario "CSP Queue Unassigned tab has the correct number in the tab name and the number of table rows" do
-    #   unassigned_tab_button = find("button", text: unassigned_tab_text)
-    #   num_table_rows = all("tbody > tr").count
-    #   expect(unassigned_tab_button.text).to eq("#{unassigned_tab_text} (#{num_unassigned_rows})")
-    #   expect(num_table_rows).to eq(num_unassigned_rows)
-    # end
+    scenario "In Progress tab has the correct number in the tab name and the number of table rows" do
+      in_progress_tab_button = find("button", text: in_progress_tab_text)
+      in_progress_tab_button.click
+      num_table_rows = all("tbody > tr").count
+      expect(in_progress_tab_button.text).to eq("#{in_progress_tab_text} (#{num_in_progress_rows})")
+      expect(num_table_rows).to eq(num_in_progress_rows)
+    end
 
-    # scenario "CSP Queue In Progress tab has the correct number in the tab name and the number of table rows" do
-    #   # Navigate to the In Progress Tab
-    #   # click_button(in_progress_tab_text)
-    #   in_progress_tab_button = find("button", text: in_progress_tab_text)
-    #   in_progress_tab_button.click
-    #   num_table_rows = all("tbody > tr").count
-    #   expect(in_progress_tab_button.text).to eq("#{in_progress_tab_text} (#{num_in_progress_rows})")
-    #   expect(num_table_rows).to eq(num_in_progress_rows)
-    # end
+    scenario "On hold tab has the correct number in the tab name and the number of table rows" do
+      on_hold_tab_button = find("button", text: on_hold_tab_text)
+      on_hold_tab_button.click
+      num_table_rows = all("tbody > tr").count
+      expect(on_hold_tab_button.text).to eq("#{on_hold_tab_text} (#{num_on_hold_rows})")
+      expect(num_table_rows).to eq(num_on_hold_rows)
+    end
 
-    # scenario "CSP Queue Completed tab has the correct number of table rows" do
-    #   # Navigate to the Completed Tab
-    #   click_button(completed_tab_text)
-    #   num_table_rows = all("tbody > tr").count
-    #   expect(num_table_rows).to eq(num_completed_rows)
-    # end
+    scenario "Completed tab has the correct number of table rows" do
+      # Navigate to the Completed Tab
+      click_button(completed_tab_text)
+      num_table_rows = all("tbody > tr").count
+      expect(num_table_rows).to eq(num_completed_rows)
+    end
   end
 end

--- a/spec/feature/queue/vha_regional_queue_spec.rb
+++ b/spec/feature/queue/vha_regional_queue_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+feature "VhaRegionalQueue", :all_dbs do
+  context "Load VhaRegional Queue aka VISN" do
+    let(:csp_visn) { create(:vha_regional_office) }
+    let(:csp_user) { User.authenticate!(roles: ["VISNADMIN"]) }
+    let(:unassigned_tab_text) { "Unassigned" }
+    let(:in_progress_tab_text) { "In Progress" }
+    let(:on_hold_tab_text) { "On Hold" }
+    let(:completed_tab_text) { "Completed" }
+    let(:column_heading_names) do
+      [
+        "Case Details", "Tasks", "Assigned By", "Types", "Docket", "Days Waiting", "Veteran Documents"
+      ]
+    end
+    let!(:num_unassigned_rows) { 3 }
+    let!(:num_in_progress_rows) { 9 }
+    let!(:num_on_hold_rows) { 4 }
+    let!(:num_completed_rows) { 5 }
+
+    let!(:vha_regional_unassigned_tasks) do
+      create_list(:vha_document_search_task, num_unassigned_rows, :assigned, assigned_to: csp_visn)
+    end
+    let!(:vha_regional_in_progress_tasks) do
+      create_list(:vha_document_search_task, num_in_progress_rows, :in_progress, assigned_to: csp_visn)
+    end
+    let!(:vha_regional_on_hold_tasks) do
+      create_list(:vha_document_search_task, num_in_progress_rows, :on_hold, assigned_to: csp_visn)
+    end
+    let!(:vha_regional_completed_tasks) do
+      create_list(:vha_document_search_task, num_completed_rows, :completed, assigned_to: csp_visn)
+    end
+
+    before do
+      csp_visn.add_user(csp_user)
+      csp_user.reload
+      visit "/organizations/#{csp_visn.url}"
+    end
+
+    scenario "Vha Regional office Queue Loads" do
+      expect(find("h1")).to have_content("#{csp_visn.name} System cases")
+    end
+
+    # scenario "CSP Queue Has unassigned, in progress, and completed tabs" do
+    #   expect(page).to have_content unassigned_tab_text
+    #   expect(page).to have_content in_progress_tab_text
+    #   expect(page).to have_content completed_tab_text
+    # end
+
+    # scenario "CSP Queue Unassigned tab has the correct column Headings and description text" do
+    #   # The first tab is the unassigned tab so there is no need to navigate
+    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
+    #   expect(page).to have_content "Cases assigned to VHA Caregiver Support Program:"
+    #   expect(html_table_headings).to eq(column_heading_names)
+    # end
+
+    # scenario "CSP Queue In Progress tab has the correct column Headings and description text" do
+    #   # Navigate to the In Progress Tab
+    #   click_button(in_progress_tab_text)
+
+    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
+    #   expect(page).to have_content "Cases assigned to VHA Caregiver Support Program:"
+    #   expect(html_table_headings).to eq(column_heading_names)
+    # end
+
+    # scenario "CSP Queue Completed tab has the correct column Headings and description text" do
+    #   # Navigate to the Completed Tab
+    #   click_button(completed_tab_text)
+
+    #   html_table_headings = all("th").map(&:text).reject(&:empty?).compact
+    #   expect(page).to have_content "Cases completed (last 7 days):"
+    #   expect(html_table_headings).to eq(column_heading_names)
+    # end
+
+    # scenario "CSP Queue Unassigned tab has the correct number in the tab name and the number of table rows" do
+    #   unassigned_tab_button = find("button", text: unassigned_tab_text)
+    #   num_table_rows = all("tbody > tr").count
+    #   expect(unassigned_tab_button.text).to eq("#{unassigned_tab_text} (#{num_unassigned_rows})")
+    #   expect(num_table_rows).to eq(num_unassigned_rows)
+    # end
+
+    # scenario "CSP Queue In Progress tab has the correct number in the tab name and the number of table rows" do
+    #   # Navigate to the In Progress Tab
+    #   # click_button(in_progress_tab_text)
+    #   in_progress_tab_button = find("button", text: in_progress_tab_text)
+    #   in_progress_tab_button.click
+    #   num_table_rows = all("tbody > tr").count
+    #   expect(in_progress_tab_button.text).to eq("#{in_progress_tab_text} (#{num_in_progress_rows})")
+    #   expect(num_table_rows).to eq(num_in_progress_rows)
+    # end
+
+    # scenario "CSP Queue Completed tab has the correct number of table rows" do
+    #   # Navigate to the Completed Tab
+    #   click_button(completed_tab_text)
+    #   num_table_rows = all("tbody > tr").count
+    #   expect(num_table_rows).to eq(num_completed_rows)
+    # end
+  end
+end

--- a/spec/models/queue_tabs/vha_regional_office_assigned_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_regional_office_assigned_tasks_tab_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe VhaRegionalOfficeAssignedTasksTab, :postgres do
+  let(:tab) { VhaRegionalOfficeAssignedTasksTab.new(params) }
+  let(:params) do
+    {
+      assignee: assignee
+    }
+  end
+  let(:assignee) { create(:vha_regional_office) }
+  let(:column_name) do
+    COLUMN_NAMES = [
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
+    ].compact
+  end
+  describe ".column_names" do
+    subject { tab.column_names }
+
+    context "when only the assignee argument is passed when instantiating an VhaRegionalOfficeAssignedTasksTab" do
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq 8
+      end
+
+      it "returns the correct column name" do
+        expect(subject).to match_array(column_name)
+      end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it "matches expected tab label" do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_ASSIGNED_TAB_TITLE
+      is_expected.to eq "Assigned (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it "contains and matches description provided" do
+      is_expected.to_not be nil
+      is_expected.to eq "Cases assigned to a member of the #{assignee.name} team:"
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_ASSIGNED_TASKS_TAB_NAME)
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+    context "when there are task assigned" do
+      let!(:assignee_assigned_task) { create_list(:assess_documentation_task, 4, :assigned, assigned_to: assignee) }
+      it "Number of task with assigned status should match the number of task present in tab" do
+        expect(assignee_assigned_task.count { |task| task.status.eql? "assigned" }).to be tab.tasks.length
+      end
+
+      it "returns a list of assigned tasks" do
+        is_expected.to match_array assignee_assigned_task
+        expect(subject.empty?).not_to eq true
+      end
+    end
+  end
+end

--- a/spec/models/queue_tabs/vha_regional_office_completed_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_regional_office_completed_tasks_tab_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe VhaRegionalOfficeCompletedTasksTab, :postgres do
+  let(:tab) { VhaRegionalOfficeCompletedTasksTab.new(params) }
+  let(:params) do
+    {
+      assignee: assignee
+    }
+  end
+  let(:assignee) { create(:vha_regional_office) }
+  let(:column_name) do
+    COLUMN_NAMES = [
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
+    ].compact
+  end
+  describe ".column_names" do
+    subject { tab.column_names }
+
+    context "when only the assignee argument is passed when instantiating an VhaRegionalOfficeCompletedTasksTab" do
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq 8
+      end
+
+      it "returns the correct column name" do
+        expect(subject).to match_array(column_name)
+      end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it "matches expected tab label" do
+      is_expected.to eq "Completed"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it "contains and matches description provided" do
+      is_expected.to_not be nil
+      is_expected.to eq COPY::QUEUE_PAGE_COMPLETE_TASKS_DESCRIPTION
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_COMPLETED_TASKS_TAB_NAME)
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+    context "when there are task assigned" do
+      let!(:assignee_completed_tasks) { create_list(:assess_documentation_task, 4, :completed, assigned_to: assignee) }
+      let!(:assignee_active_tasks) { create_list(:assess_documentation_task, 4, :assigned, assigned_to: assignee) }
+      it "Number of task with assigned status should match the number of task present in tab" do
+        expect(assignee_completed_tasks.count { |task| task.status.eql? "completed" }).to be tab.tasks.length
+      end
+
+      it "returns a list of assigned tasks" do
+        is_expected.to match_array assignee_completed_tasks
+        expect(subject.empty?).not_to eq true
+      end
+    end
+  end
+end

--- a/spec/models/queue_tabs/vha_regional_office_in_progress_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_regional_office_in_progress_tasks_tab_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe VhaRegionalOfficeInProgressTasksTab, :postgres do
+  let(:tab) { VhaRegionalOfficeInProgressTasksTab.new(params) }
+  let(:params) do
+    {
+      assignee: assignee
+    }
+  end
+  let(:assignee) { create(:vha_regional_office) }
+  let(:column_name) do
+    COLUMN_NAMES = [
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
+    ].compact
+  end
+  describe ".column_names" do
+    subject { tab.column_names }
+
+    context "when only the assignee argument is passed when instantiating an VhaRegionalOfficeInProgressTasksTab" do
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq 8
+      end
+
+      it "returns the correct column name" do
+        expect(subject).to match_array(column_name)
+      end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it "matches expected tab label" do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_PAGE_IN_PROGRESS_TAB_TITLE
+      is_expected.to eq "In Progress (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it "contains and matches description provided" do
+      is_expected.to_not be nil
+      is_expected.to eq "Cases in progress in a #{assignee.name} team member's queue."
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_IN_PROGRESS_TASKS_TAB_NAME)
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+    context "when there are task assigned" do
+      let!(:assignee_in_progress_tasks) { create_list(:assess_documentation_task, 4, :in_progress, assigned_to: assignee) }
+      it "Number of task with assigned status should match the number of task present in tab" do
+        expect(assignee_in_progress_tasks.count { |task| task.status = "in_progress" }).to be tab.tasks.length
+      end
+
+      it "returns a list of assigned tasks" do
+        is_expected.to match_array assignee_in_progress_tasks
+        expect(subject.empty?).not_to eq true
+      end
+    end
+  end
+end

--- a/spec/models/queue_tabs/vha_regional_office_in_progress_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_regional_office_in_progress_tasks_tab_spec.rb
@@ -63,7 +63,14 @@ describe VhaRegionalOfficeInProgressTasksTab, :postgres do
   describe ".tasks" do
     subject { tab.tasks }
     context "when there are task assigned" do
-      let!(:assignee_in_progress_tasks) { create_list(:assess_documentation_task, 4, :in_progress, assigned_to: assignee) }
+      let!(:assignee_in_progress_tasks) do
+        create_list(
+          :assess_documentation_task,
+          4,
+          :in_progress,
+          assigned_to: assignee
+        )
+      end
       it "Number of task with assigned status should match the number of task present in tab" do
         expect(assignee_in_progress_tasks.count { |task| task.status = "in_progress" }).to be tab.tasks.length
       end

--- a/spec/models/queue_tabs/vha_regional_office_on_hold_tasks_tab_spec.rb
+++ b/spec/models/queue_tabs/vha_regional_office_on_hold_tasks_tab_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+describe VhaRegionalOfficeOnHoldTasksTab, :postgres do
+  let(:tab) { VhaRegionalOfficeOnHoldTasksTab.new(params) }
+  let(:params) do
+    {
+      assignee: assignee
+    }
+  end
+  let(:assignee) { create(:vha_regional_office) }
+  let(:column_name) do
+    COLUMN_NAMES = [
+      Constants.QUEUE_CONFIG.COLUMNS.BADGES.name,
+      Constants.QUEUE_CONFIG.COLUMNS.CASE_DETAILS_LINK.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.TASK_ASSIGNED_BY.name,
+      Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCKET_NUMBER.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+      Constants.QUEUE_CONFIG.COLUMNS.DOCUMENT_COUNT_READER_LINK.name
+    ].compact
+  end
+  describe ".column_names" do
+    subject { tab.column_names }
+
+    context "when only the assignee argument is passed when instantiating an VhaRegionalOfficeOnHoldTasksTab" do
+      it "returns the correct number of columns" do
+        expect(subject.length).to eq 8
+      end
+
+      it "returns the correct column name" do
+        expect(subject).to match_array(column_name)
+      end
+    end
+  end
+
+  describe ".label" do
+    subject { tab.label }
+
+    it "matches expected tab label" do
+      is_expected.to eq COPY::ORGANIZATIONAL_QUEUE_ON_HOLD_TAB_TITLE
+      is_expected.to eq "On Hold (%d)"
+    end
+  end
+
+  describe ".description" do
+    subject { tab.description }
+
+    it "contains and matches description provided" do
+      is_expected.to_not be nil
+      is_expected.to eq "Cases on hold in a #{assignee.name} team member's queue."
+    end
+  end
+
+  describe ".self.tab_name" do
+    subject { described_class.tab_name }
+
+    it "matches expected tab name" do
+      is_expected.to eq(Constants.QUEUE_CONFIG.VHA_PO_ON_HOLD_TASKS_TAB_NAME)
+    end
+  end
+
+  describe ".tasks" do
+    subject { tab.tasks }
+    context "when there are task status are on hold" do
+      let!(:assignee_on_hold_tasks) { create_list(:assess_documentation_task, 4, :on_hold, assigned_to: assignee) }
+      it "Number of task with assigned status should match the number of task present in tab" do
+        expect(assignee_on_hold_tasks.count { |task| task.status = "on_hold" }).to be tab.tasks.length
+      end
+
+      it "returns a list of assigned tasks" do
+        is_expected.to match_array assignee_on_hold_tasks
+        expect(subject.empty?).not_to eq true
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves [Appeals-17255](https://vajira.max.gov/browse/APPEALS-17255)

### Description
- Changed Tabs in VHA VISN Queue to have -> Assigned, In Progress, On Hold and Completed.
- Changed Column on each tab to be -> Case Details, Tasks, Assigned_by Types, Docket, Days Waiting, Veteran Document
- Added 4 model spec for each tabs.
- Added 1 feature spec for VhaRegionalOffice

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ]  All VHA VISN organization queues have the following tabs
    - Assigned
    - In Progress
    - On Hold
    - Completed
- [ ] Assigned tab should Includes all appeals with assigned AssessDocumentationTask in VISN queue
          -           Appeals received from Program Office
          -           'End hold early' task action is selected on an appeal
          -           Appeal that has reached its On hold day limit
- [ ] In Progress tab should Includes all appeals with in progress AssessDocumentationTask in VISN queue
  'Mark task as in progress' task action is selected on an appeal
-[ ] On Hold tab should Includes all appeals with on hold AssessDocumentationTask in VISN queue
'Put task on hold' task action is selected on an appeal
- [ ] Completed tab should Include all appeals with completed and cancelled AssessDocumentationTasks in VISN queue
        - 'Documents ready for Program Office review' task action is selected on an appeal
        - 'Return to Program Office' task action is selected on an appeal
- [ ] All tabs have the following columns
        - Case Details
        - Tasks
        - Assigned By
        - Types
        - Docket
        - Days Waiting
        - Veteran Documents

### Testing Plan
SET UP 
```
regional_offices = VhaRegionalOffice.all
regional_offices.each do |ro| 
  FactoryBot.create_list(:assess_documentation_task, 5 , :assigned, assigned_to: ro) 
  FactoryBot.create_list(:assess_documentation_task, 4, :in_progress, assigned_to: ro)
  FactoryBot.create_list(:assess_documentation_task, 5, :on_hold, assigned_to: ro)
  FactoryBot.create_list(:assess_documentation_task, 3, :completed, assigned_to: ro)
end
```

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
**Before**
![image](https://user-images.githubusercontent.com/122557351/232141362-0518a745-e28f-4769-a23e-7e00a0a84b25.png)

 ---|---
**After** 
![image](https://user-images.githubusercontent.com/122557351/232141554-cf2430f8-850c-47cf-8623-5ec8a55f982f.png)

### Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

### Storybook Story
*For Frontend (Presentationa) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

### Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Post this PR in #appeals-schema with a summary
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

### Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
* [ ] Update Fakes
* [ ] Integrations impacting functionality are tested in Caseflow UAT
