### PR TITLE
akonhilas/APPEALS-13396

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -421,9 +421,9 @@
   "MTV_CHECKOUT_RETURN_TO_JUDGE_SUCCESS_DETAILS": "If you made a mistake, please email your judge to resolve the issue.",
 
   "MTV_TASK_INSTRUCTIONS": "**Motion To Vacate:**  \n",
-  "MTV_TASK_INSTRUCTIONS_TYPE": "**Type:**  \n",
-  "MTV_TASK_INSTRUCTIONS_DETAIL": "**Detail:**  \n",
-  "MTV_TASK_INSTRUCTIONS_HYPERLINK": "**Hyperlink:**  \n",
+  "MTV_TASK_INSTRUCTIONS_TYPE": "**Type:**  ",
+  "MTV_TASK_INSTRUCTIONS_DETAIL": "**Detail:**  ",
+  "MTV_TASK_INSTRUCTIONS_HYPERLINK": "**Hyperlink:**  ",
 
   "VACATE_AND_DE_NOVO_TASK_LABEL": "Vacate and De Novo",
   "VACATE_AND_READJUDICATION_TASK_LABEL": "Vacate and Readjudication",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -420,6 +420,11 @@
   "MTV_CHECKOUT_RETURN_TO_JUDGE_SUCCESS_TITLE": "%s's Motion to Vacate has been returned to %s",
   "MTV_CHECKOUT_RETURN_TO_JUDGE_SUCCESS_DETAILS": "If you made a mistake, please email your judge to resolve the issue.",
 
+  "MTV_TASK_INSTRUCTIONS": "**Motion To Vacate:**  \n",
+  "MTV_TASK_INSTRUCTIONS_TYPE": "**Type:**  \n",
+  "MTV_TASK_INSTRUCTIONS_DETAIL": "**Detail:**  \n",
+  "MTV_TASK_INSTRUCTIONS_HYPERLINK": "**Hyperlink:**  \n",
+
   "VACATE_AND_DE_NOVO_TASK_LABEL": "Vacate and De Novo",
   "VACATE_AND_READJUDICATION_TASK_LABEL": "Vacate and Readjudication",
   "STRAIGHT_VACATE_TASK_LABEL": "Straight Vacate",

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -32,6 +32,7 @@ import StringUtil from '../../util/StringUtil';
 import { ReturnToLitSupportAlert } from './ReturnToLitSupportAlert';
 import { grantTypes, dispositionStrings } from './mtvConstants';
 import { sprintf } from 'sprintf-js';
