### PR TITLE
APPEALS-24058: fixing the enabled return button bug when task is retu…

### DIFF
--- a/client/app/queue/components/CompleteTaskModal.jsx
+++ b/client/app/queue/components/CompleteTaskModal.jsx
@@ -629,8 +629,9 @@ const MODAL_TYPE_ATTRS = {
     title: () => COPY.VHA_RETURN_TO_BOARD_INTAKE_MODAL_TITLE,
     getContent: VhaCamoReturnToBoardIntakeModal,
     buttonText: COPY.MODAL_RETURN_BUTTON,
-    submitDisabled: ({ state }) => (
-      !validDropdown(state.dropdown) || (state.dropdown === 'other' && !validInstructions(state.otherInstructions))
+    customValidation: ({ state }) => (
+      state.dropdown === 'other' ? validInstructions(state.otherInstructions) && validDropdown(state.dropdown) :
+        validDropdown(state.dropdown)
     ),
     customFormatInstructions: ({ state }) => {
       return formatOtherInstructions(state);
@@ -927,8 +928,8 @@ class CompleteTaskModal extends React.Component {
       (MODAL_TYPE_ATTRS[this.props.modalType].buttonText === 'Resend notification letter') ||
       (this.props.modalType === 'task_complete_contested_claim')
     ) ? ('/organizations/clerk-of-the-board?tab=unassignedTab&page=1') : (
-        taskData.redirect_after || '/queue'
-      );
+      taskData.redirect_after || '/queue'
+    );
 
     return (
       <QueueFlowModal

--- a/client/test/app/queue/components/CompleteTaskModal.test.js
+++ b/client/test/app/queue/components/CompleteTaskModal.test.js
@@ -180,12 +180,13 @@ describe('CompleteTaskModal', () => {
 
     test('Return button is disabled until a task is selected', () => {
       renderCompleteTaskModal(modalType, camoToBvaIntakeData, taskType);
-
-      expect(screen.findByRole('button', { name: buttonText, disabled: true })).toBeTruthy();
+      expect(screen.getByRole('button', { name: buttonText })).toBeDisabled();
+      // expect(screen.findByRole('button', { name: buttonText, disabled: true })).toBeTruthy();
 
       selectFromDropdown('Why is this appeal being returned?', 'Duplicate');
 
-      expect(screen.findByRole('button', { name: buttonText, disabled: false })).toBeTruthy();
+      // expect(screen.findByRole('button', { name: buttonText, disabled: false })).toBeTruthy();
+      expect(screen.getByRole('button', { name: buttonText })).not.toBeDisabled();
     });
 
     test('if other is selected, Return button is disabled until a reason is entered', () => {

--- a/spec/feature/queue/pre_docket_spec.rb
+++ b/spec/feature/queue/pre_docket_spec.rb
@@ -570,11 +570,100 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
           expect(page).to have_content(po_instructions)
         end
 
+        step "enacting the 'Return to Board Intake' task action returns the task to BVA intake" do
+          User.authenticate!(user: camo_user)
+
+          vha_document_search_task = VhaDocumentSearchTask.last
+
+          appeal = vha_document_search_task.appeal
+
+          visit "/queue/appeals/#{appeal.external_id}"
+
+          task_name = Constants.TASK_ACTIONS.VHA_RETURN_TO_BOARD_INTAKE.label
+
+          other_text_field_text = "Wrong type of documents"
+          optional_text_field_text = "The documents included in the appeal are incorrect"
+
+          find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL).click
+          find(
+            "div",
+            class: "cf-select__option",
+            text: task_name
+          ).click
+
+          expect(page).to have_content(COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_TITLE)
+          expect(page).to have_content(COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_BODY)
+
+          expect(page).to have_content(COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_DETAIL)
+          expect(page).to have_content(COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_INSTRUCTIONS_LABEL)
+
+          # Fill in info and check for disabled submit button and warning text before submitting
+          submit_button = find("button", class: "usa-button", text: COPY::MODAL_RETURN_BUTTON)
+
+          expect(submit_button[:disabled]).to eq "true"
+
+          # Open the searchable dropdown to view the options
+          find(".cf-select__control", text: COPY::TASK_ACTION_DROPDOWN_BOX_LABEL_SHORT).click
+
+          page_options = all("div.cf-select__option")
+          page_options_text = page_options.map(&:text)
+          controller_options = COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_DROPDOWN_OPTIONS
+          controller_options = controller_options.values.pluck("LABEL")
+
+          # Verify that all of the options are in the dropdown
+          expect(page_options_text).to eq(controller_options)
+
+          # Click the duplicate option and verify that the button is no longer disabled
+          first_tested_option_text = controller_options.first
+          find("div", class: "cf-select__option", text: first_tested_option_text).click
+          expect(submit_button[:disabled]).to eq "false"
+
+          # Check the other option functionality
+          conditional_drop_down_text = COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_DROPDOWN_OPTIONS[
+            "OTHER"
+          ]["LABEL"]
+
+          # Reclick the dropdown with the new option and change it to "Other"
+          find(".cf-select__control", text: first_tested_option_text).click
+          find("div", class: "cf-select__option", text: conditional_drop_down_text).click
+
+          # Verify the submit button is disabled again and check for the other reason text field
+          expect(submit_button[:disabled]).to eq "true"
+          expect(page).to have_content(
+            COPY::VHA_RETURN_TO_BOARD_INTAKE_OTHER_INSTRUCTIONS_LABEL
+          )
+
+          # Enter info into the optional text field and verify the submit button is still disabled
+          fill_in(COPY::VHA_RETURN_TO_BOARD_INTAKE_MODAL_INSTRUCTIONS_LABEL,
+                  with: optional_text_field_text)
+
+          expect(submit_button[:disabled]).to eq "true"
+
+          fill_in(COPY::VHA_RETURN_TO_BOARD_INTAKE_OTHER_INSTRUCTIONS_LABEL,
+                  with: other_text_field_text)
+
+          expect(submit_button[:disabled]).to eq "false"
+
+          submit_button.click
+
+          expect(page).to have_content(
+            format(
+              COPY::VHA_RETURN_TO_BOARD_INTAKE_CONFIRMATION,
+              appeal.veteran_full_name
+            )
+          )
+
+          completed_tab_name = VhaCamoCompletedTasksTab.tab_name
+          expected_url = "/organizations/#{camo.url}?tab=#{completed_tab_name}&#{default_query_params}"
+          expect(page).to have_current_path(expected_url)
+        end
+
         step "CAMO can return the appeal to BVA Intake" do
           appeal = Appeal.last
           camo_task = VhaDocumentSearchTask.last
           bva_intake_task = PreDocketTask.last
 
+          camo_task.update!(status: Constants.TASK_STATUSES.assigned)
           # Remove this section once the steps completing these tasks is available
           camo_task.children.each { |task| task.update!(status: "completed") }
 
@@ -589,8 +678,15 @@ RSpec.feature "Pre-Docket intakes", :all_dbs do
 
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_TITLE)
           expect(page).to have_content(COPY::DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_MODAL_BODY)
+          submit_button = find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON)
+
+          expect(submit_button[:disabled]).to eq "true"
+
           page.all(".cf-form-radio-option > label")[0].click
-          find("button", class: "usa-button", text: COPY::MODAL_SEND_BUTTON).click
+
+          expect(submit_button[:disabled]).to eq "false"
+
+          submit_button.click
 
           expect(page).to have_content(
             COPY::VHA_CAREGIVER_SUPPORT_DOCUMENTS_READY_FOR_BOARD_INTAKE_REVIEW_CONFIRMATION_TITLE


### PR DESCRIPTION
Resolves [APPEALS-24058](https://jira.devops.va.gov/browse/APPEALS-24058)

# Description
fixed the enabled 'return' button bug when task is returned to bva intake by CAMO
Added a step to test this functionality in pre-docket-spec.rb
corrected the jest test. 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] 'Return' button should be disabled when task is being sent from CAMO to Board Intake. 
- [ ] Jest test should capture test this feature
- [ ] feature test should also capture this behavior 

## Testing Plan
1. Go to  [APPEALS-24058](https://jira.devops.va.gov/browse/APPEALS-24058) for step to reproduce this bug OR
2. Sign in as user CAMOADMIN user
3. Click on your queue link and get redirected to /queue
4. click on Switch views dropdown and select VHA Camo team cases
5.  select an appeal and navigate to Case Appeals and under **Actions** dropdown select "Return to Board Intake"
6. Verify that the button is disabled
7. If the "Other" option is selected, a secondary textbox appears asking the user to provide the reason for return. The user should not be allowed to submit the form until that textbox is populated.

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/122557351/6f651283-9c0b-4dc6-a99b-d4a477335b7d)|![image](https://github.com/department-of-veterans-affairs/caseflow/assets/122557351/27a64ff2-5040-4ab6-a1e8-cefce584d13e)|
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/122557351/d16ec49b-337b-4a98-8506-37504f189da1)| ![image](https://github.com/department-of-veterans-affairs/caseflow/assets/122557351/89a9a3bf-0fc5-4781-a7b2-e3d1325bb440)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

