### PR TITLE
Justin/APPEALS-17533-fix

### DIFF
--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -86,8 +86,8 @@ class ContestableIssue
       timely: timely?,
       latestIssuesInChain: serialize_latest_decision_issues,
       isRating: is_rating,
-      mst_available: mst_available?,
-      pact_available: pact_available?
+      mstAvailable: mst_available?,
+      pactAvailable: pact_available?
     }
   end
 

--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -15,7 +15,7 @@ class ContestableIssue
 
   class << self
     def from_rating_issue(rating_issue, contesting_decision_review)
-      #epe = EndProductEstablishment.find_by(reference_id: rating_issue.reference_id)
+      # epe = EndProductEstablishment.find_by(reference_id: rating_issue.reference_id)
       new(
         rating_issue_reference_id: rating_issue.reference_id,
         rating_issue_profile_date: rating_issue.profile_date.to_date,
@@ -50,10 +50,8 @@ class ContestableIssue
         source_decision_review: source,
         contesting_decision_review: contesting_decision_review,
         is_rating: decision_issue.rating?,
-        mst_available: mst_available?,
-        pact_available: pact_available?
-        mstAvailable: mst_available?,
-        pactAvailable: pact_available?
+        # mst_available: mst_available?,
+        # pact_available: pact_available?
       )
     end
 
@@ -88,8 +86,8 @@ class ContestableIssue
       timely: timely?,
       latestIssuesInChain: serialize_latest_decision_issues,
       isRating: is_rating,
-      mstAvailable: mst_available?,
-      pactAvailable: pact_available?
+      mst_available: mst_available?,
+      pact_available: pact_available?
     }
   end
 

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { map, findIndex, uniq, size } from 'lodash';
+import { map, findIndex, uniq } from 'lodash';
 
 import { formatDateStr } from '../../util/DateUtil';
 import Modal from '../../components/Modal';
@@ -67,6 +67,13 @@ class AddIssuesModal extends React.Component {
 
     // Ensure we have a value for decisionDate
     currentIssue.decisionDate = currentIssue.decisionDate || currentIssue.approxDecisionDate;
+
+    if (mstChecked && mstJustification === '') {
+      return;
+    }
+    if (pactChecked && pactJustification === '') {
+      return;
+    }
 
     this.props.onSubmit({
       currentIssue: {

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -136,6 +136,7 @@ export const IntakeRadioField = (props) => {
               name="mstJustification-field"
               value={mstJustification}
               label="Why was this change made?"
+              required
               onChange={(mstJustificationText) => mstJustificationOnChange(mstJustificationText)}
             />
           }
@@ -151,6 +152,7 @@ export const IntakeRadioField = (props) => {
               name="pactJustification-field"
               value={pactJustification}
               label="Why was this change made?"
+              required
               onChange={(pactJustificationText) => pactJustificationOnChange(pactJustificationText)}
             />
           }

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -136,8 +136,6 @@ export const IntakeRadioField = (props) => {
               name="mstJustification-field"
               value={mstJustification}
               label="Why was this change made?"
-              // textAlign="left"
-              required
               onChange={(mstJustificationText) => mstJustificationOnChange(mstJustificationText)}
             />
           }
@@ -153,11 +151,7 @@ export const IntakeRadioField = (props) => {
               name="pactJustification-field"
               value={pactJustification}
               label="Why was this change made?"
-              required
               onChange={(pactJustificationText) => pactJustificationOnChange(pactJustificationText)}
-              // InputLabelProps={{
-              //   style: { textAlign: 'left' },
-              // }}
             />
           }
         </div>


### PR DESCRIPTION
Resolves [APPEALS-17533](https://vajira.max.gov/browse/APPEALS-17533)

# Description
- [ ] Moved intake edits from RadioField.jsx into new IntakeRadioField.jsx file
- [ ] Refactored/reset the RadioField.jsx file back to its initial state from the master branch
- [ ] Added a justification textbox to be rendered if a checkbox change is made 
- [ ] Saved Justification text into redux store to be utilized later
- [ ] Wrote and validated spec tests

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] AC 1. Create frontend logic for displaying the optional "why was this change made" text box when a user makes a change to the current status of the MST or PACT designation for an issue. 
- [ ] AC 2. User can include text in the textbox when editing the MST or PACT checkbox for a request issue, and Save the edited request  issue.
- [ ] AC 3. User can forego adding text in the textbox when editing the MST or PACT checkbox for a request issue, and Save the edited request  issue. 
- [ ] AC 4. SPEC test written
- [ ] AC 5. SPEC test validated

## Testing Plan
1. Log in as an intake user
2. Begin mail intake process
3. Choose VA Form 10182
4. Choose a veteran with an established appeal (for example: 400000021 or 400000025)
5. Select options on the review page and continue
6. Click on "Add Issue" button. The page should display something along the lines of: "Does issue 1 match any of these issues from past descriptions?"
7. Choose a past decision. The MST and PACT checkboxes should appear and allow the user to select them
8. When one or both of these checkboxes is selected, a new textbox should appear beneath these textboxes asking "Why was this change made?" This textbox should be optional to fill. 
9. The textbox will be saved to the redux state in the application but will not yet be visible within the application for this ticket. This functionality can be verified through the Redux Dev tools toolkit, inside appeal>addedIssues>0 (or whichever the last selected issue number was)>justification 

Screenshot included showing the state stored in redux tools:
![image](https://user-images.githubusercontent.com/95875751/235244607-bf56254b-2e43-4b1d-9d4c-9b784fe87e08.png)


# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
![image](https://user-images.githubusercontent.com/95875751/235243779-fbf11a78-060a-4991-812b-84aeee10da97.png)

 ---|---

![image](https://user-images.githubusercontent.com/95875751/235243832-25b6304d-6ed1-468e-84da-0623b6be2d12.png)
