### PR TITLE
janet/APPEALS-20062 Create Webhook API

### DIFF
--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -1,37 +1,30 @@
 # frozen_string_literal: true
 
 class Api::V1::VaNotifyController < Api::ApplicationController
-  # {POST Method for Veteran ID, Deceased Indicator, Deceased Time}
+
+  # class NotificationNotFound < StandardError; end
+
   def notifications_update
-    notif = Notification.find(params["id"])
-    if notif
-      if notif[:email_notification_external_id] == params["email_notification_external_id"]
-        notif[:email_notification_status] = params["email_notification_status"]
-      elsif notif[:sms_notification_external_id] == params["sms_notification_external_id"]
-        notif[:sms_notification_status] = params["sms_notification_status"]
+    if params["type"] == "email"
+      notif = Notification.find_by(email_notification_external_id: params["id"])
+      if notif
+        notif[:email_notification_status] = params["status"]
+      else
+        uuid = SecureRandom.uuid
+        Rails.logger.error("An email notification with id " + params["id"] + " could not be found." + "Error ID: " + uuid)
+        # Raven.capture_exception(error, extra: { error_uuid: uuid })
+        fail
       end
-    else
-      notif = Notification.new(
-        appeals_id: params["appeals_id"],
-        appeals_type: params["appeals_type"],
-        created_at: params["created_at"],
-        email_enabled: params["email_enabled"],
-        email_notification_content: params["email_notification_content"],
-        email_notification_external_id: params["email_notification_external_id"],
-        email_notification_status: params["email_notification_status"],
-        event_date: params["event_date"],
-        event_type: params["event_type"],
-        notification_content: params["notification_content"],
-        notification_type: params["notification_type"],
-        notified_at: params["notified_at"],
-        participant_id: params["participant_id"],
-        recipient_email: params["recipient_email"],
-        recipient_phone_number: params["recipient_phone_number"],
-        sms_notification_content: params["sms_notification_content"],
-        sms_notification_external_id: params["sms_notification_external_id"],
-        sms_notification_status: params["sms_notification_status"],
-        updated_at: params["updated_at"]
-      )
+    elsif params["type"] == "sms"
+      notif = Notification.find_by(sms_notification_external_id: params["id"])
+      if notif
+        notif[:sms_notification_status] = params["status"]
+      else
+        uuid = SecureRandom.uuid
+        Rails.logger.error("An SMS notification with id " + params["id"] + " could not be found." + "Error ID: " + uuid)
+        # Raven.capture_exception(error, extra: { error_uuid: uuid })
+        fail
+      end
     end
     notif.save
   end

--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Api::V1::VaNotifyController < Api::ApplicationController
+  # {POST Method for Veteran ID, Deceased Indicator, Deceased Time}
+  def notifications_update
+  # get params here
+    notif = Notification.find(params[:id])
+    if notif
+      if notif[email_notification_external_id] == params[:email_notification_external_id]
+        notif[email_notification_status] = params[:email_notification_status]
+      elsif notif[sms_notification_external_id] == params[:sms_notification_external_id]
+        notif[sms_notification_status] = params[:sms_notification_status]
+      end
+    else
+      notif = Notification.new(
+        appeals_id: appeals_id,
+        appeals_type: appeals_type,
+        event_type: event_type,
+        notification_type: notification_type,
+        participant_id: participant_id,
+        notified_at: Time.zone.now,
+        event_date: Time.zone.today
+      )
+    end
+    notif.save
+  end
+end

--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -3,23 +3,34 @@
 class Api::V1::VaNotifyController < Api::ApplicationController
   # {POST Method for Veteran ID, Deceased Indicator, Deceased Time}
   def notifications_update
-  # get params here
-    notif = Notification.find(params[:id])
+    notif = Notification.find(params["id"])
     if notif
