### PR TITLE
Adding disable dev shm usage

### DIFF
--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -53,7 +53,6 @@ Capybara.register_driver(:sniffybara_headless) do |app|
   chrome_options.args << "--headless"
   chrome_options.args << "--disable-gpu"
   chrome_options.args << "--window-size=1200,1200"
-  chrome_options.args << "--disable-dev-shm-usage"
 
   options = {
     service: ::Selenium::WebDriver::Service.chrome(args: { port: 51_674 }),

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -50,8 +50,10 @@ Capybara.register_driver(:sniffybara_headless) do |app|
   chrome_options.add_preference(:browser,
                                 disk_cache_dir: cache_directory)
 
+  chrome_options.args << "--no-sandbox"
   chrome_options.args << "--headless"
   chrome_options.args << "--disable-gpu"
+  chrome_options.args << "--disable-dev-shm-usage"
   chrome_options.args << "--window-size=1200,1200"
 
   options = {

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -53,6 +53,7 @@ Capybara.register_driver(:sniffybara_headless) do |app|
   chrome_options.args << "--headless"
   chrome_options.args << "--disable-gpu"
   chrome_options.args << "--window-size=1200,1200"
+  chrome_options.args << "--disable-dev-shm-usage"
 
   options = {
     service: ::Selenium::WebDriver::Service.chrome(args: { port: 51_674 }),


### PR DESCRIPTION
Resolves: [APPEALS-22152](https://vajira.max.gov/browse/APPEALS-22152)  

# Description
added "--disable-dev-shm-usage" in capybara to check if we can use temp folder instead of dev/shms. 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Selenium::WebDriver::Error::UnknownError should not be present in the spec failures in github.
- [ ] Selenium::WebDriver::Error::InvalidSessionIdError should not be present in the spec failure in github

## Testing Plan
1. Looking into github actions and trying to find Selenium::WebDriver::Error::UnknownError and Selenium::WebDriver::Error::InvalidSessionIdError
- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] no frontend changes

 
 ---|---

## Storybook Story
*No storybook

