### PR TITLE
APPEALS-17536 - Hotfix for prop naming

### DIFF
--- a/client/app/intake/components/AddedIssue.jsx
+++ b/client/app/intake/components/AddedIssue.jsx
@@ -109,11 +109,11 @@ class AddedIssue extends React.PureComponent {
 
     let specialIssuesMessage = 'None';
 
-    if (issue.mst_status && issue.pact_status) {
+    if (issue.mstChecked && issue.pactChecked) {
       specialIssuesMessage = COPY.MST_SHORT_LABEL + ', ' + COPY.PACT_SHORT_LABEL;
-    } else if (issue.mst_status) {
+    } else if (issue.mstChecked) {
       specialIssuesMessage = COPY.MST_SHORT_LABEL;
-    } else if (issue.pact_status) {
+    } else if (issue.pactChecked) {
       specialIssuesMessage = COPY.PACT_SHORT_LABEL;
     }
 
@@ -180,8 +180,8 @@ AddedIssue.propTypes = {
     vacolsId: PropTypes.string,
     withdrawalPending: PropTypes.string,
     withdrawalDate: PropTypes.string,
-    mst_status: PropTypes.bool,
-    pact_status: PropTypes.bool,
+    mstChecked: PropTypes.bool,
+    pactChecked: PropTypes.bool,
   }).isRequired,
   issueIdx: PropTypes.number.isRequired,
   legacyAppeals: PropTypes.array,


### PR DESCRIPTION
Resolves #{APPEALS-17536}
https://vajira.max.gov/browse/APPEALS-17536

# Description
Hotfix for APPEALS-17536.  Naming changes on the AddIssueModal broke some functionality for the conditional rendering of the Issue status on the AddedIssue component.

## Acceptance Criteria
- [X] Code compiles correctly

