### PR TITLE
Update triggers to not include edited

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -3,7 +3,7 @@ name: RSpec Jest Lint Workflow
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, synchronize]
 
 # Use this flag to turn on/off RSpec.  Please go to the lint & js_test job to disable the boolean
 env:


### PR DESCRIPTION
Editing a PR should not trigger the workflow, especially not until new workflows cancel previous ones that are no longer needed.
