### PR TITLE
APPEALS-23935 - Add Spring for faster development tasks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -130,6 +130,7 @@ end
 group :development, :test do
   gem "spring", "3.1.1" # later versions require Rails 6.0+
   gem "spring-commands-rspec"
+  gem "spring-commands-rubocop"
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -127,6 +127,10 @@ group :test, :development, :demo do
   gem "webdrivers"
 end
 
+group :development, :test do
+  gem "spring", "3.1.1" # later versions require Rails 6.0+
+end
+
 group :development do
   gem "anbt-sql-formatter"
   gem "bummr", require: false

--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,7 @@ end
 
 group :development, :test do
   gem "spring", "3.1.1" # later versions require Rails 6.0+
+  gem "spring-commands-rspec"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -650,6 +650,8 @@ GEM
       tilt (~> 2.0)
       yard (~> 0.9)
     spring (3.1.1)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -808,6 +810,7 @@ DEPENDENCIES
   sniffybara!
   solargraph
   spring (= 3.1.1)
+  spring-commands-rspec
   sql_tracker
   stringex
   strong_migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -649,6 +649,7 @@ GEM
       thor (~> 0.19, >= 0.19.4)
       tilt (~> 2.0)
       yard (~> 0.9)
+    spring (3.1.1)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -806,6 +807,7 @@ DEPENDENCIES
   single_cov
   sniffybara!
   solargraph
+  spring (= 3.1.1)
   sql_tracker
   stringex
   strong_migrations

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -652,6 +652,8 @@ GEM
     spring (3.1.1)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
+    spring-commands-rubocop (0.4.0)
+      spring (>= 1.0)
     sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -811,6 +813,7 @@ DEPENDENCIES
   solargraph
   spring (= 3.1.1)
   spring-commands-rspec
+  spring-commands-rubocop
   sql_tracker
   stringex
   strong_migrations

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,9 @@ Rails.application.configure do
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development
   # since you don't have to restart the web server when you make code changes.
+  #
+  # Note: Reloading is also necessary for Spring to work
+  # https://github.com/rails/spring/blob/e7d88f57eaaeae84ddcdc6cc000874500e812165/README.md#L69-L80
   config.cache_classes = false
 
   # Do not eager load code on boot.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,15 @@ Rails.application.configure do
   # test suite. You never need to work with it otherwise. Remember that
   # your test database is "scratch space" for the test suite and is wiped
   # and recreated between test runs. Don't rely on the data there!
-  config.cache_classes = true
+
+  # Note: Reloading is necessary for Spring to work
+  # https://github.com/rails/spring/blob/e7d88f57eaaeae84ddcdc6cc000874500e812165/README.md#L69-L80
+  # However, we want to preserve the existing behavior with class caching in CI
+  # test environments. Thus, ENV["ENABLE_SPRING_IN_TEST"] can be set to `true`
+  # to disable class caching and enable Spring in local test environments.
+  spring_enabled_in_test =
+    ActiveRecord::Type::Boolean.new.cast(ENV.fetch("ENABLE_SPRING_IN_TEST", false))
+  config.cache_classes = not(spring_enabled_in_test) # default: true
 
   cache_dir = Rails.root.join("tmp", "cache", "test_#{ENV['TEST_SUBCATEGORY']}", $$.to_s)
   FileUtils.mkdir_p(cache_dir) unless File.exists?(cache_dir)


### PR DESCRIPTION
Resolves: [APPEALS-23935](https://jira.devops.va.gov/browse/APPEALS-23935)

UAT PR: https://github.com/department-of-veterans-affairs/caseflow/pull/18838

# Description
[Spring](https://github.com/rails/spring) is a Rails application preloader. It speeds up development by keeping your application running in the background, so you don't need to boot it every time you run a test, rake task or migration.

Installs gems [spring](https://github.com/rails/spring), [spring-commands-rspec](http://example.com/), and [spring-commands-rubocop](https://github.com/toptal/spring-commands-rubocop) to enable speedier test and lint task runs in local development environments.

## Acceptance Criteria
- Spring is only installed in `development` and `test` environments.
- `Rails.application.config.cache_classes` can be optionally set to `false` in local test environments. This config value should remain `true` by default to preserve existing behavior in CI test environments.
- Both RSpec and RuboCop are able to be run with Spring from the Caseflow root directory 
  - `ENABLE_SPRING_IN_TEST=true bundle exec spring rspec`
  - `ENABLE_SPRING_IN_TEST=true bundle exec spring rubocop`

## Usage Notes
- To avoid having to prefix `ENABLE_SPRING_IN_TEST=true` every time you want to run a command with Spring, you can set this `ENV` var in your local `~/.zshrc` (or equivalent `rc` file for whatever shell you are using):

  **~/.zshrc**
  ```
  # spring: flag to disable cache classes in Rails test environment
  export ENABLE_SPRING_IN_TEST=true
  ```

- Use the following commands to run `rspec` or `rubocop` without having to wait for the Rails environment every time. The first invocation will take the usual amount of time, but subsequent runs should be much snappier.
  - `bundle exec spring rspec`
  - `bundle exec spring rubocop`

- To check if Spring server is running: `bundle exec spring status`
- To shut down Spring server: `bundle exec spring stop`

## Testing Plan<a id="testing-plan"></a>
### Local development environment
#### Running Spring without setting `ENV["ENABLE_SPRING_IN_TEST"]` to `true` leaves class caching on in `test` environment
- [x] Ensure Spring server is not running: `bundle exec spring stop`
- [x] Confirm `Rails.application.config.cache_classes == true` in `test` environment:
```
$ RAILS_ENV=test bundle exec rails c
irb(main):001:0> Rails.application.config.cache_classes
=> true
```
- [x] From the Caseflow root directory, run:
```bash
bundle exec spring rspec spec/models/veteran_spec.rb
```
- [x] Confirm that the following error is raised
```bash
~/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/spring-3.1.1/lib/spring/application.rb:101:in `block in preload': 
Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
 (RuntimeError)
```

#### Spring rspec works
- [x] From the Caseflow root directory, run:
```bash
ENABLE_SPRING_IN_TEST=true bundle exec spring rspec spec/models/veteran_spec.rb
```
- [x] The Rails environment should load and the tests run
- [x] Repeat the above command, and confirm that the tests start faster (without having to reload Rails from scratch).

#### Spring rubocop works
- [x] From the Caseflow root directory, run:
```bash
ENABLE_SPRING_IN_TEST=true bundle exec spring rubocop spec/models/veteran_spec.rb
```
- [x] The Rails environment should load and the linter run
- [x] Repeat the above command, and confirm that the linter starts faster (without having to reload Rails from scratch).

#### Cleanup
- [x] `bundle exec spring stop` to stop the Spring server.

### UAT & Prod environment
#### Spring is not installed / Spring server does not run when Rails application boots up
- [ ] Deploy this branch (to UAT / Prod)
- [ ] From the Caseflow Rails root directory, run `bundle exec spring status`
- [ ] You should get an error like:
```bash
bundler: command not found: spring
Install missing gem executables with `bundle install`
```

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added