### PR TITLE
disabling feature toggle covering justification

### DIFF
--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -57,7 +57,8 @@ end
 disabled_flags = [
   "legacy_das_deprecation",
   "cavc_dashboard_workflow",
-  "poa_auto_refresh"
+  "poa_auto_refresh",
+  "justification_reason"
 ]
 
 all_features = AllFeatureToggles.new.call.flatten.uniq


### PR DESCRIPTION

# Description
Fix for feature toggle work to disable the justification reason by default as the work for justification reason has been paused indefinitely.
