### PR TITLE
Special Issue Designation Checkboxes Now Persist: APPEALS - 23834

### DIFF
--- a/client/app/queue/components/QueueFlowPage.jsx
+++ b/client/app/queue/components/QueueFlowPage.jsx
@@ -88,7 +88,11 @@ class QueueFlowPage extends React.PureComponent {
     } = this.props;
 
     this.props.hideModal('cancelCheckout');
-    this.props.resetDecisionOptions();
+    if (location.href.includes("dispositions")) {
+      this.props.resetDecisionOptions();
+    } else {
+      this.props.goToNextStep();
+    }
     _.each(stagedAppeals, this.props.checkoutStagedAppeal);
 
     this.withUnblockedTransition(


### PR DESCRIPTION
Resolves APPEALS - 23834

# Description
Special issue designation checkboxes now persist the the user clicks cancel.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] When you refresh page special issue designations remain

