### PR TITLE
Matt g/appeals 19796 task action case movement

### DIFF
--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -22,7 +22,7 @@ class DistributionTask < Task
     return [] unless user
 
     if !appeal.is_a?(Appeal)
-      if !is_any_active_distributionTask_legacy(user)
+      if !any_active_distribution_task_legacy()
         return [Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.to_h]
       end
     elsif special_case_movement_task(user)
@@ -36,16 +36,14 @@ class DistributionTask < Task
     []
   end
 
-  def is_any_active_distributionTask_legacy(user)
-    tasks = Task.where(appeal_type:"LegacyAppeal", appeal_id:appeal.id)
-    return tasks.active.of_type(:DistributionTask).any?
+  def any_active_distribution_task_legacy()
+    tasks = Task.where(appeal_type: "LegacyAppeal", appeal_id: appeal.id)
+    tasks.active.of_type(:DistributionTask).any?
   end
 
   def special_case_movement_task(user)
     if appeal.is_a?(Appeal)
       SpecialCaseMovementTeam.singleton.user_has_access?(user) && appeal.ready_for_distribution?
-    else
-      return false
     end
   end
 

--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -21,7 +21,11 @@ class DistributionTask < Task
   def available_actions(user)
     return [] unless user
 
-    if special_case_movement_task(user)
+    if !appeal.is_a?(Appeal)
+      if !is_any_active_distributionTask_legacy(user)
+        return [Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.to_h]
+      end
+    elsif special_case_movement_task(user)
       return [Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT.to_h]
     elsif SpecialCaseMovementTeam.singleton.user_has_access?(user) && blocked_special_case_movement(user)
       return [Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT.to_h]
@@ -32,11 +36,16 @@ class DistributionTask < Task
     []
   end
 
+  def is_any_active_distributionTask_legacy(user)
+    tasks = Task.where(appeal_type:"LegacyAppeal", appeal_id:appeal.id)
+    return tasks.active.of_type(:DistributionTask).any?
+  end
+
   def special_case_movement_task(user)
     if appeal.is_a?(Appeal)
       SpecialCaseMovementTeam.singleton.user_has_access?(user) && appeal.ready_for_distribution?
     else
-      SpecialCaseMovementTeam.singleton.user_has_access?(user)
+      return false
     end
   end
 

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -236,6 +236,11 @@
     "value": "distribute_to_judge",
     "func": "blocked_special_case_movement_data"
   },
+  "BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY": {
+    "label": "Case Movement: Cancel blocking tasks and advance to judge",
+    "value": "distribute_to_judge",
+    "func": "blocked_special_case_movement_data"
+  },
   "TOGGLE_TIMED_HOLD": {
     "func": "toggle_timed_hold"
   },

--- a/spec/models/tasks/distribution_task_spec.rb
+++ b/spec/models/tasks/distribution_task_spec.rb
@@ -5,12 +5,22 @@ describe DistributionTask, :postgres do
   let(:scm_user) { create(:user) }
   let(:scm_org) { SpecialCaseMovementTeam.singleton }
   let(:root_task) { create(:root_task) }
+  let(:legacy_appeal) { create(:legacy_appeal, :with_schedule_hearing_tasks) }
+  let(:root_task_legacy) { create(:root_task, :legacy_appeal) }
   let(:distribution_task) do
     DistributionTask.create!(
       appeal: root_task.appeal,
       assigned_to: Bva.singleton
     )
   end
+  let(:distribution_task_legacy) do
+    DistributionTask.create!(
+      appeal: root_task_legacy.appeal,
+      assigned_to: Bva.singleton
+    )
+  end
+
+  let(:distribution_task_legacy) { legacy_appeal.tasks.find { |task| task.type == "DistributionTask" } }
 
   before do
     MailTeam.singleton.add_user(user)
@@ -60,6 +70,10 @@ describe DistributionTask, :postgres do
           Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT.to_h
         )
       end
+    end
+
+    it "with legacy case" do
+      expect(distribution_task.available_actions(scm_user).count).to eq(1)
     end
   end
 


### PR DESCRIPTION
Resolves #19796

### Description
Added logic to check if appeal is a legacy appeal and added new logic to check if said legacy appeal is not ready for distribution

### Acceptance Criteria
- Legacy appeals that have an active distribution task as well as are not ready for distribution should now have the new task action

### Testing Plan
1. Log in as a special case movement team member
2. Search any appeal that is legacy, has an active distribution task, and is not ready for distribution(191750319)
3. Click in the task drop down to confirm new selection is available there.
