### PR TITLE
Cancel Tasks and Reassign” button functionality

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -746,6 +746,12 @@
   "REASSIGN_TASK_SUCCESS_MESSAGE": "Task reassigned to %s",
   "HEARING_ASSIGN_TASK_SUCCESS_MESSAGE_DETAIL": "You can continue to assign tasks to yourself and others using this queue.",
 
+  "ASSIGN_TASK_SUCCESS_MESSAGE_MOVE_LEGACY_APPEALS_VLJ": "You have successfully reassigned %s’s case to %s",
+  "ASSIGN_TASK_SUCCESS_MESSAGE_MOVE_LEGACY_APPEALS_VLJ_MESSAGE_DETAIL": " All blocking task have been cancelled.",
+  "LEGACY_APPEALS_VLJ_REASON_INTRUCTIONS" : "Reason:",
+  "LEGACY_APPEALS_VLJ_NEW_JUDGE_INTRUCTIONS" : "New Judge:",
+  "LEGACY_APPEALS_VLJ_DETAILS_INTRUCTIONS" : "Details:",
+
   "CREATE_MAIL_TASK_TITLE": "Create new mail task",
   "MAIL_TASK_DROPDOWN_TYPE_SELECTOR_LABEL": "Select correspondence type",
   "MAIL_TASK_CREATION_SUCCESS_MESSAGE": "Created %s task",