-      if notif[email_notification_external_id] == params[:email_notification_external_id]
-        notif[email_notification_status] = params[:email_notification_status]
-      elsif notif[sms_notification_external_id] == params[:sms_notification_external_id]
-        notif[sms_notification_status] = params[:sms_notification_status]
+      if notif[:email_notification_external_id] == params["email_notification_external_id"]
+        notif[:email_notification_status] = params["email_notification_status"]
+      elsif notif[:sms_notification_external_id] == params["sms_notification_external_id"]
+        notif[:sms_notification_status] = params["sms_notification_status"]
       end
     else
       notif = Notification.new(
-        appeals_id: appeals_id,
-        appeals_type: appeals_type,
-        event_type: event_type,
-        notification_type: notification_type,
-        participant_id: participant_id,
-        notified_at: Time.zone.now,
-        event_date: Time.zone.today
+        appeals_id: params["appeals_id"],
+        appeals_type: params["appeals_type"],
+        created_at: params["created_at"],
+        email_enabled: params["email_enabled"],
+        email_notification_content: params["email_notification_content"],
+        email_notification_external_id: params["email_notification_external_id"],
+        email_notification_status: params["email_notification_status"],
+        event_date: params["event_date"],
+        event_type: params["event_type"],
+        notification_content: params["notification_content"],
+        notification_type: params["notification_type"],
+        notified_at: params["notified_at"],
+        participant_id: params["participant_id"],
+        recipient_email: params["recipient_email"],
+        recipient_phone_number: params["recipient_phone_number"],
+        sms_notification_content: params["sms_notification_content"],
+        sms_notification_external_id: params["sms_notification_external_id"],
+        sms_notification_status: params["sms_notification_status"],
+        updated_at: params["updated_at"]
       )
     end
     notif.save

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       resources :appeals, only: :index
       resources :jobs, only: :create
       post 'mpi', to: 'mpi#veteran_updates'
+      post 'va_notify', to: 'va_notify#notifications_update'
     end
     namespace :v2 do
       resources :appeals, only: :index

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
       resources :appeals, only: :index
       resources :jobs, only: :create
       post 'mpi', to: 'mpi#veteran_updates'
-      post 'va_notify', to: 'va_notify#notifications_update'
+      post 'va_notify_update', to: 'va_notify#notifications_update'
     end
     namespace :v2 do
       resources :appeals, only: :index

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1261,7 +1261,7 @@ ActiveRecord::Schema.define(version: 2023_03_17_164013) do
     t.string "recipient_email", comment: "Participant's Email Address"
     t.string "recipient_phone_number", comment: "Participants Phone Number"
     t.text "sms_notification_content", comment: "Full SMS Text Content of Notification"
-    t.string "sms_notification_external_id", comment: "VA Notify Notification Id for the sms notification send through their API "
+    t.string "sms_notification_external_id"
     t.string "sms_notification_status", comment: "Status of SMS/Text Notification"
     t.datetime "updated_at", comment: "TImestamp of when Notification was Updated"
     t.index ["appeals_id", "appeals_type"], name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
@@ -1563,7 +1563,6 @@ ActiveRecord::Schema.define(version: 2023_03_17_164013) do
     t.boolean "national_cemetery_administration", default: false
     t.boolean "no_special_issues", default: false, comment: "Affirmative no special issues, added belatedly"
     t.boolean "nonrating_issue", default: false
-    t.boolean "pact_act", default: false, comment: "The Sergeant First Class (SFC) Heath Robinson Honoring our Promise to Address Comprehensive Toxics (PACT) Act"
     t.boolean "pension_united_states", default: false
     t.boolean "private_attorney_or_agent", default: false
     t.boolean "radiation", default: false

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+describe Api::V1::VaNotifyController, type: :controller do
+  let!(:veteran) { create(:veteran) }
+  let!(:appeal) { create(:appeal, veteran: veteran) }
+  let!(:notification_email) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Appeal docketed", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", email_notification_status: "No Claimant Found") }
+  let!(:notification_sms) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Appeal docketed", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", sms_notification_status: "Preferences Declined") }
+  let(:msg) { VANotifySendMessageTemplate.new(success_message_attributes, good_template_name) }
+
+  context "notification record not found" do
+  end
+
+  context "email notification status is changed" do
+    let(:payload) do
+      {
+        "appeals_id": appeal.uuid,
+        "appeals_type": "Appeal",
+        "created_at": params["created_at"],
+        "email_enabled": true,
+        "email_notification_content": msg,
+        "email_notification_external_id": notification_email.id,
+        "email_notification_status": "Success",
+        "event_date": params["event_date"],
+        "event_type": params["event_type"],
+        "notification_content": params["notification_content"],
+        "notification_type": params["notification_type"],
+        "notified_at": params["notified_at"],
+        "participant_id": params["participant_id"],
+        "recipient_email": params["recipient_email"],
+        "recipient_phone_number": params["recipient_phone_number"],
+        "updated_at": params["updated_at"]
+    }
+    end
+  end
+
+  context "sms notification status is changed" do
+    let(:payload) do
+      {
+        "appeals_id": appeal.uuid,
+        "appeals_type": "Appeal",
+        "created_at": params["created_at"],
+        "email_enabled": false,
+        "event_date": params["event_date"],
+        "event_type": params["event_type"],
+        "notification_content": params["notification_content"],
+        "notification_type": params["notification_type"],
+        "notified_at": params["notified_at"],
+        "participant_id": params["participant_id"],
+        "recipient_email": params["recipient_email"],
+        "recipient_phone_number": params["recipient_phone_number"],
+        "sms_notification_content": params["sms_notification_content"],
+        "sms_notification_external_id": params["sms_notification_external_id"],
+        "sms_notification_status": params["sms_notification_status"],
+        "updated_at": params["updated_at"]
+    }
+    end
+  end
+
+end

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 describe Api::V1::VaNotifyController, type: :controller do
+  before do
+    Seeds::NotificationEvents.new.seed!
+  end
   let!(:appeal) { create(:appeal) }
   let(:notification_email) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Quarterly Notification", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", email_notification_external_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", email_notification_status: "No Claimant Found") }
   let(:notification_sms) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Quarterly Notification", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", sms_notification_external_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", sms_notification_status: "Preferences Declined") }
