### PR TITLE
Prepopulate MST/PACT checkboxes if pre-existing issues are on the ContestableIssue model.

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -10,7 +10,6 @@ class IntakesController < ApplicationController
 
   def index
     no_cache
-
     respond_to do |format|
       format.html { render(:index) }
     end
@@ -43,6 +42,7 @@ class IntakesController < ApplicationController
   def review
     if intake.review!(params)
       render json: intake.ui_hash
+
     else
       render json: { error_codes: intake.review_errors }, status: :unprocessable_entity
     end
@@ -151,7 +151,8 @@ class IntakesController < ApplicationController
       eduPreDocketAppeals: FeatureToggle.enabled?(:edu_predocket_appeals, user: current_user),
       updatedAppealForm: FeatureToggle.enabled?(:updated_appeal_form, user: current_user),
       hlrScUnrecognizedClaimants: FeatureToggle.enabled?(:hlr_sc_unrecognized_claimants, user: current_user),
-      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user)
+      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user),
+      mstPactIdentification: FeatureToggle.enabled?(:mst_pact_identification, user: current_user)
     }
   end
 

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -66,6 +66,7 @@ class ContestableIssue
     end
   end
 
+
   def serialize
     {
       ratingIssueReferenceId: rating_issue_reference_id,
@@ -81,8 +82,11 @@ class ContestableIssue
       timely: timely?,
       latestIssuesInChain: serialize_latest_decision_issues,
       isRating: is_rating,
-      mst:true,
-      pact:false
+      mst: true,
+      pact: true
+
+      #test uses a gui in some ways it performs
+
     }
   end
 

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -80,7 +80,9 @@ class ContestableIssue
       sourceReviewType: source_review_type,
       timely: timely?,
       latestIssuesInChain: serialize_latest_decision_issues,
-      isRating: is_rating
+      isRating: is_rating,
+      mst:true,
+      pact:false
     }
   end
 

--- a/client/app/components/Checkbox.jsx
+++ b/client/app/components/Checkbox.jsx
@@ -22,7 +22,6 @@ export const Checkbox = (props) => {
   } = props;
 
   const handleChange = (event) => onChange?.(event.target.checked, event);
