### PR TITLE
Jruuuu/APPEALS-21357

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -176,6 +176,8 @@ jobs:
         run: |
           ./ci-bin/capture-log "DB=etl bundle exec rake db:create db:schema:load db:migrate"
           ./ci-bin/capture-log "bundle exec rake db:create db:schema:load db:migrate"
+          ./ci-bin/capture-log "make -f Makefile.example external-db-create"
+        # added line to create external table(s) that are needed for tests
 
       - name: make seed-dbs
         run: |

--- a/Makefile.example
+++ b/Makefile.example
@@ -160,9 +160,11 @@ audit-remove: ## Remove caseflow_audit schema, tables and triggers in postgres
 
 external-db-create: ## Creates external_vbms_ext_claim table
 	bundle exec rails r db/scripts/external/create_vbms_ext_claim_table.rb
+	bundle exec rails r -e test db/scripts/external/create_vbms_ext_claim_table.rb
 
 external-db-remove:  ## Remove external_vbms_ext_claim table
 	bundle exec rails r db/scripts/external/remove_vbms_ext_claim_table.rb
+	bundle exec rails r -e test db/scripts/external/remove_vbms_ext_claim_table.rb
 
 c:  ## Start rails console
 	bundle exec rails console

--- a/Makefile.example
+++ b/Makefile.example
@@ -160,11 +160,9 @@ audit-remove: ## Remove caseflow_audit schema, tables and triggers in postgres
 
 external-db-create: ## Creates external_vbms_ext_claim table
 	bundle exec rails r db/scripts/external/create_vbms_ext_claim_table.rb
-	bundle exec rails r -e test db/scripts/external/create_vbms_ext_claim_table.rb
 
 external-db-remove:  ## Remove external_vbms_ext_claim table
 	bundle exec rails r db/scripts/external/remove_vbms_ext_claim_table.rb
-	bundle exec rails r -e test db/scripts/external/remove_vbms_ext_claim_table.rb
 
 c:  ## Start rails console
 	bundle exec rails console

--- a/Makefile.example
+++ b/Makefile.example
@@ -199,6 +199,9 @@ reset-dbs: ## Resets Caseflow and ETL database schemas
 	make audit
 	make external-db-create
 
+seed-vbms-ext-claim: ## Seed only vbms_ext_claim
+	bundle exec rake db:seed:vbms_ext_claim
+
 seed-dbs:	## Seed all databases
 	bundle exec rake local:vacols:seed
 	bundle exec rake spec:setup_vacols

--- a/Makefile.example
+++ b/Makefile.example
@@ -164,6 +164,9 @@ external-db-create: ## Creates external_vbms_ext_claim table
 external-db-remove:  ## Remove external_vbms_ext_claim table
 	bundle exec rails r db/scripts/external/remove_vbms_ext_claim_table.rb
 
+external-db-create-test: ## Creates table in caseflow_certification_test DB for local RSPEC
+	bundle exec rails r -e test db/scripts/external/create_vbms_ext_claim_table.rb
+
 c:  ## Start rails console
 	bundle exec rails console
 

--- a/app/models/external_modals/vbms_ext_claim.rb
+++ b/app/models/external_modals/vbms_ext_claim.rb
@@ -46,7 +46,4 @@ class VbmsExtClaim < CaseflowRecord
   alias_attribute :allow_poa_access, :ALLOW_POA_ACCESS
   alias_attribute :poa_code, :POA_CODE
 
-  # def find_last_claim_id
-  #   VbmsExtClaim.last.claim_id
-  # end
 end

--- a/app/models/external_modals/vbms_ext_claim.rb
+++ b/app/models/external_modals/vbms_ext_claim.rb
@@ -45,4 +45,8 @@ class VbmsExtClaim < CaseflowRecord
   alias_attribute :organization_soj, :ORGANIZATION_SOJ
   alias_attribute :allow_poa_access, :ALLOW_POA_ACCESS
   alias_attribute :poa_code, :POA_CODE
+
+  # def find_last_claim_id
+  #   VbmsExtClaim.last.claim_id
+  # end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1788,44 +1788,6 @@ ActiveRecord::Schema.define(version: 2023_03_17_164013) do
     t.index ["updated_at"], name: "index_users_on_updated_at"
   end
 
-  create_table "vbms_ext_claim", primary_key: "CLAIM_ID", id: :decimal, precision: 38, force: :cascade do |t|
-    t.string "ALLOW_POA_ACCESS", limit: 5
-    t.decimal "CLAIMANT_PERSON_ID", precision: 38
-    t.datetime "CLAIM_DATE"
-    t.string "CLAIM_SOJ", limit: 25
-    t.integer "CONTENTION_COUNT"
-    t.datetime "CREATEDDT", null: false
-    t.string "EP_CODE", limit: 25
-    t.datetime "ESTABLISHMENT_DATE"
-    t.datetime "EXPIRATIONDT"
-    t.string "INTAKE_SITE", limit: 25
-    t.datetime "LASTUPDATEDT", null: false
-    t.string "LEVEL_STATUS_CODE", limit: 25
-    t.datetime "LIFECYCLE_STATUS_CHANGE_DATE"
-    t.string "LIFECYCLE_STATUS_NAME", limit: 50
-    t.string "ORGANIZATION_NAME", limit: 100
-    t.string "ORGANIZATION_SOJ", limit: 25
-    t.string "PAYEE_CODE", limit: 25
-    t.string "POA_CODE", limit: 25
-    t.integer "PREVENT_AUDIT_TRIG", limit: 2, default: 0, null: false
-    t.string "PRE_DISCHARGE_IND", limit: 5
-    t.string "PRE_DISCHARGE_TYPE_CODE", limit: 10
-    t.string "PRIORITY", limit: 10
-    t.string "PROGRAM_TYPE_CODE", limit: 10
-    t.string "RATING_SOJ", limit: 25
-    t.string "SERVICE_TYPE_CODE", limit: 10
-    t.string "SUBMITTER_APPLICATION_CODE", limit: 25
-    t.string "SUBMITTER_ROLE_CODE", limit: 25
-    t.datetime "SUSPENSE_DATE"
-    t.string "SUSPENSE_REASON_CODE", limit: 25
-    t.string "SUSPENSE_REASON_COMMENTS", limit: 1000
-    t.decimal "SYNC_ID", precision: 38, null: false
-    t.string "TEMPORARY_CLAIM_SOJ", limit: 25
-    t.string "TYPE_CODE", limit: 25
-    t.decimal "VERSION", precision: 38, null: false
-    t.decimal "VETERAN_PERSON_ID", precision: 15
-  end
-
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", comment: "Appeal/LegacyAppeal ID; use as FK to appeals/legacy_appeals"
     t.string "appeal_type", comment: "'Appeal' or 'LegacyAppeal'"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1788,6 +1788,44 @@ ActiveRecord::Schema.define(version: 2023_03_17_164013) do
     t.index ["updated_at"], name: "index_users_on_updated_at"
   end
 
