### PR TITLE
fix checkbox not prepopulating on mst/pact issue legacy decision

### DIFF
--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -112,8 +112,8 @@ class AddEditIssueView extends React.Component {
           level_2: _.get(issue.codes, 1, null),
           level_3: _.get(issue.codes, 2, null),
           ..._.pick(issue, 'note', 'program'),
-          mst_status: issue.mst_status ? 'Y' : 'N',
-          pact_status: issue.pact_status ? 'Y' : 'N'
+          mst_status: issue.legacy_appeal_vacols_mst ? 'Y' : 'N',
+          pact_status: issue.legacy_appeal_vacols_pact ? 'Y' : 'N'
         }
       }
     };
@@ -337,16 +337,16 @@ class AddEditIssueView extends React.Component {
       <Checkbox
         name="MST"
         label="Military Sexual Trauma (MST)"
-        defaultValue={issue.mst_status}
+        value={issue.legacy_appeal_vacols_mst}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ mst_status: checked })}
+        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_mst: checked })}
       />
       <Checkbox
         name="PACT"
         label="PACT Act"
-        defaultValue={issue.pact_status}
+        value={issue.legacy_appeal_vacols_pact}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ pact_status: checked })}
+        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_pact: checked })}
       />
     </QueueFlowPage>;
   };
@@ -380,8 +380,8 @@ AddEditIssueView.propTypes = {
     type: PropTypes.string,
     codes: PropTypes.arrayOf(PropTypes.string),
     program: PropTypes.string,
-    mst_status: PropTypes.bool,
-    pact_status: PropTypes.bool
+    legacy_appeal_vacols_mst: PropTypes.bool,
+    legacy_appeal_vacols_pact: PropTypes.bool
   }),
   issueId: PropTypes.string,
   issues: PropTypes.object,

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -337,16 +337,18 @@ class AddEditIssueView extends React.Component {
       <Checkbox
         name="MST"
         label="Military Sexual Trauma (MST)"
-        value={issue.legacy_appeal_vacols_mst}
+        // defaultValue={issue.legacy_appeal_vacols_mst}
+        value={issue.mst_status}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_mst: checked })}
+        onChange={(checked) => this.updateIssue({ mst_status: checked })}
       />
       <Checkbox
         name="PACT"
         label="PACT Act"
-        value={issue.legacy_appeal_vacols_pact}
+        // defaultValue={issue.legacy_appeal_vacols_pact}
+        value={issue.pact_status}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_pact: checked })}
+        onChange={(checked) => this.updateIssue({ pact_status: checked })}
       />
     </QueueFlowPage>;
   };

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -337,18 +337,18 @@ class AddEditIssueView extends React.Component {
       <Checkbox
         name="MST"
         label="Military Sexual Trauma (MST)"
-        // defaultValue={issue.legacy_appeal_vacols_mst}
-        value={issue.mst_status}
+        defaultValue={issue.legacy_appeal_vacols_mst}
+        value={issue.legacy_appeal_vacols_mst}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ mst_status: checked })}
+        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_mst: checked })}
       />
       <Checkbox
         name="PACT"
         label="PACT Act"
-        // defaultValue={issue.legacy_appeal_vacols_pact}
-        value={issue.pact_status}
+        defaultValue={issue.legacy_appeal_vacols_pact}
+        value={issue.legacy_appeal_vacols_pact}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ pact_status: checked })}
+        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_pact: checked })}
       />
     </QueueFlowPage>;
   };

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -317,8 +317,6 @@ export const prepareAppealIssuesForStore = (appeal) => {
   if (appeal.attributes.docket_name === 'legacy') {
     issues = issues.map((issue) => ({
       id: issue.vacols_sequence_id,
-      mst_status: false,
-      pact_status: false,
       ...issue,
     }));
   }


### PR DESCRIPTION
Resolves [23335](https://vajira.max.gov/browse/APPEALS-23335)

# Description
Fix bug on the legacy decision workflow when opening the Edit Issue page, it does not pre-fill MST/PACT checkboxes when the issue has MST/PACT status on it.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Login as BVAAABSHIRE
2. Click on Your Queue
3. Click on any Legacy case
4. Under the Actions dropdown, click on Ready for Dispatch
5. On the special issues page, click continue
6. Here if the issue by default has no MST or PACT, click on Edit Issue then click on both MST and PACT checkboxes.
7. Click Continue
8. Click on Edit Issue again and observe that both checkboxes are pre-filled
