### PR TITLE
[DOCUMENTATION] - Fix MAC_INTEL.md formatting and links

### DIFF
--- a/MAC_INTEL.md
+++ b/MAC_INTEL.md
@@ -18,7 +18,7 @@
 
 1. Open the terminal - The terminal will open to your user folder (I.E youruser@host ~ %)
 2. Install Homebrew
-    a. Using BAH Self Service if BAH employee Run ```brew install git-lfs .``` This is required to clone caseflow-facols repo
+    * a. Using BAH Self Service if BAH employee Run ```brew install git-lfs .``` This is required to clone caseflow-facols repo
 
 3. Create a caseflow-setup folder by typing: `mkdir caseflow-setup` (step can be skipped if you have the file transfer files)
 
@@ -97,7 +97,7 @@
 
 18. Run `docker-compose up –d`
 
-19. Run bundle exec rake db:create
+19. Run `bundle exec rake db:create`
     * If you get connection issues stating no file to be found, run the following:
         * `rm /opt/homebrew/var/postgres/postmaster.pid` or possibly `rm /usr/local/var/postgres/postmaster.pid`
         * `brew services restart postgresql`

--- a/MAC_INTEL.md
+++ b/MAC_INTEL.md
@@ -10,7 +10,7 @@
 
 3. Create [oracle.com](http://oracle.com/) user account to download instant client [Create Account](https://profile.oracle.com/myprofile/account/create-account.jspx) (Step can be skipped if you have the zip files from file transfer)
 
-4. Install github on the Mac (here)
+4. Install github on the Mac [here](https://desktop.github.com/)
 
 5. Install git-lfs for pulling large files down from github [Install instructions](https://git-lfs.github.com/)
 


### PR DESCRIPTION
# Description
There was a missing link and some broken formatting that is now updated.


## Acceptance Criteria
- [x] Code compiles correctly
- [x] The MAC_INTEL.md doc matches the [sharepoint doc](https://boozallen.sharepoint.com/teams/VABID/appeals/_layouts/15/Doc.aspx?sourcedoc={20830a1e-4aae-459b-80d9-64b76d8dfebf}&action=edit&wd=target%28Developer%20Setup.one%7C319614ad-d7af-4973-aeb4-a8418a647fb8%2FMac%20Catalina%2010.15.7%20Setup%20Notes%7Cb4165eb7-fb8e-4067-9e71-5ef6d708d163%2F%29&wdorigin=NavigationUrl)

### BEFORE
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/820449d8-2cd2-4f52-b5d7-fddb8b83f029)

--------
### AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/c35d59f2-f2aa-4882-a6a6-b23831d59230)

