### PR TITLE
APPEALS-22479: added try block to contestable issue model cycling request issues

### DIFF
--- a/app/models/contestable_issue.rb
+++ b/app/models/contestable_issue.rb
@@ -117,7 +117,7 @@ class ContestableIssue
 
   # cycle the issues to see if the past decision had any mst codes on contentions
   def mst_available?
-    source_request_issues.each do |issue|
+    source_request_issues.try(:each) do |issue|
       return true if issue.mst_contention_status? || issue.mst_status?
     end
     false
@@ -125,7 +125,7 @@ class ContestableIssue
 
   # cycle the issues to see if the past decision had any pact codes on contentions
   def pact_available?
-    source_request_issues.each do |issue|
+    source_request_issues.try(:each) do |issue|
       return true if issue.pact_contention_status? || issue.pact_status?
     end
     false


### PR DESCRIPTION
Resolves [APPEALS-22479](https://vajira.max.gov/browse/APPEALS-22479)

# Description
Added try block for Contestable Issue MST and PACT checks so previous cases without Request Issues will be able to load within Intake

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Go to Caseflow UAT as a BVA Intake User (CF_Q_283, CF_KHAN_397)
2. Navigate to Intake.
3. Select **decision review: 10182** form.
4. For the veteran file number, enter 666077190.
5. Fill out the next form.
6. You should arrive on the add issues page without hitting a red error banner. If you click **add issues** it should show the previous issues for the veteran.
 