@@ -39,7 +42,8 @@ describe Api::V1::VaNotifyController, type: :controller do
     it "updates status of notification" do
       byebug
       post :notifications_update, params: payload_email
-      expect(notification_email.status).to eq("created")
+      byebug
+      expect(notification_email.email_notification_status).to eq("created")
     end
   end
 
@@ -83,7 +87,7 @@ describe Api::V1::VaNotifyController, type: :controller do
     end
     it "updates status of notification" do
       post :notifications_update, params: payload_sms
-      expect(notification_email.status).to eq("created")
+      expect(notification_email.sms_notification_status).to eq("created")
     end
   end
   context "notification does not exist" do

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -1,59 +1,133 @@
 # frozen_string_literal: true
 
 describe Api::V1::VaNotifyController, type: :controller do
-  let!(:veteran) { create(:veteran) }
-  let!(:appeal) { create(:appeal, veteran: veteran) }
-  let!(:notification_email) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Appeal docketed", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", email_notification_status: "No Claimant Found") }
-  let!(:notification_sms) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Appeal docketed", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", sms_notification_status: "Preferences Declined") }
-  let(:msg) { VANotifySendMessageTemplate.new(success_message_attributes, good_template_name) }
+  let!(:appeal) { create(:appeal) }
+  let(:notification_email) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Quarterly Notification", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", email_notification_external_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", email_notification_status: "No Claimant Found") }
+  let(:notification_sms) { create(:notification, appeals_id: appeal.uuid, appeals_type: "Appeal", event_date: "2023-02-27 13:11:51.91467", event_type: "Quarterly Notification", notification_type: "Email", notified_at: "2023-02-28 14:11:51.91467", sms_notification_external_id: "3fa85f64-5717-4562-b3fc-2c963f66afa6", sms_notification_status: "Preferences Declined") }
+  # let(:msg) { VANotifySendMessageTemplate.new(success_message_attributes, good_template_name) }
 
   context "notification record not found" do
   end
 
   context "email notification status is changed" do
-    let(:payload) do
+    let(:payload_email) do
       {
-        "appeals_id": appeal.uuid,
-        "appeals_type": "Appeal",
-        "created_at": params["created_at"],
-        "email_enabled": true,
-        "email_notification_content": msg,
-        "email_notification_external_id": notification_email.id,
-        "email_notification_status": "Success",
-        "event_date": params["event_date"],
-        "event_type": params["event_type"],
-        "notification_content": params["notification_content"],
-        "notification_type": params["notification_type"],
-        "notified_at": params["notified_at"],
-        "participant_id": params["participant_id"],
-        "recipient_email": params["recipient_email"],
-        "recipient_phone_number": params["recipient_phone_number"],
-        "updated_at": params["updated_at"]
-    }
+        id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        body: "string",
+        completed_at: "2023-04-17T12:38:48.699Z",
+        created_at: "2023-04-17T12:38:48.699Z",
+        created_by_name: "string",
+        email_address: "user@example.com",
+        line_1: "string",
+        line_2: "string",
+        line_3: "string",
+        line_4: "string",
+        line_5: "string",
+        line_6: "string",
+        phone_number: "+16502532222",
+        postage: "string",
+        postcode: "string",
+        reference: "string",
+        scheduled_for: "2023-04-17T12:38:48.699Z",
+        sent_at: "2023-04-17T12:38:48.699Z",
+        sent_by: "string",
+        status: "created",
+        subject: "string",
+        type: "email"
+      }
+    end
+    it "updates status of notification" do
+      byebug
+      post :notifications_update, params: payload_email
+      expect(notification_email.status).to eq("created")
     end
   end
 
   context "sms notification status is changed" do
