### PR TITLE
HunJerBAH/Legacy and AMA Edit Page Bug Fix

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -9,7 +9,7 @@ class Issue
 
   attr_accessor :id, :vacols_sequence_id, :codes, :disposition, :disposition_date,
                 :disposition_id, :readable_disposition, :close_date, :note,
-                :legacy_appeal_vacols_mst, :legacy_appeal_vacols_pact
+                :mst_status, :pact_status
 
   # Labels are only loaded if we run the joins to ISSREF and VFTYPES (see VACOLS::CaseIssue)
   attr_writer :labels
@@ -330,8 +330,8 @@ class Issue
         # readable disposition is a string, i.e. "Remanded"
         readable_disposition: Constants::VACOLS_DISPOSITIONS_BY_ID[hash["issdc"]],
         close_date: AppealRepository.normalize_vacols_date(hash["issdcls"]),
-        legacy_appeal_vacols_mst: hash["issmst"]&.casecmp("y")&.zero? || false,
-        legacy_appeal_vacols_pact: hash["isspact"]&.casecmp("y")&.zero? || false
+        mst_status: hash["issmst"]&.casecmp("y")&.zero? || false,
+        pact_status: hash["isspact"]&.casecmp("y")&.zero? || false
       )
     end
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -632,7 +632,7 @@ class LegacyAppeal < CaseflowRecord
   def mst?
     return false unless FeatureToggle.enabled?(:mst_pact_identification)
 
-    issues.any?(&:legacy_appeal_vacols_mst) ||
+    issues.any?(&:mst_status) ||
       (special_issue_list &&
         special_issue_list.created_at < "2023-06-01".to_date &&
         special_issue_list.military_sexual_trauma)
@@ -641,7 +641,7 @@ class LegacyAppeal < CaseflowRecord
   def pact?
     return false unless FeatureToggle.enabled?(:mst_pact_identification)
 
-    issues.any?(&:legacy_appeal_vacols_pact)
+    issues.any?(&:pact_status)
   end
 
   def documents_with_type(*types)

--- a/app/models/serializers/work_queue/legacy_issue_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_issue_serializer.rb
@@ -16,6 +16,6 @@ class WorkQueue::LegacyIssueSerializer
   attribute :labels
   attribute(:readjudication) { false }
   attribute :remand_reasons
-  attribute :legacy_appeal_vacols_mst
-  attribute :legacy_appeal_vacols_pact
+  attribute :mst_status
+  attribute :pact_status
 end

