### PR TITLE
JHoang/appeals 17546

### DIFF
--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -261,10 +261,6 @@ class SelectDispositionsView extends React.PureComponent {
       this.props.appeal.externalId, { decisionIssues: remainingDecisionIssues }
     );
 
-    // this.props.editStagedAppeal(
-    //   this.props.appeal.externalId, { specialIssues: null }
-    // );
-
     this.handleModalClose();
   }
 

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -93,27 +93,20 @@ class SelectDispositionsView extends React.PureComponent {
   }
 
   stageSpecialIssues = (decisionIssues) => {
-    // eslint-disable-next-line camelcase
-    const appealIsBlueWater = decisionIssues.filter((decision) => decision.decisionSpecialIssue?.blue_water);
-    // eslint-disable-next-line camelcase
-    const appealIsBurnPit = decisionIssues.filter((decision) => decision.decisionSpecialIssue?.burn_pit);
-    let blueWater = '';
-    let burnPit = '';
+    const appealIsBlueWater = decisionIssues.filter(
+      // eslint-disable-next-line camelcase, no-unneeded-ternary
+      (decision) => decision.decisionSpecialIssue?.blue_water)[0]?.decisionSpecialIssue.blue_water ? true : false;
 
-    if (appealIsBlueWater[0]?.decisionSpecialIssue) {
-      blueWater = Object.keys(appealIsBlueWater[0]?.decisionSpecialIssue)[0];
-    }
-
-    if (appealIsBurnPit[0]?.decisionSpecialIssue) {
-      burnPit = Object.keys(appealIsBurnPit[0]?.decisionSpecialIssue)[0];
-    }
+    const appealIsBurnPit = decisionIssues.filter(
+      // eslint-disable-next-line camelcase, no-unneeded-ternary
+      (decision) => decision.decisionSpecialIssue?.burn_pit)[0]?.decisionSpecialIssue.burn_pit ? true : false;
 
     this.props.editStagedAppeal(
       this.props.appeal.externalId, {
         specialIssues: {
           ...this.state.specialIssues,
-          [blueWater]: appealIsBlueWater[0]?.decisionSpecialIssue[blueWater],
-          [burnPit]: appealIsBurnPit[0]?.decisionSpecialIssue[burnPit]
+          blue_water: appealIsBlueWater,
+          burn_pit: appealIsBurnPit
         }
       }
     );

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -199,7 +199,7 @@ class SelectDispositionsView extends React.PureComponent {
       openRequestIssueId: requestIssueId,
       decisionIssue: decisionIssue || newDecisionIssue,
       editingExistingIssue: Boolean(decisionIssue),
-      deleteAddedDecisionIssue: null,
+      deleteAddedDecisionIssue: null
     });
   }
 
@@ -210,7 +210,7 @@ class SelectDispositionsView extends React.PureComponent {
       editingExistingIssue: false,
       highlightModal: false,
       deleteAddedDecisionIssue: null,
-      requestIdToDelete: null,
+      requestIdToDelete: null
     });
   }
 

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -257,12 +257,16 @@ class SelectDispositionsView extends React.PureComponent {
   }
 
   onCheckboxChange = (event, decision) => {
-    this.setState({
-      decisionIssue: {
-        ...decision,
-        [event.target.getAttribute('id')]: event.target.checked,
-      }
-    });
+    const checkboxId = event.target.getAttribute('id');
+
+    if (checkboxId === 'mstStatus' || checkboxId === 'pactStatus') {
+      this.setState({
+        decisionIssue: {
+          ...decision,
+          [checkboxId]: event.target.checked,
+        }
+      });
+    }
   };
 
   render = () => {
@@ -407,7 +411,7 @@ class SelectDispositionsView extends React.PureComponent {
           })}
         />
         <CheckboxGroup
