### PR TITLE
APPEALS-24350 - Update Seed Script for vbms_ext_claims.rb

### DIFF
--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -19,9 +19,9 @@ module Seeds
       create_out_of_sync_epes_and_vbms_ext_claims
     end
 
-private
+  private
 
- # maintains previous file number values while allowing for reseeding
+  # maintains previous file number values while allowing for reseeding
  	def file_number_initial_value
   	@file_number ||= 300_000
   	# this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
@@ -61,6 +61,7 @@ private
       create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
 			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
+
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # # vbms_ext_claims
     25.times do

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -168,10 +168,10 @@ private
 	end
 
 
-	def create_vbms_ext_claim(veteran, trait1, trait2)
+	def create_vbms_ext_claim(veteran, claim_status, claim)
 		create(:vbms_ext_claim,
-					 trait1,
-			     trait2,
+					 claim_status,
+			     claim,
 			     claimant_person_id: veteran.participant_id)
 	end
 
@@ -187,9 +187,9 @@ private
 					 benefit_type: "compensation")
 	end
 
-	def create_end_product_establishment(source, trait, vbms_ext_claim, veteran)
+	def create_end_product_establishment(source, claim_status, vbms_ext_claim, veteran)
 		create(:end_product_establishment,
-					 trait,
+					 claim_status,
 					 source: source,
 				   reference_id: vbms_ext_claim.claim_id,
 					 established_at: vbms_ext_claim.establishment_date,

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -18,200 +18,199 @@ module Seeds
       create_in_sync_epes_and_vbms_ext_claims
       create_out_of_sync_epes_and_vbms_ext_claims
     end
+    private
 
-  private
+    # maintains previous file number values while allowing for reseeding
+    def file_number_initial_value
+	    @file_number ||= 300_000
+	    # this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
+	    @file_number += 250 while Veteran.find_by(file_number: format("%<n>09d", n: @file_number))
+    end
 
-  # maintains previous file number values while allowing for reseeding
- 	def file_number_initial_value
-  	@file_number ||= 300_000
-  	# this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
-  	@file_number += 250 while Veteran.find_by(file_number: format("%<n>09d", n: @file_number))
+    ##
+    # this out_of_sync method creates and seeds Vbms_Ext_Claims that have a Level_Status_Code DIFFERENT then the
+    # End_Product_Establishment sync_status in order to test the sync_job and batch_job that finds differences between
+    # VbmsExtClaim associated with the End Product Establishment
+    ##
+    def create_out_of_sync_epes_and_vbms_ext_claims
+      # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
+      # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
+        higher_level_review = create_high_level_review(veteran)
+        # out_of_sync end_product_establishment sync_status "PEND"
+        end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+
+        request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+      end
+
+      # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
+      # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
+        higher_level_review = create_high_level_review(veteran)
+        # out_of_sync end_product_establishment sync_status "PEND"
+        end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+      end
+
+      # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
+      # # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
+        supplemental_claim = create_supplemental_claim(veteran)
+        # out_of_sync end_product_establishment sync_status "PEND"
+        end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      end
+
+      # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
+      # # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
+        supplemental_claim = create_supplemental_claim(veteran)
+        # out_of_sync end_product_establishment sync_status "PEND"
+        end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      end
+	  end
+
+    ##
+    # this in_sync method creates and seeds Vbms_Ext_Claims that have a Level_Status_Code matching the
+    # End_Product_Establishment sync_status in order to test the sync_job and batch_job that finds differences between
+    # VbmsExtClaim associated with the End Product Establishment. Both jobs should skip these objects because
+    # Level_Status_Code matches the sync_status
+    ##
+    def create_in_sync_epes_and_vbms_ext_claims
+      # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
+      # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
+        higher_level_review = create_high_level_review(veteran)
+        end_product_establishment = create_end_product_establishment(higher_level_review,:canceled, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+      end
+
+      # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
+      # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
+        higher_level_review = create_high_level_review(veteran)
+        end_product_establishment = create_end_product_establishment(higher_level_review,:cleared, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+      end
+      # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
+      # # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
+        supplemental_claim = create_supplemental_claim(veteran)
+        end_product_establishment = create_end_product_establishment(supplemental_claim, :cleared, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      end
+
+      # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
+      # # vbms_ext_claims
+      25.times do
+        veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+        @file_number += 1
+        # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
+        vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
+        supplemental_claim = create_supplemental_claim(veteran)
+        end_product_establishment = create_end_product_establishment(supplemental_claim, :canceled, vbms_ext_claim, veteran)
+        request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+        request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      end
+    end
+    ##
+    # this method creates VBMS_EXT_CLAIMS that have yet to be Established in CASEFLOW to mimic
+    # the VBMS API CALL. The VBMS_EXT_CLAIMS have no assocations to an End Product Establishment.
+    ##
+    def create_vbms_ext_claims_with_no_end_product_establishment
+      # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CLR"
+      50.times do
+        create(:vbms_ext_claim, :cleared)
+      end
+      # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CAN"
+      50.times do
+        create(:vbms_ext_claim,:canceled)
+      end
+      # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "RDC"
+      25.times do
+        create(:vbms_ext_claim,:rdc)
+      end
+	  end
+
+
+    def create_vbms_ext_claim(veteran, claim_status, claim)
+        create(:vbms_ext_claim,
+                claim_status,
+                claim,
+                claimant_person_id: veteran.participant_id)
+    end
+
+    def create_high_level_review(veteran)
+      create(:higher_level_review,
+              veteran_file_number: veteran.file_number)
+    end
+
+    def create_supplemental_claim(veteran)
+      create(:supplemental_claim,
+              veteran_file_number: veteran.file_number,
+              receipt_date: Time.zone.now,
+              benefit_type: "compensation")
+    end
+
+    def create_end_product_establishment(source, claim_status, vbms_ext_claim, veteran)
+      create(:end_product_establishment,
+              claim_status,
+              source: source,
+              reference_id: vbms_ext_claim.claim_id,
+              established_at: vbms_ext_claim.establishment_date,
+              claim_date: vbms_ext_claim.claim_date,
+              modifier: vbms_ext_claim.ep_code,
+              code: vbms_ext_claim.type_code,
+              veteran_file_number: veteran.file_number,
+              claimant_participant_id: veteran.participant_id)
+    end
+
+    def create_request_issue(decision_review, end_product_establishment, nonrating_issue_category)
+      create(:request_issue,
+             decision_review: decision_review,
+             end_product_establishment: end_product_establishment,
+             nonrating_issue_category: nonrating_issue_category,
+             nonrating_issue_description: "nonrating description",
+             ineligible_reason: nil,
+             benefit_type: "compensation",
+             decision_date: Date.new(2018, 5, 1))
+    end
+
   end
-
-  ##
-  # this out_of_sync method creates and seeds Vbms_Ext_Claims that have a Level_Status_Code DIFFERENT then the
-  # End_Product_Establishment sync_status in order to test the sync_job and batch_job that finds differences between
-  # VbmsExtClaim associated with the End Product Establishment
-  ##
-	def create_out_of_sync_epes_and_vbms_ext_claims
-    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
-    # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
-      higher_level_review = create_high_level_review(veteran)
-			# out_of_sync end_product_establishment sync_status "PEND"
-			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
-
-			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
-		end
-
-    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
-    # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
-			higher_level_review = create_high_level_review(veteran)
-			# out_of_sync end_product_establishment sync_status "PEND"
-			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
-      request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
-    end
-
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
-    # # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
-      supplemental_claim = create_supplemental_claim(veteran)
-			# out_of_sync end_product_establishment sync_status "PEND"
-			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
-      request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
-    end
-
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
-    # # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
-      supplemental_claim = create_supplemental_claim(veteran)
-			# out_of_sync end_product_establishment sync_status "PEND"
-			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
-      request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
-    end
-	end
-
-  ##
-  # this in_sync method creates and seeds Vbms_Ext_Claims that have a Level_Status_Code matching the
-  # End_Product_Establishment sync_status in order to test the sync_job and batch_job that finds differences between
-  # VbmsExtClaim associated with the End Product Establishment. Both jobs should skip these objects because
-  # Level_Status_Code matches the sync_status
-  ##
-	def create_in_sync_epes_and_vbms_ext_claims
-    # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
-    # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
-			higher_level_review = create_high_level_review(veteran)
-			end_product_establishment = create_end_product_establishment(higher_level_review,:canceled, vbms_ext_claim, veteran)
-			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
-    end
-
-    # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
-    # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
-			higher_level_review = create_high_level_review(veteran)
-			end_product_establishment = create_end_product_establishment(higher_level_review,:cleared, vbms_ext_claim, veteran)
-			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
-    end
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
-    # # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
-			supplemental_claim = create_supplemental_claim(veteran)
-			end_product_establishment = create_end_product_establishment(supplemental_claim, :cleared, vbms_ext_claim, veteran)
-			request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
-    end
-
-    # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
-    # # vbms_ext_claims
-    25.times do
-      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
-      @file_number += 1
-      # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
-			supplemental_claim = create_supplemental_claim(veteran)
-			end_product_establishment = create_end_product_establishment(supplemental_claim, :canceled, vbms_ext_claim, veteran)
-			request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
-    end
-	end
-  ##
-  # this method creates VBMS_EXT_CLAIMS that have yet to be Established in CASEFLOW to mimic
-  # the VBMS API CALL. The VBMS_EXT_CLAIMS have no assocations to an End Product Establishment.
-  ##
-	def create_vbms_ext_claims_with_no_end_product_establishment
-    # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CLR"
-    50.times do
-      create(:vbms_ext_claim, :cleared)
-    end
-     # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "CAN"
-    50.times do
-      create(:vbms_ext_claim,:canceled)
-    end
-     # creates 50 none epe assocated vbms_ext_claims with LEVEL_STATUS_CODE "RDC"
-    25.times do
-      create(:vbms_ext_claim,:rdc)
-    end
-	end
-
-
-	def create_vbms_ext_claim(veteran, claim_status, claim)
-		create(:vbms_ext_claim,
-					 claim_status,
-			     claim,
-			     claimant_person_id: veteran.participant_id)
-	end
-
-	def create_high_level_review(veteran)
-		create(:higher_level_review,
-			     veteran_file_number: veteran.file_number)
-	end
-
-	def create_supplemental_claim(veteran)
-		create(:supplemental_claim,
-			     veteran_file_number: veteran.file_number,
-					 receipt_date: Time.zone.now,
-					 benefit_type: "compensation")
-	end
-
-	def create_end_product_establishment(source, claim_status, vbms_ext_claim, veteran)
-		create(:end_product_establishment,
-					 claim_status,
-					 source: source,
-				   reference_id: vbms_ext_claim.claim_id,
-					 established_at: vbms_ext_claim.establishment_date,
-					 claim_date: vbms_ext_claim.claim_date,
-					 modifier: vbms_ext_claim.ep_code,
-					 code: vbms_ext_claim.type_code,
-					 veteran_file_number: veteran.file_number,
-					 claimant_participant_id: veteran.participant_id)
-	end
-
-	def create_request_issue(decision_review, end_product_establishment, nonrating_issue_category)
-		create(:request_issue,
-					 decision_review: decision_review,
-					 end_product_establishment: end_product_establishment,
-					 nonrating_issue_category: nonrating_issue_category,
-					 nonrating_issue_description: "nonrating description",
-					 ineligible_reason: nil,
-				 	 benefit_type: "compensation",
-				 	 decision_date: Date.new(2018, 5, 1))
-	end
-
- end
 end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -44,6 +44,7 @@ module Seeds
       higher_level_review = create_high_level_review(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+
 			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
 			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
 		end
@@ -58,6 +59,7 @@ module Seeds
 			higher_level_review = create_high_level_review(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+
       create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
 			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
@@ -72,6 +74,7 @@ module Seeds
       supplemental_claim = create_supplemental_claim(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+
       create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
 			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
@@ -86,6 +89,7 @@ module Seeds
       supplemental_claim = create_supplemental_claim(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+
       create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
 			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
@@ -107,6 +111,7 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
 			higher_level_review = create_high_level_review(veteran)
 			end_product_establishment = create_end_product_establishment(higher_level_review,:canceled, vbms_ext_claim, veteran)
+
 			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
 			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
@@ -120,6 +125,7 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
 			higher_level_review = create_high_level_review(veteran)
 			end_product_establishment = create_end_product_establishment(higher_level_review,:cleared, vbms_ext_claim, veteran)
+
 			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
 			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
@@ -132,6 +138,7 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
 			supplemental_claim = create_supplemental_claim(veteran)
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :cleared, vbms_ext_claim, veteran)
+
 			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
 			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
@@ -145,6 +152,7 @@ module Seeds
       vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
 			supplemental_claim = create_supplemental_claim(veteran)
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :canceled, vbms_ext_claim, veteran)
+
 			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
 			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -4,6 +4,11 @@
 module Seeds
 
   class VbmsExtClaim < Base
+
+
+    def initialize
+      file_number_initial_value
+    end
     ##
     # creates and seeds 325 total vbms_ext_claims
     # The number of claims created are subject to change in order to meet testing requirements
@@ -16,6 +21,14 @@ module Seeds
 
 private
 
+ # maintains previous file number values while allowing for reseeding
+ def file_number_initial_value
+  @file_number ||= 300_000
+  # this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
+  @file_number += 250 while Veteran.find_by(file_number: format("%<n>09d", n: @file_number))
+  @file_number
+  end
+
   ##
   # this out_of_sync method creates and seeds Vbms_Ext_Claims that have a Level_Status_Code DIFFERENT then the
   # End_Product_Establishment sync_status in order to test the sync_job and batch_job that finds differences between
@@ -25,7 +38,8 @@ private
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
                    :canceled,
@@ -54,7 +68,8 @@ private
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
                    :cleared,
@@ -83,7 +98,8 @@ private
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
                    :cleared,
@@ -115,7 +131,8 @@ private
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
                    :cleared,
@@ -155,7 +172,8 @@ private
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are in_sync with
     # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
                    :canceled,
@@ -184,7 +202,8 @@ private
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
     # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
                    :cleared,
@@ -213,7 +232,8 @@ private
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
     # # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
       vec = create(:vbms_ext_claim,
                    :cleared,
@@ -245,7 +265,8 @@ private
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
     # # vbms_ext_claims
     25.times do
-      veteran = create(:veteran)
+      veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
+      @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
       vec = create(:vbms_ext_claim,
                    :canceled,

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -22,11 +22,10 @@ module Seeds
 private
 
  # maintains previous file number values while allowing for reseeding
- def file_number_initial_value
-  @file_number ||= 300_000
-  # this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
-  @file_number += 250 while Veteran.find_by(file_number: format("%<n>09d", n: @file_number))
-  @file_number
+ 	def file_number_initial_value
+  	@file_number ||= 300_000
+  	# this seed file creates 200 new veterans on each run, 250 is sufficient margin to add more data
+  	@file_number += 250 while Veteran.find_by(file_number: format("%<n>09d", n: @file_number))
   end
 
   ##
@@ -41,73 +40,26 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim,
-                   :canceled,
-                   :hlr,
-                   claimant_person_id: veteran.participant_id)
-      higher_level_review = create(:higher_level_review,
-                                    veteran_file_number: veteran.file_number)
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :active,
-              source: higher_level_review,
-              reference_id: vec.claim_id,
-              established_at: vec.establishment_date,
-              claim_date: vec.claim_date,
-              modifier: vec.ep_code,
-              code: vec.type_code,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
-    end
+      vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
+      higher_level_review = create_high_level_review(veteran)
+			# out_of_sync end_product_establishment sync_status "PEND"
+			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+		end
+
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
     # vbms_ext_claims
     25.times do
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim,
-                   :cleared,
-                   :hlr,
-                   claimant_person_id: veteran.participant_id)
-      higher_level_review = create(:higher_level_review,
-                                    veteran_file_number: veteran.file_number)
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :active,
-             source: higher_level_review,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
+			higher_level_review = create_high_level_review(veteran)
+			# out_of_sync end_product_establishment sync_status "PEND"
+			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
+      create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
     # # vbms_ext_claims
@@ -115,38 +67,12 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim,
-                   :cleared,
-                   :slc,
-                   claimant_person_id: veteran.participant_id)
-      supplemental_claim = create(:supplemental_claim,
-            veteran_file_number: veteran.file_number,
-            receipt_date: Time.zone.now,
-            benefit_type: "compensation")
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :active,
-             source: supplemental_claim,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
+      supplemental_claim = create_supplemental_claim(veteran)
+			# out_of_sync end_product_establishment sync_status "PEND"
+			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+      create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
@@ -155,38 +81,12 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # out_of_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim,
-                   :cleared,
-                   :slc,
-                   claimant_person_id: veteran.participant_id)
-      supplemental_claim = create(:supplemental_claim,
-            veteran_file_number: veteran.file_number,
-            receipt_date: Time.zone.now,
-            benefit_type: "compensation")
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :active,
-             source: supplemental_claim,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
+      supplemental_claim = create_supplemental_claim(veteran)
+			# out_of_sync end_product_establishment sync_status "PEND"
+			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
+      create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 	end
 
@@ -203,73 +103,24 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim,
-                   :canceled,
-                   :hlr,
-                   claimant_person_id: veteran.participant_id)
-      higher_level_review = create(:higher_level_review,
-                                    veteran_file_number: veteran.file_number)
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :canceled,
-              source: higher_level_review,
-              reference_id: vec.claim_id,
-              established_at: vec.establishment_date,
-              claim_date: vec.claim_date,
-              modifier: vec.ep_code,
-              code: vec.type_code,
-              veteran_file_number: veteran.file_number,
-              claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
+			higher_level_review = create_high_level_review(veteran)
+			end_product_establishment = create_end_product_establishment(higher_level_review,:canceled, vbms_ext_claim, veteran)
+			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
+
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
     # vbms_ext_claims
     25.times do
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim,
-                   :cleared,
-                   :hlr,
-                   claimant_person_id: veteran.participant_id)
-      higher_level_review = create(:higher_level_review,
-                                    veteran_file_number: veteran.file_number)
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: higher_level_review,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :cleared,
-             source: higher_level_review,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
+			higher_level_review = create_high_level_review(veteran)
+			end_product_establishment = create_end_product_establishment(higher_level_review,:cleared, vbms_ext_claim, veteran)
+			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
     # # vbms_ext_claims
@@ -277,38 +128,11 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CLR"
-      vec = create(:vbms_ext_claim,
-                   :cleared,
-                   :slc,
-                   claimant_person_id: veteran.participant_id)
-      supplemental_claim = create(:supplemental_claim,
-            veteran_file_number: veteran.file_number,
-            receipt_date: Time.zone.now,
-            benefit_type: "compensation")
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :cleared,
-             source: supplemental_claim,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
+			supplemental_claim = create_supplemental_claim(veteran)
+			end_product_establishment = create_end_product_establishment(supplemental_claim, :cleared, vbms_ext_claim, veteran)
+			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
@@ -317,38 +141,11 @@ private
       veteran = create(:veteran, file_number: format("%<n>09d", n: @file_number))
       @file_number += 1
       # in_sync vbms_ext_claim LEVEL_STATUS_CODE "CAN"
-      vec = create(:vbms_ext_claim,
-                   :canceled,
-                   :slc,
-                   claimant_person_id: veteran.participant_id)
-      supplemental_claim = create(:supplemental_claim,
-            veteran_file_number: veteran.file_number,
-            receipt_date: Time.zone.now,
-            benefit_type: "compensation")
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Military Retired Pay",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:request_issue,
-              decision_review: supplemental_claim,
-              nonrating_issue_category: "Active Duty Adjustments",
-              nonrating_issue_description: "nonrating description",
-              ineligible_reason: nil,
-              benefit_type: "compensation",
-              decision_date: Date.new(2018, 5, 1))
-      create(:end_product_establishment,
-             :canceled,
-             source: supplemental_claim,
-             reference_id: vec.claim_id,
-             established_at: vec.establishment_date,
-             claim_date: vec.claim_date,
-             modifier: vec.ep_code,
-             code: vec.type_code,
-             veteran_file_number: veteran.file_number,
-             claimant_participant_id: veteran.participant_id)
+      vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
+			supplemental_claim = create_supplemental_claim(veteran)
+			end_product_establishment = create_end_product_establishment(supplemental_claim, :canceled, vbms_ext_claim, veteran)
+			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 	end
   ##
@@ -369,5 +166,50 @@ private
       create(:vbms_ext_claim,:rdc)
     end
 	end
+
+
+	def create_vbms_ext_claim(veteran, trait1, trait2)
+		create(:vbms_ext_claim,
+					 trait1,
+			     trait2,
+			     claimant_person_id: veteran.participant_id)
+	end
+
+	def create_high_level_review(veteran)
+		create(:higher_level_review,
+			     veteran_file_number: veteran.file_number)
+	end
+
+	def create_supplemental_claim(veteran)
+		create(:supplemental_claim,
+			     veteran_file_number: veteran.file_number,
+					 receipt_date: Time.zone.now,
+					 benefit_type: "compensation")
+	end
+
+	def create_end_product_establishment(source, trait, vbms_ext_claim, veteran)
+		create(:end_product_establishment,
+					 trait,
+					 source: source,
+				   reference_id: vbms_ext_claim.claim_id,
+					 established_at: vbms_ext_claim.establishment_date,
+					 claim_date: vbms_ext_claim.claim_date,
+					 modifier: vbms_ext_claim.ep_code,
+					 code: vbms_ext_claim.type_code,
+					 veteran_file_number: veteran.file_number,
+					 claimant_participant_id: veteran.participant_id)
+	end
+
+	def create_request_issue(decision_review, end_product_establishment, nonrating_issue_category)
+		create(:request_issue,
+					 decision_review: decision_review,
+					 end_product_establishment: end_product_establishment,
+					 nonrating_issue_category: nonrating_issue_category,
+					 nonrating_issue_description: "nonrating description",
+					 ineligible_reason: nil,
+				 	 benefit_type: "compensation",
+				 	 decision_date: Date.new(2018, 5, 1))
+	end
+
  end
 end

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -45,8 +45,8 @@ module Seeds
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
 
-			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
 		end
 
     # 25 High Level Review, End Product Establishments that have a sync_status of canceled and are out_of_sync with
@@ -59,9 +59,8 @@ module Seeds
 			higher_level_review = create_high_level_review(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
-
-      create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+      request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
 
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are out_of_sync with
@@ -74,9 +73,8 @@ module Seeds
       supplemental_claim = create_supplemental_claim(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
-
-      create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_of_sync with
@@ -89,9 +87,8 @@ module Seeds
       supplemental_claim = create_supplemental_claim(veteran)
 			# out_of_sync end_product_establishment sync_status "PEND"
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :active, vbms_ext_claim, veteran)
-
-      create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+      request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 	end
 
@@ -111,9 +108,8 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :hlr)
 			higher_level_review = create_high_level_review(veteran)
 			end_product_establishment = create_end_product_establishment(higher_level_review,:canceled, vbms_ext_claim, veteran)
-
-			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
 
     # 25 High Level Review, End Product Establishments that have a sync_status of cleared and are in_sync with
@@ -125,9 +121,8 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :hlr)
 			higher_level_review = create_high_level_review(veteran)
 			end_product_establishment = create_end_product_establishment(higher_level_review,:cleared, vbms_ext_claim, veteran)