--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -74,6 +74,7 @@ export default class IssuesList extends React.Component {
 
     return <div className="issues">
       <div>
+      {console.log(`'added issues: ${JSON.stringify(intakeData.addedIssues)}`)}
         { withdrawReview && <p className="cf-red-text">{COPY.INTAKE_WITHDRAWN_BANNER}</p> }
         { issues.map((issue) => {
           // Issues from rating issues or decision issues have editable contention text. New non-rating issues do not.

--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -74,7 +74,6 @@ export default class IssuesList extends React.Component {
 
     return <div className="issues">
       <div>
-      {console.log(`'added issues: ${JSON.stringify(intakeData.addedIssues)}`)}
         { withdrawReview && <p className="cf-red-text">{COPY.INTAKE_WITHDRAWN_BANNER}</p> }
         { issues.map((issue) => {
           // Issues from rating issues or decision issues have editable contention text. New non-rating issues do not.

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -20,7 +20,7 @@ import DateSelector from '../../components/DateSelector';
 import ErrorAlert from '../components/ErrorAlert';
 import { REQUEST_STATE, PAGE_PATHS, VBMS_BENEFIT_TYPES, FORM_TYPES } from '../constants';
 import EP_CLAIM_TYPES from '../../../constants/EP_CLAIM_TYPES';
-import { formatAddedIssues, formatRequestIssues, getAddIssuesFields, formatIssuesBySection } from '../util/issues';
+import { formatAddedIssues, formatLegacyAddedIssues, formatRequestIssues, getAddIssuesFields, formatIssuesBySection } from '../util/issues';
 import Table from '../../components/Table';
 import IssueList from '../components/IssueList';
 import Alert from 'app/components/Alert';
@@ -221,7 +221,8 @@ class AddIssuesPage extends React.Component {
       addingIssue,
       userCanWithdrawIssues,
       userCanEditIntakeIssues,
-      userCanSplitAppeal
+      userCanSplitAppeal,
+      isLegacy
     } = this.props;
     const intakeData = intakeForms[formType];
     const appealInfo = intakeForms.appeal;
@@ -252,7 +253,8 @@ class AddIssuesPage extends React.Component {
       );
 
     // eslint-disable-next-line max-len
-    const issues = intakeData.docketType === 'Legacy' ? formatAddedIssues(intakeData.requestIssues) : formatAddedIssues(intakeData.addedIssues, useAmaActivationDate);
+    const issues = intakeData.docketType === 'Legacy' ? formatLegacyAddedIssues(intakeData.requestIssues, intakeData.addedIssues) :
+      formatAddedIssues(intakeData.addedIssues, useAmaActivationDate);
 
     const issuesPendingWithdrawal = issues.filter((issue) => issue.withdrawalPending);
     const issuesBySection = formatIssuesBySection(issues);
@@ -413,10 +415,6 @@ class AddIssuesPage extends React.Component {
               (this.props.featureToggles.mst_identification ||
               this.props.featureToggles.pact_identification ||
               this.props.featureToggles.legacy_mst_pact_identification)}
-              userCanEditIntakeIssues={userCanEditIntakeIssues &&
-              (this.props.featureToggles.mst_identification ||
-              this.props.featureToggles.pact_identification ||
-              this.props.featureToggles.legacy_mst_pact_identification)}
               editPage={editPage}
             />
             {showPreDocketBanner && <Alert message={COPY.VHA_PRE_DOCKET_ADD_ISSUES_NOTICE} type="info" />}
@@ -535,8 +533,9 @@ class AddIssuesPage extends React.Component {
         {intakeData.editIntakeIssueModalVisible && (
           <EditIntakeIssueModal
             issueIndex={this.state.issueIndex}
-            intakeData={intakeData}
+            currentIssue ={this.props.intakeForms[this.props.formType].addedIssues[this.state.issueIndex]}
             legacyIssues={issues}
+            appealIsLegacy={isLegacy}
             mstIdentification={this.props.featureToggles.mst_identification}
             pactIdentification={this.props.featureToggles.pact_identification}
             onCancel={() => {
@@ -608,7 +607,8 @@ AddIssuesPage.propTypes = {
   withdrawIssue: PropTypes.func,
   userCanWithdrawIssues: PropTypes.bool,
   userCanEditIntakeIssues: PropTypes.bool,
-  userCanSplitAppeal: PropTypes.bool
+  userCanSplitAppeal: PropTypes.bool,
+  isLegacy: PropTypes.bool
 };
 
 export const IntakeAddIssuesPage = connect(
@@ -622,7 +622,7 @@ export const IntakeAddIssuesPage = connect(
     veteran: intake.veteran,
     featureToggles,
     activeIssue,
-    addingIssue
+    addingIssue,
   }),
   (dispatch) =>
     bindActionCreators(
@@ -659,7 +659,8 @@ export const EditAddIssuesPage = connect(
     addingIssue: state.addingIssue,
     userCanWithdrawIssues: state.userCanWithdrawIssues,
     userCanEditIntakeIssues: state.userCanEditIntakeIssues,
-    userCanSplitAppeal: state.userCanSplitAppeal
+    userCanSplitAppeal: state.userCanSplitAppeal,
+    isLegacy: state.isLegacy
   }),
   (dispatch) =>
     bindActionCreators(

--- a/client/app/intake/pages/addIssues.jsx
+++ b/client/app/intake/pages/addIssues.jsx
@@ -622,7 +622,7 @@ export const IntakeAddIssuesPage = connect(
     veteran: intake.veteran,
     featureToggles,
     activeIssue,
-    addingIssue,
+    addingIssue
   }),
   (dispatch) =>
     bindActionCreators(

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -146,8 +146,8 @@ export const formatRequestIssues = (requestIssues, contestableIssues) => {
       rampClaimId: issue.ramp_claim_id,
       verifiedUnidentifiedIssue: issue.verified_unidentified_issue,
       isPreDocketNeeded: issue.is_predocket_needed,
-      mstChecked: issue.vacols_sequence_id ? issue.legacy_appeal_vacols_mst : issue.mst_status,
-      pactChecked: issue.vacols_sequence_id ? issue.legacy_appeal_vacols_pact : issue.pact_status,
+      mstChecked: issue.mst_status,
+      pactChecked: issue.pact_status,
       mst_status_update_reason_notes: issue?.mstJustification,
       pact_status_update_reason_notes: issue?.pactJustification
     };

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -201,8 +201,6 @@ const formatUnidentifiedIssues = (state) => {
         verified_unidentified_issue: issue.verifiedUnidentifiedIssue,
         mst_status: issue.mstChecked,
         pact_status: issue.pactChecked,
-        // legacy_mst_status: issue.legacy_appeal_vacols_mst,
-        // legacy_pact_status: issue.legacy_appeal_vacols_mst,
         mst_status_update_reason_notes: issue?.mstJustification,
         pact_status_update_reason_notes: issue?.pactJustification
       };

--- a/client/app/intake/util/issues.js
+++ b/client/app/intake/util/issues.js
@@ -14,7 +14,7 @@ const getClaimantField = (veteran, intakeData) => {
   let claimantDisplayText = [claimantName, claimantRelationship].filter(Boolean).join(', ');
 
   if (payeeCode) {
-    claimantDisplayText += ` (payee code ${payeeCode})`
+    claimantDisplayText += ` (payee code ${payeeCode})`;
   }
 
   return [{
@@ -54,7 +54,7 @@ export const legacyIssue = (issue, legacyAppeals) => {
       throw new Error(`No legacyAppeal found for '${issue.vacolsId}'`);
     }
 
-    return _.find(legacyAppeal.issues, { vacols_sequence_id: parseInt(issue.vacolsSequenceId, 10) })
+    return _.find(legacyAppeal.issues, { vacols_sequence_id: parseInt(issue.vacolsSequenceId, 10) });
   }
 };
 
@@ -146,8 +146,8 @@ export const formatRequestIssues = (requestIssues, contestableIssues) => {
       rampClaimId: issue.ramp_claim_id,
       verifiedUnidentifiedIssue: issue.verified_unidentified_issue,
       isPreDocketNeeded: issue.is_predocket_needed,
-      mstChecked: issue.mst_status,
-      pactChecked: issue.pact_status,
+      mstChecked: issue.vacols_sequence_id ? issue.legacy_appeal_vacols_mst : issue.mst_status,
+      pactChecked: issue.vacols_sequence_id ? issue.legacy_appeal_vacols_pact : issue.pact_status,
       mst_status_update_reason_notes: issue?.mstJustification,
       pact_status_update_reason_notes: issue?.pactJustification
     };
@@ -201,6 +201,8 @@ const formatUnidentifiedIssues = (state) => {
         verified_unidentified_issue: issue.verifiedUnidentifiedIssue,
         mst_status: issue.mstChecked,
         pact_status: issue.pactChecked,
+        // legacy_mst_status: issue.legacy_appeal_vacols_mst,
+        // legacy_pact_status: issue.legacy_appeal_vacols_mst,
         mst_status_update_reason_notes: issue?.mstJustification,
         pact_status_update_reason_notes: issue?.pactJustification
       };
@@ -364,6 +366,22 @@ export const formatIssuesBySection = (issues) => {
   );
 };
 
+export const formatLegacyAddedIssues = (issues = [], addedIssues = []) => {
+  return issues.map((issue, index) => {
+    return {
+      index,
+      id: issue.id,
+      benefitType: issue.labels[0].toLowerCase(),
+      description: `${issue.labels[1]} - ${issue.labels[2]} - ${issue.labels[3]}`,
+      text: `${issue.labels[1]} - ${issue.labels[2]} - ${issue.labels[3]}`,
+      vacolsSequenceId: issue.vacols_sequence_id,
+      mstChecked: addedIssues[index].mstChecked,
+      pactChecked: addedIssues[index].pactChecked
+    };
+  }
+  );
+};
+
 export const formatAddedIssues = (issues = [], useAmaActivationDate = false) => {
   const amaActivationDate = new Date(useAmaActivationDate ? DATES.AMA_ACTIVATION : DATES.AMA_ACTIVATION_TEST);
 
@@ -376,7 +394,7 @@ export const formatAddedIssues = (issues = [], useAmaActivationDate = false) => 
         benefitType: issue.labels[0].toLowerCase(),
         description: `${issue.labels[1]} - ${issue.labels[2]} - ${issue.labels[3]}`,
         text: `${issue.labels[1]} - ${issue.labels[2]} - ${issue.labels[3]}`,
-        vacolsSequenceId: issue.vacols_sequence_id,
+        vacolsSequenceId: issue.vacols_sequence_id
       };
     }
 

--- a/client/app/intakeEdit/IntakeEditFrame.jsx
+++ b/client/app/intakeEdit/IntakeEditFrame.jsx
@@ -277,6 +277,7 @@ IntakeEditFrame.propTypes = {
   appeal: PropTypes.object,
   claimId: PropTypes.string,
   user: PropTypes.string,
+  isLegacy: PropTypes.bool,
   routerTestProps: PropTypes.object,
   router: PropTypes.object
 };

--- a/client/app/intakeEdit/components/EditIntakeIssueModal.jsx
+++ b/client/app/intakeEdit/components/EditIntakeIssueModal.jsx
@@ -21,8 +21,9 @@ export class EditIntakeIssueModal extends React.Component {
 
   constructor(props) {
     super(props);
-
     this.state = {
+      mstChecked: props.appealIsLegacy ? props.legacyIssues[props.issueIndex]?.mstChecked : props.currentIssue?.mstChecked,
+      pactChecked: props.appealIsLegacy ? props.legacyIssues[props.issueIndex]?.pactChecked : props.currentIssue?.pactChecked,
       mstJustification: '',
       pactJustification: ''
     };
@@ -47,8 +48,8 @@ export class EditIntakeIssueModal extends React.Component {
   render() {
     const {
       issueIndex,
+      currentIssue,
       onCancel,
-      currentIssue = this.props.intakeData.addedIssues[issueIndex],
       issue = this.props.legacyIssues[issueIndex],
       currentIssueCategory = currentIssue.category,
       currentIssueDescription = currentIssue.description,
@@ -122,7 +123,7 @@ export class EditIntakeIssueModal extends React.Component {
             { mstIdentification &&
               <Checkbox style={{ marginTop: 0, marginBottom: 0 }}
                 name={MST_LABEL} strongLabel
-                value={this.state.currentIssueMstChecked}
+                value={this.state.mstChecked}
                 onChange={this.handleMstCheckboxChange}
               />
             }
@@ -144,7 +145,7 @@ export class EditIntakeIssueModal extends React.Component {
               { pactIdentification &&
                 <Checkbox style={{ marginTop: 0, marginBottom: 0 }}
                   name={PACT_LABEL} strongLabel
-                  value={this.state.currentIssuePactChecked}
+                  value={this.state.pactChecked}
                   onChange={this.handlePactCheckboxChange}
                 />
               }
@@ -195,6 +196,7 @@ EditIntakeIssueModal.propTypes = {
   pactChecked: PropTypes.bool,
   mstJustification: PropTypes.object,
   pactJustification: PropTypes.object,
+  editedIssue: PropTypes.object,
   intakeData: PropTypes.object,
   currentIssue: PropTypes.object,
   currentIssueCategory: PropTypes.string,
@@ -202,7 +204,9 @@ EditIntakeIssueModal.propTypes = {
   currentIssueBenefitType: PropTypes.string,
   currentIssueDecisionDate: PropTypes.string,
   currentIssueText: PropTypes.string,
-  issue: PropTypes.object
+  issue: PropTypes.object,
+  appealIsLegacy: PropTypes.bool,
+  legacyIssues: PropTypes.object
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(EditIntakeIssueModal);

--- a/client/app/intakeEdit/reducers/index.js
+++ b/client/app/intakeEdit/reducers/index.js
@@ -13,7 +13,8 @@ export const mapDataToInitialState = function(props = {}) {
     featureToggles,
     userCanWithdrawIssues,
     userCanEditIntakeIssues,
-    userCanSplitAppeal } = props;
+    userCanSplitAppeal,
+    isLegacy } = props;
 
   serverIntake.relationships = formatRelationships(serverIntake.relationships);
   serverIntake.contestableIssues = formatContestableIssues(serverIntake.contestableIssuesByDate);
@@ -36,6 +37,7 @@ export const mapDataToInitialState = function(props = {}) {
     userCanWithdrawIssues,
     userCanEditIntakeIssues,
     userCanSplitAppeal,
+    isLegacy,
     addIssuesModalVisible: false,
     nonRatingRequestIssueModalVisible: false,
     unidentifiedIssuesModalVisible: false,

--- a/client/app/queue/AddEditIssueView.jsx
+++ b/client/app/queue/AddEditIssueView.jsx
@@ -112,8 +112,8 @@ class AddEditIssueView extends React.Component {
           level_2: _.get(issue.codes, 1, null),
           level_3: _.get(issue.codes, 2, null),
           ..._.pick(issue, 'note', 'program'),
-          mst_status: issue.legacy_appeal_vacols_mst ? 'Y' : 'N',
-          pact_status: issue.legacy_appeal_vacols_pact ? 'Y' : 'N'
+          mst_status: issue.mst_status ? 'Y' : 'N',
+          pact_status: issue.pact_status ? 'Y' : 'N'
         }
       }
     };
@@ -337,18 +337,18 @@ class AddEditIssueView extends React.Component {
       <Checkbox
         name="MST"
         label="Military Sexual Trauma (MST)"
-        defaultValue={issue.legacy_appeal_vacols_mst}
-        value={issue.legacy_appeal_vacols_mst}
+        defaultValue={issue.mst_status}
+        value={issue.mst_status}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_mst: checked })}
+        onChange={(checked) => this.updateIssue({ mst_status: checked })}
       />
       <Checkbox
         name="PACT"
         label="PACT Act"
-        defaultValue={issue.legacy_appeal_vacols_pact}
-        value={issue.legacy_appeal_vacols_pact}
+        defaultValue={issue.pact_status}
+        value={issue.pact_status}
         styling={checkboxStyle}
-        onChange={(checked) => this.updateIssue({ legacy_appeal_vacols_pact: checked })}
+        onChange={(checked) => this.updateIssue({ pact_status: checked })}
       />
     </QueueFlowPage>;
   };
@@ -382,8 +382,8 @@ AddEditIssueView.propTypes = {
     type: PropTypes.string,
     codes: PropTypes.arrayOf(PropTypes.string),
     program: PropTypes.string,
-    legacy_appeal_vacols_mst: PropTypes.bool,
-    legacy_appeal_vacols_pact: PropTypes.bool
+    mst_status: PropTypes.bool,
+    pact_status: PropTypes.bool
   }),
   issueId: PropTypes.string,
   issues: PropTypes.object,

--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -93,8 +93,8 @@ const getDescriptionsFromCodes = (levels, codes, descriptions = []) => {
 
 // format special issues to display 'None', 'PACT', 'MST', or 'MST and PACT'
 const specialIssuesFormatting = (props) => {
-  const mstStatus = props.legacy_appeal_vacols_mst;
-  const pactStatus = props.legacy_appeal_vacols_pact;
+  const mstStatus = props.mst_status;
+  const pactStatus = props.pact_status;
 
   if (!mstStatus && !pactStatus) {
     return 'None';
@@ -142,6 +142,6 @@ CaseDetailsIssueList.propTypes = {
 
 SpecialIssueListItem.propTypes = {
   children: PropTypes.object,
-  legacy_appeal_vacols_mst: PropTypes.bool,
-  legacy_appeal_vacols_pact: PropTypes.bool
+  mst_status: PropTypes.bool,
+  pact_status: PropTypes.bool
 };

--- a/client/app/queue/components/LegacyIssueListItem.jsx
+++ b/client/app/queue/components/LegacyIssueListItem.jsx
@@ -26,8 +26,8 @@ const leftAlignTd = css({
 });
 
 const specialIssuesFormatting = (props) => {
-  const mstStatus = props.legacy_appeal_vacols_mst;
-  const pactStatus = props.legacy_appeal_vacols_pact;
+  const mstStatus = props.mst_status;
+  const pactStatus = props.pact_status;
 
   if (!mstStatus && !pactStatus) {
     return 'None';


### PR DESCRIPTION
Resolves [APPEALS-23340](https://vajira.max.gov/browse/APPEALS-23340)

# Description
Resolved bugs in edit page:

1. Legacy issues on the edit page do not display accurate MST/PACT status on the issue
2. Legacy issues changes on the edit page via the Edit Modal do not update the MST/PACT status on a legacy issue
3. Legacy issues mst/pact status do not auto-populate in the Edit Modal.
4. Legacy Issue changes not setting up params properly.
5. AMA issues do not auto-populate MST/PACT status in the Edit Modal.
6. AMA issue changes not setting up params properly.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
### For Legacy:

1. Find a legacy appeal with past issues. For my testing I used this URL in demo (3449656 is the legacy identifier): http://localhost:3000/appeals/3449656/edit
2. If need be, sign in as a Judge (BVAAABSHIRE) and access the Add Decisions workflow to Edit the MST/PACT status on the legacy issue.
3. Sign in as BVADWISE and access the appeal that was edited. Go to the correct issues link.
![image (13)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/80381527-41f4-439c-8d1c-9f5543629edd)

5. Notice the MST/PACT statuses are now properly showing (image 2)
![image (14)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/4ac206e8-551c-4715-8afb-d3a329676763)

7. For an issue with MST/PACT displaying, click the action dropdown, and edit. Notice that the MST/PACT status is now prepopulating (3rd image)
![image (15)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/10e9ed16-9a86-4335-aa5c-ed3601d71045)


9. Uncheck both checkboxes and notice how the status changes to none (4th image).
![image (16)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/c429d5bb-b3e4-48b4-9871-122b51d1ce26)

11. Rinse and repeat with other issues.
12. Clicking save and viewing the parameters shows that all issues have a status (either true or false for MST/PACT) (5th image).
![image (17)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/7ade258f-1cd2-4a7b-953d-9c4c1a9c2672)


**NOTE:** since the controller for the method isn't in the feature branch, the banner will show as red.

### For AMA

1. Sign in as BVADWISE or another BVA Intake user. Find an appeal with MST/PACT on an issue (or intake a new appeal with MST/PACT). Navigate to that appeal's case details page.
3. Click the correct issues link.
4. Notice the original issues MST/PACT status (6th image).
![image (18)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/9f94f012-9a36-4c7d-95a2-70d1dcf3d827)

6. For an issue with MST/PACT displaying, click the action dropdown, and edit. Notice that the MST/PACT status is now prepopulating (7th image)
![image (19)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/9047778e-f1be-4904-8aa3-887c26ccd043)

8. Repeat step 3 and 4 with other issues.
9. Clicking save and viewing the parameters shows that all issues have a status (either true or false for MST/PACT) (8th image).
![image (20)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/7f3a1cfc-893e-4580-9d98-612c2d4b7414)