+  create_table "vbms_ext_claim", primary_key: "CLAIM_ID", id: :decimal, precision: 38, force: :cascade do |t|
+    t.string "ALLOW_POA_ACCESS", limit: 5
+    t.decimal "CLAIMANT_PERSON_ID", precision: 38
+    t.datetime "CLAIM_DATE"
+    t.string "CLAIM_SOJ", limit: 25
+    t.integer "CONTENTION_COUNT"
+    t.datetime "CREATEDDT", null: false
+    t.string "EP_CODE", limit: 25
+    t.datetime "ESTABLISHMENT_DATE"
+    t.datetime "EXPIRATIONDT"
+    t.string "INTAKE_SITE", limit: 25
+    t.datetime "LASTUPDATEDT", null: false
+    t.string "LEVEL_STATUS_CODE", limit: 25
+    t.datetime "LIFECYCLE_STATUS_CHANGE_DATE"
+    t.string "LIFECYCLE_STATUS_NAME", limit: 50
+    t.string "ORGANIZATION_NAME", limit: 100
+    t.string "ORGANIZATION_SOJ", limit: 25
+    t.string "PAYEE_CODE", limit: 25
+    t.string "POA_CODE", limit: 25
+    t.integer "PREVENT_AUDIT_TRIG", limit: 2, default: 0, null: false
+    t.string "PRE_DISCHARGE_IND", limit: 5
+    t.string "PRE_DISCHARGE_TYPE_CODE", limit: 10
+    t.string "PRIORITY", limit: 10
+    t.string "PROGRAM_TYPE_CODE", limit: 10
+    t.string "RATING_SOJ", limit: 25
+    t.string "SERVICE_TYPE_CODE", limit: 10
+    t.string "SUBMITTER_APPLICATION_CODE", limit: 25
+    t.string "SUBMITTER_ROLE_CODE", limit: 25
+    t.datetime "SUSPENSE_DATE"
+    t.string "SUSPENSE_REASON_CODE", limit: 25
+    t.string "SUSPENSE_REASON_COMMENTS", limit: 1000
+    t.decimal "SYNC_ID", precision: 38, null: false
+    t.string "TEMPORARY_CLAIM_SOJ", limit: 25
+    t.string "TYPE_CODE", limit: 25
+    t.decimal "VERSION", precision: 38, null: false
+    t.decimal "VETERAN_PERSON_ID", precision: 15
+  end
+
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", comment: "Appeal/LegacyAppeal ID; use as FK to appeals/legacy_appeals"
     t.string "appeal_type", comment: "'Appeal' or 'LegacyAppeal'"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -57,6 +57,7 @@ class SeedDB
     call_and_log_seed_step Seeds::TestCaseData
     call_and_log_seed_step Seeds::Notifications
     call_and_log_seed_step Seeds::CavcDashboardData
+    call_and_log_seed_step Seeds::VbmsExtClaim
     # Always run this as last one
     call_and_log_seed_step Seeds::StaticTestCaseData
     call_and_log_seed_step Seeds::StaticDispatchedAppealsTestData

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -5,7 +5,6 @@ module Seeds
 
   class VbmsExtClaim < Base
     def seed!
-      puts "******seed has been called******"
       create_vbms_ext_claims_with_no_end_product_establishment
       create_in_sync_epes_and_vbms_ext_claims
       # create_out_of_sync_epes_and_vbms_ext_claims
@@ -23,7 +22,7 @@ module Seeds
     # vbms_ext_claims
     25.times do |n|
       veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :cleared, reference_id: 200_00 + n, veteran_file_number: veteran.file_number)
