### PR TITLE
MattT/APPEALS-21885

### DIFF
--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -7,9 +7,9 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   #
   # Response: Update corresponding Notification status
   def notifications_update
-    if required_params[:type] == "email"
+    if required_params[:notification_type] == "email"
       email_update
-    elsif required_params[:type] == "sms"
+    elsif required_params[:notification_type] == "sms"
       sms_update
     end
   end
@@ -21,10 +21,10 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   # Params:  Notification type string, either "email" or "SMS"
   #
   # Response: json error message with uuid and 500 error
-  def log_error(type)
+  def log_error(notification_type)
     uuid = SecureRandom.uuid
-    error_msg = "An " + type + "notification with id " + required_params[:id] +
-                " could not be found. " + "Error ID: " + uuid
+    error_msg = "An #{notification_type} notification with id #{required_params[:id]} could not be found. " \
+                "Error ID: #{uuid}"
     Rails.logger.error(error_msg)
     render json: { message: error_msg }, status: :internal_server_error
   end
@@ -38,7 +38,7 @@ class Api::V1::VaNotifyController < Api::ApplicationController
     # find notification through external id
     notif = Notification.find_by(email_notification_external_id: required_params[:id])
     # log external id if notification doesn't exist
-    return log_error(required_params[:type]) unless notif
+    return log_error(required_params[:notification_type]) unless notif
 
     # update notification if it exists
     notif.update!(email_notification_status: required_params[:status])
@@ -54,7 +54,7 @@ class Api::V1::VaNotifyController < Api::ApplicationController
     # find notification through external id
     notif = Notification.find_by(sms_notification_external_id: required_params[:id])
     # log external id if notification doesn't exist
-    return log_error(required_params[:type]) unless notif
+    return log_error(required_params[:notification_type]) unless notif
 
     # update notification if it exists
     notif.update!(sms_notification_status: params[:status])
@@ -62,8 +62,8 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   end
 
   def required_params
-    id_param, type_param, status_param = params.require([:id, :type, :status])
+    id_param, notification_type_param, status_param = params.require([:id, :notification_type, :status])
 
-    { id: id_param, type: type_param, status: status_param }
+    { id: id_param, notification_type: notification_type_param, status: status_param }
   end
 end

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -55,15 +55,17 @@ describe Api::V1::VaNotifyController, type: :controller do
       sent_by: "string",
       status: "created",
       subject: "string",
-      type: ""
+      notification_type: ""
     }
   end
+
   context "email notification status is changed" do
     let(:payload_email) do
       default_payload.deep_dup.tap do |payload|
-        payload[:type] = "email"
+        payload[:notification_type] = "email"
       end
     end
+
     it "updates status of notification" do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_email
@@ -75,9 +77,10 @@ describe Api::V1::VaNotifyController, type: :controller do
   context "sms notification status is changed" do
     let(:payload_sms) do
       default_payload.deep_dup.tap do |payload|
-        payload[:type] = "sms"
+        payload[:notification_type] = "sms"
       end
     end
+
     it "updates status of notification" do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_sms
@@ -85,44 +88,46 @@ describe Api::V1::VaNotifyController, type: :controller do
       expect(notification_sms.sms_notification_status).to eq("created")
     end
   end