-          name="Select any special issues that apply"
+          name={COPY.INTAKE_EDIT_ISSUE_SELECT_SPECIAL_ISSUES}
           options={DECISION_SPECIAL_ISSUES}
           styling={specialIssuesCheckboxStyling}
           onChange={(event) => this.onCheckboxChange(event, decisionIssue)}

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -23,13 +23,15 @@ import {
 import { hideSuccessMessage } from './uiReducer/uiActions';
 import {
   VACOLS_DISPOSITIONS,
-  ISSUE_DISPOSITIONS
+  ISSUE_DISPOSITIONS,
+  DECISION_SPECIAL_ISSUES,
 } from './constants';
 
 import BENEFIT_TYPES from '../../constants/BENEFIT_TYPES';
 import DIAGNOSTIC_CODE_DESCRIPTIONS from '../../constants/DIAGNOSTIC_CODE_DESCRIPTIONS';
 import uuid from 'uuid';
 import QueueFlowPage from './components/QueueFlowPage';
+import CheckboxGroup from '../components/CheckboxGroup';
 
 const connectedIssueDiv = css({
   display: 'flex',
@@ -46,6 +48,18 @@ const exampleDiv = css({
 
 const textAreaStyle = css({
   maxWidth: '100%'
+});
+
+const specialIssuesCheckboxStyling = css({
+  columnCount: '2',
+  marginTop: '2%',
+  maxWidth: '70%',
+  '& legend': {
+    marginBottom: '2%',
+  },
+  '& .checkbox': {
+    marginTop: '0',
+  },
 });
 
 class SelectDispositionsView extends React.PureComponent {
@@ -123,6 +137,8 @@ class SelectDispositionsView extends React.PureComponent {
     const benefitType = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).program;
     const diagnosticCode = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).diagnostic_code;
     const closedStatus = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).closed_status;
+    const mstStatus = false;
+    const pactStatus = false;
 
     const newDecisionIssue = {
       id: `temporary-id-${uuid.v4()}`,
@@ -130,7 +146,9 @@ class SelectDispositionsView extends React.PureComponent {
       disposition: closedStatus,
       benefit_type: benefitType,
       diagnostic_code: diagnosticCode,
-      request_issue_ids: [requestIssueId]
+      request_issue_ids: [requestIssueId],
+      mstCheckboxValue: mstStatus,
+      pactCheckboxValue: pactStatus,
     };
 
     this.setState({
@@ -381,6 +399,13 @@ class SelectDispositionsView extends React.PureComponent {
             }
           })}
         />
+        <CheckboxGroup
+          name="Select any special issues that apply"
+          options={DECISION_SPECIAL_ISSUES}
+          styling={specialIssuesCheckboxStyling}
+          value={DECISION_SPECIAL_ISSUES.forEach((item) => item.id)}
+          // onChange={}
+        />
         <h3>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_DESCRIPTION}</h3>
         <p {...exampleDiv} {...paragraphH3SiblingStyle}>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_EXAMPLE}</p>
         <h3>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_TITLE}</h3>
@@ -458,3 +483,4 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 }, dispatch);
 
 export default connect(mapStateToProps, mapDispatchToProps)(SelectDispositionsView);
+

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -137,8 +137,6 @@ class SelectDispositionsView extends React.PureComponent {
     const benefitType = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).program;
     const diagnosticCode = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).diagnostic_code;
     const closedStatus = _.find(this.props.appeal.issues, (issue) => requestIssueId === issue.id).closed_status;
