### PR TITLE
TYLERB/VHA-Team-Management-Rspec-Fixes: Resolving some of the Team Management Rspec failures

### DIFF
--- a/spec/mailers/membership_request_mailer_spec.rb
+++ b/spec/mailers/membership_request_mailer_spec.rb
@@ -18,6 +18,7 @@ describe MembershipRequestMailer do
       create(:membership_request, organization: caregiver_support_org, requestor: requestor)
     ]
   end
+  let(:vha_gov_delivery_email_address) { "vhabenefitappeals@messages.va.gov" }
 
   before do
     user_orgs.each do |org|
@@ -35,7 +36,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do
@@ -62,7 +63,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do
@@ -89,7 +90,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do
@@ -119,7 +120,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do
@@ -158,7 +159,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do
@@ -227,7 +228,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
+      expect(mailer.from).to include(vha_gov_delivery_email_address)
     end
 
     it "has the correct to email address" do

--- a/spec/mailers/membership_request_mailer_spec.rb
+++ b/spec/mailers/membership_request_mailer_spec.rb
@@ -35,7 +35,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do
@@ -62,7 +62,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do
@@ -89,7 +89,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do
@@ -119,7 +119,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do
@@ -158,7 +158,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do
@@ -227,7 +227,7 @@ describe MembershipRequestMailer do
     end
 
     it "has the correct from email address" do
-      expect(mailer.from).to include(COPY::VHA_BENEFIT_EMAIL_ADDRESS)
+      expect(mailer.from).to include("vhabenefitappeals@messages.va.gov")
     end
 
     it "has the correct to email address" do

--- a/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
+++ b/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "./send_notification_shared_examples_spec.rb"
+
 describe PostSendInitialNotificationLetterHoldingTask do
   let(:user) { create(:user) }
   let(:cob_team) { ClerkOfTheBoard.singleton }
@@ -16,20 +18,7 @@ describe PostSendInitialNotificationLetterHoldingTask do
     Timecop.return
   end
 
-  describe ".verify_user_can_create" do
-    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name } }
-    let(:distribution_task_id) { distribution_task.id }
-
-    context "when no distribution_task exists for appeal" do
-      let(:distribution_task_id) { nil }
-
-      it "throws an error" do
-        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    # test contexts for successfully creating task when an appeal has a CC will go here once other tasks are made
-  end
+  include_examples "verify_user_can_create"
 
   describe ".available_actions" do
     let(:post_send_initial_notification_letter_holding_task) do

--- a/spec/models/send_final_notification_letter_task_spec.rb
+++ b/spec/models/send_final_notification_letter_task_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "./send_notification_shared_examples_spec.rb"
+
 describe SendFinalNotificationLetterTask do
   let(:user) { create(:user) }
   let(:cob_team) { ClerkOfTheBoard.singleton }
@@ -12,20 +14,7 @@ describe SendFinalNotificationLetterTask do
     FeatureToggle.enable!(:cc_appeal_workflow)
   end
 
-  describe ".verify_user_can_create" do
-    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name } }
-    let(:distribution_task_id) { distribution_task.id }
-
-    context "when no distribution_task exists for appeal" do
-      let(:distribution_task_id) { nil }
-
-      it "throws an error" do
-        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    # test contexts for successfully creating task when an appeal has a CC will go here once other tasks are made
-  end
+  include_examples "verify_user_can_create"
 
   describe ".available_actions" do
     let(:final_notification_letter_task) {

--- a/spec/models/send_initial_notification_letter_task_spec.rb
+++ b/spec/models/send_initial_notification_letter_task_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "./send_notification_shared_examples_spec.rb"
+
 describe SendInitialNotificationLetterTask do
   let(:user) { create(:user) }
   let(:cob_team) { ClerkOfTheBoard.singleton }
@@ -12,20 +14,7 @@ describe SendInitialNotificationLetterTask do
     FeatureToggle.enable!(:cc_appeal_workflow)
   end
 
-  describe ".verify_user_can_create" do
-    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name } }
-    let(:distribution_task_id) { distribution_task.id }
-
-    context "when no distribution_task exists for appeal" do
-      let(:distribution_task_id) { nil }
-
-      it "throws an error" do
-        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
-      end
-    end
-
-    # test contexts for successfully creating task when an appeal has a CC will go here once other tasks are made
-  end
+  include_examples "verify_user_can_create"
 
   describe ".available_actions" do
     let(:send_initial_notification_letter_task) do

--- a/spec/models/send_initial_notification_letter_task_spec.rb
+++ b/spec/models/send_initial_notification_letter_task_spec.rb
@@ -28,10 +28,9 @@ describe SendInitialNotificationLetterTask do
   end
 
   describe ".available_actions" do
-    let(:send_initial_notification_letter_task) {
-      task_class.create!
-      (appeal: distribution_task.appeal, parent_id: distribution_task.id, assigned_to: cob_team)
-    }
+    let(:send_initial_notification_letter_task) do
+      task_class.create!(appeal: distribution_task.appeal, parent_id: distribution_task.id, assigned_to: cob_team)
+    end
 
     let(:available_task_actions) do
       [

--- a/spec/models/send_notification_shared_examples_spec.rb
+++ b/spec/models/send_notification_shared_examples_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.shared_examples_for "verify_user_can_create" do
+  describe ".verify_user_can_create" do
+    let(:params) { { appeal: root_task.appeal, parent_id: distribution_task_id, type: task_class.name } }
+    let(:distribution_task_id) { distribution_task.id }
+
+    context "when no distribution_task exists for appeal" do
+      let(:distribution_task_id) { nil }
+
+      it "throws an error" do
+        expect { task_class.create_from_params(params, user) }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves #{github issue number}

### Description
During the Circle CI to Github-action migration, there were some tests that merged into master in a failing state. This PR will address those testing failures.

### Acceptance Criteria
- [x] All VHA Team Management rspec tests pass
- [x] All of the VHA Team Management jest tests pass
- [x] All of the VHA Team Management linting errors are resolved

### Testing Plan
1. Check the github action results to verify that all of the VHA Team Management rspec tests pass
2. Check the github action results to verify that all of the VHA Team Management jest tests pass
3. Check the github action results to verify that all of the VHA Team Management linting errors are resolved

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)
