### PR TITLE
HunJerBAH/APPEALS-17509 addition

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -60,6 +60,7 @@ class SeedDB
     # Always run this as last one
     call_and_log_seed_step Seeds::StaticTestCaseData
     call_and_log_seed_step Seeds::StaticDispatchedAppealsTestData
+    call_and_log_seed_step Seeds::BGSServiceRecordMaker
   end
 end
 

--- a/db/seeds/bgs_service_record_maker.rb
+++ b/db/seeds/bgs_service_record_maker.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Seeds
+  class BGSServiceRecordMaker < Base
+    def seed!
+      # run the BGSServiceMaker file located in lib/fakes
+      # seed data comes from a CSV file called 'bgs_setup.csv' located at local/vacols/bgs_setup.csv
+      Fakes::BGSServiceRecordMaker.new.call
+    end
+  end
+end


### PR DESCRIPTION
Relates to [APPEALS-17509 GitHub release](https://github.com/department-of-veterans-affairs/caseflow/pull/18457)

### Description
Added BGS record generator to the seed script in Demo so that we could have test cases with MST and PACT contentions.

### Acceptance Criteria
- [ ] Code compiles correctly
- [ ] HLRs for these veterans show up on the Past Issues modal when intaking an appeal with the veteran file number
992190636
107924012
329146737
981775045
738464961
245620198
955197769
473949326
933747849
696650437
598042239
787148925
657332982
416322111
968514949
779309925
169397130
276880282
138034137
192920593
190595135
- [ ] These HLRs with have issues with contentions: 1 MST contention and 1 Pact contention 


### Testing Plan
1. Go to Intake as a BVA intake user (BVADWISE).
2. Select Decision Review from the dropdown.
3. Enter a veteran file number from the list above into the search bar.
4. Fill out the form.
5. Click the **add Issues** button.
6. Past issues will show up on the screen
![image](https://user-images.githubusercontent.com/99915461/235150378-f3b5e191-3d87-4f0f-8c48-1288709c5a2a.png)