--- a/client/app/queue/BlockedAdvanceToJudgeLegacyView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeLegacyView.jsx
@@ -61,7 +61,7 @@ class BlockedAdvanceToJudgeLegacyView extends React.Component {
 
   validAssignee = () => this.state.selectedAssignee !== null;
   validInstructions = () => this.state.instructions.length > 0;
-  validCancellationInstructions = () => this.state.cancellationInstructions.length > 0;
+  validCancellationInstructions = () => this.state.cancellationInstructions.trim().length > 0;
   validReason = () => this.state.selectedReason !== null;
 
   validatePage = () => this.validCancellationInstructions() && this.validReason();
@@ -83,12 +83,18 @@ class BlockedAdvanceToJudgeLegacyView extends React.Component {
     return assignee;
   };
 
+  rowValue = (currentValue) => {
+    return currentValue ? (
+      <b>{COPY.TASK_SNAPSHOT_TASK_ASSIGNOR_LABEL}</b>
+    ) : null;
+  };
+
   setOnChangeValue = (stateValue, value) => {
     this.setState({ [stateValue]: value }, function () {
-      if ((this.state.selectedReason !== null && this.state.cancellationInstructions !== '')) {
+      if ((this.state.selectedReason !== null && this.state.cancellationInstructions.trim().length > 0)) {
         this.setState({ disableButton: false });
       }
-      if ((this.state.cancellationInstructions === '' && this.state.selectedReason !== null)) {
+      if ((this.state.cancellationInstructions.trim().length === 0 && this.state.selectedReason !== null)) {
         this.setState({ disableButton: true });
       }
     });
@@ -96,7 +102,7 @@ class BlockedAdvanceToJudgeLegacyView extends React.Component {
 
   setModalOnChangeValue = (stateValue, value) => {
     this.setState({ [stateValue]: value }, function () {
-      if (this.state.selectedAssignee !== null && this.state.instructions !== '') {
+      if (this.state.selectedAssignee !== null && this.state.instructions.trim().length > 0) {
         this.setState({ modalDisableButton: false });
       } else {
         this.setState({ modalDisableButton: true });
@@ -123,17 +129,28 @@ class BlockedAdvanceToJudgeLegacyView extends React.Component {
             assigned_to_id: this.state.selectedAssignee,
             assigned_to_type: 'User',
             instructions: [
-              `${this.state.selectedReason}: ${this.state.cancellationInstructions}`,
-              this.state.instructions
+              `${this.state.selectedReason.trim()}: ${this.state.cancellationInstructions.trim()}`,
+              `${task.taskId}`,
+              `${this.state.instructions}`
             ]
           }
         ]
       }
     };
 
+    const assignedByListItem = () => {
+      const assignor = task.assignedBy.firstName ?
+        this.getAbbrevName(task.assignedBy) :
+        null;
+
+      return assignor;
+    };
+
     const successMessage = {
-      title: sprintf(COPY.ASSIGN_TASK_SUCCESS_MESSAGE, this.getAssigneeLabel()),
-      detail: this.actionData().message_detail
+      title: sprintf(COPY.ASSIGN_TASK_SUCCESS_MESSAGE_MOVE_LEGACY_APPEALS_VLJ,
+        assignedByListItem(),
+        this.getAssigneeLabel()),
+      detail: sprintf(COPY.ASSIGN_TASK_SUCCESS_MESSAGE_MOVE_LEGACY_APPEALS_VLJ_MESSAGE_DETAIL)
     };
 
     return this.props.
@@ -292,7 +309,8 @@ BlockedAdvanceToJudgeLegacyView.propTypes = {
   resetSuccessMessages: PropTypes.func,
   task: PropTypes.shape({
     instructions: PropTypes.string,
-    taskId: PropTypes.string
+    taskId: PropTypes.string,
+    assignedBy: PropTypes.string
   })
 };
 

--- a/client/app/queue/BlockedAdvanceToJudgeLegacyView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeLegacyView.jsx
@@ -83,12 +83,6 @@ class BlockedAdvanceToJudgeLegacyView extends React.Component {
     return assignee;
   };
 
-  rowValue = (currentValue) => {
-    return currentValue ? (
-      <b>{COPY.TASK_SNAPSHOT_TASK_ASSIGNOR_LABEL}</b>
-    ) : null;
-  };
-
   setOnChangeValue = (stateValue, value) => {
     this.setState({ [stateValue]: value }, function () {
       if ((this.state.selectedReason !== null && this.state.cancellationInstructions.trim().length > 0)) {

--- a/client/app/queue/CaseDetailsView.jsx
+++ b/client/app/queue/CaseDetailsView.jsx
@@ -325,6 +325,7 @@ export const CaseDetailsView = (props) => {
         <TaskSnapshot
           appealId={appealId}
           showPulacCerulloAlert={doPulacCerulloReminder}
+          VLJ_featureToggles = {props.featureToggles.vlj_legacy_appeal}
         />
         <hr {...horizontalRuleStyling} />
         <StickyNavContentArea>
@@ -416,6 +417,7 @@ export const CaseDetailsView = (props) => {
           )}
 
           <CaseTimeline title="Case Timeline" appeal={appeal}
+            VLJ_featureToggles = {props.featureToggles.vlj_legacy_appeal}
             additionalHeaderContent={
               true && (
                 <span className="cf-push-right" {...anchorEditLinkStyling}>

--- a/client/app/queue/CaseTimeline.jsx
+++ b/client/app/queue/CaseTimeline.jsx
@@ -20,6 +20,7 @@ export const CaseTimeline = ({ appeal }) => {
             editNodDateEnabled={!appeal.isLegacyAppeal && canEditNodDate}
             timeline
             statusSplit
+            VLJ_featureToggles
           />
         </tbody>
       </table>
@@ -29,5 +30,6 @@ export const CaseTimeline = ({ appeal }) => {
 
 CaseTimeline.propTypes = {
   appeal: PropTypes.object,
-  statusSplit: PropTypes.bool
+  statusSplit: PropTypes.bool,
+  VLJ_featureToggles: PropTypes.string,
 };

--- a/client/app/queue/TaskSnapshot.jsx
+++ b/client/app/queue/TaskSnapshot.jsx
@@ -32,6 +32,7 @@ export const TaskSnapshot = ({ appeal, hideDropdown, tasks, showPulacCerulloAler
           timeline={false}
           editNodDateEnabled={!appeal.isLegacyAppeal && canEditNodDate}
           hideDropdown={hideDropdown}
+          VLJ_featureToggles
         />
       </tbody>
     </table>
@@ -73,7 +74,8 @@ TaskSnapshot.propTypes = {
   tasks: PropTypes.array,
   appeal: PropTypes.object,
   hideDropdown: PropTypes.bool,
-  showPulacCerulloAlert: PropTypes.bool
+  showPulacCerulloAlert: PropTypes.bool,
+  VLJ_featureToggles: PropTypes.string,
 };
 
 const mapStateToProps = (state, ownProps) => {

--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -306,7 +306,47 @@ class TaskRows extends React.PureComponent {
 
     // We specify the same 2.4rem margin-bottom as paragraphs to each set of instructions
     // to ensure a consistent margin between instruction content and the "Hide" button
-    const divStyles = { marginBottom: '2.4rem' };
+    const divStyles = { marginTop: '2rem' };
+
+    if (task.appealType === 'LegacyAppeal' && this.props.VLJ_featureToggles) {
+      const values = [`${COPY.LEGACY_APPEALS_VLJ_REASON_INTRUCTIONS}`,
+       `${COPY.LEGACY_APPEALS_VLJ_NEW_JUDGE_INTRUCTIONS}`,
+       `${COPY.LEGACY_APPEALS_VLJ_DETAILS_INTRUCTIONS}`];
+
+      return (
+        <React.Fragment key={`${task.uniqueId} fragment`}>
+          {task.instructions.map((text, index) => {
+            if (index === 1) {
+              return (
+                <React.Fragment key={`${task.uniqueId} div`}>
+                  <div
+                    key={`${task.uniqueId} instructions`}
+                    style={divStyles}
+                    className="task-instructions"
+                  >
+                    <b>{values[index]}</b>
+                    <ReactMarkdown className="markdownVJL">{task.assigneeName}</ReactMarkdown>
+                  </div>
+                </React.Fragment>
+              );
+            }
+
+            return (
+              <React.Fragment key={`${task.uniqueId} div`}>
+                <div
+                  key={`${task.uniqueId} instructions`}
+                  style={divStyles}
+                  className="task-instructions"
+                >
+                  <b>{values[index]}</b>
+                  <ReactMarkdown className="markdownVJL">{formatBreaks(text)}</ReactMarkdown>
+                </div>
+              </React.Fragment>
+            );
+          })}
+        </React.Fragment>
+      );
+    }
 
     return (
       <React.Fragment key={`${task.uniqueId} fragment`}>
@@ -344,7 +384,7 @@ class TaskRows extends React.PureComponent {
         )}
         <Button
           linkStyling
-          styling={css({ padding: '0' })}
+          styling={css({ padding: '0', marginTop: '0rem', outline: 'none' })}
           id={task.uniqueId}
           name={
             this.state.taskInstructionsIsVisible[task.uniqueId] ?
@@ -468,7 +508,7 @@ class TaskRows extends React.PureComponent {
         >
           <CaseDetailsDescriptionList>
             {timeline && timelineTitle}
-            {this.showTimelineDescriptionItems(task, timeline)}
+            {this.showTimelineDescriptionItems(task, timeline, appeal)}
           </CaseDetailsDescriptionList>
 
         </td>
@@ -617,6 +657,7 @@ TaskRows.propTypes = {
   hideDropdown: PropTypes.bool,
   taskList: PropTypes.array,
   timeline: PropTypes.bool,
+  VLJ_featureToggles: PropTypes.string,
 };
 
 export default TaskRows;

--- a/client/app/styles/queue/_timeline.scss
+++ b/client/app/styles/queue/_timeline.scss
@@ -82,3 +82,12 @@
 .greyDotStyling {
   padding-left: 6px;
 }
+
+.markdownVJL {
+  p {
+    margin: 0px;
+    &:last-of-type{
+      margin-bottom: 1rem;
+    }
+  }
+}


### PR DESCRIPTION
Resolves [APPEALS-21082](https://vajira.max.gov/browse/APPEALS-21082)

### Description

 As a developer, I need to create a “Cancel Tasks and Reassign” button on the Confirm Cancellation modal so that the user can select their desired functionality. 

### Acceptance Criteria:

- [ ] Code compiles correctly

1- The "Cancel Task and Reassign" button remains disabled until all required fields are completed

##### The following occurs when "Case movement: Cancel Blocking Tasks and Advance to judge" task is completed:

- [ ] User is redirected to the "Case Details" page and A success banner appears

###### New Task is found in the "Currently active tasks" section 
- Assigned To: <VLJ>
- Assigned By: <Board user>
- Task:
- Task Instructions:
- Reason:
- New Judge:
- Details:

### Testing Plan

1. Go to Caseflow login and sign in as `BVARDUNKLE`
2. Navigate `https://voyager.caseflowdemo.com/queue/appeals/` and any legacy appeal in my case `http://127.0.0.1:3000/queue/appeals/239870265`

![Capture3](https://user-images.githubusercontent.com/110848569/234765538-02f6501a-b53c-4906-8827-988cb8b4179a.PNG)

3. Open the dropdown and select `Case Movement: Cancel blocking task and advance to judge `
4. Complete the form and click on `Continue`

![Capture4](https://user-images.githubusercontent.com/110848569/234766123-9812ec1d-336e-4ec8-a8e2-9c66ffb1a3f0.PNG)

5. When clicking on `Continue` a new modal is open, in this case, need to select a new attorney, and provide some instructions, then the `Cancel Task and Reassign` bottom display enable

![Capture6](https://user-images.githubusercontent.com/110848569/234766937-4d4952bb-83ba-467f-9c59-bd53e02542e3.PNG)

![Capture5](https://user-images.githubusercontent.com/110848569/234766954-dcb0fc81-ebbf-44e4-b17b-6a400bb707a6.PNG)

6. When clicking on `Cancel Task and Reassign` if everything is fine, you see the Detail page with the new changes and a green banner shows up.

![Capture7](https://user-images.githubusercontent.com/110848569/234767655-00418b8c-b458-402a-bfa9-8bf98b1a293e.PNG)

![Capture8](https://user-images.githubusercontent.com/110848569/234767835-c3cb3e45-b144-4ebf-97c1-65c21d3a62da.PNG)