-
-			create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
-			create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
+			request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
     end
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of cleared and are in_sync with
     # # vbms_ext_claims
@@ -138,9 +133,8 @@ module Seeds
 			vbms_ext_claim = create_vbms_ext_claim(veteran, :cleared, :slc)
 			supplemental_claim = create_supplemental_claim(veteran)
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :cleared, vbms_ext_claim, veteran)
-
-			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+			request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 
     # # 25 Supplemental Claims, End Product Establishments that have a sync_status of canceled and are out_sync with
@@ -152,9 +146,8 @@ module Seeds
       vbms_ext_claim = create_vbms_ext_claim(veteran, :canceled, :slc)
 			supplemental_claim = create_supplemental_claim(veteran)
 			end_product_establishment = create_end_product_establishment(supplemental_claim, :canceled, vbms_ext_claim, veteran)
-
-			create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
-			create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
+			request_issue1 = create_request_issue(supplemental_claim, end_product_establishment, "Military Retired Pay")
+			request_issue2 = create_request_issue(supplemental_claim, end_product_establishment, "Active Duty Adjustments")
     end
 	end
   ##

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -47,13 +47,20 @@ private
                    claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: higher_level_review,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :active,
               source: higher_level_review,
@@ -77,13 +84,20 @@ private
                    claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: higher_level_review,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :active,
              source: higher_level_review,