-    const mstStatus = false;
-    const pactStatus = false;
 
     const newDecisionIssue = {
       id: `temporary-id-${uuid.v4()}`,
@@ -147,8 +145,8 @@ class SelectDispositionsView extends React.PureComponent {
       benefit_type: benefitType,
       diagnostic_code: diagnosticCode,
       request_issue_ids: [requestIssueId],
-      mstCheckboxValue: mstStatus,
-      pactCheckboxValue: pactStatus,
+      mstStatus: false,
+      pactStatus: false,
     };
 
     this.setState({
@@ -257,6 +255,15 @@ class SelectDispositionsView extends React.PureComponent {
       return issue.id !== idToFilter;
     });
   }
+
+  onCheckboxChange = (event, decision) => {
+    this.setState({
+      decisionIssue: {
+        ...decision,
+        [event.target.getAttribute('id')]: event.target.checked,
+      }
+    });
+  };
 
   render = () => {
     const { appeal, highlight, ...otherProps } = this.props;
@@ -403,8 +410,7 @@ class SelectDispositionsView extends React.PureComponent {
           name="Select any special issues that apply"
           options={DECISION_SPECIAL_ISSUES}
           styling={specialIssuesCheckboxStyling}
-          value={DECISION_SPECIAL_ISSUES.forEach((item) => item.id)}
-          // onChange={}
+          onChange={(event) => this.onCheckboxChange(event, decisionIssue)}
         />
         <h3>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_DESCRIPTION}</h3>
         <p {...exampleDiv} {...paragraphH3SiblingStyle}>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_EXAMPLE}</p>

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -334,7 +334,7 @@ class SelectDispositionsView extends React.PureComponent {
       openRequestIssueId,
       editingExistingIssue,
       deleteAddedDecisionIssue,
-      requestIdToDelete,
+      requestIdToDelete
     } = this.state;
     const connectedRequestIssues = appeal.issues.filter((issue) => {
       return decisionIssue && decisionIssue.request_issue_ids.includes(issue.id);

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -76,7 +76,6 @@ class SelectDispositionsView extends React.PureComponent {
       specialIssues: null,
     };
   }
-
   decisionReviewCheckoutFlow = () => this.props.checkoutFlow === 'dispatch_decision';
 
   componentDidMount = () => {
@@ -155,15 +154,23 @@ class SelectDispositionsView extends React.PureComponent {
       benefit_type: benefitType,
       diagnostic_code: diagnosticCode,
       request_issue_ids: [requestIssueId],
-      mstStatus: false,
-      pactStatus: false,
+      mstStatus: decisionIssue?.mstStatus ? decisionIssue.mstStatus : false,
+      pactStatus: decisionIssue?.pactStatus ? decisionIssue.pactStatus : false,
+
+      /*
+        Since AMA appeals no longer utilizes SelectSpecialIssuesView.jsx
+        but are still tracked on the appeal level, this will be used
+        to temporarily track burn pit and blue water on issue level since
+        there are multiple decision issues.
+      */
+      issueSpecialIssues: null,
     };
 
     this.setState({
       openRequestIssueId: requestIssueId,
       decisionIssue: decisionIssue || newDecisionIssue,
       editingExistingIssue: Boolean(decisionIssue),
-      deleteAddedDecisionIssue: null
+      deleteAddedDecisionIssue: null,
     });
   }
 
@@ -174,7 +181,7 @@ class SelectDispositionsView extends React.PureComponent {
       editingExistingIssue: false,
       highlightModal: false,
       deleteAddedDecisionIssue: null,
-      requestIdToDelete: null
+      requestIdToDelete: null,
     });
   }
 
@@ -274,31 +281,25 @@ class SelectDispositionsView extends React.PureComponent {
     });
   }
 
-  convertToSnakeCase = (str) => {
-    return str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);
-  }
-
   onCheckboxChange = (event, decision, spIssues) => {
-    let checkboxId = event.target.getAttribute('id');
+    const checkboxId = event.target.getAttribute('id');
 
-    if (checkboxId === 'mstStatus' || checkboxId === 'pactStatus') {
+    // if (checkboxId === 'mstStatus' || checkboxId === 'pactStatus') {
       this.setState({
         decisionIssue: {
           ...decision,
           [checkboxId]: event.target.checked,
         }
       });
-    }
-    if (checkboxId === 'blueWater' || checkboxId === 'burnPit') {
-      checkboxId = this.convertToSnakeCase(checkboxId);
-
-      this.setState({
-        specialIssues: {
-          ...spIssues,
-          [checkboxId]: event.target.checked,
-        }
-      });
-    }
+    // }
+    // if (checkboxId === 'blue_water' || checkboxId === 'burn_pit') {
+    //   this.setState({
+    //     specialIssues: {
+    //       ...spIssues,
+    //       [checkboxId]: event.target.checked,
+    //     }
+    //   });
+    // }
   };
 
   render = () => {
@@ -317,6 +318,15 @@ class SelectDispositionsView extends React.PureComponent {
     });
     const connectedIssues = this.connectedRequestIssuesWithoutCurrentId(connectedRequestIssues, requestIdToDelete);
     const toDeleteHasConnectedIssue = connectedIssues.length > 0;
