### PR TITLE
Hide MST/PACT checkboxes for HLRS and SCs

### DIFF
--- a/client/app/intake/components/AddIssuesModal.jsx
+++ b/client/app/intake/components/AddIssuesModal.jsx
@@ -101,7 +101,8 @@ class AddIssuesModal extends React.Component {
   };
 
   getContestableIssuesSections() {
-    const { intakeData } = this.props;
+    const { intakeData, formType, featureToggles } = this.props;
+
     let iterations = -1;
     const addedIssues = intakeData.addedIssues ? intakeData.addedIssues : [];
     let counter = 0;
@@ -134,6 +135,30 @@ class AddIssuesModal extends React.Component {
       }
       accumulationArr[i] = accumulation;
     }
+
+    const renderTrueOrFalse = (whatToRender) => {
+      let featureFlagToUse;
+
+      switch (whatToRender) {
+      case 'mst':
+        featureFlagToUse = featureToggles.mst_identification ?
+          featureToggles.mst_identification : featureToggles.mstIdentification;
+        break;
+      case 'pact':
+        featureFlagToUse = featureToggles.pact_identification ?
+          featureToggles.mst_identification : featureToggles.pactIdentification;
+        break;
+      case 'justification':
+        featureFlagToUse = featureToggles.justification_reason ?
+          featureToggles.justification_reason : featureToggles.justificationReason;
+        break;
+      default:
+        // Do nothing if variable not specified in list
+        break;
+      }
+      
+      return featureFlagToUse && formType === 'appeal';
+    };
 
     return map(intakeData.contestableIssues, (contestableIssuesByIndex, approxDecisionDate) => {
       const radioOptions = map(contestableIssuesByIndex, (issue) => {
@@ -186,12 +211,9 @@ class AddIssuesModal extends React.Component {
           mstJustificationOnChange={this.mstJustificationOnChange}
           pactJustification={this.state.pactJustification}
           pactJustificationOnChange={this.pactJustificationOnChange}
-          renderMst={this.props.featureToggles.mst_identification ?
-            this.props.featureToggles.mst_identification : this.props.featureToggles.mstIdentification}
-          renderPact={this.props.featureToggles.pact_identification ?
-            this.props.featureToggles.pact_identification : this.props.featureToggles.pactIdentification}
-          renderJustification={this.props.featureToggles.justification_reason ?
-            this.props.featureToggles.justification_reason: this.props.featureToggles.justificationReason}
+          renderMst={renderTrueOrFalse('mst')}
+          renderPact={renderTrueOrFalse('pact')}
+          renderJustification={renderTrueOrFalse('justification')}
           userCanEditIntakeIssues={this.props.userCanEditIntakeIssues}
           mstChecked={this.state.mstChecked}
           setMstCheckboxFunction={this.mstCheckboxChange}
@@ -262,7 +284,8 @@ AddIssuesModal.propTypes = {
   skipText: PropTypes.string,
   intakeData: PropTypes.object,
   featureToggles: PropTypes.object,
-  userCanEditIntakeIssues: PropTypes.bool
+  userCanEditIntakeIssues: PropTypes.bool,
+  formType: PropTypes.string
 };
 
 AddIssuesModal.defaultProps = {

--- a/client/app/intake/components/NonratingRequestIssueModal.jsx
+++ b/client/app/intake/components/NonratingRequestIssueModal.jsx
@@ -317,9 +317,9 @@ class NonratingRequestIssueModal extends React.Component {
     const { formType, intakeData, onCancel, featureToggles } = this.props;
     const { benefitType, category, selectedNonratingIssueId, isPreDocketNeeded } = this.state;
     const eduPreDocketAppeals = featureToggles.eduPreDocketAppeals;
-    const mstIdentification = featureToggles.mstIdentification ?
+    const mstIdentification = featureToggles.mstIdentification && formType === 'appeal' ?
       featureToggles.mstIdentification : featureToggles.mst_identification;
-    const pactIdentification = featureToggles.pactIdentification ?
+    const pactIdentification = featureToggles.pactIdentification && formType === 'appeal' ?
       featureToggles.pactIdentification : featureToggles.pact_identification;
 
     const issueNumber = (intakeData.addedIssues || []).length + 1;


### PR DESCRIPTION
Resolves #{[APPEALS-23892](https://jira.devops.va.gov/browse/APPEALS-23892)}

# Description
Hid MST/PACT checkboxes for HLR and SC

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan

1. Sign in as BVADWISE
2. Go to Mail Intake and select High Level Review to initiate
3. Continue through the option and pages until you reach the Add Issues Page
4. Click on Add Issue
5. If there are past decisions select one of the decisions and notice that MST/PACT checkboxes are rendering. Click on "None of these match - see more options" and note MST/PACT checkboxes are also rendering
6. If there are no past decisions, note that MST/PACT checkboxes are rendering on the modal
7. Cancel intake and now select Supplemental Claim
8. Go to Add Issues Page and click on add issue
9. If there are past decisions select one of the decisions and notice that MST/PACT checkboxes are rendering. Click on "None of these match - see more options" and note MST/PACT checkboxes are also rendering
10. If there are no past decisions, note that MST/PACT checkboxes are rendering on the modal

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [X] Other - Manual

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added



