### PR TITLE
hotfix/APPEALS-15457v2

### DIFF
--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -166,12 +166,14 @@ class Hearing < CaseflowRecord
   end
 
   def claimant_id
-    return nil if appeal.appellant.nil?
+    return nil if appeal.appellant.nil? || appeal.appellant.unrecognized_claimant?
 
     appeal.appellant.person.id
   end
 
   def aod?
+    return false if appeal.appellant.unrecognized_claimant?
+
     advance_on_docket_motion.present?
   end
 

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -284,11 +284,21 @@ describe Hearing, :postgres do
     end
   end
 
+  context "claimant_id" do
+    let(:unrecognized_appellant) { create(:claimant, type: "OtherClaimant") }
+    let(:appeal) { create(:appeal, claimants: [unrecognized_appellant]) }
+    let!(:hearing) { create(:hearing, appeal: appeal) }
+
+    it "returns nil if there is no claimant or if the claimant/appellant is unrecognized" do
+      expect(hearing.claimant_id).to eq(nil)
+    end
+  end
+
   context "aod?" do
     let(:unrecognized_appellant) { create(:claimant, type: "OtherClaimant") }
     let(:appeal) { create(:appeal, claimants: [unrecognized_appellant]) }
     let!(:hearing) { create(:hearing, appeal: appeal) }
-    it "returns nil if the appeals claimant is an unrecognized claimant" do
+    it "returns false if the appeals claimant is an unrecognized claimant" do
       expect(hearing.aod?).to eq(false)
     end
   end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -283,4 +283,13 @@ describe Hearing, :postgres do
       expect(hearing.hearing_day_regional_office).to eq(nil)
     end
   end
+
+  context "aod?" do
+    let(:unrecognized_appellant) { create(:claimant, type: "OtherClaimant") }
+    let(:appeal) { create(:appeal, claimants: [unrecognized_appellant]) }
+    let!(:hearing) { create(:hearing, appeal: appeal) }
+    it "returns nil if the appeals claimant is an unrecognized claimant" do
+      expect(hearing.aod?).to eq(false)
+    end
+  end
 end

--- a/spec/models/hearing_spec.rb
+++ b/spec/models/hearing_spec.rb
@@ -284,20 +284,21 @@ describe Hearing, :postgres do
     end
   end
 
-  context "claimant_id" do
+  shared_context "hearing associated with an appeal with an unrecognized claimant" do
     let(:unrecognized_appellant) { create(:claimant, type: "OtherClaimant") }
     let(:appeal) { create(:appeal, claimants: [unrecognized_appellant]) }
     let!(:hearing) { create(:hearing, appeal: appeal) }
+  end
 
+  context "claimant_id" do
+    include_context "hearing associated with an appeal with an unrecognized claimant"
     it "returns nil if there is no claimant or if the claimant/appellant is unrecognized" do
       expect(hearing.claimant_id).to eq(nil)
     end
   end
 
   context "aod?" do
-    let(:unrecognized_appellant) { create(:claimant, type: "OtherClaimant") }
-    let(:appeal) { create(:appeal, claimants: [unrecognized_appellant]) }
-    let!(:hearing) { create(:hearing, appeal: appeal) }
+    include_context "hearing associated with an appeal with an unrecognized claimant"
     it "returns false if the appeals claimant is an unrecognized claimant" do
       expect(hearing.aod?).to eq(false)
     end


### PR DESCRIPTION
Resolves [APPEALS-15457](https://vajira.max.gov/browse/APPEALS-15457)

### Description
Fixes issue where a hearing with an appellant that has a nil Participant ID blocks the daily docket page from loading.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] Hearing with an appellant that has a nil Participant ID can be viewed.

### Testing Plan
1. Go to [Testing Plan](https://vajira.max.gov/browse/APPEALS-21068)

