### PR TITLE
add VhaRegionalOffice to conditional url in task action repository

### DIFF
--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -954,7 +954,7 @@ class TaskActionRepository # rubocop:disable Metrics/ClassLength
     end
 
     def po_user(organization)
-      return unless organization.is_a?(VhaProgramOffice)
+      return unless organization.is_a?(VhaProgramOffice) || organization.is_a?(VhaRegionalOffice)
 
       "po_"
     end


### PR DESCRIPTION
# Description
Fix bug that caused AssessDocumentationTasks assigned to a VISN to not redirect to the "On Hold" tab for VISN organizations when the task was placed on hold

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] A/C from [APPEALS-17252](https://vajira.max.gov/browse/APPEALS-17252) are met

## Testing Plan
1. Intake case to VHA CAMO predocket
2. Assign to a Program Office
3. Assign from PO to VISN
4. As a VISN user, place case on hold
5. Verify that you are redirected to the VISN On Hold tab
