### PR TITLE
jefftmarks/APPEALS-22155

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -96,7 +96,7 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   # Notifications page eFolder link
-  ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage8.bip.va.gov"
+  ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage.bip.va.gov"
 
   if ENV["WITH_TEST_EMAIL_SERVER"]
     config.action_mailer.delivery_method = :smtp

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -109,7 +109,7 @@ Rails.application.configure do
   ENV["TRAVEL_BOARD_HEARING_SYNC_BATCH_LIMIT"] ||= "250"
 
   # Notifications page eFolder link
-  ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage8.bip.va.gov"
+  ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage.bip.va.gov"
 
   ENV['TEST_VACOLS_HOST'] ||= "localhost"
 end


### PR DESCRIPTION
Resolves [APPEALS-22155](https://vajira.max.gov/browse/APPEALS-22155)

# Description
The base URL for the staging instance of the Claim Evidence UI has changed from https://vefs-claimevidence-ui-uat.stage8.bip.va.gov/ to https://vefs-claimevidence-ui-uat.stage.bip.va.gov/

We will need to update our environmental variables to utilize this new URL so that our links to the Claim Evidence UI within our UAT instance work properly.

## Acceptance Criteria
- [x] The value of [CLAIM_EVIDENCE_EFOLDER_BASE_URL](https://github.com/department-of-veterans-affairs/caseflow/blob/7f22ca5da85577ec41ed585272154b9afcb72436/config/environments/development.rb#L99) for our development environment is updated to https://vefs-claimevidence-ui-uat.stage8.bip.va.gov/
- [x] The value of [CLAIM_EVIDENCE_EFOLDER_BASE_URL](https://github.com/department-of-veterans-affairs/caseflow/blob/7f22ca5da85577ec41ed585272154b9afcb72436/config/environments/test.rb#L112) for our test environment is updated to https://vefs-claimevidence-ui-uat.stage8.bip.va.gov/
- [ ] Any tests that fail due to the 8 being removed from the URL should be updated to check for the updated version without the 8 

## Testing Plan
Go to [APPEALS-22155](https://vajira.max.gov/browse/APPEALS-22155)