-    let(:payload) do
+    let(:payload_sms) do
       {
-        "appeals_id": appeal.uuid,
-        "appeals_type": "Appeal",
-        "created_at": params["created_at"],
-        "email_enabled": false,
-        "event_date": params["event_date"],
-        "event_type": params["event_type"],
-        "notification_content": params["notification_content"],
-        "notification_type": params["notification_type"],
-        "notified_at": params["notified_at"],
-        "participant_id": params["participant_id"],
-        "recipient_email": params["recipient_email"],
-        "recipient_phone_number": params["recipient_phone_number"],
-        "sms_notification_content": params["sms_notification_content"],
-        "sms_notification_external_id": params["sms_notification_external_id"],
-        "sms_notification_status": params["sms_notification_status"],
-        "updated_at": params["updated_at"]
-    }
+        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+        "body": "string",
+        "completed_at": "2023-04-17T12:38:48.699Z",
+        "created_at": "2023-04-17T12:38:48.699Z",
+        "created_by_name": "string",
+        "email_address": "user@example.com",
+        "line_1": "string",
+        "line_2": "string",
+        "line_3": "string",
+        "line_4": "string",
+        "line_5": "string",
+        "line_6": "string",
+        "phone_number": "+16502532222",
+        "postage": "string",
+        "postcode": "string",
+        "recipient_identifiers": [
+          {
+            "id_type": "VAPROFILEID",
+            "id_value": "string"
+          }
+        ],
+        "reference": "string",
+        "scheduled_for": "2023-04-17T12:38:48.699Z",
+        "sent_at": "2023-04-17T12:38:48.699Z",
+        "sent_by": "string",
+        "status": "created",
+        "subject": "string",
+        "template": {
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "uri": "string",
+          "version": 0
+        },
+        "type": "sms"
+      }
+    end
+    it "updates status of notification" do
+      post :notifications_update, params: payload_sms
+      expect(notification_email.status).to eq("created")
     end
   end
-
+  context "notification does not exist" do
+    let(:payload_fake) do
+      {
+        "id": "fake",
+        "body": "string",
+        "completed_at": "2023-04-17T12:38:48.699Z",
+        "created_at": "2023-04-17T12:38:48.699Z",
+        "created_by_name": "string",
+        "email_address": "user@example.com",
+        "line_1": "string",
+        "line_2": "string",
+        "line_3": "string",
+        "line_4": "string",
+        "line_5": "string",
+        "line_6": "string",
+        "phone_number": "+16502532222",
+        "postage": "string",
+        "postcode": "string",
+        "recipient_identifiers": [
+          {
+            "id_type": "VAPROFILEID",
+            "id_value": "string"
+          }
+        ],
+        "reference": "string",
+        "scheduled_for": "2023-04-17T12:38:48.699Z",
+        "sent_at": "2023-04-17T12:38:48.699Z",
+        "sent_by": "string",
+        "status": "created",
+        "subject": "string",
+        "template": {
+          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "uri": "string",
+          "version": 0
+        },
+        "type": "sms"
+      }
+    end
+    it "updates status of notification" do
+      post :notifications_update, params: payload_fake
+      error_msg = JSON.parse(response.body)["message"]
+      expect(error_msg).to include("could not be found.")
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-20062](https://vajira.max.gov/browse/APPEALS-20062)

### Description
As a Caseflow developer, I need to create a means for the Caseflow API to receive real-time updates from VA Notify so that (a) the status of case notifications is kept current and (b) we can avoid losing information about notification status that has expired in VA Notify.

### Acceptance Criteria

- [ ] A new Caseflow v1 API endpoint exists

Will receive a POST request from VA Notify webhook
Will use the same authentication system as the Caselfow external v1 API

- [ ] Notifications API endpoint will update the notification in our system with the status from VA Notify Platform

### Testing Plan
1. Go to ...