+      epe =  create(:end_product_establishment, :cleared, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
       higher_level_review = create(
         :higher_level_review,
         end_product_establishments: [epe],
@@ -36,12 +35,38 @@ module Seeds
     # vbms_ext_claims
     25.times do |n|
       veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :canceled, reference_id: 300_00 + n, veteran_file_number: veteran.file_number)
+      epe =  create(:end_product_establishment, :canceled, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
       higher_level_review = create(
         :higher_level_review,
         end_product_establishments: [epe],
         veteran_file_number: veteran.file_number
       )
+      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      create(:vbms_ext_claim, :canceled, claim_id: epe.reference_id )
+    end
+    # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      veteran = create(:veteran)
+      epe =  create(:end_product_establishment, :cleared, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
+      create(:supplemental_claim,
+        end_product_establishments: [epe],
+        veteran_file_number: veteran.file_number,
+        receipt_date: Time.zone.now,
+        benefit_type: "compensation")
+      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      create(:vbms_ext_claim, :cleared, claim_id: epe.reference_id )
+    end
+    # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      veteran = create(:veteran)
+      epe =  create(:end_product_establishment, :canceled, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
+      create(:supplemental_claim,
+        end_product_establishments: [epe],
+        veteran_file_number: veteran.file_number,
+        receipt_date: Time.zone.now,
+        benefit_type: "compensation")
       # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       create(:vbms_ext_claim, :canceled, claim_id: epe.reference_id )
     end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# create vbms-ext-claim seeds
+# create vbms claims
 module Seeds
 
   class VbmsExtClaim < Base
@@ -11,7 +11,7 @@ module Seeds
       create_out_of_sync_epes_and_vbms_ext_claims
     end
 
-	 private
+private
 
   # creates out_of_sync vbms_ext_claims and end_produdct_establishments
 	def create_out_of_sync_epes_and_vbms_ext_claims

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -5,8 +5,8 @@ module Seeds
 
   class VbmsExtClaim < Base
     def seed!
-      create_vbms_ext_claims_with_no_end_product_establishment
-      create_in_sync_epes_and_vbms_ext_claims
+      # create_vbms_ext_claims_with_no_end_product_establishment
+      # create_in_sync_epes_and_vbms_ext_claims
       create_out_of_sync_epes_and_vbms_ext_claims
     end
 
@@ -16,9 +16,12 @@ module Seeds
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # vbms_ext_claims
     25.times do |n|
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim, :canceled)
       veteran = create(:veteran)
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim,
+                   :canceled,
+                   :hlr,
+                   claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
       eligible_request_issue = create(:request_issue,
@@ -29,19 +32,27 @@ module Seeds
                                       benefit_type: "compensation",
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
-             :cleared,
+             :active,
               source: higher_level_review,
               reference_id: vec.claim_id,
+              established_at: vec.establishment_date,
+              claim_date: vec.claim_date,
+              modifier: vec.ep_code,
+              code: vec.type_code,
               veteran_file_number: veteran.file_number,
               claimant_participant_id: veteran.participant_id)
+
 
     end
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # vbms_ext_claims
     25.times do |n|
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim, :cleared)
       veteran = create(:veteran)
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim,
+                   :cleared,
+                   :hlr,
+                   claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
       eligible_request_issue = create(:request_issue,
@@ -52,19 +63,26 @@ module Seeds
                                       benefit_type: "compensation",
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
-             :canceled,
-              source: higher_level_review,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
+             :active,
+             source: higher_level_review,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
 
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # # vbms_ext_claims
     25.times do |n|
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim, :canceled)
       veteran = create(:veteran)
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim,
+                   :cleared,
+                   :slc,
+                   claimant_person_id: veteran.participant_id)
       supplemental_claim = create(:supplemental_claim,
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
@@ -77,20 +95,27 @@ module Seeds
                                       benefit_type: "compensation",
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
-             :cleared,
-              source: supplemental_claim,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
+             :active,
+             source: supplemental_claim,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
 
     end
 
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
     # # vbms_ext_claims
     25.times do |n|
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim, :cleared)
       veteran = create(:veteran)
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim,
+                   :cleared,
+                   :slc,
+                   claimant_person_id: veteran.participant_id)
       supplemental_claim = create(:supplemental_claim,
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
@@ -103,11 +128,15 @@ module Seeds
                                       benefit_type: "compensation",
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
-             :canceled,
-              source: supplemental_claim,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
+             :active,
+             source: supplemental_claim,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
 
     end
 

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -5,8 +5,8 @@ module Seeds
 
   class VbmsExtClaim < Base
     def seed!
-      # create_vbms_ext_claims_with_no_end_product_establishment
-      # create_in_sync_epes_and_vbms_ext_claims
+      create_vbms_ext_claims_with_no_end_product_establishment
+      create_in_sync_epes_and_vbms_ext_claims
       create_out_of_sync_epes_and_vbms_ext_claims
     end
 
@@ -115,6 +115,102 @@ module Seeds
 	end
 
 	def create_in_sync_epes_and_vbms_ext_claims
+    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim, :canceled)
+      veteran = create(:veteran)
+      higher_level_review = create(:higher_level_review,
+                                    veteran_file_number: veteran.file_number)
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: higher_level_review,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :canceled,
+             source: higher_level_review,
+             reference_id: vec.claim_id,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
+    end
+    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim, :cleared)
+      veteran = create(:veteran)
+      higher_level_review = create(:higher_level_review,
+                                    veteran_file_number: veteran.file_number)
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: higher_level_review,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :cleared,
+              source: higher_level_review,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
+    # # vbms_ext_claims
+    25.times do |n|
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim, :cleared)
+      veteran = create(:veteran)
+      supplemental_claim = create(:supplemental_claim,
+            veteran_file_number: veteran.file_number,
+            receipt_date: Time.zone.now,
+            benefit_type: "compensation")
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: supplemental_claim,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :cleared,
+              source: supplemental_claim,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
+
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # # vbms_ext_claims
+    25.times do |n|
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim, :canceled)
+      veteran = create(:veteran)
+      supplemental_claim = create(:supplemental_claim,
+            veteran_file_number: veteran.file_number,
+            receipt_date: Time.zone.now,
+            benefit_type: "compensation")
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: supplemental_claim,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :canceled,
+              source: supplemental_claim,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
 
 
 	end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -5,71 +5,117 @@ module Seeds
 
   class VbmsExtClaim < Base
     def seed!
-      create_vbms_ext_claims_with_no_end_product_establishment
-      create_in_sync_epes_and_vbms_ext_claims
-      # create_out_of_sync_epes_and_vbms_ext_claims
+      # create_vbms_ext_claims_with_no_end_product_establishment
+      # create_in_sync_epes_and_vbms_ext_claims
+      create_out_of_sync_epes_and_vbms_ext_claims
     end
 
 	 private
 