+import { isEmpty } from 'lodash';
 
 const vacateTypeText = (val) => {
   const opt = VACATE_TYPE_OPTIONS.find((i) => i.value === val);
@@ -40,14 +41,14 @@ const vacateTypeText = (val) => {
 };
 
 const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }) => {
-  const parts = [`${MTV_TASK_INSTRUCTIONS} ${DISPOSITION_TEXT[disposition].replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase())}\n`];
+  const parts = [`${MTV_TASK_INSTRUCTIONS}${StringUtil.titleCase(DISPOSITION_TEXT[disposition])}\n`];
 
   switch (disposition) {
   case 'granted':
   case 'partially_granted':
     parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
     parts.push(`${vacateTypeText(vacateType)}\n`);
-    if (instructions !== '') {
+    if (isEmpty(instructions) === false) {
       parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
       parts.push(`${instructions}\n`);
     }
@@ -55,7 +56,7 @@ const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }
   case 'denied':
   case 'dismissed':
   default:
-    if (instructions !== '') {
+    if (isEmpty(instructions) === false) {
       parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
       parts.push(`${instructions}\n`);
     }
@@ -195,7 +196,8 @@ export const MTVJudgeDisposition = ({
 
         <TextareaField
           name="instructions"
-          label={sprintf(JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL, disposition || 'granted')}
+          label={sprintf(JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL,
+            disposition === 'partially_granted' ? 'partially granted' : disposition || 'granted')}
           onChange={(val) => setInstructions(val)}
           value={instructions}
           className={['mtv-decision-instructions']}

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -19,7 +19,7 @@ import {
   MTV_TASK_INSTRUCTIONS_DETAIL,
   MTV_TASK_INSTRUCTIONS_HYPERLINK
 } from '../../../COPY';
-import { DISPOSITION_TEXT, VACATE_TYPE_OPTIONS } from '../../../constants/MOTION_TO_VACATE';
+import { DISPOSITION_TIMELINE_TEXT, VACATE_TYPE_OPTIONS } from '../../../constants/MOTION_TO_VACATE';
 import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS';
 import SearchableDropdown from '../../components/SearchableDropdown';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
@@ -41,7 +41,7 @@ const vacateTypeText = (val) => {
 };
 
 const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }) => {
-  const parts = [`${MTV_TASK_INSTRUCTIONS}${StringUtil.titleCase(DISPOSITION_TEXT[disposition])}\n`];
+  const parts = [`${MTV_TASK_INSTRUCTIONS}${DISPOSITION_TIMELINE_TEXT[disposition]}\n`];
 
   switch (disposition) {
   case 'granted':

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -40,32 +40,28 @@ const vacateTypeText = (val) => {
 };
 
 const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }) => {
-  const parts = [`I am proceeding with a ${DISPOSITION_TEXT[disposition]}.`];
+  const parts = [`${MTV_TASK_INSTRUCTIONS} ${DISPOSITION_TEXT[disposition].replace(/(^\w{1})|(\s+\w{1})/g, (letter) => letter.toUpperCase())}\n`];
 
   switch (disposition) {
   case 'granted':
-    parts.push(`${MTV_TASK_INSTRUCTIONS} + Full Vacatur`);
     parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
-    parts.push(vacateTypeText(vacateType));
+    parts.push(`${vacateTypeText(vacateType)}\n`);
     parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
-    parts.push(instructions);
+    parts.push(`${instructions}\n`);
     break;
   case 'partially_granted':
-    parts.push(`${MTV_TASK_INSTRUCTIONS} + Partial Vacatur`);
     parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
     parts.push(vacateTypeText(vacateType));
     parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
     parts.push(instructions);
     break;
   case 'denied':
-    parts.push(`${MTV_TASK_INSTRUCTIONS} + Deny all issues for vacatur`);
     parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
     parts.push(instructions);
     parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
     parts.push(hyperlink);
     break;
   case 'dismissed':
-    parts.push(`${MTV_TASK_INSTRUCTIONS} + Dismiss all issues for vacatur`);
     parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
     parts.push(instructions);
     parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -44,7 +44,7 @@ const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }
 
   switch (disposition) {
   case 'granted':
-  case 'partially-granted':
+  case 'partially_granted':
     parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
     parts.push(`${vacateTypeText(vacateType)}\n`);
     if (instructions !== '') {

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -13,7 +13,11 @@ import {
   JUDGE_ADDRESS_MTV_VACATE_TYPE_LABEL,
   JUDGE_ADDRESS_MTV_HYPERLINK_LABEL,
   JUDGE_ADDRESS_MTV_DISPOSITION_NOTES_LABEL,
-  JUDGE_ADDRESS_MTV_ASSIGN_ATTORNEY_LABEL
+  JUDGE_ADDRESS_MTV_ASSIGN_ATTORNEY_LABEL,
+  MTV_TASK_INSTRUCTIONS,
+  MTV_TASK_INSTRUCTIONS_TYPE,
+  MTV_TASK_INSTRUCTIONS_DETAIL,
+  MTV_TASK_INSTRUCTIONS_HYPERLINK
 } from '../../../COPY';
 import { DISPOSITION_TEXT, VACATE_TYPE_OPTIONS } from '../../../constants/MOTION_TO_VACATE';
 import { JUDGE_RETURN_TO_LIT_SUPPORT } from '../../../constants/TASK_ACTIONS';
@@ -40,9 +44,32 @@ const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }
 
   switch (disposition) {
   case 'granted':
-  case 'partially_granted':
-    parts.push(`This will be a ${vacateTypeText(vacateType)}`);
+    parts.push(`${MTV_TASK_INSTRUCTIONS} + Full Vacatur`);
+    parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
+    parts.push(vacateTypeText(vacateType));
+    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
     parts.push(instructions);
+    break;
+  case 'partially_granted':
+    parts.push(`${MTV_TASK_INSTRUCTIONS} + Partial Vacatur`);
+    parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
+    parts.push(vacateTypeText(vacateType));
+    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
+    parts.push(instructions);
+    break;
+  case 'denied':
+    parts.push(`${MTV_TASK_INSTRUCTIONS} + Deny all issues for vacatur`);
+    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
+    parts.push(instructions);
+    parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
+    parts.push(hyperlink);
+    break;
+  case 'dismissed':
+    parts.push(`${MTV_TASK_INSTRUCTIONS} + Dismiss all issues for vacatur`);
+    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
+    parts.push(instructions);
+    parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
+    parts.push(hyperlink);
     break;
   default:
     parts.push(instructions);

--- a/client/app/queue/mtv/MTVJudgeDisposition.jsx
+++ b/client/app/queue/mtv/MTVJudgeDisposition.jsx
@@ -44,33 +44,25 @@ const formatInstructions = ({ disposition, vacateType, hyperlink, instructions }
 
   switch (disposition) {
   case 'granted':
+  case 'partially-granted':
     parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
     parts.push(`${vacateTypeText(vacateType)}\n`);
-    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
-    parts.push(`${instructions}\n`);
-    break;
-  case 'partially_granted':
-    parts.push(MTV_TASK_INSTRUCTIONS_TYPE);
-    parts.push(vacateTypeText(vacateType));
-    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
-    parts.push(instructions);
+    if (instructions !== '') {
+      parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
+      parts.push(`${instructions}\n`);
+    }
     break;
   case 'denied':
-    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
-    parts.push(instructions);
-    parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
-    parts.push(hyperlink);
-    break;
   case 'dismissed':
-    parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
-    parts.push(instructions);
-    parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
-    parts.push(hyperlink);
-    break;
   default:
-    parts.push(instructions);
-    parts.push('\nHere is the hyperlink to the signed denial document');
-    parts.push(hyperlink);
+    if (instructions !== '') {
+      parts.push(MTV_TASK_INSTRUCTIONS_DETAIL);
+      parts.push(`${instructions}\n`);
+    }
+    if (hyperlink !== null) {
+      parts.push(MTV_TASK_INSTRUCTIONS_HYPERLINK);
+      parts.push(`${hyperlink}\n`);
+    }
     break;
   }
 

--- a/client/constants/MOTION_TO_VACATE.json
+++ b/client/constants/MOTION_TO_VACATE.json
@@ -39,6 +39,14 @@
     "denied": "denial of all issues for vacatur",
     "dismissed": "dismissal"
   },
+
+  "DISPOSITION_TIMELINE_TEXT": {
+    "granted": "Full vacatur",
+    "partially_granted": "Partial vacatur",
+    "denied": "Deny all issues for vacatur",
+    "dismissed": "Dismiss all issues for vacatur"
+  },
+
   "DISPOSITION_RECOMMENDATIONS": {
     "granted": "I recommend granting a vacatur.",
     "partially_granted": "I recommend granting a partial vacatur.",

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -31,7 +31,27 @@ const enterAdditionalContext = (text, selectedField) => {
   userEvent.type(textField, text);
 };
 
-const selectDisposition = async (disposition, vacateType, vacateIssues, hyperlink, instructions) => {
+const selectDisposition = async (disposition = 'grant all') => {
+  userEvent.click(
+    screen.getByLabelText(new RegExp(disposition, 'i'))
+  );
+
+  if ((/grant/i).test(disposition)) {
+    await waitFor(() => {
+      expect(
+        screen.getByText(/what type of vacate/i)
+      ).toBeInTheDocument();
+    });
+  } else {
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/insert caseflow reader document hyperlink/i)
+      ).toBeInTheDocument();
+    });
+  }
+};
+
+const fillForm = async (disposition, vacateType, vacateIssues, hyperlink, instructions) => {
   userEvent.click(
     screen.getByLabelText(new RegExp(disposition, 'i'))
   );
@@ -140,7 +160,7 @@ describe('MTVJudgeDisposition', () => {
 
       setup();
 
-      await selectDisposition(
+      await fillForm(
         disposition,
         vacateType,
         vacateIssues,
@@ -172,7 +192,7 @@ describe('MTVJudgeDisposition', () => {
 
       setup();
 
-      await selectDisposition(
+      await fillForm(
         disposition,
         vacateType,
         vacateIssues,
@@ -206,7 +226,7 @@ describe('MTVJudgeDisposition', () => {
 
     setup();
 
-    await selectDisposition(
+    await fillForm(
       disposition,
       vacateType,
       vacateIssues,
@@ -215,7 +235,10 @@ describe('MTVJudgeDisposition', () => {
     );
 
     expect(onSubmit.mock.calls[0][0].instructions).toMatch(
-      '**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
+      '**Motion To Vacate:**  \n' +
+      'Denial Of All Issues For Vacatur\n\n' +
+      '**Detail:**  \ntesting\n\n' +
+      '**Hyperlink:**  \nwww.caseflow.com\n'
     );
 
   });
@@ -231,7 +254,7 @@ describe('MTVJudgeDisposition', () => {
 
     setup();
 
-    await selectDisposition(
+    await fillForm(
       disposition,
       vacateType,
       vacateIssues,
@@ -242,7 +265,5 @@ describe('MTVJudgeDisposition', () => {
     expect(onSubmit.mock.calls[0][0].instructions).toMatch(
       '**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
     );
-
   });
 });
-

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -16,38 +16,79 @@ const task = generateAmaTask({
   instructions: ['Lorem ipsum dolor sit amet, consectetur adipiscing'],
 });
 
+let disposition = 'grant all';
+let vacateType = 'Vacate and Readjudication (1 document)';
+let vacateIssues = '1. This is a description of the decision';
+let linkField = /Insert Caseflow Reader document hyperlink to/;
+let hyperlink = 'www.caseflow.com';
+let instructionsField = /Provide context and instructions on which issues should be/;
+let instructions = 'testing';
+
 describe('MTVJudgeDisposition', () => {
+
   const onSubmit = jest.fn();
+
   const defaults = {
     appeal: amaAppeal,
     attorneys: generateAttorneys(5),
     task,
     onSubmit,
   };
+
   const setup = (props) =>
     render(<MTVJudgeDisposition {...defaults} {...props} />, {
       wrapper: BrowserRouter,
     });
 
-  const selectDisposition = async (disposition = 'grant all') => {
+  const selectRadioField = (radioSelection) => {
+    const radioFieldToSelect = screen.getByLabelText(radioSelection);
 
-    await userEvent.click(
+    userEvent.click(radioFieldToSelect);
+  };
+
+  const enterAdditionalContext = (text, selectedField) => {
+    const textField = screen.getByText(selectedField);
+
+    userEvent.type(textField, text);
+  };
+
+  const selectDisposition = async () => {
+    userEvent.click(
       screen.getByLabelText(new RegExp(disposition, 'i'))
     );
 
-    if ((/grant/i).test(disposition)) {
+    if ((/grant all/i).test(disposition)) {
       await waitFor(() => {
         expect(
           screen.getByText(/what type of vacate/i)
         ).toBeInTheDocument();
       });
+
+      selectRadioField(vacateType);
+
+    } else if ((/grant partial/i).test(disposition)) {
+      await waitFor(() => {
+        expect(
+          screen.getByText(/which issues would you like to vacate/i)
+        ).toBeInTheDocument();
+      });
+
+      selectRadioField(vacateType);
+      selectRadioField(vacateIssues);
+
     } else {
       await waitFor(() => {
         expect(
           screen.getByLabelText(/insert caseflow reader document hyperlink/i)
         ).toBeInTheDocument();
       });
+
+      enterAdditionalContext(hyperlink, linkField);
+
     }
+
+    enterAdditionalContext(instructions, instructionsField);
+
     await userEvent.click(
       screen.getByText('Submit')
     );
@@ -71,7 +112,7 @@ describe('MTVJudgeDisposition', () => {
 
   describe.each(DISPOSITION_OPTIONS.map((item) => [item.value, item]))(
     'with %s disposition selected',
-    (disposition, { displayText: label }) => {
+    ({ displayText: label }) => {
       it('renders correctly', async () => {
         const { container } = setup();
 
@@ -93,71 +134,84 @@ describe('MTVJudgeDisposition', () => {
   );
 
   describe('instructions sent', () => {
-    let vacateType = '';
-    let hyperlink = '';
-    let instructions = '';
-    let disposition = '';
-    const formatInstructions = () => {
-      const parts = [disposition];
 
-      switch (disposition) {
-      case 'grant all':
-      case 'partially_granted':
-        parts.push(vacateType);
-        parts.push(instructions);
-        break;
-      case 'denied':
-      case 'dismissed':
-        parts.push(instructions);
-        parts.push(hyperlink);
-        break;
-      default:
-        parts.push(instructions);
-      }
-
-      return parts.join('\n');
-    };
-    const handleSubmit = () => {
-      task.instructions = formatInstructions({ disposition, vacateType, hyperlink, instructions });
-    };
-
-    it('sends the correct instructions based on grant all disposition', () => {
+    it('sends the correct instructions based on grant all disposition', async () => {
 
       disposition = 'grant all';
-      vacateType = 'vacate and de novo';
+      vacateType = 'Vacate and De Novo (2 documents)';
       instructions = 'instructions from judge';
-      handleSubmit(disposition, vacateType, hyperlink, instructions);
-      expect(task.instructions).toMatch('grant all\nvacate and de novo\ninstructions from judge');
+
+      setup();
+
+      await selectDisposition(
+        disposition,
+        vacateType,
+        instructions
+      );
+
+      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
+        '\nGrant Or Partial Vacatur' +
+        '\n' +
+        '\n**Type:**  ' +
+        '\nVacate and De Novo (2 documents)' +
+        '\n' +
+        '\n**Detail:**  ' +
+        '\ninstructions from judge' +
+        '\n'
+      );
 
     });
 
-    it('sends the correct instructions based on partially granted disposition', () => {
+    it('sends the correct instructions based on partially granted disposition', async () => {
 
-      disposition = 'partially_granted';
-      vacateType = 'straight vacate';
+      disposition = 'Grant partial vacatur';
+      vacateType = 'Straight Vacate (1 document)';
       instructions = 'some instructions from judge';
-      handleSubmit(disposition, vacateType, hyperlink, instructions);
-      expect(task.instructions).toMatch('partially_granted\nstraight vacate\nsome instructions from judge');
+
+      setup();
+
+      await selectDisposition(
+        disposition,
+        vacateType,
+        instructions
+      );
+
+      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
+        '\nPartial Vacatur' +
+        '\n' +
+        '\n**Type:**  ' +
+        '\nStraight Vacate (1 document)' +
+        '\n' +
+        '\n**Detail:**  ' +
+        '\nsome instructions from judge' +
+        '\n'
+      );
 
     });
 
-    it('sends the correct instructions based on denied disposition', () => {
+    it('sends the correct instructions based on denied disposition', async () => {
 
-      disposition = 'denied';
-      instructions = 'instructions from judge';
-      hyperlink = 'www.caseflow.com';
-      handleSubmit(disposition, vacateType, hyperlink, instructions);
-      expect(task.instructions).toMatch('denied\ninstructions from judge\nwww.caseflow.com');
+      disposition = 'deny';
+
+      setup();
+
+      await selectDisposition(disposition);
+
+      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
+      );
 
     });
 
-    it('sends the correct instructions based on dismissed disposition', () => {
+    it('sends the correct instructions based on dismissed disposition', async () => {
 
-      disposition = 'dismissed';
+      disposition = 'dismiss';
       instructions = 'new instructions from judge';
       hyperlink = 'www.google.com';
-      handleSubmit(disposition, vacateType, hyperlink, instructions);
-      expect(task.instructions).toMatch('dismissed\nnew instructions from judge\nwww.google.com');
+
+      setup();
+      await selectDisposition(disposition, instructions, hyperlink)
+      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
+      );
 
     });
   });

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -161,11 +161,9 @@ describe('MTVJudgeDisposition', () => {
 
     });
 
-  });
-
-  describe('partial instructions sent', () => {
     it('sends the correct instructions based on partially granted disposition', async () => {
 
+      jest.clearAllMocks();
       const disposition = 'Grant partial vacatur';
       const vacateType = 'Straight Vacate (1 document)';
       const vacateIssues = '1. This is a description of the decision';
@@ -197,32 +195,54 @@ describe('MTVJudgeDisposition', () => {
 
   });
 
-  //   it('sends the correct instructions based on denied disposition', () => {
+  it('sends the correct instructions based on denied disposition', async () => {
 
-  //     disposition = 'deny';
+    jest.clearAllMocks();
+    const disposition = 'deny';
+    let vacateType;
+    let vacateIssues;
+    const hyperlink = 'www.caseflow.com';
+    const instructions = 'testing';
 
-  //     setup();
+    setup();
 
-  //     selectDisposition(disposition);
+    await selectDisposition(
+      disposition,
+      vacateType,
+      vacateIssues,
+      hyperlink,
+      instructions
+    );
 
-  //     expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
-  //     );
+    expect(onSubmit.mock.calls[0][0].instructions).toMatch(
+      '**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
+    );
 
-  //   });
+  });
 
-  //   it('sends the correct instructions based on dismissed disposition', () => {
+  it('sends the correct instructions based on dismissed disposition', async () => {
 
-  //     disposition = 'dismiss';
-  //     instructions = 'new instructions from judge';
-  //     hyperlink = 'www.google.com';
+    jest.clearAllMocks();
+    const disposition = 'dismiss';
+    let vacateType;
+    let vacateIssues;
+    const hyperlink = 'www.google.com';
+    const instructions = 'new instructions from judge';
 
-  //     setup();
+    setup();
 
-  //     selectDisposition(disposition, instructions, hyperlink);
+    await selectDisposition(
+      disposition,
+      vacateType,
+      vacateIssues,
+      hyperlink,
+      instructions
+    );
 
-  //     expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
-  //     );
+    expect(onSubmit.mock.calls[0][0].instructions).toMatch(
+      '**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
+    );
 
-  //   });
-  // });
+  });
 });
+

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -172,7 +172,7 @@ describe('MTVJudgeDisposition', () => {
         );
 
         expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
-          '\nGrant Or Partial Vacatur' +
+          '\nFull vacatur' +
           '\n' +
           '\n**Type:**  ' +
           '\nVacate and De Novo (2 documents)' +
@@ -201,7 +201,7 @@ describe('MTVJudgeDisposition', () => {
         );
 
         expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
-          '\nPartial Vacatur' +
+          '\nPartial vacatur' +
           '\n' +
           '\n**Type:**  ' +
           '\nStraight Vacate (1 document)' +
@@ -233,7 +233,7 @@ describe('MTVJudgeDisposition', () => {
 
         expect(onSubmit.mock.calls[0][0].instructions).toMatch(
           '**Motion To Vacate:**  \n' +
-          'Denial Of All Issues For Vacatur\n\n' +
+          'Deny all issues for vacatur\n\n' +
           '**Detail:**  \ntesting\n\n' +
           '**Hyperlink:**  \nwww.caseflow.com\n'
         );
@@ -258,7 +258,7 @@ describe('MTVJudgeDisposition', () => {
 
         expect(onSubmit.mock.calls[0][0].instructions).toMatch(
           '**Motion To Vacate:**  \n' +
-          'Dismissal\n\n**Detail:**  \nnew instructions from judge\n\n' +
+          'Dismiss all issues for vacatur\n\n**Detail:**  \nnew instructions from judge\n\n' +
           '**Hyperlink:**  \nwww.google.com\n'
         );
       });

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -148,122 +148,120 @@ describe('MTVJudgeDisposition', () => {
     }
   );
 
-  describe('grant instructions sent', () => {
-
-    it('sends the correct instructions based on grant all disposition', async () => {
-
-      const disposition = 'grant all';
-      const vacateType = 'Vacate and De Novo (2 documents)';
-      let vacateIssues;
-      let hyperlink;
-      const instructions = 'instructions from judge';
-
-      setup();
-
-      await fillForm(
-        disposition,
-        vacateType,
-        vacateIssues,
-        hyperlink,
-        instructions
-      );
-
-      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
-        '\nGrant Or Partial Vacatur' +
-        '\n' +
-        '\n**Type:**  ' +
-        '\nVacate and De Novo (2 documents)' +
-        '\n' +
-        '\n**Detail:**  ' +
-        '\ninstructions from judge' +
-        '\n'
-      );
-
-    });
-
-    it('sends the correct instructions based on partially granted disposition', async () => {
-
+  describe('Case timeline instructions', () => {
+    beforeEach(() => {
       jest.clearAllMocks();
-      const disposition = 'Grant partial vacatur';
-      const vacateType = 'Straight Vacate (1 document)';
-      const vacateIssues = '1. This is a description of the decision';
-      let hyperlink;
-      const instructions = 'some instructions from judge';
-
-      setup();
-
-      await fillForm(
-        disposition,
-        vacateType,
-        vacateIssues,
-        hyperlink,
-        instructions
-      );
-
-      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
-        '\nPartial Vacatur' +
-        '\n' +
-        '\n**Type:**  ' +
-        '\nStraight Vacate (1 document)' +
-        '\n' +
-        '\n**Detail:**  ' +
-        '\nsome instructions from judge' +
-        '\n'
-      );
-
     });
 
-  });
+    describe('grant or partial grant instructions sent', () => {
+      it('sends the correct instructions based on grant all disposition', async () => {
+        const disposition = 'grant all';
+        const vacateType = 'Vacate and De Novo (2 documents)';
+        let vacateIssues;
+        let hyperlink;
+        const instructions = 'instructions from judge';
 
-  it('sends the correct instructions based on denied disposition', async () => {
+        setup();
 
-    jest.clearAllMocks();
-    const disposition = 'deny';
-    let vacateType;
-    let vacateIssues;
-    const hyperlink = 'www.caseflow.com';
-    const instructions = 'testing';
+        await fillForm(
+          disposition,
+          vacateType,
+          vacateIssues,
+          hyperlink,
+          instructions
+        );
 
-    setup();
+        expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
+          '\nGrant Or Partial Vacatur' +
+          '\n' +
+          '\n**Type:**  ' +
+          '\nVacate and De Novo (2 documents)' +
+          '\n' +
+          '\n**Detail:**  ' +
+          '\ninstructions from judge' +
+          '\n'
+        );
+      });
 
-    await fillForm(
-      disposition,
-      vacateType,
-      vacateIssues,
-      hyperlink,
-      instructions
-    );
+      it('sends the correct instructions based on partially granted disposition', async () => {
+        const disposition = 'Grant partial vacatur';
+        const vacateType = 'Straight Vacate (1 document)';
+        const vacateIssues = '1. This is a description of the decision';
+        let hyperlink;
+        const instructions = 'some instructions from judge';
 
-    expect(onSubmit.mock.calls[0][0].instructions).toMatch(
-      '**Motion To Vacate:**  \n' +
-      'Denial Of All Issues For Vacatur\n\n' +
-      '**Detail:**  \ntesting\n\n' +
-      '**Hyperlink:**  \nwww.caseflow.com\n'
-    );
+        setup();
 
-  });
+        await fillForm(
+          disposition,
+          vacateType,
+          vacateIssues,
+          hyperlink,
+          instructions
+        );
 
-  it('sends the correct instructions based on dismissed disposition', async () => {
+        expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
+          '\nPartial Vacatur' +
+          '\n' +
+          '\n**Type:**  ' +
+          '\nStraight Vacate (1 document)' +
+          '\n' +
+          '\n**Detail:**  ' +
+          '\nsome instructions from judge' +
+          '\n'
+        );
+      });
+    });
 
-    jest.clearAllMocks();
-    const disposition = 'dismiss';
-    let vacateType;
-    let vacateIssues;
-    const hyperlink = 'www.google.com';
-    const instructions = 'new instructions from judge';
+    describe('deny or dismiss instructions sent', () => {
+      it('sends the correct instructions based on denied disposition', async () => {
+        const disposition = 'deny';
+        let vacateType;
+        let vacateIssues;
+        const hyperlink = 'www.caseflow.com';
+        const instructions = 'testing';
 
-    setup();
+        setup();
 
-    await fillForm(
-      disposition,
-      vacateType,
-      vacateIssues,
-      hyperlink,
-      instructions
-    );
+        await fillForm(
+          disposition,
+          vacateType,
+          vacateIssues,
+          hyperlink,
+          instructions
+        );
 
-    expect(onSubmit.mock.calls[0][0].instructions).toMatch(
-      '**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
-    );
+        expect(onSubmit.mock.calls[0][0].instructions).toMatch(
+          '**Motion To Vacate:**  \n' +
+          'Denial Of All Issues For Vacatur\n\n' +
+          '**Detail:**  \ntesting\n\n' +
+          '**Hyperlink:**  \nwww.caseflow.com\n'
+        );
+      });
+
+      it('sends the correct instructions based on dismissed disposition', async () => {
+        const disposition = 'dismiss';
+        let vacateType;
+        let vacateIssues;
+        const hyperlink = 'www.google.com';
+        const instructions = 'new instructions from judge';
+
+        setup();
+
+        await fillForm(
+          disposition,
+          vacateType,
+          vacateIssues,
+          hyperlink,
+          instructions
+        );
+
+        expect(onSubmit.mock.calls[0][0].instructions).toMatch(
+          '**Motion To Vacate:**  \n' +
+          'Dismissal\n\n**Detail:**  \nnew instructions from judge\n\n' +
+          '**Hyperlink:**  \nwww.google.com\n'
+        );
+      });
+    });
   });
 });

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -146,7 +146,8 @@ describe('MTVJudgeDisposition', () => {
       await selectDisposition(
         disposition,
         vacateType,
-        instructions
+        instructions,
+        instructionsField
       );
 
       expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -16,13 +16,62 @@ const task = generateAmaTask({
   instructions: ['Lorem ipsum dolor sit amet, consectetur adipiscing'],
 });
 
-let disposition = 'grant all';
-let vacateType = 'Vacate and Readjudication (1 document)';
-let vacateIssues = '1. This is a description of the decision';
 let linkField = /Insert Caseflow Reader document hyperlink to/;
-let hyperlink = 'www.caseflow.com';
 let instructionsField = /Provide context and instructions on which issues should be/;
-let instructions = 'testing';
+
+const selectRadioField = (radioSelection) => {
+  const radioFieldToSelect = screen.getByLabelText(radioSelection);
+
+  userEvent.click(radioFieldToSelect);
+};
+
+const enterAdditionalContext = (text, selectedField) => {
+  const textField = screen.getByText(selectedField);
+
+  userEvent.type(textField, text);
+};
+
+const selectDisposition = async (disposition, vacateType, vacateIssues, hyperlink, instructions) => {
+  userEvent.click(
+    screen.getByLabelText(new RegExp(disposition, 'i'))
+  );
+
+  if ((/grant all/i).test(disposition)) {
+    await waitFor(() => {
+      expect(
+        screen.getByText(/what type of vacate/i)
+      ).toBeInTheDocument();
+    });
+
+    selectRadioField(vacateType);
+
+  } else if ((/grant partial/i).test(disposition)) {
+    await waitFor(() => {
+      expect(
+        screen.getByText(/which issues would you like to vacate/i)
+      ).toBeInTheDocument();
+    });
+
+    selectRadioField(vacateType);
+    selectRadioField(vacateIssues);
+
+  } else {
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/insert caseflow reader document hyperlink/i)
+      ).toBeInTheDocument();
+    });
+
+    enterAdditionalContext(hyperlink, linkField);
+
+  }
+
+  enterAdditionalContext(instructions, instructionsField);
+
+  await userEvent.click(
+    screen.getByText('Submit')
+  );
+};
 
 describe('MTVJudgeDisposition', () => {
 
@@ -39,60 +88,6 @@ describe('MTVJudgeDisposition', () => {
     render(<MTVJudgeDisposition {...defaults} {...props} />, {
       wrapper: BrowserRouter,
     });
-
-  const selectRadioField = (radioSelection) => {
-    const radioFieldToSelect = screen.getByLabelText(radioSelection);
-
-    userEvent.click(radioFieldToSelect);
-  };
-
-  const enterAdditionalContext = (text, selectedField) => {
-    const textField = screen.getByText(selectedField);
-
-    userEvent.type(textField, text);
-  };
-
-  const selectDisposition = async () => {
-    userEvent.click(
-      screen.getByLabelText(new RegExp(disposition, 'i'))
-    );
-
-    if ((/grant all/i).test(disposition)) {
-      await waitFor(() => {
-        expect(
-          screen.getByText(/what type of vacate/i)
-        ).toBeInTheDocument();
-      });
-
-      selectRadioField(vacateType);
-
-    } else if ((/grant partial/i).test(disposition)) {
-      await waitFor(() => {
-        expect(
-          screen.getByText(/which issues would you like to vacate/i)
-        ).toBeInTheDocument();
-      });
-
-      selectRadioField(vacateType);
-      selectRadioField(vacateIssues);
-
-    } else {
-      await waitFor(() => {
-        expect(
-          screen.getByLabelText(/insert caseflow reader document hyperlink/i)
-        ).toBeInTheDocument();
-      });
-
-      enterAdditionalContext(hyperlink, linkField);
-
-    }
-
-    enterAdditionalContext(instructions, instructionsField);
-
-    await userEvent.click(
-      screen.getByText('Submit')
-    );
-  };
 
   describe('default view', () => {
     it('renders correctly', () => {
@@ -133,21 +128,24 @@ describe('MTVJudgeDisposition', () => {
     }
   );
 
-  describe('instructions sent', () => {
+  describe('grant instructions sent', () => {
 
     it('sends the correct instructions based on grant all disposition', async () => {
 
-      disposition = 'grant all';
-      vacateType = 'Vacate and De Novo (2 documents)';
-      instructions = 'instructions from judge';
+      const disposition = 'grant all';
+      const vacateType = 'Vacate and De Novo (2 documents)';
+      let vacateIssues;
+      let hyperlink;
+      const instructions = 'instructions from judge';
 
       setup();
 
       await selectDisposition(
         disposition,
         vacateType,
-        instructions,
-        instructionsField
+        vacateIssues,
+        hyperlink,
+        instructions
       );
 
       expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  ' +
@@ -163,17 +161,24 @@ describe('MTVJudgeDisposition', () => {
 
     });
 
+  });
+
+  describe('partial instructions sent', () => {
     it('sends the correct instructions based on partially granted disposition', async () => {
 
-      disposition = 'Grant partial vacatur';
-      vacateType = 'Straight Vacate (1 document)';
-      instructions = 'some instructions from judge';
+      const disposition = 'Grant partial vacatur';
+      const vacateType = 'Straight Vacate (1 document)';
+      const vacateIssues = '1. This is a description of the decision';
+      let hyperlink;
+      const instructions = 'some instructions from judge';
 
       setup();
 
       await selectDisposition(
         disposition,
         vacateType,
+        vacateIssues,
+        hyperlink,
         instructions
       );
 
@@ -190,30 +195,34 @@ describe('MTVJudgeDisposition', () => {
 
     });
 
-    it('sends the correct instructions based on denied disposition', async () => {
-
-      disposition = 'deny';
-
-      setup();
-
-      await selectDisposition(disposition);
-
-      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
-      );
-
-    });
-
-    it('sends the correct instructions based on dismissed disposition', async () => {
-
-      disposition = 'dismiss';
-      instructions = 'new instructions from judge';
-      hyperlink = 'www.google.com';
-
-      setup();
-      await selectDisposition(disposition, instructions, hyperlink)
-      expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
-      );
-
-    });
   });
+
+  //   it('sends the correct instructions based on denied disposition', () => {
+
+  //     disposition = 'deny';
+
+  //     setup();
+
+  //     selectDisposition(disposition);
+
+  //     expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDenial of All Issues For Vacatur\n\n**Detail:**  \ntesting\n\n**Hyperlink:**  \nwww.caseflow.com\n'
+  //     );
+
+  //   });
+
+  //   it('sends the correct instructions based on dismissed disposition', () => {
+
+  //     disposition = 'dismiss';
+  //     instructions = 'new instructions from judge';
+  //     hyperlink = 'www.google.com';
+
+  //     setup();
+
+  //     selectDisposition(disposition, instructions, hyperlink);
+
+  //     expect(onSubmit.mock.calls[0][0].instructions).toMatch('**Motion To Vacate:**  \nDismissal\n\n**Detail:**  \nnew instructions from judge\n\n**Hyperlink:**  \nwww.google.com\n'
+  //     );
+
+  //   });
+  // });
 });

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -30,6 +30,7 @@ describe('MTVJudgeDisposition', () => {
     });
 
   const selectDisposition = async (disposition = 'grant all') => {
+
     await userEvent.click(
       screen.getByLabelText(new RegExp(disposition, 'i'))
     );
@@ -47,6 +48,9 @@ describe('MTVJudgeDisposition', () => {
         ).toBeInTheDocument();
       });
     }
+    await userEvent.click(
+      screen.getByText('Submit')
+    );
   };
 
   describe('default view', () => {
@@ -87,4 +91,74 @@ describe('MTVJudgeDisposition', () => {
       });
     }
   );
+
+  describe('instructions sent', () => {
+    let vacateType = '';
+    let hyperlink = '';
+    let instructions = '';
+    let disposition = '';
+    const formatInstructions = () => {
+      const parts = [disposition];
+
+      switch (disposition) {
+      case 'grant all':
+      case 'partially-granted':
+        parts.push(vacateType);
+        parts.push(instructions);
+        break;
+      case 'denied':
+      case 'dismissed':
+        parts.push(instructions);
+        parts.push(hyperlink);
+        break;
+      default:
+        parts.push(instructions);
+      }
+
+      return parts.join('\n');
+    };
+    const handleSubmit = () => {
+      task.instructions = formatInstructions({ disposition, vacateType, hyperlink, instructions });
+    };
+
+    it('sends the correct instructions based on grant all disposition', () => {
+
+      disposition = 'grant all';
+      vacateType = 'vacate and de novo';
+      instructions = 'instructions from judge';
+      handleSubmit(disposition, vacateType, hyperlink, instructions);
+      expect(task.instructions).toMatch('grant all\nvacate and de novo\ninstructions from judge');
+
+    });
+
+    it('sends the correct instructions based on partially granted disposition', () => {
+
+      disposition = 'partially-granted';
+      vacateType = 'straight vacate';
+      instructions = 'some instructions from judge';
+      handleSubmit(disposition, vacateType, hyperlink, instructions);
+      expect(task.instructions).toMatch('partially-granted\nstraight vacate\nsome instructions from judge');
+
+    });
+
+    it('sends the correct instructions based on denied disposition', () => {
+
+      disposition = 'denied';
+      instructions = 'instructions from judge';
+      hyperlink = 'www.caseflow.com';
+      handleSubmit(disposition, vacateType, hyperlink, instructions);
+      expect(task.instructions).toMatch('denied\ninstructions from judge\nwww.caseflow.com');
+
+    });
+
+    it('sends the correct instructions based on dismissed disposition', () => {
+
+      disposition = 'dismissed';
+      instructions = 'new instructions from judge';
+      hyperlink = 'www.google.com';
+      handleSubmit(disposition, vacateType, hyperlink, instructions);
+      expect(task.instructions).toMatch('dismissed\nnew instructions from judge\nwww.google.com');
+
+    });
+  });
 });

--- a/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
+++ b/client/test/app/queue/mtv/MTVJudgeDisposition.test.js
@@ -102,7 +102,7 @@ describe('MTVJudgeDisposition', () => {
 
       switch (disposition) {
       case 'grant all':
-      case 'partially-granted':
+      case 'partially_granted':
         parts.push(vacateType);
         parts.push(instructions);
         break;
@@ -133,11 +133,11 @@ describe('MTVJudgeDisposition', () => {
 
     it('sends the correct instructions based on partially granted disposition', () => {
 
-      disposition = 'partially-granted';
+      disposition = 'partially_granted';
       vacateType = 'straight vacate';
       instructions = 'some instructions from judge';
       handleSubmit(disposition, vacateType, hyperlink, instructions);
-      expect(task.instructions).toMatch('partially-granted\nstraight vacate\nsome instructions from judge');
+      expect(task.instructions).toMatch('partially_granted\nstraight vacate\nsome instructions from judge');
 
     });
 

--- a/client/test/app/queue/mtv/__snapshots__/MTVJudgeDisposition.test.js.snap
+++ b/client/test/app/queue/mtv/__snapshots__/MTVJudgeDisposition.test.js.snap
@@ -514,9 +514,7 @@ exports[`MTVJudgeDisposition with denied disposition selected renders correctly 
         <textarea
           id="instructions"
           name="instructions"
-        >
-          testing
-        </textarea>
+        />
       </div>
       <div
         class=""
@@ -623,8 +621,9 @@ exports[`MTVJudgeDisposition with denied disposition selected renders correctly 
     >
       <span>
         <button
-          class="cf-right-side usa-button"
+          class="cf-right-side usa-button-disabled usa-button"
           data-css-wn5k45=""
+          disabled=""
           id="button-submit"
           type="button"
         >
@@ -924,9 +923,7 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
         <textarea
           id="instructions"
           name="instructions"
-        >
-          testing
-        </textarea>
+        />
       </div>
       <div
         class=""
@@ -1033,8 +1030,9 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
     >
       <span>
         <button
-          class="cf-right-side usa-button"
+          class="cf-right-side usa-button-disabled usa-button"
           data-css-wn5k45=""
+          disabled=""
           id="button-submit"
           type="button"
         >
@@ -1334,9 +1332,7 @@ exports[`MTVJudgeDisposition with granted disposition selected renders correctly
         <textarea
           id="instructions"
           name="instructions"
-        >
-          testing
-        </textarea>
+        />
       </div>
       <div
         class=""
@@ -1443,8 +1439,9 @@ exports[`MTVJudgeDisposition with granted disposition selected renders correctly
     >
       <span>
         <button
-          class="cf-right-side usa-button"
+          class="cf-right-side usa-button-disabled usa-button"
           data-css-wn5k45=""
+          disabled=""
           id="button-submit"
           type="button"
         >
@@ -1744,9 +1741,7 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
         <textarea
           id="instructions"
           name="instructions"
-        >
-          testing
-        </textarea>
+        />
       </div>
       <div
         class=""
@@ -1853,8 +1848,9 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
     >
       <span>
         <button
-          class="cf-right-side usa-button"
+          class="cf-right-side usa-button-disabled usa-button"
           data-css-wn5k45=""
+          disabled=""
           id="button-submit"
           type="button"
         >

--- a/client/test/app/queue/mtv/__snapshots__/MTVJudgeDisposition.test.js.snap
+++ b/client/test/app/queue/mtv/__snapshots__/MTVJudgeDisposition.test.js.snap
@@ -422,31 +422,77 @@ exports[`MTVJudgeDisposition with denied disposition selected renders correctly 
           </div>
         </div>
       </div>
-      <div
-        class="mtv-review-hyperlink cf-margin-bottom-2rem   "
+      <fieldset
+        class="mtv-vacate-type cf-form-radio "
       >
-        <label
-          for="hyperlink"
+        <legend
+          class=""
         >
           <strong>
             <span>
-              Insert Caseflow Reader document hyperlink to denial draft
+              What type of vacate?
+               
               <span
-                class="cf-optional"
+                class="cf-required"
               >
-                Optional
+                 Required
               </span>
             </span>
           </strong>
-        </label>
-        <input
-          class="mtv-review-hyperlink,cf-margin-bottom-2rem"
-          id="hyperlink"
-          name="hyperlink"
-          type="text"
-          value=""
-        />
-      </div>
+        </legend>
+        <div
+          class="cf-form-radio-options"
+        >
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_vacate_and_readjudication"
+              name="vacate_type"
+              type="radio"
+              value="vacate_and_readjudication"
+            />
+            <label
+              class=""
+              for="vacate-type_vacate_and_readjudication"
+            >
+              Vacate and Readjudication (1 document)
+            </label>
+          </div>
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_straight_vacate"
+              name="vacate_type"
+              type="radio"
+              value="straight_vacate"
+            />
+            <label
+              class=""
+              for="vacate-type_straight_vacate"
+            >
+              Straight Vacate (1 document)
+            </label>
+          </div>
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_vacate_and_de_novo"
+              name="vacate_type"
+              type="radio"
+              value="vacate_and_de_novo"
+            />
+            <label
+              class=""
+              for="vacate-type_vacate_and_de_novo"
+            >
+              Vacate and De Novo (2 documents)
+            </label>
+          </div>
+        </div>
+      </fieldset>
       <div
         class="cf-form-textarea"
       >
@@ -456,7 +502,7 @@ exports[`MTVJudgeDisposition with denied disposition selected renders correctly 
         >
           <strong>
             <span>
-              Provide context and instructions on which issues should be denied
+              Provide context and instructions on which issues should be granted
               <span
                 class="cf-optional"
               >
@@ -468,7 +514,108 @@ exports[`MTVJudgeDisposition with denied disposition selected renders correctly 
         <textarea
           id="instructions"
           name="instructions"
-        />
+        >
+          testing
+        </textarea>
+      </div>
+      <div
+        class=""
+      >
+        <div
+          class="cf-form-dropdown dropdown-attorney"
+          data-css-33yksw=""
+        >
+          <label
+            class="question-label"
+            for="attorney"
+            id="attorney-label"
+          >
+            <strong>
+              <span>
+                Assign to decisions attorney
+              </span>
+            </strong>
+          </label>
+          <div
+            class="cf-select"
+          >
+            <div
+              class=" css-2b097c-container"
+            >
+              <div
+                class="cf-select__control css-yk16xz-control"
+              >
+                <div
+                  class="cf-select__value-container css-g1d714-ValueContainer"
+                >
+                  <div
+                    class="cf-select__placeholder css-1wa3eu0-placeholder"
+                  >
+                    Select attorney
+                  </div>
+                  <div
+                    class="css-81nyic-Input"
+                  >
+                    <div
+                      class="cf-select__input"
+                      style="display: inline-block;"
+                    >
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        aria-labelledby="attorney-label"
+                        aria-owns="attorney-listbox"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        autocorrect="off"
+                        id="attorney"
+                        role="combobox"
+                        spellcheck="false"
+                        style="box-sizing: content-box; width: 2px; border: 0px; opacity: 1; outline: 0; padding: 0px;"
+                        tabindex="0"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="cf-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="cf-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="cf-select__indicator cf-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <input
+                name="attorney"
+                type="hidden"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <div
@@ -685,31 +832,77 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
           </div>
         </div>
       </div>
-      <div
-        class="mtv-review-hyperlink cf-margin-bottom-2rem   "
+      <fieldset
+        class="mtv-vacate-type cf-form-radio "
       >
-        <label
-          for="hyperlink"
+        <legend
+          class=""
         >
           <strong>
             <span>
-              Insert Caseflow Reader document hyperlink to dismissal draft
+              What type of vacate?
+               
               <span
-                class="cf-optional"
+                class="cf-required"
               >
-                Optional
+                 Required
               </span>
             </span>
           </strong>
-        </label>
-        <input
-          class="mtv-review-hyperlink,cf-margin-bottom-2rem"
-          id="hyperlink"
-          name="hyperlink"
-          type="text"
-          value=""
-        />
-      </div>
+        </legend>
+        <div
+          class="cf-form-radio-options"
+        >
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_vacate_and_readjudication"
+              name="vacate_type"
+              type="radio"
+              value="vacate_and_readjudication"
+            />
+            <label
+              class=""
+              for="vacate-type_vacate_and_readjudication"
+            >
+              Vacate and Readjudication (1 document)
+            </label>
+          </div>
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_straight_vacate"
+              name="vacate_type"
+              type="radio"
+              value="straight_vacate"
+            />
+            <label
+              class=""
+              for="vacate-type_straight_vacate"
+            >
+              Straight Vacate (1 document)
+            </label>
+          </div>
+          <div
+            class="cf-form-radio-option"
+          >
+            <input
+              id="vacate-type_vacate_and_de_novo"
+              name="vacate_type"
+              type="radio"
+              value="vacate_and_de_novo"
+            />
+            <label
+              class=""
+              for="vacate-type_vacate_and_de_novo"
+            >
+              Vacate and De Novo (2 documents)
+            </label>
+          </div>
+        </div>
+      </fieldset>
       <div
         class="cf-form-textarea"
       >
@@ -719,7 +912,7 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
         >
           <strong>
             <span>
-              Provide context and instructions on which issues should be dismissed
+              Provide context and instructions on which issues should be granted
               <span
                 class="cf-optional"
               >
@@ -731,7 +924,108 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
         <textarea
           id="instructions"
           name="instructions"
-        />
+        >
+          testing
+        </textarea>
+      </div>
+      <div
+        class=""
+      >
+        <div
+          class="cf-form-dropdown dropdown-attorney"
+          data-css-33yksw=""
+        >
+          <label
+            class="question-label"
+            for="attorney"
+            id="attorney-label"
+          >
+            <strong>
+              <span>
+                Assign to decisions attorney
+              </span>
+            </strong>
+          </label>
+          <div
+            class="cf-select"
+          >
+            <div
+              class=" css-2b097c-container"
+            >
+              <div
+                class="cf-select__control css-yk16xz-control"
+              >
+                <div
+                  class="cf-select__value-container css-g1d714-ValueContainer"
+                >
+                  <div
+                    class="cf-select__placeholder css-1wa3eu0-placeholder"
+                  >
+                    Select attorney
+                  </div>
+                  <div
+                    class="css-81nyic-Input"
+                  >
+                    <div
+                      class="cf-select__input"
+                      style="display: inline-block;"
+                    >
+                      <input
+                        aria-autocomplete="list"
+                        aria-expanded="false"
+                        aria-haspopup="true"
+                        aria-labelledby="attorney-label"
+                        aria-owns="attorney-listbox"
+                        autocapitalize="none"
+                        autocomplete="off"
+                        autocorrect="off"
+                        id="attorney"
+                        role="combobox"
+                        spellcheck="false"
+                        style="box-sizing: content-box; width: 2px; border: 0px; opacity: 1; outline: 0; padding: 0px;"
+                        tabindex="0"
+                        type="text"
+                        value=""
+                      />
+                      <div
+                        style="position: absolute; top: 0px; left: 0px; visibility: hidden; height: 0px; overflow: scroll; white-space: pre; font-family: -webkit-small-control; letter-spacing: normal; text-transform: none;"
+                      />
+                    </div>
+                  </div>
+                </div>
+                <div
+                  class="cf-select__indicators css-1hb7zxy-IndicatorsContainer"
+                >
+                  <span
+                    class="cf-select__indicator-separator css-1okebmr-indicatorSeparator"
+                  />
+                  <div
+                    aria-hidden="true"
+                    class="cf-select__indicator cf-select__dropdown-indicator css-tlfecz-indicatorContainer"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="css-6q0nyr-Svg"
+                      focusable="false"
+                      height="20"
+                      viewBox="0 0 20 20"
+                      width="20"
+                    >
+                      <path
+                        d="M4.516 7.548c0.436-0.446 1.043-0.481 1.576 0l3.908 3.747 3.908-3.747c0.533-0.481 1.141-0.446 1.574 0 0.436 0.445 0.408 1.197 0 1.615-0.406 0.418-4.695 4.502-4.695 4.502-0.217 0.223-0.502 0.335-0.787 0.335s-0.57-0.112-0.789-0.335c0 0-4.287-4.084-4.695-4.502s-0.436-1.17 0-1.615z"
+                      />
+                    </svg>
+                  </div>
+                </div>
+              </div>
+              <input
+                name="attorney"
+                type="hidden"
+                value=""
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </section>
     <div
@@ -764,8 +1058,6 @@ exports[`MTVJudgeDisposition with dismissed disposition selected renders correct
   </div>
 </div>
 `;
-
-exports[`MTVJudgeDisposition with granted disposition selected passes a11y 1`] = `<div />`;
 
 exports[`MTVJudgeDisposition with granted disposition selected renders correctly 1`] = `
 <div>
@@ -1042,7 +1334,9 @@ exports[`MTVJudgeDisposition with granted disposition selected renders correctly
         <textarea
           id="instructions"
           name="instructions"
-        />
+        >
+          testing
+        </textarea>
       </div>
       <div
         class=""
@@ -1149,9 +1443,8 @@ exports[`MTVJudgeDisposition with granted disposition selected renders correctly
     >
       <span>
         <button
-          class="cf-right-side usa-button-disabled usa-button"
+          class="cf-right-side usa-button"
           data-css-wn5k45=""
-          disabled=""
           id="button-submit"
           type="button"
         >
@@ -1330,47 +1623,6 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
           </div>
         </div>
       </fieldset>
-      <fieldset
-        class="checkbox-wrapper-issues cf-form-checkboxes cf-checkbox-group"
-      >
-        <legend
-          class=""
-        >
-          <strong>
-            <span>
-              Which issues would you like to vacate?
-            </span>
-          </strong>
-        </legend>
-        <div
-          class="checkbox"
-        >
-          <input
-            id="1"
-            name="1"
-            type="checkbox"
-          />
-          <label
-            for="1"
-          >
-            1. This is a description of the decision
-          </label>
-        </div>
-        <div
-          class="checkbox"
-        >
-          <input
-            id="2"
-            name="2"
-            type="checkbox"
-          />
-          <label
-            for="2"
-          >
-            2. This is a description of another decision
-          </label>
-        </div>
-      </fieldset>
       <div
         style="max-width: 46rem; margin-bottom: 1.5em;"
       >
@@ -1480,7 +1732,7 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
         >
           <strong>
             <span>
-              Provide context and instructions on which issues should be partially_granted
+              Provide context and instructions on which issues should be granted
               <span
                 class="cf-optional"
               >
@@ -1492,7 +1744,9 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
         <textarea
           id="instructions"
           name="instructions"
-        />
+        >
+          testing
+        </textarea>
       </div>
       <div
         class=""
@@ -1599,9 +1853,8 @@ exports[`MTVJudgeDisposition with partially_granted disposition selected renders
     >
       <span>
         <button
-          class="cf-right-side usa-button-disabled usa-button"
+          class="cf-right-side usa-button"
           data-css-wn5k45=""
-          disabled=""
           id="button-submit"
           type="button"
         >

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -397,6 +397,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
     end
 
     context "denial" do
+      byebug
       let(:atty_disposition) { "denied" }
       let(:atty_hyperlink) { "https://efolder.link/file" }
 

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -435,6 +435,7 @@ RSpec.feature "Motion to vacate", :all_dbs do
         expect(new_task.available_actions(motions_attorney)).to include(
           Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h
         )
+        byebug
         expect(new_task.instructions.join("")).to eq(instructions)
       end
     end

--- a/spec/feature/queue/motion_to_vacate_spec.rb
+++ b/spec/feature/queue/motion_to_vacate_spec.rb
@@ -397,7 +397,6 @@ RSpec.feature "Motion to vacate", :all_dbs do
     end
 
     context "denial" do
-      byebug
       let(:atty_disposition) { "denied" }
       let(:atty_hyperlink) { "https://efolder.link/file" }
 
@@ -436,7 +435,6 @@ RSpec.feature "Motion to vacate", :all_dbs do
         expect(new_task.available_actions(motions_attorney)).to include(
           Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h
         )
-        byebug
         expect(new_task.instructions.join("")).to eq(instructions)
       end
     end

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -32,7 +32,7 @@ module QueueHelpers
   end
 
   def format_mtv_judge_instructions(notes:, disposition:, vacate_type: nil, hyperlink: nil)
-    parts = ["**Motion To Vacate:**  \n#{(DISPOSITION_TEXT[disposition])}\n"]
+    parts = ["**Motion To Vacate:**  \n#{(disposition_text[disposition])}\n"]
 
     case disposition
     when "granted", "partially_granted"

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -9,6 +9,10 @@ module QueueHelpers
     mtv_const.DISPOSITION_TEXT.to_h
   end
 
+  def disposition_timeline_text
+    mtv_const.DISPOSITION_TIMELINE_TEXT.to_h
+  end
+
   def recommendation_text
     mtv_const.DISPOSITION_RECOMMENDATIONS.to_h
   end
@@ -32,7 +36,7 @@ module QueueHelpers
   end
 
   def format_mtv_judge_instructions(notes:, disposition:, vacate_type: nil, hyperlink: nil)
-    parts = ["**Motion To Vacate:**  \n#{disposition_text[disposition.to_sym].titlecase}\n"]
+    parts = ["**Motion To Vacate:**  \n#{disposition_timeline_text[disposition.to_sym]}\n"]
 
     case disposition
     when "granted", "partially_granted"

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -32,7 +32,7 @@ module QueueHelpers
   end
 
   def format_mtv_judge_instructions(notes:, disposition:, vacate_type: nil, hyperlink: nil)
-    parts = ["**Motion To Vacate:**  \n#{(disposition_text[disposition])}\n"]
+    parts = ["**Motion To Vacate:**  \n#{disposition_text[disposition]}\n"]
 
     case disposition
     when "granted", "partially_granted"

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -32,7 +32,7 @@ module QueueHelpers
   end
 
   def format_mtv_judge_instructions(notes:, disposition:, vacate_type: nil, hyperlink: nil)
-    parts = ["**Motion To Vacate:**  \n#{disposition_text[disposition]}\n"]
+    parts = ["**Motion To Vacate:**  \n#{disposition_text[disposition.to_sym].titlecase}\n"]
 
     case disposition
     when "granted", "partially_granted"
@@ -48,7 +48,7 @@ module QueueHelpers
         parts += ["#{notes}\n"]
       end
       if hyperlink.present?
-        parts += ["**Hyperlink**  "]
+        parts += ["**Hyperlink:**  "]
         parts += ["#{hyperlink}\n"]
       end
     end

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -32,14 +32,26 @@ module QueueHelpers
   end
 
   def format_mtv_judge_instructions(notes:, disposition:, vacate_type: nil, hyperlink: nil)
-    parts = ["I am proceeding with a #{disposition_text[disposition.to_sym]}."]
+    parts = ["**Motion To Vacate:**  \n#{(DISPOSITION_TEXT[disposition])}\n"]
 
-    parts += case disposition
-             when "granted", "partial"
-               ["This will be a #{vacate_types[vacate_type.to_sym]}", notes]
-             else
-               [notes, "\nHere is the hyperlink to the signed denial document", hyperlink]
-             end
+    case disposition
+    when "granted", "partially_granted"
+      parts += ["**Type:**  "]
+      parts +=["#{vacate_types[vacate_type.to_sym]}\n"]
+      if !notes.empty?
+        parts += ["**Detail:**  "]
+        parts += ["#{notes}\n"]
+      end
+    when "denied", "dismissed"
+      if !notes.empty?
+        parts += ["**Detail:**  "]
+        parts += ["#{notes}\n"]
+      end
+      if hyperlink.present?
+        parts += ["**Hyperlink**  "]
+        parts += ["#{hyperlink}\n"]
+      end
+    end
 
     parts.join("\n")
   end

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -37,7 +37,7 @@ module QueueHelpers
     case disposition
     when "granted", "partially_granted"
       parts += ["**Type:**  "]
-      parts +=["#{vacate_types[vacate_type.to_sym]}\n"]
+      parts += ["#{vacate_types[vacate_type.to_sym]}\n"]
       if !notes.empty?
         parts += ["**Detail:**  "]
         parts += ["#{notes}\n"]


### PR DESCRIPTION
Resolves #APPEALS-13396
https://vajira.max.gov/browse/APPEALS-13396

# Description
Value Statement:

As a Caseflow Developer, I need to add to the case details/timeline section which vacatur type the VLJ selected for the Motion to Vacate task so that the case can be processed correctly.

Assumptions:

This is a point-in-time update and will not retroactively update the task instructions of previously executed Address Motion to Vacate task actions (prior to the release of this enhancement)

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] If "Grant all issues for vacatur" is selected when processing the Address Motion to Vacate task action (by the Judge - "How will you address this motion to vacate?" field) the Task Instructions entry on the Vacate stream is updated for the Draft Decision task entry (active task section) to the following:
Motion to Vacate: Full vacatur
Type: dynamic content based on user selection from the <"What type of Vacate?> field
Detail: <comments by the judge in free text field>
If "Grant partial vacatur" is selected when processing the Address Motion to Vacate task action (by the Judge - "How will you address this motion to vacate?" field) the Task Instructions entry on the Vacate stream is updated for the Draft Decision task entry (active task section) to the following:
Motion to Vacate: Partial vacatur
Type: dynamic content based on user selection from the <"What type of Vacate?> field
Detail: <comments added by the judge in free text field>
If "Deny all issues for vacatur" is selected when processing the Address Motion to Vacate task action (by the Judge - "How will you address this motion to vacate?" field) the Task Instructions entry on the Original stream is updated for the Denied Motion to Vacate task entry (active task section) to the following:
Motion to Vacate: Deny all issues for vacatur
Detail: <comments added by the judge in the "Provide context and instruction on which issues should be dismissed" free text field>
Hyperlink: <link provided in the "insert Caseflow Reader document hyperlink to dismissal draft" field>
If "Dismiss" is selected when processing the Address Motion to Vacate task action (by the Judge - "How will you address this motion to vacate?" field) the Task Instructions entry on the Original stream is updated for the Dismiss Motion to Vacate task entry (active task section) to the following:
Motion to Vacate: Dismiss all issues for vacatur
Detail: <comments added by the judge in the "Provide context and instruction on which issues should be dismissed" free text field>
Hyperlink: <link provided in the "Insert Caseflow Reader document hyperlink to denial draft" field>
The task instructions on the Decision Drafted by Attorney case timeline entry on the Vacate stream are updated to the following format:
Motion to Vacate <Insert Judge's selection (Grant full vacatur; or Grant partial vacatur> (from the Motion to Vacate task action)
Type: dynamic content based on the Judge's selection from the <"What type of Vacate?> field (from the Motion to Vacate task action)
Detail: <comments added by judge> (from the Motion to Vacate task action)

## Testing Plan
1. Go to https://vajira.max.gov/browse/APPEALS-21913

# Frontend
## User Facing Changes

 BEFORE
<img width="569" alt="Screen Shot 2023-05-04 at 10 12 07 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/109693628/40a8ceaf-16cb-467a-928b-609d8369e17d">

AFTER
<img width="970" alt="Screen Shot 2023-05-03 at 4 01 44 PM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/109693628/0fe02f10-623a-436f-a789-0a1215020355">

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] Jest