### PR TITLE
Hotfix/APPEALS-21350

### DIFF
--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -47,7 +47,7 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
       international_postal_code: address.international_postal_code,
       state_name: address.state_province[:name],
       country_name: address.request_country[:country_name],
-      address_POU: address.address_POU
+      address_pou: address.address_pou
     )
     response = VADotGovService.validate_address(formatted_address)
     fail Caseflow::Error::LighthouseApiError if [401, 403, 429].include? response.code

--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -36,8 +36,12 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
     body = params.require(:request_address).permit!.to_h
     address = OpenStruct.new(body)
     response = VADotGovService.validate_address(format_address(address))
-    fail Caseflow::Error::LighthouseApiError if [401, 403, 429].include? response.code
-
+    byebug
+    # specific error handling occurs in va_dot_gov_service/response.rb
+    if response.error.present?
+      log_error(response.error)
+      fail response.error
+    end
     render json: format_response(response), status: response.code
   end
 

--- a/app/controllers/idt/api/v1/appeals_controller.rb
+++ b/app/controllers/idt/api/v1/appeals_controller.rb
@@ -36,7 +36,6 @@ class Idt::Api::V1::AppealsController < Idt::Api::V1::BaseController
     body = params.require(:request_address).permit!.to_h
     address = OpenStruct.new(body)
     response = VADotGovService.validate_address(format_address(address))
-    byebug
     # specific error handling occurs in va_dot_gov_service/response.rb
     if response.error.present?
       log_error(response.error)

--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -96,6 +96,6 @@ class Idt::Api::V1::BaseController < ActionController::Base
   def log_error(error)
     Raven.capture_exception(error)
     Rails.logger.error(error)
-    Rails.logger.error(error.backtrace.join("\n"))
+    Rails.logger.error(error&.backtrace&.join("\n"))
   end
 end

--- a/app/controllers/idt/api/v1/base_controller.rb
+++ b/app/controllers/idt/api/v1/base_controller.rb
@@ -21,13 +21,6 @@ class Idt::Api::V1::BaseController < ActionController::Base
   end
   # :nocov:
 