-	# def create_out_of_sync_epes_and_vbms_ext_claims
+	def create_out_of_sync_epes_and_vbms_ext_claims
+    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim, :canceled)
+      veteran = create(:veteran)
+      higher_level_review = create(:higher_level_review,
+                                    veteran_file_number: veteran.file_number)
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: higher_level_review,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :cleared,
+              source: higher_level_review,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
 
-	# end
+    end
+    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim, :cleared)
+      veteran = create(:veteran)
+      higher_level_review = create(:higher_level_review,
+                                    veteran_file_number: veteran.file_number)
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: higher_level_review,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :canceled,
+              source: higher_level_review,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
+    # # vbms_ext_claims
+    25.times do |n|
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim, :canceled)
+      veteran = create(:veteran)
+      supplemental_claim = create(:supplemental_claim,
+            veteran_file_number: veteran.file_number,
+            receipt_date: Time.zone.now,
+            benefit_type: "compensation")
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: supplemental_claim,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :cleared,
+              source: supplemental_claim,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
+
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # # vbms_ext_claims
+    25.times do |n|
+      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim, :cleared)
+      veteran = create(:veteran)
+      supplemental_claim = create(:supplemental_claim,
+            veteran_file_number: veteran.file_number,
+            receipt_date: Time.zone.now,
+            benefit_type: "compensation")
+      eligible_request_issue = create(:request_issue,
+                                      decision_review: supplemental_claim,
+                                      nonrating_issue_category: "Military Retired Pay",
+                                      nonrating_issue_description: "nonrating description",
+                                      ineligible_reason: nil,
+                                      benefit_type: "compensation",
+                                      decision_date: Date.new(2018, 5, 1))
+      create(:end_product_establishment,
+             :canceled,
+              source: supplemental_claim,
+              reference_id: vec.claim_id,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+
+    end
+
+
+	end
 
 	def create_in_sync_epes_and_vbms_ext_claims
 
-    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
-    # vbms_ext_claims
-    25.times do |n|
-      veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :cleared, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
-      higher_level_review = create(
-        :higher_level_review,
-        end_product_establishments: [epe],
-        veteran_file_number: veteran.file_number
-      )
-      # vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      create(:vbms_ext_claim, :cleared, claim_id: epe.reference_id )
-    end
-    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
-    # vbms_ext_claims
-    25.times do |n|
-      veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :canceled, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
-      higher_level_review = create(
-        :higher_level_review,
-        end_product_establishments: [epe],
-        veteran_file_number: veteran.file_number
-      )
-      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      create(:vbms_ext_claim, :canceled, claim_id: epe.reference_id )
-    end
-    # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
-    # vbms_ext_claims
-    25.times do |n|
-      veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :cleared, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
-      create(:supplemental_claim,
-        end_product_establishments: [epe],
-        veteran_file_number: veteran.file_number,
-        receipt_date: Time.zone.now,
-        benefit_type: "compensation")
-      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      create(:vbms_ext_claim, :cleared, claim_id: epe.reference_id )
-    end
-    # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
-    # vbms_ext_claims
-    25.times do |n|
-      veteran = create(:veteran)
-      epe =  create(:end_product_establishment, :canceled, reference_id: (Random.rand(n..10_000_00)), veteran_file_number: veteran.file_number)
-      create(:supplemental_claim,
-        end_product_establishments: [epe],
-        veteran_file_number: veteran.file_number,
-        receipt_date: Time.zone.now,
-        benefit_type: "compensation")
-      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      create(:vbms_ext_claim, :canceled, claim_id: epe.reference_id )
-    end
 
 	end
 

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -6,9 +6,9 @@ module Seeds
   class VbmsExtClaim < Base
     def seed!
       puts "******seed has been called******"
-      # create_out_of_sync_epes_and_vbms_ext_claims
-      # create_in_sync_epes_and_vbms_ext_claims
       create_vbms_ext_claims_with_no_end_product_establishment
+      create_in_sync_epes_and_vbms_ext_claims
+      # create_out_of_sync_epes_and_vbms_ext_claims
     end
 
 	 private
@@ -17,13 +17,49 @@ module Seeds
 
 	# end
 
-	# def create_in_sync_epes_and_vbms_ext_claims
+	def create_in_sync_epes_and_vbms_ext_claims
 
-	# end
+    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      veteran = create(:veteran)
+      epe =  create(:end_product_establishment, :cleared, reference_id: 200_00 + n, veteran_file_number: veteran.file_number)
+      higher_level_review = create(
+        :higher_level_review,
+        end_product_establishments: [epe],
+        veteran_file_number: veteran.file_number
+      )
+      # vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      create(:vbms_ext_claim, :cleared, claim_id: epe.reference_id )
+    end
+    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # vbms_ext_claims
+    25.times do |n|
+      veteran = create(:veteran)
+      epe =  create(:end_product_establishment, :canceled, reference_id: 300_00 + n, veteran_file_number: veteran.file_number)
+      higher_level_review = create(
+        :higher_level_review,
+        end_product_establishments: [epe],
+        veteran_file_number: veteran.file_number
+      )
+      # vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      create(:vbms_ext_claim, :canceled, claim_id: epe.reference_id )
+    end
+
+	end
 
 	def create_vbms_ext_claims_with_no_end_product_establishment
-    100.times do
-      create(:vbms_ext_claim)
+    # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CLR"
+    50.times do
+      create(:vbms_ext_claim, :cleared)
+    end
+     # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CAN"
+    50.times do
+      create(:vbms_ext_claim,:canceled)
+    end
+     # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "RDC"
+    25.times do
+      create(:vbms_ext_claim,:rdc)
     end
 	end
  end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# create vbms-ext-claim seeds
+module Seeds
+
+  class VbmsExtClaim < Base
+    def seed!
+      puts "******seed has been called******"
+      # create_out_of_sync_epes_and_vbms_ext_claims
+      # create_in_sync_epes_and_vbms_ext_claims
+      create_vbms_ext_claims_with_no_end_product_establishment
+    end
+
+	 private
+
+	# def create_out_of_sync_epes_and_vbms_ext_claims
+
+	# end
+
+	# def create_in_sync_epes_and_vbms_ext_claims
+
+	# end
+
+	def create_vbms_ext_claims_with_no_end_product_establishment
+    100.times do
+      create(:vbms_ext_claim)
+    end
+	end
+ end
+end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -4,18 +4,20 @@
 module Seeds
 
   class VbmsExtClaim < Base
+    # creates and seeds 325 total vbms_ext_claims
     def seed!
-      # create_vbms_ext_claims_with_no_end_product_establishment
-      # create_in_sync_epes_and_vbms_ext_claims
+      create_vbms_ext_claims_with_no_end_product_establishment
+      create_in_sync_epes_and_vbms_ext_claims
       create_out_of_sync_epes_and_vbms_ext_claims
     end
 
 	 private
 
+  # creates out_of_sync vbms_ext_claims and end_produdct_establishments
 	def create_out_of_sync_epes_and_vbms_ext_claims
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # vbms_ext_claims
-    25.times do |n|
+    25.times do
       veteran = create(:veteran)
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
@@ -41,12 +43,10 @@ module Seeds
               code: vec.type_code,
               veteran_file_number: veteran.file_number,
               claimant_participant_id: veteran.participant_id)
