### PR TITLE
Justin/APPEALS-22806

### DIFF
--- a/client/app/components/RadioField.jsx
+++ b/client/app/components/RadioField.jsx
@@ -197,10 +197,6 @@ RadioField.propTypes = {
        * Help text to be displayed below the label
        */
       help: PropTypes.string,
-
-      mst: PropTypes.Boolean,
-      pact: PropTypes.Boolean,
-      counterVal: PropTypes.number
     })
   ),
 

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -91,8 +91,6 @@ class AddIssuesModal extends React.Component {
     const { intakeData } = this.props;
     let iterations = -1;
     const addedIssues = intakeData.addedIssues ? intakeData.addedIssues : [];
-    let preExistingMST;
-    let preExistingPACT;
     let counter = 0;
     const issueKeys = Object.keys(intakeData.contestableIssues);
 
@@ -185,8 +183,6 @@ class AddIssuesModal extends React.Component {
           setMstCheckboxFunction={this.mstCheckboxChange}
           pactChecked={this.state.pactChecked}
           setPactCheckboxFunction={this.pactCheckboxChange}
-          preExistingMST={preExistingMST}
-          preExistingPACT={preExistingPACT}
         />
       );
     });

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -69,10 +69,14 @@ class AddIssuesModal extends React.Component {
     currentIssue.decisionDate = currentIssue.decisionDate || currentIssue.approxDecisionDate;
 
     if (mstChecked && mstJustification === '') {
-      return;
+      if (!currentIssue.mstAvailable) {
+        return;
+      }
     }
     if (pactChecked && pactJustification === '') {
-      return;
+      if (!currentIssue.pactAvailable) {
+        return;
+      }
     }
 
     this.props.onSubmit({

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -77,31 +77,9 @@ export const IntakeRadioField = (props) => {
     </span>
   );
 
-  const returnMstOrCheckboxValue = (counter) => {
-    let valueToCheck = counter - totalElements;
-    const existingMst = options[valueToCheck].mst;
-
-    if (existingMst) {
-      return existingMst;
-    }
-
-    return mstChecked;
-  };
-
-  const returnPactOrCheckboxValue = (counter) => {
-    let valueToCheck = counter - totalElements;
-    const existingPact = options[valueToCheck].pact;
-
-    if (existingPact) {
-      return existingPact;
-    }
-
-    return pactChecked;
-  };
-
   // prepopulated MST and PACT checkbox values
-  let prePopulatedMst = options[value - totalElements].mst
-  let prePopulatedPact = options[value - totalElements].pact
+  let prePopulatedMst = options[value - totalElements]?.mst;
+  let prePopulatedPact = options[value - totalElements]?.pact;
 
   // handle both MST and PACT pre-populated checkbox status on load
   const handlePrepopulatedCheckboxes = (radioOption) => {

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -100,27 +100,13 @@ export const IntakeRadioField = (props) => {
   };
 
   // prepopulated MST and PACT checkbox values
-  const prePopulatedMst = options[value - totalElements].mst
-  const prePopulatedPact = options[value - totalElements].pact
+  let prePopulatedMst = options[value - totalElements].mst
+  let prePopulatedPact = options[value - totalElements].pact
 
   // handle both MST and PACT pre-populated checkbox status on load
   const handlePrepopulatedCheckboxes = (radioOption) => {
     setMstCheckboxFunction(radioOption.mst);
     setPactCheckboxFunction(radioOption.pact);
-  };
-
-  // format prepopulated checkbox text to say the values came from VBMS
-  const formatJustificationText = (prePopulatedStatus) => {
-    let text = 'Prepopulated from VBMS';
-
-    if (prePopulatedMst) {
-      mstJustificationOnChange(text);
-    }
-
-    if (prePopulatedPact) {
-      pactJustificationOnChange(text);
-    }
-
   };
 
   const maybeAddTooltip = (option, radioField) => {
@@ -148,8 +134,6 @@ export const IntakeRadioField = (props) => {
 
       return (
         <div>
-        {console.log(`mst prefilled: ${JSON.stringify(prePopulatedMst)}`)}
-        {console.log(`pact prefilled: ${JSON.stringify(prePopulatedPact)}`)}
           <Checkbox
             label="Issue is related to Military Sexual Trauma (MST)"
             name="MST"
@@ -195,15 +179,6 @@ export const IntakeRadioField = (props) => {
 
     // if the radio option has a pre-populated MST/PACT checkbox, update the value
     handlePrepopulatedCheckboxes(props.options[event.target.value]);
-
-    // prepopulate the justification text for MST and PACT
-    if (prePopulatedMst) {
-      formatJustificationText(prePopulatedMst);
-    }
-
-    if (prePopulatedPact) {
-      formatJustificationText(prePopulatedPact);
-    }
   };
 
   const controlled = useMemo(() => typeof value !== 'undefined', [value]);
@@ -345,8 +320,8 @@ IntakeRadioField.propTypes = {
   mstJustificationOnChange: PropTypes.func,
   setPactCheckboxFunction: PropTypes.func,
   totalElements: PropTypes.number,
-  preExistingMST: PropTypes.bool,
-  preExistingPACT: PropTypes.bool,
+  prePopulatedMst: PropTypes.bool,
+  prePopulatedPact: PropTypes.bool
 };
 
 export default IntakeRadioField;

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -99,6 +99,30 @@ export const IntakeRadioField = (props) => {
     return pactChecked;
   };
 
+  // prepopulated MST and PACT checkbox values
+  const prePopulatedMst = options[value - totalElements].mst
+  const prePopulatedPact = options[value - totalElements].pact
+
+  // handle both MST and PACT pre-populated checkbox status on load
+  const handlePrepopulatedCheckboxes = (radioOption) => {
+    setMstCheckboxFunction(radioOption.mst);
+    setPactCheckboxFunction(radioOption.pact);
+  };
+
+  // format prepopulated checkbox text to say the values came from VBMS
+  const formatJustificationText = (prePopulatedStatus) => {
+    let text = 'Prepopulated from VBMS';
+
+    if (prePopulatedMst) {
+      mstJustificationOnChange(text);
+    }
+
+    if (prePopulatedPact) {
+      pactJustificationOnChange(text);
+    }
+
+  };
+
   const maybeAddTooltip = (option, radioField) => {
     if (option.tooltipText) {
       const idKey = `tooltip-${option.value}`;
@@ -124,14 +148,16 @@ export const IntakeRadioField = (props) => {
 
       return (
         <div>
+        {console.log(`mst prefilled: ${JSON.stringify(prePopulatedMst)}`)}
+        {console.log(`pact prefilled: ${JSON.stringify(prePopulatedPact)}`)}
           <Checkbox
             label="Issue is related to Military Sexual Trauma (MST)"
             name="MST"
-            value={returnMstOrCheckboxValue(value)}
-            disabled={options[value - totalElements].mst}
+            value={mstChecked}
+            disabled={prePopulatedMst}
             onChange={(checked) => setMstCheckboxFunction(checked)}
           />
-          { mstChecked &&
+          { (mstChecked && !prePopulatedMst) &&
             <TextField
               name="mstJustification-field"
               value={mstJustification}
@@ -143,16 +169,17 @@ export const IntakeRadioField = (props) => {
           <Checkbox
             label="Issue is related to PACT act"
             name="Pact"
-            value={returnPactOrCheckboxValue(value)}
-            disabled={options[value - totalElements].pact}
+            value={pactChecked}
+            disabled={prePopulatedPact}
             onChange={(checked) => setPactCheckboxFunction(checked)}
           />
-          { pactChecked &&
+          { (pactChecked && !prePopulatedPact) &&
             <TextField
               name="pactJustification-field"
               value={pactJustification}
               label="Why was this change made?"
               required
+              optional={prePopulatedPact}
               onChange={(pactJustificationText) => pactJustificationOnChange(pactJustificationText)}
             />
           }
@@ -163,7 +190,22 @@ export const IntakeRadioField = (props) => {
 
   const isDisabled = (option) => Boolean(option.disabled);
 
-  const handleChange = (event) => onChange?.(event.target.value);
+  const handleChange = (event) => {
+    onChange?.(event.target.value);
+
+    // if the radio option has a pre-populated MST/PACT checkbox, update the value
+    handlePrepopulatedCheckboxes(props.options[event.target.value]);
+
+    // prepopulate the justification text for MST and PACT
+    if (prePopulatedMst) {
+      formatJustificationText(prePopulatedMst);
+    }
+
+    if (prePopulatedPact) {
+      formatJustificationText(prePopulatedPact);
+    }
+  };
+
   const controlled = useMemo(() => typeof value !== 'undefined', [value]);
 
   return (


### PR DESCRIPTION
Resolves [APPEALS-22806](https://vajira.max.gov/browse/APPEALS-22806)

# Description
When intaking an appeal with MST/PACT issues pre-checked, the redux stores tracking these values were not reading the prechecks correctly. Also, the submit button was not always functioning because the redux store was not updating at the correct time. These two bugs have been worked out in this PR.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Expected Results: The MST/PACT status is updated if pre-checked.
- [ ] Expected Results: The Submit button will function whether an issue has been prechecked or not
- [ ] Expected Results: The Justification field will only appear or be required if the 

## Testing Plan
Steps to Reproduce: # Sign into Caseflow as an Intake user

Select Form-10182 option
Search for a Veteran with previous contentions (787148925, 657332982, or 416322111 in demo environment
Fill out the required fields for the intake
Click "Continue to next step" button
Click "Add Issue" button
Click one of the past issues that appear. Note the checkbox that was pre-checked
Click "Save" on the modal.
Verify the modal can be submitted, and verify that the MST/PACT status is updated