### PR TITLE
APPEALS-17528 Create MST and PACT status method on Appeal model (AC 2-3/ AC 9.2.1)

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -254,6 +254,19 @@ class Appeal < DecisionReview
     end
   end
 
+  def mst?
+    return false unless FeatureToggle.enabled?(:mst_pact_identification)
+
+    request_issues.active.any?(&:mst_status) ||
+      (special_issue_list && special_issue_list.created_at < "2023-06-01".to_date && special_issue_list.military_sexual_trauma)
+  end
+
+  def pact?
+    return false unless FeatureToggle.enabled?(:mst_pact_identification)
+
+    request_issues.active.any?(&:pact_status)
+  end
+
   # Returns the most directly responsible party for an appeal when it is at the Board,
   # mirroring Legacy Appeals' location code in VACOLS
   def assigned_to_location

--- a/spec/factories/special_issue_list.rb
+++ b/spec/factories/special_issue_list.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :special_issue_list do
+    military_sexual_trauma { true }
+    appeal_type { "Appeal" }
+  end
+end

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -1265,6 +1265,101 @@ describe Appeal, :all_dbs do
     end
   end
 
+  describe "#mst?" do
+    subject { appeal.mst? }
+
+    before { FeatureToggle.enable!(:mst_pact_identification) }
+    after { FeatureToggle.disable!(:mst_pact_identification) }
+
+    let(:request_issues) do
+      [
+        create(:request_issue, mst_status: mst_status)
+      ]
+    end
+
+    context "when request issues with mst_status are associated with appeal" do
+      let(:appeal) { create(:appeal, request_issues: request_issues) }
+
+      context "when mst_status is enabled" do
+        let(:mst_status) { true }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context "when mst_status is disabled" do
+        let(:mst_status) { false }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+
+    context "when request issues with mst_status are not associated with appeal and has special_issue_list" do
+      let!(:appeal) { create(:appeal) }
+
+      before do
+        Timecop.freeze(Time.utc(2023, 4, 28, 12, 0, 0))
+        create(:special_issue_list, appeal_id: appeal.id, military_sexual_trauma: military_sexual_trauma)
+      end
+
+      after do
+        Timecop.return
+      end
+
+      context "when military_sexual_trauma is enabled" do
+        let(:military_sexual_trauma) { true }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context "when military_sexual_trauma is disabled" do
+        let(:military_sexual_trauma) { false }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+  end
+
+  describe "#pact?" do
+    subject { appeal.pact? }
+
+    before { FeatureToggle.enable!(:mst_pact_identification) }
+    after { FeatureToggle.disable!(:mst_pact_identification) }
+
+    let(:request_issues) do
+      [
+        create(:request_issue, pact_status: pact_status)
+      ]
+    end
+
+    context "when request issues with pact_status are associated with appeal" do
+      let(:appeal) { create(:appeal, request_issues: request_issues) }
+
+      context "when pact_status is enabled" do
+        let(:pact_status) { true }
+
+        it "returns true" do
+          expect(subject).to be_truthy
+        end
+      end
+
+      context "when pact_status is disabled" do
+        let(:pact_status) { false }
+
+        it "returns false" do
+          expect(subject).to be_falsey
+        end
+      end
+    end
+  end
+
   describe "#vacate_type" do
     subject { appeal.vacate_type }
 


### PR DESCRIPTION
Resolves [APPEALS-17528](https://vajira.max.gov/browse/APPEALS-17528)

# Description
As a Caseflow developer, I need to create the MST and PACT status method on the Appeal model to get the MST and PACT statuses from request issues on an appeal as well as account for existing MST and PACT statuses on older appeals currently on the special issues list. 

## Acceptance Criteria
- [x]  AC 1. MST and PACT status methods on appeal model created for request issues.
- [x]  AC 2. MST and PACT status from the special issues list converted and available for existing issues.
- [x]  AC 3. SPEC test performed/passed for MST/PACT request issues
- [x]  AC 4. SPEC test performed/passed for MST/PACT special issues list
- [x] Code compiles correctly

## Testing Plan