-
-
     end
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # vbms_ext_claims
-    25.times do |n|
+    25.times do
       veteran = create(:veteran)
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
@@ -72,11 +72,10 @@ module Seeds
              code: vec.type_code,
              veteran_file_number: veteran.file_number,
              claimant_participant_id: veteran.participant_id)
-
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # # vbms_ext_claims
-    25.times do |n|
+    25.times do
       veteran = create(:veteran)
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
@@ -104,12 +103,11 @@ module Seeds
              code: vec.type_code,
              veteran_file_number: veteran.file_number,
              claimant_participant_id: veteran.participant_id)
-
     end
 
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # # vbms_ext_claims
-    25.times do |n|
+    25.times do
       veteran = create(:veteran)
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
@@ -137,19 +135,20 @@ module Seeds
              code: vec.type_code,
              veteran_file_number: veteran.file_number,
              claimant_participant_id: veteran.participant_id)
-
     end
-
-
 	end
 
+  # creates in_sync vbms_ext_claims and end_produdct_establishments
 	def create_in_sync_epes_and_vbms_ext_claims
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
     # vbms_ext_claims
-    25.times do |n|
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim, :canceled)
+    25.times do
       veteran = create(:veteran)
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim,
+                   :canceled,
+                   :hlr,
+                   claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
       eligible_request_issue = create(:request_issue,
@@ -161,17 +160,24 @@ module Seeds
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :canceled,
-             source: higher_level_review,
-             reference_id: vec.claim_id,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+              source: higher_level_review,
+              reference_id: vec.claim_id,
+              established_at: vec.establishment_date,
+              claim_date: vec.claim_date,
+              modifier: vec.ep_code,
+              code: vec.type_code,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
     end
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
     # vbms_ext_claims
-    25.times do |n|
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim, :cleared)
+    25.times do
       veteran = create(:veteran)
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim,
+                   :cleared,
+                   :hlr,
+                   claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
       eligible_request_issue = create(:request_issue,
@@ -183,18 +189,24 @@ module Seeds
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :cleared,
-              source: higher_level_review,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
-
+             source: higher_level_review,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
     # # vbms_ext_claims
-    25.times do |n|
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim, :cleared)
+    25.times do
       veteran = create(:veteran)
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+      vec = create(:vbms_ext_claim,
+                   :cleared,
+                   :slc,
+                   claimant_person_id: veteran.participant_id)
       supplemental_claim = create(:supplemental_claim,
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
@@ -208,19 +220,25 @@ module Seeds
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :cleared,
-              source: supplemental_claim,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
-
+             source: supplemental_claim,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
     end
 
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are in_sync with
+    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
     # # vbms_ext_claims
-    25.times do |n|
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim, :canceled)
+    25.times do
       veteran = create(:veteran)
+      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+      vec = create(:vbms_ext_claim,
+                   :canceled,
+                   :slc,
+                   claimant_person_id: veteran.participant_id)
       supplemental_claim = create(:supplemental_claim,
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
@@ -234,16 +252,18 @@ module Seeds
                                       decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :canceled,
-              source: supplemental_claim,
-              reference_id: vec.claim_id,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
-
+             source: supplemental_claim,
+             reference_id: vec.claim_id,
+             established_at: vec.establishment_date,
+             claim_date: vec.claim_date,
+             modifier: vec.ep_code,
+             code: vec.type_code,
+             veteran_file_number: veteran.file_number,
+             claimant_participant_id: veteran.participant_id)
     end
-
-
 	end
 
+  # creates 124 vbms_ext_claims not associated with an end_product_establishment
 	def create_vbms_ext_claims_with_no_end_product_establishment
     # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CLR"
     50.times do