-  rescue_from Caseflow::Error::LighthouseApiError do |error|
-    log_error(error)
-    uuid = SecureRandom.uuid
-    Rails.logger.error("Lighthouse API Error: " + uuid)
-    render json: { message: "Lighthouse API Error ID: " + uuid + " An unexpected error occurred, please try again." }, status: :internal_server_error
-  end
-
   rescue_from ActiveRecord::RecordNotFound do |error|
     log_error(error)
     uuid = SecureRandom.uuid

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,7 @@ class Address
   ZIP5_REGEX = /[0-9]{5}/.freeze
   ZIP_CODE_REGEX = /(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/.freeze
 
-  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state
+  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state, :zip4, :international_postal_code, :state_name, :country_name, :address_POU
 
   class << self
     # Validates a 5-digit US zip code.

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -16,7 +16,8 @@ class Address
   # rubocop:disable Metrics/ParameterLists
   def initialize(
     address_line_1: nil, address_line_2: nil, address_line_3: nil,
-    city:, zip: nil, country: nil, state: nil
+    city:, zip: nil, country: nil, state: nil, zip4: nil, international_postal_code: nil,
+    state_name: nil, country_name: nil, address_POU: nil
   )
     # rubocop:enable Metrics/ParameterLists
     @address_line_1 = address_line_1
@@ -25,7 +26,12 @@ class Address
     @city = city
     @state = state
     @zip = zip
+    @zip4 = zip4
     @country = country
+    @international_postal_code = international_postal_code
+    @state_name = state_name
+    @country_name = country_name
+    @address_POU = address_POU
   end
 
   def zip_code_not_validatable?

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,8 @@ class Address
   ZIP5_REGEX = /[0-9]{5}/.freeze
   ZIP_CODE_REGEX = /(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/.freeze
 
-  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state, :zip4, :international_postal_code, :state_name, :country_name, :address_pou
+  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state, :zip4,
+              :international_postal_code, :state_name, :country_name, :address_pou
 
   class << self
     # Validates a 5-digit US zip code.

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -4,7 +4,7 @@ class Address
   ZIP5_REGEX = /[0-9]{5}/.freeze
   ZIP_CODE_REGEX = /(?i)^[a-z0-9][a-z0-9\- ]{0,10}[a-z0-9]$/.freeze
 
-  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state, :zip4, :international_postal_code, :state_name, :country_name, :address_POU
+  attr_reader :country, :city, :zip, :address_line_1, :address_line_2, :address_line_3, :state, :zip4, :international_postal_code, :state_name, :country_name, :address_pou
 
   class << self
     # Validates a 5-digit US zip code.
@@ -17,7 +17,7 @@ class Address
   def initialize(
     address_line_1: nil, address_line_2: nil, address_line_3: nil,
     city:, zip: nil, country: nil, state: nil, zip4: nil, international_postal_code: nil,
-    state_name: nil, country_name: nil, address_POU: nil
+    state_name: nil, country_name: nil, address_pou: nil
   )
     # rubocop:enable Metrics/ParameterLists
     @address_line_1 = address_line_1
@@ -31,7 +31,7 @@ class Address
     @international_postal_code = international_postal_code
     @state_name = state_name
     @country_name = country_name
-    @address_POU = address_POU
+    @address_pou = address_pou
   end
 
   def zip_code_not_validatable?

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -378,7 +378,7 @@ class ExternalApi::VADotGovService
             international_postal_code: address.international_postal_code,
             stateProvince: { name: address.state_name, code: address.state },
             requestCountry: { countryName: address.country_name, countryCode: address.country },
-            addressPOU: address.address_POU
+            addressPOU: address.address_pou
           }
         },
         headers: {

--- a/app/services/external_api/va_dot_gov_service.rb
+++ b/app/services/external_api/va_dot_gov_service.rb
@@ -373,9 +373,12 @@ class ExternalApi::VADotGovService
             addressLine2: address.address_line_2,
             addressLine3: address.address_line_3,
             city: address.city,
-            stateProvince: { code: address.state },
-            requestCountry: { country_code: address.country },
-            zipCode5: address.zip
+            zipCode5: address.zip,
+            zipCode4: address.zip4,
+            international_postal_code: address.international_postal_code,
+            stateProvince: { name: address.state_name, code: address.state },
+            requestCountry: { countryName: address.country_name, countryCode: address.country },
+            addressPOU: address.address_POU
           }
         },
         headers: {

--- a/app/services/external_api/va_dot_gov_service/response.rb
+++ b/app/services/external_api/va_dot_gov_service/response.rb
@@ -35,22 +35,22 @@ class ExternalApi::VADotGovService::Response
     when 429
       Caseflow::Error::VaDotGovLimitError.new(
         code: code,
-        message: "Mapping service is temporarily unavailable. Please try again later."
+        message: "Service is temporarily unavailable, please try again later."
       )
     when 400
       Caseflow::Error::VaDotGovRequestError.new(
         code: code,
-        message: "An unexpected error occured when attempting to map veteran."
+        message: "An unexpected error occurred."
       )
     when 500
       Caseflow::Error::VaDotGovRequestError.new(
         code: code,
-        message: "Could not connect to the Lighthouse Address Validation API, please try again later."
+        message: "Could not connect to the Lighthouse API, please try again later."
       )
     else
       Caseflow::Error::VaDotGovServerError.new(
         code: code,
-        message: "An unexpected error occurred when attempting to map veteran."
+        message: "An unexpected error occurred."
       )
     end
   end

--- a/app/services/external_api/va_dot_gov_service/response.rb
+++ b/app/services/external_api/va_dot_gov_service/response.rb
@@ -42,6 +42,11 @@ class ExternalApi::VADotGovService::Response
         code: code,
         message: "An unexpected error occured when attempting to map veteran."
       )
