### PR TITLE
rspec for Reassign case page

### DIFF
--- a/spec/feature/queue/special_case_movement_task_legacy_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_legacy_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.feature "SpecialCaseMovementTask", :all_dbs do
+  let(:scm_user) { create(:user) }
+
+  let(:judge_user) { create(:user) }
+  let!(:vacols_judge) { create(:staff, :judge_role, sdomainid: judge_user.css_id) }
+  let!(:judgeteam) { JudgeTeam.create_for_judge(judge_user) }
+  let(:veteran) { create(:veteran, first_name: "Samuel", last_name: "Purcell") }
+  let(:ssn) { Generators::Random.unique_ssn }
+
+  let(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "#{ssn}S")) }
+  let(:root_task) { create(:root_task, appeal: appeal) }
+  let(:distribution_task) { create(:distribution_task, parent: root_task) }
+
+  let(:hearing_task) { create(:hearing_task, parent: distribution_task) }
+
+  before do
+    SpecialCaseMovementTeam.singleton.add_user(scm_user)
+    User.authenticate!(user: scm_user)
+  end
+  describe "Accessing task actions" do
+    context "With the Appeal in the right state" do
+      it "successfully assigns the task to judge" do
+        visit("queue/appeals/#{hearing_task.appeal.external_id}")
+        dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
+        dropdown.click
+        expect(page).to have_content(Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.label)
+      end
+
+      it "Checking validations on hearing task is cancelled and case assigns to judge" do
+        visit("/queue")
+        visit("/queue/appeals/#{hearing_task.appeal.external_id}")
+        prompt = COPY::TASK_ACTION_DROPDOWN_BOX_LABEL
+        text = Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.label
+        click_dropdown(prompt: prompt, text: text)
+
+        # check modal content
+        expect(page).to have_content(format(COPY::BLOCKED_SPECIAL_CASE_MOVEMENT_PAGE_SUBTITLE))
+
+        expect(page).to have_button("Continue", disabled: true)
+
+        page.all(".cf-form-radio-option > label")[1].click
+        expect(page).to have_button("Continue", disabled: true)
+
+        # fill out instructions
+        fill_in("cancellationInstructions", with: "instructions")
+        expect(page).to have_button("Continue", disabled: false)
+
+        # remove instructions in text field
+        fill_in("cancellationInstructions", with: "")
+        expect(page).to have_button("Continue", disabled: true)
+
+        click_button "Cancel"
+        expect(page).to have_content "Currently active tasks"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves APPEALS-20011, APPEALS-19799

 Description
Created Reassign Case page. From the case details page, under the Currently active task if you select the action dropdown  and select Case Movement: cancel blocking task advance to judge
This will take you to the Reassign case page. There you can see the Reasons and Context for cancelling. 

 Acceptance Criteria
- [x] Code compiles correctly
- [x] This page will appear when a user selects the task action “Case Movement: Cancel blocking tasks and advance to judge”
Page will include Veteran ID, and Task
Page will include Cancel and Continue buttons
Contains a section showing the following tasks that will be cancelled if the respective case is moved
Contains a radio section to provide reasons and context for the cancellation
Death Dismissal
Withdrawal
Medical
Other
Once reasons + context are selected, continue button will be enabled 
Continue button will lead to the Confirm Cancellation Modal 

 Testing Plan
1. Login as a Special Case Movement User and from the App selector, select Queue.
2. In Queue, click on the  Search cases and enter the Veteran ID. (Here I used the VBMS ID from Legacy_appeals table from Caseflow db). Here I gave the Veteran ID as: 300000151 and click on Search.
<img width="848" alt="image" src="https://user-images.githubusercontent.com/110078646/234097985-51c29dd2-76e5-4b82-a897-0c43b908c8b3.png">
3. Click on the Docket number and it will take to the Case Details page.
<img width="806" alt="image" src="https://user-images.githubusercontent.com/110078646/234098979-81a7f1d1-f175-40d6-b5cf-3087c5d15518.png">
<img width="808" alt="image" src="https://user-images.githubusercontent.com/110078646/234099535-955ee0b7-1948-4a20-ab23-0bead74f928c.png">
4. In the Currently active tasks you can see the Action dropdown, select the option Case Movement: Cancel blocking tasks and advance to judge.
<img width="779" alt="image" src="https://user-images.githubusercontent.com/110078646/234100214-7b408668-ef1e-41a2-9762-07aaedad63b3.png">
5. Now we can see the Reassign Case Page from which we select the reason and context for cancelling the task
<img width="803" alt="image" src="https://user-images.githubusercontent.com/110078646/234102012-4f0fb28d-1f80-44ce-93c5-af4c829da4bc.png">
<img width="835" alt="image" src="https://user-images.githubusercontent.com/110078646/234102107-2cb5f1ba-aaf8-4eaf-9c1c-87933cb9715b.png">
6. If we click on Continue button, we can see the Confirm Cancellation and Reassign modal.  