--- a/lib/tasks/custom_seed.rake
+++ b/lib/tasks/custom_seed.rake
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+namespace :db do
+  namespace :seed do
+    Dir[File.join(Rails.root, "db", "seeds", "*.rb")].each do |filename|
+      task_name = File.basename(filename, ".rb").intern
+
+      task task_name => :environment do
+        load(filename)
+        Seeds::VbmsExtClaim.new.seed!
+      end
+    end
+
+    task :all => :environment do
+      Dir[File.join(Rails.root, "db", "seeds", "*.rb")].sort.each do |filename|
+        load(filename)
+      end
+    end
+  end
+end

--- a/lib/tasks/custom_seed.rake
+++ b/lib/tasks/custom_seed.rake
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
+# This allows you to run a custom db:seed file
+# for example: bundle exec rake db:seed:custom_seed_file_name
 namespace :db do
   namespace :seed do
     Dir[File.join(Rails.root, "db", "seeds", "*.rb")].each do |filename|
       task_name = File.basename(filename, ".rb").intern
-
       task task_name => :environment do
         load(filename)
+        # when bundle exec rake db:seed:vbms_ext_claim is called
+        # it runs the seed! method inside vbms_ext_claim.rb
         Seeds::VbmsExtClaim.new.seed!
       end
     end

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -5,9 +5,9 @@ FactoryBot.define do
     # prevents vbms_ext_claim to have a duplicate key
     sequence(:claim_id) do |n|
       if VbmsExtClaim.last
-        "#{VbmsExtClaim.last.claim_id + n}"
+        (VbmsExtClaim.last.claim_id + n).to_s
       else
-        "#{100_00 + n}"
+        (100_00 + n).to_s
       end
     end
 

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :vbms_ext_claim do
+    sequence(:claim_id) { |n| "10000#{n}" }
+    sync_id { 1 }
+    createddt { Time.zone.now }
+    lastupdatedt { Time.zone.now }
+    expirationdt { Time.zone.now }
+    version { 22 }
+    prevent_audit_trig { 2 }
+
+    trait :linked_epe do
+    end
+
+    trait :cleared do
+      LEVEL_STATUS_CODE { "CLR" }
+    end
+
+    trait :canceled do
+      LEVEL_STATUS_CODE { "CAN" }
+    end
+
+    # rdc: rating decision complete
+    trait :rdc do
+      LEVEL_STATUS_CODE { "RDC" }
+    end
+  end
+end

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -18,9 +18,6 @@ FactoryBot.define do
     version { 22 }
     prevent_audit_trig { 2 }
 
-    trait :linked_epe do
-    end
-
     trait :cleared do
       LEVEL_STATUS_CODE { "CLR" }
     end

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :vbms_ext_claim do
-    # prevents vbms_ext_claim to have a duplicate key
+    # prevents vbms_ext_claim from having a duplicate key
     sequence(:claim_id) do
       if VbmsExtClaim.last
         (VbmsExtClaim.last.claim_id + 1).to_s

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -3,11 +3,11 @@
 FactoryBot.define do
   factory :vbms_ext_claim do
     # prevents vbms_ext_claim to have a duplicate key
-    sequence(:claim_id) do |n|
+    sequence(:claim_id) do
       if VbmsExtClaim.last
-        (VbmsExtClaim.last.claim_id + n).to_s
+        (VbmsExtClaim.last.claim_id + 1).to_s
       else
-        Random.rand(n..200_000_00).to_s
+        (10_000 + 1).to_s
       end
     end
 

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
       if VbmsExtClaim.last
         (VbmsExtClaim.last.claim_id + n).to_s
       else
-        (100_00 + n).to_s
+        Random.rand(n..200_000_00).to_s
       end
     end
 

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -2,11 +2,19 @@
 
 FactoryBot.define do
   factory :vbms_ext_claim do
-    sequence(:claim_id) { |n| "10000#{n}" }
+    # prevents vbms_ext_claim to have a duplicate key
+    sequence(:claim_id) do |n|
+      if VbmsExtClaim.last
+        "#{VbmsExtClaim.last.claim_id + n}"
+      else
+        "#{100_00 + n}"
+      end
+    end
+
     sync_id { 1 }
-    createddt { Time.zone.now }
+    createddt { Time.zone.now - 1.day }
     lastupdatedt { Time.zone.now }
-    expirationdt { Time.zone.now }
+    expirationdt { Time.zone.now + 5.days }
     version { 22 }
     prevent_audit_trig { 2 }
 

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -10,9 +10,10 @@ FactoryBot.define do
         (10_000 + 1).to_s
       end
     end
-
+    claim_date { Time.zone.now - 1.day }
     sync_id { 1 }
     createddt { Time.zone.now - 1.day }
+    establishment_date { Time.zone.now - 1.day }
     lastupdatedt { Time.zone.now }
     expirationdt { Time.zone.now + 5.days }
     version { 22 }
@@ -29,6 +30,18 @@ FactoryBot.define do
     # rdc: rating decision complete
     trait :rdc do
       LEVEL_STATUS_CODE { "RDC" }
+    end
+
+    trait :hlr do
+      EP_CODE { "030" }
+      TYPE_CODE { "030HLRR" }
+      PAYEE_CODE { "00" }
+    end
+
+    trait :slc do
+      EP_CODE { "040" }
+      TYPE_CODE { "040SCR" }
+      PAYEE_CODE { "00" }
     end
   end
 end

--- a/spec/factories/vbms_ext_claim.rb
+++ b/spec/factories/vbms_ext_claim.rb
@@ -32,12 +32,13 @@ FactoryBot.define do
       LEVEL_STATUS_CODE { "RDC" }
     end
 
+    # high_level_review ext claim
     trait :hlr do
       EP_CODE { "030" }
       TYPE_CODE { "030HLRR" }
       PAYEE_CODE { "00" }
     end
-
+    # supplemental_claim ext claim
     trait :slc do
       EP_CODE { "040" }
       TYPE_CODE { "040SCR" }