+
   context "notification does not exist" do
     let(:payload_fake) do
       {
-        "id": "fake",
-        "body": "string",
-        "completed_at": "2023-04-17T12:38:48.699Z",
-        "created_at": "2023-04-17T12:38:48.699Z",
-        "created_by_name": "string",
-        "email_address": "user@example.com",
-        "line_1": "string",
-        "line_2": "string",
-        "line_3": "string",
-        "line_4": "string",
-        "line_5": "string",
-        "line_6": "string",
-        "phone_number": "+16502532222",
-        "postage": "string",
-        "postcode": "string",
-        "recipient_identifiers": [
+        id: "fake",
+        body: "string",
+        completed_at: "2023-04-17T12:38:48.699Z",
+        created_at: "2023-04-17T12:38:48.699Z",
+        created_by_name: "string",
+        email_address: "user@example.com",
+        line_1: "string",
+        line_2: "string",
+        line_3: "string",
+        line_4: "string",
+        line_5: "string",
+        line_6: "string",
+        phone_number: "+16502532222",
+        postage: "string",
+        postcode: "string",
+        recipient_identifiers: [
           {
-            "id_type": "VAPROFILEID",
-            "id_value": "string"
+            id_type: "VAPROFILEID",
+            id_value: "string"
           }
         ],
-        "reference": "string",
-        "scheduled_for": "2023-04-17T12:38:48.699Z",
-        "sent_at": "2023-04-17T12:38:48.699Z",
-        "sent_by": "string",
-        "status": "created",
-        "subject": "string",
-        "template": {
-          "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
-          "uri": "string",
-          "version": 0
+        reference: "string",
+        scheduled_for: "2023-04-17T12:38:48.699Z",
+        sent_at: "2023-04-17T12:38:48.699Z",
+        sent_by: "string",
+        status: "created",
+        subject: "string",
+        template: {
+          id: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          uri: "string",
+          version: 0
         },
-        "type": "sms"
+        notification_type: "sms"
       }
     end
+
     it "updates status of notification" do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_fake


### PR DESCRIPTION
Resolves [APPEALS-21885](https://vajira.max.gov/browse/APPEALS-21885)

### Description
We are currently requiring a `type` parameter, however VA Notify is supplying us with a `notification_type` parameter. We want to alter the endpoint's param name expectations to reflect this.

### Acceptance Criteria
- [x] Code compiles correctly
- [x] `notification_type` is required instead of `type`

### Testing Plan
1. Open a Rails console, and create an ApiKey:
```ruby
key = ApiKey.create!(consumer_name: "Test Key")

key.key_string
=> "This is your API Key"
```

2. Create a Notification
```ruby
appeal = FactoryBot.create(:appeal)
notif = FactoryBot.create(:notification, event_type: "Hearing scheduled", event_date: Time.zone.today, notification_type: "Email", appeals_id: appeal.uuid, appeals_type: "Appeal")
```

3. Set the notification ID:
```ruby
notif.update!(email_notification_external_id: "f6ded912-2715-4f00-b4fd-9057902af29d")
```

4. Confirm that the notification status is not "delivered":
```ruby
notif.email_notification_status
=> nil
```

5. Open up Postman/Insomnia/curl/etc, and fire the following request to the Api:
The `Token`/`Bearer` header will need to be sent with your ApiKey from step 1.

The JSON request body:
```json
{
  "completed_at": "2023-05-02T20:48:29.386992Z",
  "created_at": "2023-05-02T20:48:26.956648Z",
  "id": "f6ded912-2715-4f00-b4fd-9057902af29d",
  "notification_type": "email",
  "provider": "ses",
  "provider_payload": {},
  "reference": "",
  "sent_at": "2023-05-02T20:48:28.097061Z",
  "status": "delivered",
  "status_reason": "None",
  "to": "test@email.com"
}
```

The request in its entirety (you will need to set your client accordingly to produce this result):
```
> POST /api/v1/va_notify_update HTTP/1.1
> Host: localhost:3000
> User-Agent: insomnia/2023.2.0
> Content-Type: application/json
> Authorization: Token 0e15cac2bab94beba83dc43553cdda84
> Accept: */*
> Content-Length: 366

| {
|   "completed_at": "2023-05-02T20:48:29.386992Z",
|   "created_at": "2023-05-02T20:48:26.956648Z",
|   "id": "f6ded912-2715-4f00-b4fd-9057902af29d",
|   "notification_type": "email",
|   "provider": "ses",
|   "provider_payload": {},
|   "reference": "",
|   "sent_at": "2023-05-02T20:48:28.097061Z",
|   "status": "delivered",
|   "status_reason": "None",
|   "to": "test@email.com"
| }
```

| Request Portion | Example |
| --- | --- |
| Authorization Header |![va_notify_auth](https://user-images.githubusercontent.com/99351305/235990174-0f15f291-0c44-4258-ba96-5a2b8351b512.PNG)|
| Header |![va_notify_headers](https://user-images.githubusercontent.com/99351305/235990362-27a7eeb0-4352-427c-a517-ccf57b7420ab.PNG)|
| Request Body |![va_notify_body](https://user-images.githubusercontent.com/99351305/235990123-87b4691c-f007-4f66-957d-183cd06aa676.PNG)|

6. You should be receive the following response:
```json
{
	"message": "Email notification successfully updated: ID f6ded912-2715-4f00-b4fd-9057902af29d"
}
```

7. Ensure the notification status has been updated:
```ruby
notif.reload.email_notification_status
=> "delivered"
```

- [ ] For higher-risk changes: [Deploy the custom branch to UAT to test](https://github.com/department-of-veterans-affairs/appeals-deployment/wiki/Applications---Deploy-Custom-Branch-to-UAT)