### PR TITLE
Lauren/APPEALS-23860

### DIFF
--- a/lib/helpers/report_load_end_product_sync.rb
+++ b/lib/helpers/report_load_end_product_sync.rb
@@ -127,11 +127,6 @@ module WarRoom
     #
     ####################################################################
 
-    # Helper method for get_error_ids to return txt file contents as an array
-    def to_array
-      body.read.gsub("\r","").split("\n").map{ |obj| obj[1...-1] }
-    end
-
     # Grab txt file of previously errored EP reference ids from s3 and return as an array
     def get_error_ids(env)
       # Set Client Resources for AWS
@@ -140,7 +135,7 @@ module WarRoom
       key_name = "ep_establishment_workaround/#{env}/ep_priority_sync/error_ids.txt"
 
       filepath = s3client.get_object(bucket:'appeals-dbas', key:key_name)
-      filepath.to_array
+      filepath.body.read.gsub("\r","").split("\n").map{ |obj| obj[1...-1] }
     end
 
     # Grab cleared EPs that are out of sync
@@ -167,7 +162,7 @@ module WarRoom
         ORDER BY
           epe.id ASC
         LIMIT
-          batch_limit
+          #{batch_limit}
       SQL
 
       conn.execute(raw_sql)
@@ -197,7 +192,7 @@ module WarRoom
         ORDER BY
           epe.id ASC
         LIMIT
-          batch_limit
+          #{batch_limit}
       SQL
 
       conn.execute(raw_sql)
@@ -251,7 +246,7 @@ module WarRoom
               data.reference_id,
               data.last_synced_at,
               data.synced_status,
-              data.prev_sync_status,
+              data.prev_synced_status,
               data.error
             ].flatten
         end


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-23860

# Description
Helper method to_array not working as intended on APPEALS-22696. Bug fix is to remove the method and add to_array functionality to the end of the get_error_ids method instead.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-23860

- [ ] For feature branches merging into master: Was this deployed to UAT?