--- a/spec/seeds/vbms_ext_claim_spec.rb
+++ b/spec/seeds/vbms_ext_claim_spec.rb
@@ -3,10 +3,23 @@
 describe Seeds::VbmsExtClaim do
   let(:seed) { Seeds::VbmsExtClaim.new }
 
+  context "#seed!" do
+    it "seeds total of 325 VBMS EXT CLAIMS, 100 High Level Review EndProduct Establishments
+      100 Supplemental Claim End Product Establishments, and 125 Non Associated End Product
+      Establishments" do
+      seed.seed!
+      expect(VbmsExtClaim.count).to eq(325)
+      expect(HigherLevelReview.count).to eq(100)
+      expect(SupplementalClaim.count).to eq(100)
+      expect(VbmsExtClaim.where(ep_code: nil).count).to eq(125)
+    end
+  end
+
   context "#create_vbms_ext_claims_with_no_end_product_establishment" do
     it "seeds total of 125 VBMS EXT CLAIMS Not associated with an EPE" do
       seed.send(:create_vbms_ext_claims_with_no_end_product_establishment)
       expect(VbmsExtClaim.count).to eq(125)
+      expect(VbmsExtClaim.where(ep_code: nil).count).to eq(125)
     end
   end
   context "#create_in_sync_epes_and_vbms_ext_claims" do

--- a/spec/seeds/vbms_ext_claim_spec.rb
+++ b/spec/seeds/vbms_ext_claim_spec.rb
@@ -3,14 +3,41 @@
 describe Seeds::VbmsExtClaim do
   let(:seed) { Seeds::VbmsExtClaim.new }
 
-  context "#seed!" do
-    it "seeds total of 325 VBMS EXT CLAIMS with 100 High Level Review and
-        100 Supplmental Claims Associated and 200 Associated with EndProduct" do
-      seed.seed!
-      expect(VbmsExtClaim.count).to eq(325)
-      expect(HigherLevelReview.count).to eq(100)
-      expect(SupplementalClaim.count).to eq(100)
-      expect(EndProductEstablishment.count).to eq(200)
+  context "#create_vbms_ext_claims_with_no_end_product_establishment" do
+    it "seeds total of 125 VBMS EXT CLAIMS Not associated with an EPE" do
+      seed.send(:create_vbms_ext_claims_with_no_end_product_establishment)
+      expect(VbmsExtClaim.count).to eq(125)
+    end
+  end
+  context "#create_in_sync_epes_and_vbms_ext_claims" do
+    it "seeds total of 100 VBMS EXT CLAIMS Associated with 50 High Level Review End Product
+        Establishments and 50 Supplemental Claims End Product Establishments that are in sync" do
+      seed.send(:create_in_sync_epes_and_vbms_ext_claims)
+      expect(VbmsExtClaim.count).to eq(100)
+      # need to show where VbmsExtClaim and EndProductEstablishment are in_sync
+      # where Level_status_code CAN is equal to sync_status code CAN
+      expect(VbmsExtClaim.where(level_status_code: "CAN").count).to eq(EndProductEstablishment
+        .where(synced_status: "CAN").count)
+      expect(VbmsExtClaim.where(level_status_code: "CLR").count).to eq(EndProductEstablishment
+        .where(synced_status: "CLR").count)
+      expect(HigherLevelReview.count).to eq(50)
+      expect(SupplementalClaim.count).to eq(50)
+      expect(EndProductEstablishment.count).to eq(100)
+    end
+  end
+  context "#create_out_of_sync_epes_and_vbms_ext_claims" do
+    it "seeds total of 100 VBMS EXT CLAIMS Associated with 50 High Level Review End Product
+        Establishments and 50 Supplemental Claims End Product Establishments that are out
+        of sync" do
+      seed.send(:create_out_of_sync_epes_and_vbms_ext_claims)
+      expect(VbmsExtClaim.count).to eq(100)
+      # need to show where VbmsExtClaim and EndProductEstablishment are out_of_sync
+      # where VbmsExtClaim.Level_status_code CAN and CLR is equal to EndProductEstablish.sync_status PEND
+      expect(VbmsExtClaim.where(level_status_code: %w[CAN CLR]).count).to eq(EndProductEstablishment
+        .where(synced_status: "PEND").count)
+      expect(HigherLevelReview.count).to eq(50)
+      expect(SupplementalClaim.count).to eq(50)
+      expect(EndProductEstablishment.count).to eq(100)
     end
   end
 end