@@ -109,13 +123,20 @@ private
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
             benefit_type: "compensation")
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: supplemental_claim,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :active,
              source: supplemental_claim,
@@ -142,13 +163,20 @@ private
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
             benefit_type: "compensation")
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: supplemental_claim,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :active,
              source: supplemental_claim,
@@ -181,13 +209,20 @@ private
                    claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: higher_level_review,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :canceled,
               source: higher_level_review,
@@ -211,13 +246,20 @@ private
                    claimant_person_id: veteran.participant_id)
       higher_level_review = create(:higher_level_review,
                                     veteran_file_number: veteran.file_number)
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: higher_level_review,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: higher_level_review,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :cleared,
              source: higher_level_review,
@@ -243,13 +285,20 @@ private
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
             benefit_type: "compensation")
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: supplemental_claim,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :cleared,
              source: supplemental_claim,
@@ -276,13 +325,20 @@ private
             veteran_file_number: veteran.file_number,
             receipt_date: Time.zone.now,
             benefit_type: "compensation")
-      eligible_request_issue = create(:request_issue,
-                                      decision_review: supplemental_claim,
-                                      nonrating_issue_category: "Military Retired Pay",
-                                      nonrating_issue_description: "nonrating description",
-                                      ineligible_reason: nil,
-                                      benefit_type: "compensation",
-                                      decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Military Retired Pay",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
+      create(:request_issue,
+              decision_review: supplemental_claim,
+              nonrating_issue_category: "Active Duty Adjustments",
+              nonrating_issue_description: "nonrating description",
+              ineligible_reason: nil,
+              benefit_type: "compensation",
+              decision_date: Date.new(2018, 5, 1))
       create(:end_product_establishment,
              :canceled,
              source: supplemental_claim,

--- a/db/seeds/vbms_ext_claim.rb
+++ b/db/seeds/vbms_ext_claim.rb
@@ -43,7 +43,6 @@ module Seeds
         higher_level_review = create_high_level_review(veteran)
         # out_of_sync end_product_establishment sync_status "PEND"
         end_product_establishment = create_end_product_establishment(higher_level_review, :active, vbms_ext_claim, veteran)
-
         request_issue1 = create_request_issue(higher_level_review, end_product_establishment, "Military Retired Pay")
         request_issue2 = create_request_issue(higher_level_review, end_product_establishment, "Active Duty Adjustments")
       end


### PR DESCRIPTION
Resolves [APPEALS-24350](https://jira.devops.va.gov/browse/APPEALS-24350)

# Description
This Fixes the duplicate veteran_file_number when running `make seed-vbms-ext-claim`

## Acceptance Criteria
- [x] - Update vbms_ext_claim seed to make sure veteran_file_number doesnt have duplicate key error
- [x] - add additional request issue 
- [x] - regression test pass

## Testing Plan
- [x] - GHA Rspec Test pass
- [x] - Local DB - veteran file_number is now unique. 
- [x] - Local DB - 2 request issues are added per vbms_ext_claim being made



## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- https://jira.devops.va.gov/browse/APPEALS-24446 
### Code Climate
Your code does not add any new code climate offenses? If so why?
-  [x] - No new code climate issues added

