### PR TITLE
Ryan/appeals 17514/mst pact checkboxes (Redo)

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -10,7 +10,6 @@ class IntakesController < ApplicationController
 
   def index
     no_cache
-
     respond_to do |format|
       format.html { render(:index) }
     end
@@ -43,6 +42,7 @@ class IntakesController < ApplicationController
   def review
     if intake.review!(params)
       render json: intake.ui_hash
+
     else
       render json: { error_codes: intake.review_errors }, status: :unprocessable_entity
     end
@@ -151,7 +151,8 @@ class IntakesController < ApplicationController
       eduPreDocketAppeals: FeatureToggle.enabled?(:edu_predocket_appeals, user: current_user),
       updatedAppealForm: FeatureToggle.enabled?(:updated_appeal_form, user: current_user),
       hlrScUnrecognizedClaimants: FeatureToggle.enabled?(:hlr_sc_unrecognized_claimants, user: current_user),
-      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user)
+      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user),
+      mstPactIdentification: FeatureToggle.enabled?(:mst_pact_identification, user: current_user)
     }
   end
 

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Checkbox from './Checkbox';
 
 import RequiredIndicator from './RequiredIndicator';
 import StringUtil from '../util/StringUtil';
@@ -42,7 +43,12 @@ export const RadioField = (props) => {
     strongLabel,
     hideLabel,
     styling,
-    vertical
+    vertical,
+    renderMstAndPact,
+    mstCheckboxValue,
+    setMstCheckboxFunction,
+    pactCheckboxValue,
+    setPactCheckboxFunction
   } = props;
 
   const isVertical = useMemo(() => props.vertical || props.options.length > 2, [
@@ -82,6 +88,28 @@ export const RadioField = (props) => {
     }
 
     return radioField;
+  };
+
+  const maybeAddMstAndPactCheckboxes = (option) => {
+    if (renderMstAndPact && (option.value === props.value)) {
+
+      return (
+        <div>
+          <Checkbox
+            label="Issue is related to Military Sexual Trauma (MST)"
+            name="MST"
+            value={mstCheckboxValue}
+            onChange={(checked) => setMstCheckboxFunction(checked)}
+          />
+          <Checkbox
+            label="Issue is related to PACT act"
+            name="Pact"
+            value={pactCheckboxValue}
+            onChange={(checked) => setPactCheckboxFunction(checked)}
+          />
+        </div>
+      );
+    }
   };
 
   const isDisabled = (option) => Boolean(option.disabled);
@@ -124,6 +152,8 @@ export const RadioField = (props) => {
               htmlFor={`${idPart}_${option.value}`}
             >
               {option.displayText || option.displayElem}
+              {props.onChange}
+              {maybeAddMstAndPactCheckboxes(option)}
             </label>
             {option.help && <RadioFieldHelpText help={option.help} />}
           </div>
@@ -213,7 +243,12 @@ RadioField.propTypes = {
   errorMessage: PropTypes.string,
   strongLabel: PropTypes.bool,
   hideLabel: PropTypes.bool,
-  styling: PropTypes.object
+  styling: PropTypes.object,
+  renderMstAndPact: PropTypes.bool,
+  mstCheckboxValue: PropTypes.bool,
+  setMstCheckboxFunction: PropTypes.func,
+  pactCheckboxValue: PropTypes.bool,
+  setPactCheckboxFunction: PropTypes.func,
 };
 
 export default RadioField;

--- a/client/app/intake/components/AddIssueManager.jsx
+++ b/client/app/intake/components/AddIssueManager.jsx
@@ -44,13 +44,14 @@ class AddIssueManager extends React.Component {
   }
 
   setupAddIssuesModal = () => {
-    const { intakeData, formType } = this.props;
+    const { intakeData, formType, featureToggles } = this.props;
 
     return {
       component: AddIssuesModal,
       props: {
         intakeData,
         formType,
+        featureToggles,
         onCancel: () => this.cancel(),
         onSubmit: ({ selectedContestableIssueIndex, currentIssue, notes }) => {
           this.setState(

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -5,7 +5,7 @@ import { map, findIndex, uniq } from 'lodash';
 
 import { formatDateStr } from '../../util/DateUtil';
 import Modal from '../../components/Modal';
-import RadioField from '../../components/RadioField';
+import IntakeRadioField from '../../components/RadioField';
 import TextField from '../../components/TextField';
 import { issueByIndex } from '../util/issues';
 
@@ -16,16 +16,21 @@ class AddIssuesModal extends React.Component {
     this.state = {
       approxDecisionDate: '',
       selectedContestableIssueIndex: '',
-      notes: ''
+      notes: '',
+      mstCheckboxValue: false,
+      pactCheckboxValue: false
     };
   }
+
+  mstCheckboxChange = (checked) => this.setState({ mstCheckboxValue: checked });
+  pactCheckboxChange = (checked) => this.setState({ pactCheckboxValue: checked });
 
   radioOnChange = (selectedContestableIssueIndex) => this.setState({ selectedContestableIssueIndex });
 
   notesOnChange = (notes) => this.setState({ notes });
 
   onAddIssue = () => {
-    const { selectedContestableIssueIndex, notes } = this.state;
+    const { selectedContestableIssueIndex, notes, mstCheckboxValue, pactCheckboxValue } = this.state;
     const currentIssue = issueByIndex(this.props.intakeData.contestableIssues, selectedContestableIssueIndex);
 
     if (selectedContestableIssueIndex && !currentIssue.index) {
@@ -38,7 +43,9 @@ class AddIssuesModal extends React.Component {
     this.props.onSubmit({
       currentIssue: {
         ...currentIssue,
-        notes
+        notes,
+        mstCheckboxValue,
+        pactCheckboxValue,
       }
     });
   };
@@ -80,7 +87,7 @@ class AddIssuesModal extends React.Component {
       });
 
       return (
-        <RadioField
+        <IntakeRadioField
           vertical
           label={<h3>Past decisions from {formatDateStr(approxDecisionDate)}</h3>}
           name="rating-radio"
@@ -88,6 +95,11 @@ class AddIssuesModal extends React.Component {
           key={approxDecisionDate}
           value={this.state.selectedContestableIssueIndex}
           onChange={this.radioOnChange}
+          renderMstAndPact={this.props.featureToggles.mstPactIdentification}
+          mstCheckboxValue={this.state.mstCheckboxValue}
+          setMstCheckboxFunction={this.mstCheckboxChange}
+          pactCheckboxValue={this.state.pactCheckboxValue}
+          setPactCheckboxFunction={this.pactCheckboxChange}
         />
       );
     });
@@ -150,7 +162,8 @@ AddIssuesModal.propTypes = {
   cancelText: PropTypes.string,
   onSkip: PropTypes.func,
   skipText: PropTypes.string,
-  intakeData: PropTypes.object
+  intakeData: PropTypes.object,
+  featureToggle: PropTypes.object
 };
 
 AddIssuesModal.defaultProps = {

--- a/client/app/intake/reducers/featureToggles.js
+++ b/client/app/intake/reducers/featureToggles.js
@@ -28,6 +28,9 @@ const updateFromServerFeatures = (state, featureToggles) => {
     },
     vhaClaimReviewEstablishment: {
       $set: Boolean(featureToggles.vhaClaimReviewEstablishment)
+    },
+    mstPactIdentification: {
+      $set: Boolean(featureToggles.mstPactIdentification)
     }
   });
 };
@@ -42,7 +45,8 @@ export const mapDataToFeatureToggle = (data = { featureToggles: {} }) =>
       eduPreDocketAppeals: false,
       updatedAppealForm: false,
       hlrScUnrecognizedClaimants: false,
-      vhaClaimReviewEstablishment: false
+      vhaClaimReviewEstablishment: false,
+      mstPactIdentification: false
     },
     data.featureToggles
   );

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -59,6 +59,16 @@ feature "Intake Add Issues Page", :all_dbs do
       add_intake_rating_issue(rating_decision_text)
       expect(page).to have_content("1. #{rating_decision_text}\nDecision date: #{promulgation_date.mdY}")
     end
+
+    scenario "MST and PACT checkboxes appear after selecting decision" do
+      start_higher_level_review(veteran)
+      visit "/intake"
+      click_intake_continue
+      click_intake_add_issue
+      choose('rating-radio_0', allow_label_click:true)
+      expect(page).to have_content("Issue is related to Military Sexual Trauma (MST)")
+      expect(page).to have_content("Issue is related to PACT Act")
+    end
   end
 
   context "check for correct time zone" do


### PR DESCRIPTION
Resolves #{17514}

### Description
Added MST/PACT status checkboxes when starting intake process, during add issues.

### Acceptance Criteria
- [ X] Code compiles correctly

### Testing Plan
1. Start with user BVADWISE
2. Start intake process
3. Fill in the form and search for veteran 
4. Press add issues
5. Click any radio option
6. Observe that a MST and PACT checkbox appears.
7. Toggle checkboxes to ensure they work.


### User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue
 
<img width="642" alt="image" src="https://user-images.githubusercontent.com/110805785/233742216-7d9a3535-12c1-4c85-bd5d-09a80cb1e0d6.png">

<img width="636" alt="image" src="https://user-images.githubusercontent.com/110805785/233742336-9f63ca7a-b15e-4b21-ab39-3339ec88ef5e.png">
