### PR TITLE
MattT/APPEALS-21850: Add ActiveRecord Associations Between VbmsUploadedDocument and Appeal/LegacyAppeal

### DIFF
--- a/app/models/appeal.rb
+++ b/app/models/appeal.rb
@@ -25,6 +25,7 @@ class Appeal < DecisionReview
   has_many :hearings
   has_many :email_recipients, class_name: "HearingEmailRecipient"
   has_many :available_hearing_locations, as: :appeal, class_name: "AvailableHearingLocations"
+  has_many :vbms_uploaded_documents, as: :appeal
 
   # decision_documents is effectively a has_one until post decisional motions are supported
   has_many :decision_documents, as: :appeal

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -41,6 +41,7 @@ class LegacyAppeal < CaseflowRecord
   has_many :email_recipients, class_name: "HearingEmailRecipient", foreign_key: :appeal_id
   accepts_nested_attributes_for :worksheet_issues, allow_destroy: true
   has_one :appeal_state, as: :appeal
+  has_many :vbms_uploaded_documents, as: :appeal
 
   class UnknownLocationError < StandardError; end
 

--- a/app/models/vbms_uploaded_document.rb
+++ b/app/models/vbms_uploaded_document.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class VbmsUploadedDocument < CaseflowRecord
+  include BelongsToPolymorphicAppealConcern
+  belongs_to_polymorphic_appeal :appeal
+
   validates :document_type, presence: true
 
   attribute :file, :string

--- a/spec/factories/vbms_uploaded_document.rb
+++ b/spec/factories/vbms_uploaded_document.rb
@@ -4,5 +4,10 @@ FactoryBot.define do
   factory :vbms_uploaded_document do
     veteran_file_number { generate :veteran_file_number }
     document_type { "Status Letter" }
+    appeal { create(:appeal) }
+
+    trait :for_legacy_appeal do
+      appeal { create(:legacy_appeal, vacols_case: create(:case)) }
+    end
   end
 end


### PR DESCRIPTION
Resolves [APPEALS-21850](https://vajira.max.gov/browse/APPEALS-21850)

## Description
Established an ActiveRecord `has_many` association between AMA and Legacy Appeals and `VbmsUploadedDocument`s. This will allow for more easily grabbing "linked" information between these entities.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Appeals are accessible via `.appeal` on  instances of `VbmsUploadedDocument`
- [ ] `VbmsUploadedDocument`s are accessible via `.vbms_uploaded_documents` on both `Appeal`s and `LegacyAppeal`s.

## Testing Plan
### Glossary
Items in code blocks are meant to be run as part of the testing plan. See the following glossary for what each portion represents:
```ruby
# Comments provide context around inputs/outputs
i_am_a_command.that_you_should(run: true)
=> "I am sample output. Don't run me- I'm just an example!"
```

### Testing Steps
1. Open a Rails console (`make c`)
2. Create a `VbmsUploadedDocument` associated with an AMA appeal:
```ruby
ama_doc = FactoryBot.create(:vbms_uploaded_document)
```
3. Ensure you can access the Appeal using `.appeal`:
```ruby
ama_doc.appeal
=> #<Appeal:0x00005604233180f8
 id: 2302,
 aod_based_on_age: nil,
 changed_hearing_request_type: nil,
 closest_regional_office: nil,
 created_at: Tue, 02 May 2023 03:27:00 UTC +00:00,
 docket_range_date: nil,
 docket_type: "evidence_submission",
 established_at: Tue, 02 May 2023 03:27:00 UTC +00:00,
 establishment_attempted_at: nil,
 establishment_canceled_at: nil,
 establishment_error: nil,
 establishment_last_submitted_at: nil
 ...
 >
```
4. Now check that you can access the document uploads associated with the appeal via `.vbms_uploaded_documents`:
```ruby
# Add an extra document to the appeal to make things more interesting:
FactoryBot.create(:vbms_uploaded_document, appeal: ama_doc.appeal)

# Run the following command:
ama_doc.appeal.vbms_document_uploads
=> [#<VbmsUploadedDocument:0x000056042618e2e8
  id: 7,
  appeal_id: 2302,
  appeal_type: "Appeal",
  attempted_at: nil,
  canceled_at: nil,
  created_at: Tue, 02 May 2023 03:29:04 UTC +00:00,
  document_name: nil,
  document_subject: nil,
  document_type: "Status Letter",
  error: nil,
  last_submitted_at: nil,
  processed_at: nil,
  ...
  >]

# Check that there are two documents:
ama_doc.appeal.vbms_document_uploads.size
=> 2
```
5. Create a `VbmsUploadedDocument` associated with a legacy appeal:
```ruby
legacy_doc = FactoryBot.create(:vbms_uploaded_document, :for_legacy_appeal)
```
6. Ensure you can access the legacy appeal using `.appeal`:
```ruby
legacy_doc.appeal
=> #<LegacyAppeal:0x00005604272148b0
 id: 365,
 appeal_series_id: nil,
 changed_hearing_request_type: nil,
 closest_regional_office: nil,
 contaminated_water_at_camp_lejeune: false,
 created_at: Tue, 02 May 2023 03:35:36 UTC +00:00,
 dic_death_or_accrued_benefits_united_states: false,
 dispatched_to_station: nil,
 education_gi_bill_dependents_educational_assistance_scholars: false,
 foreign_claim_compensation_claims_dual_claims_appeals: false,
 foreign_pension_dic_all_other_foreign_countries: false,
 foreign_pension_dic_mexico_central_and_south_america_caribb: false,
 ...
 >
```
7. Now check that you can access the document uploads associated with the legacy appeal via `.vbms_uploaded_documents`:
```ruby
# This time, add even MORE documents!
FactoryBot.create_list(:vbms_uploaded_document, 20, appeal: legacy_doc.appeal)

# Run the following command:
legacy_doc.appeal.vbms_document_uploads
=> [#<VbmsUploadedDocument:0x000056042618e2e8
  id: 7,
  appeal_id: 2302,
  appeal_type: "Appeal",
  attempted_at: nil,
  canceled_at: nil,
  created_at: Tue, 02 May 2023 03:29:04 UTC +00:00,
  document_name: nil,
  document_subject: nil,
  document_type: "Status Letter",
  error: nil,
  last_submitted_at: nil,
  processed_at: nil,
  ...
  >]

# Check that there are two documents:
legacy_doc.appeal.vbms_document_uploads.size
=> 21
```
8. That's it! Thank you for walking through this testing plan.

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)