+    when 500
+      Caseflow::Error::VaDotGovRequestError.new(
+        code: code,
+        message: "Could not connect to the Lighthouse Address Validation API, please try again later."
+      )
     else
       Caseflow::Error::VaDotGovServerError.new(
         code: code,

--- a/app/services/external_api/va_dot_gov_service/response.rb
+++ b/app/services/external_api/va_dot_gov_service/response.rb
@@ -50,7 +50,7 @@ class ExternalApi::VADotGovService::Response
     else
       Caseflow::Error::VaDotGovServerError.new(
         code: code,
-        message: "An unexpected error occured when attempting to map veteran."
+        message: "An unexpected error occurred when attempting to map veteran."
       )
     end
   end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -403,7 +403,6 @@ module Caseflow::Error
 
   class IdtApiError < StandardError; end
   class InvalidOneTimeKey < IdtApiError; end
-  class LighthouseApiError < StandardError; end
 
   class PexipApiError < SerializableError; end
   class PexipNotFoundError < PexipApiError; end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -42,8 +42,6 @@ module Caseflow::Error
   class VaDotGovNullAddressError < StandardError; end
   class VaDotGovForeignVeteranError < StandardError; end
 
-  # class TestError < SerializableError; end
-
   class FetchHearingLocationsJobError < SerializableError; end
 
   class ActionForbiddenError < SerializableError

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -42,6 +42,8 @@ module Caseflow::Error
   class VaDotGovNullAddressError < StandardError; end
   class VaDotGovForeignVeteranError < StandardError; end
 
+  # class TestError < SerializableError; end
+
   class FetchHearingLocationsJobError < SerializableError; end
 
   class ActionForbiddenError < SerializableError

--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -40,45 +40,45 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
         }
       ],
       "address": {
-        "addressLine1": "string",
-        "addressLine2": "string",
-        "addressLine3": "string",
-        "city": "string",
-        "zipCode5": "string",
-        "zipCode4": "string",
+        "addressLine1": "8633 Fordham St.",
+        "addressLine2": "",
+        "addressLine3": "",
+        "city": "Deltona",
+        "zipCode5": "32738",
+        "zipCode4": "2434",
         "internationalPostalCode": "string",
         "county": {
-          "name": "string",
-          "countyFipsCode": "string"
+          "name": "Deltona",
+          "countyFipsCode": "32738"
         },
         "stateProvince": {
-          "name": "string",
-          "code": "string"
+          "name": "Florida",
+          "code": "FL"
         },
         "country": {
-          "name": "string",
-          "code": "string",
-          "fipsCode": "string",
-          "iso2Code": "string",
-          "iso3Code": "string"
-        }
+          "name": "United States",
+          "code": "USA",
+          "fipsCode": "US",
+          "iso2Code": "US",
+          "iso3Code": "USA"
+        },
       },
       "geocode": {
-        "calcDate": "2023-04-25T17:26:05.854Z",
-        "locationPrecision": 0,
-        "latitude": 0,
-        "longitude": 0
+        "calcDate": "2019-01-03T17:33:57+00:00",
+        "locationPrecision": 31.0,
+        "latitude": 38.768185,
+        "longitude": -77.450033
       },
       "usCongressionalDistrict": "string",
       "addressMetaData": {
-        "confidenceScore": 0,
-        "addressType": "string",
+        "confidenceScore": 100.0,
+        "addressType": "Domestic",
         "deliveryPointValidation": "CONFIRMED",
         "residentialDeliveryIndicator": "RESIDENTIAL",
         "nonPostalInputData": [
           "string"
         ],
-        "validationKey": 0
+        "validationKey": 113_008_568
       }
     }
   end

--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -23,9 +23,6 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
       HTTPI::Response.new 200, {}, fake_facilities.to_json
     elsif endpoint == VADotGovService::ADDRESS_VALIDATION_ENDPOINT
       HTTPI::Response.new 200, {}, fake_address_data.to_json
