### PR TITLE
Justin/APPEALS-23333

### DIFF
--- a/app/controllers/intakes_controller.rb
+++ b/app/controllers/intakes_controller.rb
@@ -155,8 +155,7 @@ class IntakesController < ApplicationController
       legacyMstPactIdentification: FeatureToggle.enabled?(:legacy_mst_pact_identification, user: current_user),
       updatedAppealForm: FeatureToggle.enabled?(:updated_appeal_form, user: current_user),
       hlrScUnrecognizedClaimants: FeatureToggle.enabled?(:hlr_sc_unrecognized_claimants, user: current_user),
-      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user),
-      mstPactIdentification: FeatureToggle.enabled?(:mst_pact_identification, user: current_user)
+      vhaClaimReviewEstablishment: FeatureToggle.enabled?(:vha_claim_review_establishment, user: current_user)
     }
   end
 

--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -173,7 +173,6 @@ class AddIssuesModal extends React.Component {
           key={approxDecisionDate}
           value={this.state.selectedContestableIssueIndex}
           onChange={this.radioOnChange}
-          renderMstAndPact={this.props.featureToggles.mstPactIdentification}
           mstJustification={this.state.mstJustification}
           mstJustificationOnChange={this.mstJustificationOnChange}
           pactJustification={this.state.pactJustification}

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -109,44 +109,49 @@ export const IntakeRadioField = (props) => {
 
   // Creating MST and PACT checkboxes, along with a text input for justification of change
   const maybeAddMstAndPactCheckboxes = (option) => {
-    if ((renderMst && renderPact) && (option.value === props.value)) {
-
+    if (option.value === props.value) {
       return (
-        <div>
-          <Checkbox
-            label="Issue is related to Military Sexual Trauma (MST)"
-            name="MST"
-            value={mstChecked}
-            disabled={prePopulatedMst}
-            onChange={(checked) => setMstCheckboxFunction(checked)}
-          />
-          { (mstChecked && !prePopulatedMst) &&
-            <TextField
-              name="mstJustification-field"
-              value={mstJustification}
-              label="Why was this change made?"
-              required
-              onChange={(mstJustificationText) => mstJustificationOnChange(mstJustificationText)}
+        <React.Fragment>
+          { renderMst && <div>
+            <Checkbox
+              label="Issue is related to Military Sexual Trauma (MST)"
+              name="MST"
+              value={mstChecked}
+              disabled={prePopulatedMst}
+              onChange={(checked) => setMstCheckboxFunction(checked)}
             />
+            { (mstChecked && !prePopulatedMst) &&
+              <TextField
+                name="mstJustification-field"
+                value={mstJustification}
+                label="Why was this change made?"
+                required
+                onChange={(mstJustificationText) => mstJustificationOnChange(mstJustificationText)}
+              />
+            }
+          </div>
           }
-          <Checkbox
-            label="Issue is related to PACT act"
-            name="Pact"
-            value={pactChecked}
-            disabled={prePopulatedPact}
-            onChange={(checked) => setPactCheckboxFunction(checked)}
-          />
-          { (pactChecked && !prePopulatedPact) &&
-            <TextField
-              name="pactJustification-field"
-              value={pactJustification}
-              label="Why was this change made?"
-              required
-              optional={prePopulatedPact}
-              onChange={(pactJustificationText) => pactJustificationOnChange(pactJustificationText)}
+          { renderPact && <div>
+            <Checkbox
+              label="Issue is related to PACT act"
+              name="Pact"
+              value={pactChecked}
+              disabled={prePopulatedPact}
+              onChange={(checked) => setPactCheckboxFunction(checked)}
             />
+            { (pactChecked && !prePopulatedPact) &&
+              <TextField
+                name="pactJustification-field"
+                value={pactJustification}
+                label="Why was this change made?"
+                required
+                optional={prePopulatedPact}
+                onChange={(pactJustificationText) => pactJustificationOnChange(pactJustificationText)}
+              />
+            }
+          </div>
           }
-        </div>
+        </React.Fragment>
       );
     }
   };

--- a/client/app/intake/components/IntakeRadioField.jsx
+++ b/client/app/intake/components/IntakeRadioField.jsx
@@ -46,7 +46,8 @@ export const IntakeRadioField = (props) => {
     styling,
     vertical,
     totalElements,
-    renderMstAndPact,
+    renderMst,
+    renderPact,
     mstChecked,
     setMstCheckboxFunction,
     pactChecked,
@@ -108,7 +109,7 @@ export const IntakeRadioField = (props) => {
 
   // Creating MST and PACT checkboxes, along with a text input for justification of change
   const maybeAddMstAndPactCheckboxes = (option) => {
-    if (renderMstAndPact && (option.value === props.value)) {
+    if ((renderMst && renderPact) && (option.value === props.value)) {
 
       return (
         <div>
@@ -288,7 +289,8 @@ IntakeRadioField.propTypes = {
   strongLabel: PropTypes.bool,
   hideLabel: PropTypes.bool,
   styling: PropTypes.object,
-  renderMstAndPact: PropTypes.bool,
+  renderMst: PropTypes.bool,
+  renderPact: PropTypes.bool,
   mstChecked: PropTypes.bool,
   setMstCheckboxFunction: PropTypes.func,
   pactChecked: PropTypes.bool,

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -413,10 +413,6 @@ class AddIssuesPage extends React.Component {
               (this.props.featureToggles.mst_identification ||
               this.props.featureToggles.pact_identification ||
               this.props.featureToggles.legacy_mst_pact_identification)}
-              userCanEditIntakeIssues={userCanEditIntakeIssues &&
-              (this.props.featureToggles.mst_identification ||
-              this.props.featureToggles.pact_identification ||
-              this.props.featureToggles.legacy_mst_pact_identification)}
               editPage={editPage}
             />
             {showPreDocketBanner && <Alert message={COPY.VHA_PRE_DOCKET_ADD_ISSUES_NOTICE} type="info" />}

--- a/client/app/intake/reducers/featureToggles.js
+++ b/client/app/intake/reducers/featureToggles.js
@@ -37,9 +37,6 @@ const updateFromServerFeatures = (state, featureToggles) => {
     },
     vhaClaimReviewEstablishment: {
       $set: Boolean(featureToggles.vhaClaimReviewEstablishment)
-    },
-    mstPactIdentification: {
-      $set: Boolean(featureToggles.mstPactIdentification)
     }
   });
 };
@@ -57,8 +54,7 @@ export const mapDataToFeatureToggle = (data = { featureToggles: {} }) =>
       legacyMstPactIdentification: false,
       updatedAppealForm: false,
       hlrScUnrecognizedClaimants: false,
-      vhaClaimReviewEstablishment: false,
-      mstPactIdentification: false
+      vhaClaimReviewEstablishment: false
     },
     data.featureToggles
   );


### PR DESCRIPTION
Resolves [APPEALS-23335](https://vajira.max.gov/browse/APPEALS-23335)

# Description
Removed renderMstAndPact store, as this was returning as undefined in the correct issues page. Replaced this with renderMst and renderPact, which were created previously and were returning true as expected in the correct issues page. 

Removed deprecated usage of mst_pact_identification and mstPactIdentification feature toggles (now replaced by the separate toggles mst_identification/mstIdentification and pact_identification/pactIdentification)

Also separated mst checkbox rendering and pact checkbox rendering, so that each box can be separately removed if removing that feature toggle 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Bug where mst and pact checkboxes did not appear in the add issues modal from the correct issues page is resolved

## Testing Plan
Find them below or go to [APPEALS-23335](https://vajira.max.gov/browse/APPEALS-23335)

1. Select Form-10182 option
2. Search for a Veteran with previous contentions (787148925, 657332982, or 416322111 in demo environment
3. Fill out the required fields for the intake
4. Click "Continue to next step" button
5. Click "Add Issue" button
6. Click one of the past issues that appear. Make a change by adding mst or pact check and then adding in a justification for the change
7. Click "Save" on the modal.

1. On the Intake Completed screen, click "correct the issues"
2. Click "Add Issue" button
3. Click one of the past issues that appear. Note that the MST/PACT special issues text boxes do appear in this modal after the bug fix, while they did not appear previously.


 BEFORE|AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/95875751/416940ab-abfd-4ede-8cde-afaf921ae4bb)
 ---|---
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/95875751/7d983e3a-5793-48d5-85fb-888115b12837)

