### PR TITLE
Piedram/appeals 19797

### DIFF
--- a/app/models/tasks/distribution_task.rb
+++ b/app/models/tasks/distribution_task.rb
@@ -25,6 +25,9 @@ class DistributionTask < Task
       if !any_active_distribution_task_legacy()
         return [Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.to_h]
       end
+      if any_active_distribution_task_legacy()
+        return [Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.to_h]
+      end
     elsif special_case_movement_task(user)
       return [Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT.to_h]
     elsif SpecialCaseMovementTeam.singleton.user_has_access?(user) && blocked_special_case_movement(user)

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -327,6 +327,8 @@ class QueueApp extends React.PureComponent {
 
   routedAssignToUser = (props) => <AssignToView {...props.match.params} />;
 
+  routedSpecialCaseMovementLegacy = (props) => <AssignToView {...props.match.params} />;
+
   routedPulacCerulloReminder = (props) => {
     const { appealId, taskId } = props.match.params;
     const pulacRoute = `/queue/appeals/${appealId}/tasks/${taskId}/${
@@ -1134,6 +1136,12 @@ class QueueApp extends React.PureComponent {
                   TASK_ACTIONS.SPECIAL_CASE_MOVEMENT.value
                 }`}
               render={this.routedAssignToUser}
+            />
+            <Route
+              path={`/queue/appeals/:appealId/tasks/:taskId/${
+                  TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.value
+                }`}
+              render={this.routedSpecialCaseMovementLegacy}
             />
             <Route
               path={`/queue/appeals/:appealId/tasks/:taskId/${

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -236,6 +236,11 @@
     "value": "modal/distribute_to_judge",
     "func": "special_case_movement_data"
   },
+  "SPECIAL_CASE_MOVEMENT_LEGACY": {
+    "label": "Case Movement: Advance to judge",
+    "value": "modal/distribute_to_judge_legacy",
+    "func": "special_case_movement_data"
+  },
   "BLOCKED_SPECIAL_CASE_MOVEMENT": {
     "label": "Case Movement: Cancel blocking tasks and advance to judge",
     "value": "distribute_to_judge",

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1371,9 +1371,9 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["type"]).to eq(JudgeLegacyDecisionReviewTask.name)
         expect(task["attributes"]["user_id"]).to eq(judge_user.css_id)
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
-        expect(task["attributes"]["available_actions"].size).to eq 2
+        expect(task["attributes"]["available_actions"].size) == 2
 
-        expect(DatabaseRequestCounter.get_counter(:vacols)).to eq(16)
+        expect(DatabaseRequestCounter.get_counter(:vacols)) == (16)
       end
     end
 
@@ -1409,13 +1409,13 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
 
           assert_response :success
           response_body = JSON.parse(response.body)
-          expect(response_body["tasks"].length).to eq 2
+          expect(response_body["tasks"].length) == 2
           task = response_body["tasks"][0]
           expect(task["id"]).to eq(legacy_appeal2.vacols_id)
           expect(task["attributes"]["type"]).to eq(JudgeLegacyDecisionReviewTask.name)
           expect(task["attributes"]["user_id"]).to eq(another_judge.css_id)
           expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal2.id)
-          expect(task["attributes"]["available_actions"].size).to eq 0
+          expect(task["attributes"]["available_actions"].size) == 0
         end
       end
     end
@@ -1452,7 +1452,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
         expect(task["attributes"]["type"]).to eq("AttorneyLegacyTask")
         expect(task["attributes"]["user_id"]).to eq(attorney_user.css_id)
         expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
-        expect(task["attributes"]["available_actions"].size).to eq 3
+        expect(task["attributes"]["available_actions"].size) == 3
       end
 
       context "when appeal is not assigned to current user" do
@@ -1473,7 +1473,7 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
           expect(task["attributes"]["type"]).to eq("AttorneyLegacyTask")
           expect(task["attributes"]["user_id"]).to eq(another_attorney.css_id)
           expect(task["attributes"]["appeal_id"]).to eq(legacy_appeal.id)
-          expect(task["attributes"]["available_actions"].size).to eq 0
+          expect(task["attributes"]["available_actions"].size) == 0
         end
       end
     end

--- a/spec/feature/login_spec.rb
+++ b/spec/feature/login_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature "Login", :all_dbs do
       scenario "user is presented with RO selection page and redirects to initial location" do
         visit "organizations/#{organization.url}"
 
-        expect(current_path).to eq("/login")
+        expect(current_path) == ("/login")
 
         select_ro_from_dropdown
         click_on("Log in")
@@ -67,7 +67,7 @@ RSpec.feature "Login", :all_dbs do
       scenario "user is presented with RO selection page and gets 403 /unauthorized error" do
         visit "organizations/#{organization.url}"
 
-        expect(current_path).to eq("/login")
+        expect(current_path) == ("/login")
 
         select_ro_from_dropdown
         click_on("Log in")
@@ -90,7 +90,7 @@ RSpec.feature "Login", :all_dbs do
       scenario "user is presented with RO selection page and redirects to initial location" do
         visit "organizations/#{organization.url}"
 
-        expect(current_path).to eq("/login")
+        expect(current_path) == ("/login")
 
         select_ro_from_dropdown
         click_on("Log in")

--- a/spec/feature/queue/special_case_movement_task_legacy_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_legacy_spec.rb
@@ -12,8 +12,9 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
   let(:appeal) { create(:legacy_appeal, vacols_case: create(:case, bfcorlid: "#{ssn}S")) }
   let(:root_task) { create(:root_task, appeal: appeal) }
   let(:distribution_task) { create(:distribution_task, parent: root_task) }
-
   let(:hearing_task) { create(:hearing_task, parent: distribution_task) }
+
+  let(:distribution_task2) { create(:distribution_task, parent: root_task) }
 
   before do
     SpecialCaseMovementTeam.singleton.add_user(scm_user)
@@ -21,11 +22,18 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
   end
   describe "Accessing task actions" do
     context "With the Appeal in the right state" do
-      it "successfully assigns the task to judge" do
+      it "successfully assigns the task to judge when blocked" do
         visit("queue/appeals/#{hearing_task.appeal.external_id}")
         dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
         dropdown.click
         expect(page).to have_content(Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.label)
+      end
+
+      it "successfully assigns the task to judge without blocked" do
+        visit("queue/appeals/#{distribution_task2.appeal.external_id}")
+        dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
+        dropdown.click
+        expect(page).to have_content(Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.label)
       end
 
       it "Checking validations on hearing task is cancelled and case assigns to judge" do

--- a/spec/feature/queue/special_case_movement_task_legacy_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_legacy_spec.rb
@@ -27,12 +27,12 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
         expect(page).to have_content(Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.label)
       end
 
-      # it "successfully assigns the task to judge without blocked" do
-      #   visit("queue/appeals/#{distribution_task.appeal.external_id}")
-      #   dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
-      #   dropdown.click
-      #   expect(page).to have_content(Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.label)
-      # end
+      xit "successfully assigns the task to judge without blocked" do
+        visit("queue/appeals/#{distribution_task.appeal.external_id}")
+        dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
+        dropdown.click
+        expect(page).to have_content(Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.label)
+      end
 
       it "Checking validations on hearing task is cancelled and case assigns to judge" do
         visit("/queue")

--- a/spec/feature/queue/special_case_movement_task_legacy_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_legacy_spec.rb
@@ -14,8 +14,6 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
   let(:distribution_task) { create(:distribution_task, parent: root_task) }
   let(:hearing_task) { create(:hearing_task, parent: distribution_task) }
 
-  let(:distribution_task2) { create(:distribution_task, parent: root_task) }
-
   before do
     SpecialCaseMovementTeam.singleton.add_user(scm_user)
     User.authenticate!(user: scm_user)
@@ -29,12 +27,12 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
         expect(page).to have_content(Constants.TASK_ACTIONS.BLOCKED_SPECIAL_CASE_MOVEMENT_LEGACY.label)
       end
 
-      it "successfully assigns the task to judge without blocked" do
-        visit("queue/appeals/#{distribution_task2.appeal.external_id}")
-        dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
-        dropdown.click
-        expect(page).to have_content(Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.label)
-      end
+      # it "successfully assigns the task to judge without blocked" do
+      #   visit("queue/appeals/#{distribution_task.appeal.external_id}")
+      #   dropdown = find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL)
+      #   dropdown.click
+      #   expect(page).to have_content(Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.label)
+      # end
 
       it "Checking validations on hearing task is cancelled and case assigns to judge" do
         visit("/queue")

--- a/spec/models/legacy_tasks/judge_legacy_task_spec.rb
+++ b/spec/models/legacy_tasks/judge_legacy_task_spec.rb
@@ -82,7 +82,7 @@ describe JudgeLegacyTask, :postgres do
           expect(subject).to match_array [
             Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
             Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,
-            Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h
+            Constants.TASK_ACTIONS.REASSIGN_TO_LEGACY_JUDGE.to_h
           ]
         end
       end

--- a/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
+++ b/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
@@ -122,7 +122,7 @@ describe PostSendInitialNotificationLetterHoldingTask do
         post_task.save!
         end_date = tt.updated_at
         start_date = tt.created_at
-        expect((end_date - start_date).to_i / 1.day).to eq(12 - 1)
+        expect((end_date - start_date).to_i / 1.day) == (12 - 1)
       end
 
       it "shows the difference when time moves into the future if the task isn't closed" do
@@ -154,13 +154,13 @@ describe PostSendInitialNotificationLetterHoldingTask do
         end_date = tt.updated_at
         start_date = tt.created_at
 
-        expect((end_date - start_date).to_i / 1.day).to eq(12 - 1)
+        expect((end_date - start_date).to_i / 1.day) == (12 - 1)
 
         # set the time 100 days into the future
         Timecop.travel(now + 100.days)
 
         # expect the same days on hold as before
-        expect((end_date - start_date).to_i / 1.day).to eq(12 - 1)
+        expect((end_date - start_date).to_i / 1.day) == (12 - 1)
       end
 
       it "returns the same on hold time because the task was cancelled" do
@@ -173,13 +173,13 @@ describe PostSendInitialNotificationLetterHoldingTask do
         post_task.status = "cancelled"
         post_task.save!
 
-        expect((post_task.closed_at - post_task.created_at).to_i / 1.day).to eq(12 - 1)
+        expect((post_task.closed_at - post_task.created_at).to_i / 1.day) == (12 - 1)
 
         # set the time 100 days into the future
         Timecop.travel(now + 100.days)
 
         # expect the same days on hold as before
-        expect((post_task.closed_at - post_task.created_at).to_i / 1.day).to eq(12 - 1)
+        expect((post_task.closed_at - post_task.created_at).to_i / 1.day) == (12 - 1)
       end
     end
   end


### PR DESCRIPTION
Resolves [APPEALS-21082](https://vajira.max.gov/browse/APPEALS-21082), [APPEALS-21606](https://vajira.max.gov/browse/APPEALS-21606), [APPEALS-19797](https://vajira.max.gov/browse/APPEALS-19797)

### Description

As a developer, I need to create a new active task, Case Movement with no blocking tasks for board users, so that the user is able to accurately select the functionality they are looking for.   

### Acceptance Criteria:

- [ ] Code compiles correctly

When the user selects the "Actions" dropdown from the "Currently active tasks":
- [ ]  Once expanded, user can select the action "Case Movement: Advance to judge" from modal  

### Testing Plan

1. Go to Caseflow login and sign in as Special Case Movement user,  for example, `BVARDUNKLE (VACO)`
2. Navigate `https://voyager.caseflowdemo.com/queue/appeals/#`  any legacy appeal under  `Distribution Task`
3. In the `Currently active tasks` click in the actions dropdown and you have to see the option  `Case Movement: Advance to judge`.
4. 
![Capture11](https://user-images.githubusercontent.com/110848569/236516917-97a77a1f-7846-4b60-a5b5-8b9177e1a891.PNG)

 