### PR TITLE
VLJ legacy appeals feature toggle

### DIFF
--- a/app/views/queue/index.html.erb
+++ b/app/views/queue/index.html.erb
@@ -52,7 +52,8 @@
       split_appeal_workflow: FeatureToggle.enabled?(:split_appeal_workflow, user: current_user),
       cavc_remand_granted_substitute_appellant: FeatureToggle.enabled?(:cavc_remand_granted_substitute_appellant, user: current_user),
       cavc_dashboard_workflow: FeatureToggle.enabled?(:cavc_dashboard_workflow, user: current_user),
-      cc_appeal_workflow: FeatureToggle.enabled?(:cc_appeal_workflow, user: current_user)
-    }
+      cc_appeal_workflow: FeatureToggle.enabled?(:cc_appeal_workflow, user: current_user),
+      vlj_legacy_appeal: FeatureToggle.enabled?(:vlj_legacy_appeal, user: current_user)
+}
   }) %>
 <% end %>


### PR DESCRIPTION
Resolves APPEALS-20688

Description
Created feature toggle for Moving a legacy appeal from one VLJ to another.
After reviewing the entire process, I determined that the Feature Toggle is required in app/views/Queue/index.html.erb

 Acceptance Criteria
The feature flag vlj_legacy_appeal is created
When the feature flag is:
True: Moving a legacy appeal from one VLJ to another is enabled









 