-      # HTTPI::Response.new 404, {}, error_message.to_json
-      # fail StandardError
-      # fail Caseflow::Error::TestError.new(code: 404)
     elsif endpoint == VADotGovService::FACILITY_IDS_ENDPOINT
       HTTPI::Response.new 200, {}, fake_facilities_ids_data.to_json
     end

--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -23,9 +23,22 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
       HTTPI::Response.new 200, {}, fake_facilities.to_json
     elsif endpoint == VADotGovService::ADDRESS_VALIDATION_ENDPOINT
       HTTPI::Response.new 200, {}, fake_address_data.to_json
+      # HTTPI::Response.new 404, {}, error_message.to_json
+      # fail StandardError
+      # fail Caseflow::Error::TestError.new(code: 404)
     elsif endpoint == VADotGovService::FACILITY_IDS_ENDPOINT
       HTTPI::Response.new 200, {}, fake_facilities_ids_data.to_json
     end
+  end
+
+  def self.error_message
+    {
+      data: [
+        {
+          "message": "something went wrong"
+        }
+      ]
+    }
   end
 
   def self.fake_address_data

--- a/lib/fakes/va_dot_gov_service.rb
+++ b/lib/fakes/va_dot_gov_service.rb
@@ -28,53 +28,57 @@ class Fakes::VADotGovService < ExternalApi::VADotGovService
     end
   end
 
-  def self.error_message
-    {
-      data: [
-        {
-          "message": "something went wrong"
-        }
-      ]
-    }
-  end
-
   def self.fake_address_data
     {
+      "messages": [
+        {
+          "code": "string",
+          "key": "string",
+          "text": "string",
+          "severity": "INFO",
+          "potentiallySelfCorrectingOnRetry": true
+        }
+      ],
       "address": {
+        "addressLine1": "string",
+        "addressLine2": "string",
+        "addressLine3": "string",
+        "city": "string",
+        "zipCode5": "string",
+        "zipCode4": "string",
+        "internationalPostalCode": "string",
         "county": {
-          "name": "Deltona",
-          "countyFipsCode": "32738"
+          "name": "string",
+          "countyFipsCode": "string"
         },
         "stateProvince": {
-          "name": "Florida",
-          "code": "FL"
+          "name": "string",
+          "code": "string"
         },
         "country": {
-          "name": "United States",
-          "code": "USA",
-          "fipsCode": "US",
-          "iso2Code": "US",
-          "iso3Code": "USA"
-        },
-        "addressLine1": "8633 Fordham St.",
-        "addressLine2": "",
-        "addressLine3": "",
-        "city": "Deltona",
-        "zipCode5": "32738",
-        "zipCode4": "2434"
+          "name": "string",
+          "code": "string",
+          "fipsCode": "string",
+          "iso2Code": "string",
+          "iso3Code": "string"
+        }
       },
       "geocode": {
-        "calcDate": "2019-01-03T17:33:57+00:00",
-        "locationPrecision": 31.0,
-        "latitude": 38.768185,
-        "longitude": -77.450033
+        "calcDate": "2023-04-25T17:26:05.854Z",
+        "locationPrecision": 0,
+        "latitude": 0,
+        "longitude": 0
       },
+      "usCongressionalDistrict": "string",
       "addressMetaData": {
-        "confidenceScore": 100.0,
-        "addressType": "Domestic",
+        "confidenceScore": 0,
+        "addressType": "string",
         "deliveryPointValidation": "CONFIRMED",
         "residentialDeliveryIndicator": "RESIDENTIAL",
-        "validationKey": 113_008_568
+        "nonPostalInputData": [
+          "string"
+        ],
+        "validationKey": 0
       }
     }
   end

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -648,7 +648,7 @@ RSpec.describe HearingsController, type: :controller do
 
         expect(response.status).to eq 500
         expect(JSON.parse(response.body).dig("errors").first.dig("detail"))
-          .to eq("An unexpected error occured when attempting to map veteran.")
+          .to eq("Could not connect to the Lighthouse API, please try again later.")
       end
     end
 