--- a/spec/seeds/vbms_ext_claim_spec.rb
+++ b/spec/seeds/vbms_ext_claim_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+describe Seeds::VbmsExtClaim do
+  let(:seed) { Seeds::VbmsExtClaim.new }
+
+  context "#seed!" do
+    it "seeds total of 325 VBMS EXT CLAIMS with 100 High Level Review and
+        100 Supplmental Claims Associated and 200 Associated with EndProduct" do
+      seed.seed!
+      expect(VbmsExtClaim.count).to eq(325)
+      expect(HigherLevelReview.count).to eq(100)
+      expect(SupplementalClaim.count).to eq(100)
+      expect(EndProductEstablishment.count).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
Resolves [APPEALS-21357](https://jira.devops.va.gov/browse/APPEALS-21357)

# Description
This story creates the seed data for vbms_ext_claims with and without associations to High Level Review End Product Establishments or Supplemental End Product Establishments

## Acceptance Criteria
- [x] create vbms_ext_claim factory.
- [x] create VbmsExtClaim Class that part of the Seeds module
- [x] create 3 different cases of VbmsExtClaims. None Associated to EPE HLR or SLC, Associated to EPE HLR or SLC & in_sync, and Associated to EPE HLR or SLC & out_of_sync
- [x] add VbmsExtClaim class to Seeds Module
- [x] create make target that seeds vbms_ext_claims, high level reviews, supplemental claims, and End Product Establishments
- [x] create unit and feature Rspec test for vbms_ext_claims_spec.rb for the Seeds Module  

## Testing Plan
1. Go to [APPEALS-24065](https://jira.devops.va.gov/browse/APPEALS-24065)

### Steps
1.  run `make rest`
	1. Expected Result: Runs without Error
2. run `make seed-dbs`
	1. Expected Result:
		1. Runs without Error
3. run `make external-db-remove`
	1. Expected Result:
		1. runs without error
		2. runs command: 
			1. `bundle exec rails r db/scripts/external/remove_vbms_ext_claim_table.rb`
		3. removes `vbms_ext_claim_table` from database caseflow_certification_development
4.  run `make external-db-create`
	1. Expected Result:
		1. runs without error
		2. runs both commands: 
			1. `bundle exec rails r db/scripts/external/create_vbms_ext_claim_table.rb`
		3. creates `vbms_ext_claim_table` in database caseflow_certification_development
5. run `make external-db-create-test`
	1. Expected Result:
		1. runs without error
		2. runs command
			1. `bundle exec rails r -e test db/scripts/external/create_vbms_ext_claim_table.rb`
6. run `make one-test spec/seeds/vbms_ext_claim_spec.rb`
	1. Expected Result:
		1. Test Pass without failures
7.  run `make seed-vbms-ext-claim`
	1. Expected Result:
		1. runs without error
		2. Seeds New 325 vbms_ext_claims
			1. Confirm in rails console that VbmsExtClaim.count  = 325
				1. run `make c`
				2. run `VbmsExtClaim.count`
				3. 325
			2. Confirm in rails console that VbmsExtClaim.CLAIMANT_PERSON_ID  matches End_Product_Establishment.claimant_participant_id
			3.  run `VbmsExtClaim.last`
			4.  run `EndProductEstablishment.last`
			5. verify that CLAIMANT_PERSON_ID matches claimant_participant_id
			6. verify that EP_CODE matches modifier
			7. verify that TYPE_CODE matches code
		3. Verify that 3 Seeding Methods Ran correctly 
			1. Expected Result:
				1. in DBeaver Confirm Data is correct in caseflow_certification_development database for the 3 cases
					1. Open DBeaver > Connect to Postgres > Databases > caseflow_certification_development > Schemas > public > and open tables vbms_ext_claims and end_product_establishments
					2. CASE: create_vbms_ext_claims_with_no_end_product_establishment  
						1. Verify that VbmsExtClaim.CLAIM_ID with EP_CODE: NULL does not exist in EndProductEstablishment.reference_id
							1. for example: 
								1. if VbmsExtClaim.CLAIM_ID = 100001 then EndProductEstablishment.reference_id should not have  100001
					3. CASE: create_in_sync_epes_and_vbms_ext_claims 
						1. Find an EPE.sync_status of "CAN"
						2. Verify that the following are matching
							1. VEC."CLAIM_ID" == EPE.reference_id
								VEC."CLAIM_DATE" == EPE.claim_date
								VEC."EP_CODE" == EPE.modifier
								VEC."CLAIMANT_PERSON_ID" == EPE.claimant_participant_id
								VEC."TYPE_CODE" == EPE.code
								VEC."PAYEE_CODE" == EPE.payee_code
								VEC."ESTABLISHMENT_DATE" == EPE.established_at
							2. Verify that HLR or SLC EPE has the correct data associated with the VEC
								1. Find a VEC with an EP_CODE
								2. Find the matching VEC."CLAIMANT_PERSON_ID" == EPE.claimant_participant_id
								3. verify EPE.reference_id == VEC.claim_id
								4. confirm EPE.source_type is  HLR or SLC
								5. confirm veteran_file_number match EPE.veteran_file_number == HLR.veteran_file_number  or EPE.veteran_file_number == SLC.veteran_file_number 
						3. Verify that they are in_sync
							1. VEC.CLAIM_ID == EPE.reference_id
							2. VEC.LEVEL_STATUS_CODE == EPE.sync_status
								1. for example:
									1.  VEC.LEVEL_STATUS_CODE = "CAN" 
									2.  EPE.sync_status = "CAN"
					1. CASE: create_out_of_sync_epes_and_vbms_ext_claims
						1. Find an EPE.sync_status of "PEND"
						2. Verify that the following are matching
							1. VEC."CLAIM_ID" == EPE.reference_id
								VEC."CLAIM_DATE" == EPE.claim_date
								VEC."EP_CODE" == EPE.modifier
								VEC."CLAIMANT_PERSON_ID" == EPE.claimant_participant_id
								VEC."TYPE_CODE" == EPE.code
								VEC."PAYEE_CODE" == EPE.payee_code
								VEC."ESTABLISHMENT_DATE" == EPE.established_at
						3. Verify that HLR or SLC EPE has the correct data associated with the VEC
							1. Find a VEC with an EP_CODE
							2. Find the matching VEC."CLAIMANT_PERSON_ID" == EPE.claimant_participant_id
							3. verify EPE.reference_id == VEC.claim_id
							4. confirm EPE.source_type is  HLR or SLC
							5. confirm veteran_file_number match 
							EPE.veteran_file_number == HLR.veteran_file_number  or EPE.veteran_file_number == SLC.veteran_file_number 
						4.  Verify that they are out_of_sync
							1. Find an EPE.sync_status of "PEND"
							2. Find the EPE.reference_id
							3. Find the Matching VEC.CLAIM_ID
							4. Verify that the VEC.LEVEL_STATUS_CODE do not match EPE.sync_status
								1. for example:
									1. EPE.sync_status = "PENDING"
									2. VEC.LEVEL_STATUS_CODE = "CAN"




## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added