+
+    const specialIssuesValues = {
+      // eslint-disable-next-line camelcase
+      blue_water: decisionIssue?.blue_water,
+      // eslint-disable-next-line camelcase
+      burn_pit: decisionIssue?.burn_pit,
+      mstStatus: decisionIssue?.mstStatus,
+      pactStatus: decisionIssue?.pactStatus
+    };
 
     // In order to determine whether or not to display error styling and an error message for each issue,
     // determine if highlight is set to true and if there is not a decision issue
@@ -446,6 +456,7 @@ class SelectDispositionsView extends React.PureComponent {
         <CheckboxGroup
           name={COPY.INTAKE_EDIT_ISSUE_SELECT_SPECIAL_ISSUES}
           options={DECISION_SPECIAL_ISSUES}
+          values={specialIssuesValues}
           styling={specialIssuesCheckboxStyling}
           onChange={(event) => this.onCheckboxChange(event, decisionIssue, specialIssues)}
         />

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -184,3 +184,23 @@ export const PAGE_TITLES = {
 export const CUSTOM_HOLD_DURATION_TEXT = 'Custom';
 export const COLOCATED_HOLD_DURATIONS = [15, 30, 45, 60, 90, 120, CUSTOM_HOLD_DURATION_TEXT];
 export const VHA_HOLD_DURATIONS = [15, 30, CUSTOM_HOLD_DURATION_TEXT];
+
+export const DECISION_SPECIAL_ISSUES = [
+  {
+    id: '1',
+    label: 'Blue Water',
+  },
+  {
+    id: '2',
+    label: 'Burn Put',
+  },
+  {
+    id: '3',
+    label: 'Military Sexual Trauma',
+  },
+  {
+    id: '4',
+    label: 'PACT Act',
+  },
+]
+

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -187,20 +187,20 @@ export const VHA_HOLD_DURATIONS = [15, 30, CUSTOM_HOLD_DURATION_TEXT];
 
 export const DECISION_SPECIAL_ISSUES = [
   {
-    id: '1',
+    id: 'blueWater',
     label: 'Blue Water',
   },
   {
-    id: '2',
-    label: 'Burn Put',
+    id: 'burnPit',
+    label: 'Burn Pit',
   },
   {
-    id: '3',
-    label: 'Military Sexual Trauma',
+    id: 'mstStatus',
+    label: 'Military Sexual Trauma (MST)',
   },
   {
-    id: '4',
+    id: 'pactStatus',
     label: 'PACT Act',
   },
-]
+];
 

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -187,11 +187,11 @@ export const VHA_HOLD_DURATIONS = [15, 30, CUSTOM_HOLD_DURATION_TEXT];
 
 export const DECISION_SPECIAL_ISSUES = [
   {
-    id: 'blueWater',
+    id: 'blue_water',
     label: 'Blue Water',
   },
   {
-    id: 'burnPit',
+    id: 'burn_pit',
     label: 'Burn Pit',
   },
   {
@@ -203,4 +203,3 @@ export const DECISION_SPECIAL_ISSUES = [
     label: 'PACT Act',
   },
 ];
-

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -78,7 +78,6 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       expect(page.find("label[for=no_special_issues]")).to have_content("No Special Issues")
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
-      expect(page).to have_content("Military Sexual Trauma (MST)")
       find("label", text: "Blue Water").click
       click_on "Continue"
 
@@ -96,6 +95,10 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       # Add a first decision issue
       all("button", text: "+ Add decision", count: 2)[0].click
       expect(page).to have_content COPY::DECISION_ISSUE_MODAL_TITLE
+      expect(page).to have_content "Blue Water"
+      expect(page).to have_content "Burn Pit"
+      expect(page).to have_content "Military Sexual Trauma (MST)"
+      expect(page).to have_content "PACT Act"
 
       click_on "Save"
 
@@ -267,7 +270,6 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
       expect(page.find("label[for=no_special_issues]")).to have_content("No Special Issues")
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
-      expect(page).to have_content("Military Sexual Trauma (MST)")
       find("label", text: "Burn Pit").click
       click_on "Continue"
 

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -146,7 +146,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       # Special Issues screen
       find("label", text: "No Special Issues").click
       click_on "Continue"
-      # sleep(30)
+
       all("button", text: "+ Add decision")[0].click
       expect(page).to have_content "Blue Water"
       expect(page).to have_content "Burn Pit"

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -146,6 +146,13 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       # Special Issues screen
       find("label", text: "No Special Issues").click
       click_on "Continue"
+      # sleep(30)
+      all("button", text: "+ Add decision")[0].click
+      expect(page).to have_content "Blue Water"
+      expect(page).to have_content "Burn Pit"
+      expect(page).to have_content "Military Sexual Trauma (MST)"
+      expect(page).to have_content "PACT Act"
+      click_on "Close"
 
       # Decision Issues Screen
       click_on "Continue"

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -198,7 +198,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
 
       expect(page).to have_content("Blue Water")
       expect(page).to have_content("Burn Pit")
-      expect(page).to have_content("Military Sexual Trauma (MST)")
+
       find("label", text: "Blue Water").click
       expect(page.find("#blue_water", visible: false).checked?).to eq true
       find("label", text: "No Special Issues").click


### PR DESCRIPTION
Resolves [17546](https://vajira.max.gov/browse/APPEALS-17546?workflowName=VA+Caseflow+Sandbox+Story+Enabler+Workflow&stepId=20)

### Description
Added MST, PACT, Blue Water, and Burn Pit Checkboxes to the Add Decision modal for the decision review process.

MST and PACT Act will now be tracked on the issue level while Blue Water and Burn Pit will not. In [17497](https://vajira.max.gov/browse/APPEALS-17497), the Special Issues page will no longer be utilized by AMA appeals during the decision review process. Since Blue Water and Burn Pit were previously tracked here and will still be tracked on the appeal level, we will temporarily track Blue Water and Burn Pit on the issue level. After submitting the decision for review, if at least one issue contains Blue Water or Burn Pit, it will be applied to the appeal in whole.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] As a user Adding a Decision to an AMA appeal, I have the option to mark an issue as PACT Act  using the PACT Act checkbox in the "Select any special issues that apply" section of the Add Decision modal.
- [x] As a user Adding a Decision to an AMA appeal, I have the option to mark an issue as MST using the MST checkbox in the "Select any special issues that apply" section of the Add Decision modal.
- [x] Blue Water and Burn Pit statuses are saved within the Special Issues List model for the appeal. 
- [x] SPEC test written
- [ ] SPEC test validated

### Testing Plan
1. Login as an attorney or judge (BVASCASPER or BVAAABSHIRE)
2. Click on "Your Queue"
3. Click on an AMA appeal with at least one issue.
4. Under the Actions dropdown, click on "Decision ready for review" or "Ready for Dispatch"
5. Press "+ Add Decision"
6. Observe that there are four new checkboxes under the Benefit Type Dropdown
**Validating states of checkboxes in redux**
8. Check on all four checkboxes
<img width="1914" alt="Screenshot 2023-04-28 at 1 08 39 PM" src="https://user-images.githubusercontent.com/111081469/235222593-9a1cdb51-92ba-4880-9607-d46ac9290e2c.png">

9. Press "Save"
10. Check redux state for MST & PACT:  queue -> stagedChanges -> appeals -> _appealId_ -> decisionIssues
<img width="961" alt="Screenshot 2023-04-28 at 1 11 13 PM" src="https://user-images.githubusercontent.com/111081469/235222756-c7574c24-8b6d-452b-91fe-7714b0d4607a.png">
<img width="1919" alt="Screenshot 2023-04-28 at 1 11 28 PM" src="https://user-images.githubusercontent.com/111081469/235223913-00b49181-0339-48d2-b2f4-c806f4beea13.png">

11. Click on "Continue"
12. Check redux state for Blue Water and Burn Pit: queue -> stagedChanges -> appeals -> _appealId_ -> specialIssues
<img width="1651" alt="Screenshot 2023-04-28 at 1 48 41 PM" src="https://user-images.githubusercontent.com/111081469/235229259-efb97723-3304-4a64-acd8-8dea2ad2056c.png">


### User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
---|---
<img width="534" alt="Screenshot 2023-04-26 at 3 41 08 PM" src="https://user-images.githubusercontent.com/111081469/234697339-fbc812c7-b002-48ea-b984-f57cfb18d7d6.png">|<img width="537" alt="Screenshot 2023-04-26 at 3 40 51 PM" src="https://user-images.githubusercontent.com/111081469/234697351-b2ba1fe6-c56f-42db-872e-8b68bb6c9264.png">

