### PR TITLE
Appeals 23336 - BUGFIX - Update back button routing for AMA in Add Decisions workflow

### DIFF
--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -35,6 +35,6 @@ class JudgeDecisionReviewTask < JudgeTask
   private
 
   def ama_judge_actions
-    Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SP_ISSUES.to_h
+    Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h
   end
 end

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -141,12 +141,10 @@ class SelectDispositionsView extends React.PureComponent {
 
   getPrevStepUrl = () => {
     const {
-      appealId,
-      taskId,
-      checkoutFlow
+      appealId
     } = this.props;
 
-    return `/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/special_issues`;
+    return `/queue/appeals/${appealId}`;
   }
 
   validateForm = () => {

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -169,10 +169,6 @@
     "label": "Ready for Dispatch",
     "value": "dispatch_decision/dispositions"
   },
-  "JUDGE_AMA_CHECKOUT_SP_ISSUES": {
-    "label": "Ready for Dispatch",
-    "value": "dispatch_decision/special_issues"
-  },
   "JUDGE_CHECKOUT_PULAC_CERULLO_REMINDER": {
     "label": "Ready for Dispatch",
     "value": "modal/check_cavc"

--- a/spec/models/tasks/judge_task_spec.rb
+++ b/spec/models/tasks/judge_task_spec.rb
@@ -163,7 +163,7 @@ describe JudgeTask, :all_dbs do
               Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
               Constants.TASK_ACTIONS.PLACE_TIMED_HOLD.to_h,
               Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h,
-              Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SP_ISSUES.to_h,
+              Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h,
               Constants.TASK_ACTIONS.JUDGE_RETURN_TO_ATTORNEY.to_h
             ].map { |action| subject_task.build_action_hash(action, judge) }
           )
@@ -206,7 +206,7 @@ describe JudgeTask, :all_dbs do
       it "should show pulac cerullo task action along with special actions" do
         expect(task.additional_available_actions(user)).to eq(
           [Constants.TASK_ACTIONS.LIT_SUPPORT_PULAC_CERULLO.to_h,
-           Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SP_ISSUES.to_h,
+           Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h,
            Constants.TASK_ACTIONS.JUDGE_RETURN_TO_ATTORNEY.to_h]
         )
       end


### PR DESCRIPTION
Resolves #{https://jira.devops.va.gov/browse/APPEALS-23336}

# Description
Updated routing for AMA add decision workflow to no longer include special issues. Fixed routing bug where special issues page was still accessible in the add decision workflow

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
1. Switch users to BVAAABSHIRE
2. Go to Queue and select any AMA appeal awaiting a review
3. In the Task Action dropdown, select "Ready for Dispatch"
4. Note that clicking Ready for Dispatch routes you to the Add Decisions Page. 
5. Now click "Back" and note that it takes you back to the previous screen (Case Details page)

# Backend
1. Removed JUDGE_AMA_CHECKOUT_SP_ISSUES from TASK_ACTIONS.json
2. Updated judge_task_spec.rb Rspec unit tests where applicable
3. Updated ama_judge_action method in judge_decision_review_task.rb

# Best practices
## Code Documentation Updates
- [X] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [X] Other - Manual validation

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [X] No new code climate issues added