@@ -672,7 +672,7 @@ RSpec.describe HearingsController, type: :controller do
 
         expect(response.status).to eq 500
         expect(JSON.parse(response.body).dig("errors").first.dig("detail"))
-          .to eq("An unexpected error occured when attempting to map veteran.")
+          .to eq("Could not connect to the Lighthouse API, please try again later.")
       end
     end
   end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -746,7 +746,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
             "country_name": "string",
             "country_code": "string"
           },
-          "address_POU": "RESIDENCE/CHOICE"
+          "address_pou": "RESIDENCE/CHOICE"
         }
       }
     end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -727,7 +727,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
   end
 
   describe "POST /idt/api/v1/services/address_validation/v1/validate", :postgres do
-    let(:user) { create(:user) }
+    let(:user) { create(:user, roles: ["Mail Intake"]) }
     let(:params) do
       {
         "request_address": {
@@ -751,19 +751,60 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
       }
     end
 
+    before do
+      key, t = Idt::Token.generate_one_time_key_and_proposed_token
+      Idt::Token.activate_proposed_token(key, user.css_id)
+      request.headers["TOKEN"] = t
+    end
+
+    subject { post :validate, params: params }
+
     context "VADotGovService is responsive" do
-      let(:user) { create(:user) }
-      before do
-        BvaDispatch.singleton.add_user(user)
-        key, t = Idt::Token.generate_one_time_key_and_proposed_token
-        Idt::Token.activate_proposed_token(key, user.css_id)
-        request.headers["TOKEN"] = t
-      end
       it "should send back a valid address" do
-        allow(controller).to receive(:verify_access).and_return(true)
-        post :validate, params: params
+        subject
+
         expect(response.status).to eq(200)
-        expect(OpenStruct.new(OpenStruct.new(JSON.parse(response.body)).response).raw_body.to_json).to eq(Fakes::VADotGovService.fake_address_data.to_json)
+        expect(
+          OpenStruct.new(JSON.parse(response.body))[:address].first.last.first.last
+        ).to eq(
+          Fakes::VADotGovService.fake_address_data[:address][:county][:name]
+        )
+      end
+    end
+
+    context "VADotGovService status check" do
+      let(:expected_lighthouse_response) do
+        OpenStruct.new(
+          code: expected_status_code,
+          response: OpenStruct.new(
+            raw_body: "{\"json\":\"jsoff\"}"
+          )
+        )
+      end
+
+      before do
+        allow(ExternalApi::VADotGovService).to receive(:validate_address)
+          .and_return(expected_lighthouse_response)
+      end
+
+      context "Lighthouse returns a 404" do
+        let!(:expected_status_code) { 404 }
+
+        it "Caseflow returns a 404 as well" do
+          subject
+
+          expect(response.status).to eq(expected_status_code)
+        end
+      end
+
+      context "Lighthouse returns a 429" do
+        let!(:expected_status_code) { 429 }
+
+        it "Caseflow returns a 500" do
+          subject
+
+          expect(response.status).to eq(500)
+        end
       end
     end
   end

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -730,7 +730,7 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
     let(:user) { create(:user) }
     let(:params) do
       {
-        "requestAddress": {
+        "request_address": {
           "address_line_1": "string",
           "address_line_2": "string",
           "address_line_3": "string",

--- a/spec/controllers/idt/api/appeals_controller_spec.rb
+++ b/spec/controllers/idt/api/appeals_controller_spec.rb
@@ -765,9 +765,9 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
 
         expect(response.status).to eq(200)
         expect(
-          OpenStruct.new(JSON.parse(response.body))[:address].first.last.first.last
+          JSON.parse(response.body)["address"]["city"]
         ).to eq(
-          Fakes::VADotGovService.fake_address_data[:address][:county][:name]
+          Fakes::VADotGovService.fake_address_data[:address][:city]
         )
       end
     end
@@ -797,8 +797,8 @@ RSpec.describe Idt::Api::V1::AppealsController, type: :controller do
         end
       end
 
-      context "Lighthouse returns a 429" do
-        let!(:expected_status_code) { 429 }
+      context "Lighthouse returns a 500" do
+        let!(:expected_status_code) { 500 }
 
         it "Caseflow returns a 500" do
           subject

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -441,7 +441,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
           click_dropdown(text: Constants.TASK_ACTIONS.SCHEDULE_VETERAN.to_h[:label])
           expect(page).to have_css(
             ".usa-alert-error",
-            text: "Mapping service is temporarily unavailable. Please try again later."
+            text: "Service is temporarily unavailable, please try again later."
           )
         end
       end


### PR DESCRIPTION
Resolves #https://vajira.max.gov/browse/APPEALS-21350

### Description
The following defects related to [APPEALS-20080](https://vajira.max.gov/browse/APPEALS-20080) have been identified:

- The required key in [this line of code](https://github.com/department-of-veterans-affairs/caseflow/blob/a98b0c9025fb59a10127481d5736c2cf4ac62c0f/app/controllers/idt/api/v1/appeals_controller.rb#L36) should be :request_address opposed to :requestAddress
- The response handed to IDT should not contain the headers for the request that Caseflow sends to Lighthouse and will need removed before being rendered to the client.
Keys in the response received by IDT clients from Caseflow are in camelCase, whereas [the documentation](https://github.com/department-of-veterans-affairs/caseflow/wiki/Lighthouse-API-Implementation#success-object) specifies that they should be in snake_case.
- Status codes given to Caseflow by Lighthouse are not given to IDT clients. For example, if Caseflow receives an HTTP 429 status code from Lighthouse, we are including a "code": 429 key-value pair in the JSON response body but are doing so while presenting an HTTP 200 status code to IDT. The "code" key, and its value, should be omitted from the response body, and instead be used to determine which [status](https://github.com/department-of-veterans-affairs/caseflow/blob/a98b0c9025fb59a10127481d5736c2cf4ac62c0f/app/controllers/idt/api/v1/appeals_controller.rb#L40) code to give to the initial requestor. status here should instead be the status code received by Caseflow from Lighthouse.
- The values from the request body are placed into an OpenStruct [here](https://github.com/department-of-veterans-affairs/caseflow/blob/a98b0c9025fb59a10127481d5736c2cf4ac62c0f/app/controllers/idt/api/v1/appeals_controller.rb#L37) in the same format as they are sent. The keys and structure are not what [ExternalAPI::VADotGovService#address_validation_request](https://github.com/department-of-veterans-affairs/caseflow/blob/a98b0c9025fb59a10127481d5736c2cf4ac62c0f/app/services/external_api/va_dot_gov_service.rb#L371) expects, and currently the state and zip values are not being transmitted to Lighthouse as a result. It may be better to place the values of the JSON request body sent to the address validation route into an instance of the [Address class](https://github.com/department-of-veterans-affairs/caseflow/blob/akonhilas/APPEALS-20080/app/models/address.rb), which is what I believe has been used with ExternalAPI::VADotGovService#address_validation_request up to this point.
- The [address request sent to Lighthouse](https://github.com/department-of-veterans-affairs/caseflow/blob/a98b0c9025fb59a10127481d5736c2cf4ac62c0f/app/services/external_api/va_dot_gov_service.rb#L368-L386) doesn't include the following fields that are currently specified as [valid inputs to Caseflow's endpoint](https://github.com/department-of-veterans-affairs/caseflow/wiki/Lighthouse-API-Implementation#example-request-parameters):
  * zip_code_4
  * international_postal_code
  * state_province.name - (Only code is currently utilized in staging the request)
  * request_country.name - (Only code is currently utilized in staging the request)
  * address_pou
 

Automated tests will likely need to be updated, and additional tests being created to cover the defects listed above in order to protect against regressions is highly advisable.

### Acceptance Criteria
- [ ] Code compiles correctly

### Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-21548

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

### Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
* [ ] Update Fakes
* [ ] Integrations impacting functionality are tested in Caseflow UAT