-
   const wrapperClasses = classnames(`checkbox-wrapper-${name}`, {
     'cf-form-checkboxes': !unpadded,
     'usa-input-error': Boolean(errorMessage),

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -48,7 +48,9 @@ export const RadioField = (props) => {
     mstCheckboxValue,
     setMstCheckboxFunction,
     pactCheckboxValue,
-    setPactCheckboxFunction
+    setPactCheckboxFunction,
+    preExistingMST,
+    preExistingPACT
   } = props;
 
   const isVertical = useMemo(() => props.vertical || props.options.length > 2, [
@@ -90,6 +92,22 @@ export const RadioField = (props) => {
     return radioField;
   };
 
+  const returnMstOrCheckboxValue = () => {
+    if (preExistingMST) {
+      return preExistingMST;
+    }
+
+    return mstCheckboxValue;
+  };
+
+  const returnPactOrCheckboxValue = () => {
+    if (preExistingPACT) {
+      return preExistingPACT;
+    }
+
+    return pactCheckboxValue;
+  };
+
   const maybeAddMstAndPactCheckboxes = (option) => {
     if (renderMstAndPact && (option.value === props.value)) {
 
@@ -98,13 +116,15 @@ export const RadioField = (props) => {
           <Checkbox
             label="Issue is related to Military Sexual Trauma (MST)"
             name="MST"
-            value={mstCheckboxValue}
+            value={returnMstOrCheckboxValue()}
+            disabled={preExistingMST}
             onChange={(checked) => setMstCheckboxFunction(checked)}
           />
           <Checkbox
             label="Issue is related to PACT act"
             name="Pact"
-            value={pactCheckboxValue}
+            value={returnPactOrCheckboxValue()}
+            disabled={preExistingPACT}
             onChange={(checked) => setPactCheckboxFunction(checked)}
           />
         </div>
@@ -249,6 +269,8 @@ RadioField.propTypes = {
   setMstCheckboxFunction: PropTypes.func,
   pactCheckboxValue: PropTypes.bool,
   setPactCheckboxFunction: PropTypes.func,
+  preExistingMST: PropTypes.bool,
+  preExistingPACT: PropTypes.bool
 };
 
 export default RadioField;

--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Checkbox from './Checkbox';
 
 import RequiredIndicator from './RequiredIndicator';
 import StringUtil from '../util/StringUtil';
@@ -42,7 +43,12 @@ export const RadioField = (props) => {
     strongLabel,
     hideLabel,
     styling,
-    vertical
+    vertical,
+    renderMstAndPact,
+    mstCheckboxValue,
+    setMstCheckboxFunction,
+    pactCheckboxValue,
+    setPactCheckboxFunction
   } = props;
 
   const isVertical = useMemo(() => props.vertical || props.options.length > 2, [
@@ -82,6 +88,28 @@ export const RadioField = (props) => {
     }
 
     return radioField;
+  };
+
+  const maybeAddMstAndPactCheckboxes = (option) => {
+    if (renderMstAndPact && (option.value === props.value)) {
+
+      return (
+        <div>
+          <Checkbox
+            label="Issue is related to Military Sexual Trauma (MST)"
+            name="MST"
+            value={mstCheckboxValue}
+            onChange={(checked) => setMstCheckboxFunction(checked)}
+          />
+          <Checkbox
+            label="Issue is related to PACT act"
+            name="Pact"
+            value={pactCheckboxValue}
+            onChange={(checked) => setPactCheckboxFunction(checked)}
+          />
+        </div>
+      );
+    }
   };
 
   const isDisabled = (option) => Boolean(option.disabled);
@@ -124,6 +152,8 @@ export const RadioField = (props) => {
               htmlFor={`${idPart}_${option.value}`}
             >
               {option.displayText || option.displayElem}
+              {props.onChange}
+              {maybeAddMstAndPactCheckboxes(option)}
             </label>
             {option.help && <RadioFieldHelpText help={option.help} />}
           </div>
@@ -213,7 +243,12 @@ RadioField.propTypes = {
   errorMessage: PropTypes.string,
   strongLabel: PropTypes.bool,
   hideLabel: PropTypes.bool,
-  styling: PropTypes.object
+  styling: PropTypes.object,
+  renderMstAndPact: PropTypes.bool,
+  mstCheckboxValue: PropTypes.bool,
+  setMstCheckboxFunction: PropTypes.func,
+  pactCheckboxValue: PropTypes.bool,
+  setPactCheckboxFunction: PropTypes.func,
 };
 
 export default RadioField;

--- a/client/app/intake/components/AddIssueManager.jsx
+++ b/client/app/intake/components/AddIssueManager.jsx
@@ -44,13 +44,14 @@ class AddIssueManager extends React.Component {
   }
 
   setupAddIssuesModal = () => {
-    const { intakeData, formType } = this.props;
+    const { intakeData, formType, featureToggles } = this.props;
 
     return {
       component: AddIssuesModal,
       props: {
         intakeData,
         formType,
+        featureToggles,
         onCancel: () => this.cancel(),
         onSubmit: ({ selectedContestableIssueIndex, currentIssue, notes }) => {
           this.setState(

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -54,6 +54,8 @@ class AddIssuesModal extends React.Component {
     const { intakeData } = this.props;
 
     const addedIssues = intakeData.addedIssues ? intakeData.addedIssues : [];
+    let preExistingMST;
+    let preExistingPACT;
 
     return map(intakeData.contestableIssues, (contestableIssuesByIndex, approxDecisionDate) => {
       const radioOptions = map(contestableIssuesByIndex, (issue) => {
@@ -78,6 +80,8 @@ class AddIssuesModal extends React.Component {
 
           text = `${text} (Please select the most recent decision on ${dates})`;
         }
+        preExistingMST = contestableIssuesByIndex[issue.index].mst;
+        preExistingPACT = contestableIssuesByIndex[issue.index].pact;
 
         return {
           displayText: text,
@@ -100,6 +104,8 @@ class AddIssuesModal extends React.Component {
           setMstCheckboxFunction={this.mstCheckboxChange}
           pactCheckboxValue={this.state.pactCheckboxValue}
           setPactCheckboxFunction={this.pactCheckboxChange}
+          preExistingMST={preExistingMST}
+          preExistingPACT={preExistingPACT}
         />
       );
     });
@@ -133,7 +139,6 @@ class AddIssuesModal extends React.Component {
 
   render() {
     const { intakeData, onCancel } = this.props;
-
     const issueNumber = (intakeData.addedIssues || []).length + 1;
 
     return (
@@ -163,7 +168,7 @@ AddIssuesModal.propTypes = {
   onSkip: PropTypes.func,
   skipText: PropTypes.string,
   intakeData: PropTypes.object,
-  featureToggle: PropTypes.object
+  featureToggles: PropTypes.object
 };
 
 AddIssuesModal.defaultProps = {

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -5,7 +5,7 @@ import { map, findIndex, uniq } from 'lodash';
 
 import { formatDateStr } from '../../util/DateUtil';
 import Modal from '../../components/Modal';
-import RadioField from '../../components/RadioField';
+import IntakeRadioField from '../../components/RadioField';
 import TextField from '../../components/TextField';
 import { issueByIndex } from '../util/issues';
 
@@ -16,16 +16,21 @@ class AddIssuesModal extends React.Component {
     this.state = {
       approxDecisionDate: '',
       selectedContestableIssueIndex: '',
-      notes: ''
+      notes: '',
+      mstCheckboxValue: false,
+      pactCheckboxValue: false
     };
   }
+
+  mstCheckboxChange = (checked) => this.setState({ mstCheckboxValue: checked });
+  pactCheckboxChange = (checked) => this.setState({ pactCheckboxValue: checked });
 
   radioOnChange = (selectedContestableIssueIndex) => this.setState({ selectedContestableIssueIndex });
 
   notesOnChange = (notes) => this.setState({ notes });
 
   onAddIssue = () => {
-    const { selectedContestableIssueIndex, notes } = this.state;
+    const { selectedContestableIssueIndex, notes, mstCheckboxValue, pactCheckboxValue } = this.state;
     const currentIssue = issueByIndex(this.props.intakeData.contestableIssues, selectedContestableIssueIndex);
 
     if (selectedContestableIssueIndex && !currentIssue.index) {
@@ -38,7 +43,9 @@ class AddIssuesModal extends React.Component {
     this.props.onSubmit({
       currentIssue: {
         ...currentIssue,
-        notes
+        notes,
+        mstCheckboxValue,
+        pactCheckboxValue,
       }
     });
   };
@@ -80,7 +87,7 @@ class AddIssuesModal extends React.Component {
       });
 
       return (
-        <RadioField
+        <IntakeRadioField
           vertical
           label={<h3>Past decisions from {formatDateStr(approxDecisionDate)}</h3>}
           name="rating-radio"
@@ -88,6 +95,11 @@ class AddIssuesModal extends React.Component {
           key={approxDecisionDate}
           value={this.state.selectedContestableIssueIndex}
           onChange={this.radioOnChange}
+          renderMstAndPact={this.props.featureToggles.mstPactIdentification}
+          mstCheckboxValue={this.state.mstCheckboxValue}
+          setMstCheckboxFunction={this.mstCheckboxChange}
+          pactCheckboxValue={this.state.pactCheckboxValue}
+          setPactCheckboxFunction={this.pactCheckboxChange}
         />
       );
     });
@@ -150,7 +162,8 @@ AddIssuesModal.propTypes = {
   cancelText: PropTypes.string,
   onSkip: PropTypes.func,
   skipText: PropTypes.string,
-  intakeData: PropTypes.object
+  intakeData: PropTypes.object,
+  featureToggle: PropTypes.object
 };
 
 AddIssuesModal.defaultProps = {

--- a/client/app/intake/reducers/featureToggles.js
+++ b/client/app/intake/reducers/featureToggles.js
@@ -28,6 +28,9 @@ const updateFromServerFeatures = (state, featureToggles) => {
     },
     vhaClaimReviewEstablishment: {
       $set: Boolean(featureToggles.vhaClaimReviewEstablishment)
+    },
+    mstPactIdentification: {
+      $set: Boolean(featureToggles.mstPactIdentification)
     }
   });
 };
@@ -42,7 +45,8 @@ export const mapDataToFeatureToggle = (data = { featureToggles: {} }) =>
       eduPreDocketAppeals: false,
       updatedAppealForm: false,
       hlrScUnrecognizedClaimants: false,
-      vhaClaimReviewEstablishment: false
+      vhaClaimReviewEstablishment: false,
+      mstPactIdentification: false
     },
     data.featureToggles
   );

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -67,8 +67,19 @@ feature "Intake Add Issues Page", :all_dbs do
       click_intake_add_issue
       choose('rating-radio_0', allow_label_click:true)
       expect(page).to have_content("Issue is related to Military Sexual Trauma (MST)")
-      expect(page).to have_content("Issue is related to PACT Act")
-      sleep(10000)
+      expect(page).to have_content("Issue is related to PACT act")
+    end
+
+    scenario "MST and PACT checkboxes are disabled if they already exist in the model" do
+      start_higher_level_review(veteran)
+      FeatureToggle.enable!(:mst_pact_identification)
+      visit "/intake"
+      click_intake_continue
+      click_intake_add_issue
+      choose('rating-radio_0', allow_label_click:true)
+      sleep(1)
+      expect(page).to have_field("Issue is related to Military Sexual Trauma (MST)", visible: false, disabled: true)
+      expect(page).to have_field("Issue is related to PACT act", visible: false, disabled: true)
     end
 
 

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -68,7 +68,11 @@ feature "Intake Add Issues Page", :all_dbs do
       choose('rating-radio_0', allow_label_click:true)
       expect(page).to have_content("Issue is related to Military Sexual Trauma (MST)")
       expect(page).to have_content("Issue is related to PACT Act")
+      sleep(10000)
     end
+
+
+
   end
 
   context "check for correct time zone" do

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -59,6 +59,16 @@ feature "Intake Add Issues Page", :all_dbs do
       add_intake_rating_issue(rating_decision_text)
       expect(page).to have_content("1. #{rating_decision_text}\nDecision date: #{promulgation_date.mdY}")
     end
+
+    scenario "MST and PACT checkboxes appear after selecting decision" do
+      start_higher_level_review(veteran)
+      visit "/intake"
+      click_intake_continue
+      click_intake_add_issue
+      choose('rating-radio_0', allow_label_click:true)
+      expect(page).to have_content("Issue is related to Military Sexual Trauma (MST)")
+      expect(page).to have_content("Issue is related to PACT Act")
+    end
   end
 
   context "check for correct time zone" do


### PR DESCRIPTION
Resolves [#{17513}](https://vajira.max.gov/browse/APPEALS-17513)

### Description
Checkboxes on the add issues page for MST/PACT now auto populate and disable if there is already existing information on the ContestableIssue model. Users will be unable to remove the check when disabled.

### Acceptance Criteria
- [X] Code compiles correctly

### Testing Plan
1. Start with user BVADWISE
2. Start intake process
3. Fill in the form and search for veteran (I used veteran 872958715)
4. Press add issues
5. Click any radio option
6. MST/PACT checkboxes should be present and autopopulated, disabled, and, greyed out.
7. Ensure that you cannot modify the state of the checkbox by clicking it.

### User Facing Changes
User can no longer modify the value of a MST/PACT checkbox if there is pre-existing MST/PACT status on the ContestableIssue.


<img width="751" alt="disabled autopop" src="https://user-images.githubusercontent.com/110805785/234391070-3b7d6732-e7f7-48b5-b779-a50710ee1e3b.png">

<img width="747" alt="enabled autopop" src="https://user-images.githubusercontent.com/110805785/234390417-d8637fe1-0cd7-4a4a-ae09-cffa4d3aca69.png">

