### PR TITLE
SeanC/APPEALS-24042 CSS Issue Queue Table Does not Fit Screen

### DIFF
--- a/client/app/nonComp/components/TaskTableTab.jsx
+++ b/client/app/nonComp/components/TaskTableTab.jsx
@@ -97,7 +97,7 @@ class TaskTableTabUnconnected extends React.PureComponent {
           isSearchAhead
           value={this.state.searchText} />
       </div>
-      <div className="section-hearings-list">
+      <div className="section-hearings-list" style={{ clear: 'both' }}>
         <TaskTableUnconnected
           {...this.state.predefinedColumns}
           getKeyForRow={(row, object) => object.id}

--- a/client/app/nonComp/components/TaskTableTab.jsx
+++ b/client/app/nonComp/components/TaskTableTab.jsx
@@ -98,7 +98,7 @@ class TaskTableTabUnconnected extends React.PureComponent {
             isSearchAhead
             value={this.state.searchText} />
         </div>
-        <div className="section-hearings-list" style={{ clear: 'both' }}>
+        <div className="section-hearings-list">
           <TaskTableUnconnected
             {...this.state.predefinedColumns}
             getKeyForRow={(row, object) => object.id}

--- a/client/app/nonComp/components/TaskTableTab.jsx
+++ b/client/app/nonComp/components/TaskTableTab.jsx
@@ -83,30 +83,32 @@ class TaskTableTabUnconnected extends React.PureComponent {
 
     return <React.Fragment>
       {this.props.description && <div className="cf-noncomp-queue-completed-task">{this.props.description}</div>}
-      <div className="cf-search-ahead-parent cf-push-right cf-noncomp-search">
-        <SearchBar
-          id="searchBar"
-          size="small"
-          title={this.props.featureToggles.decisionReviewQueueSsnColumn ?
-            'Search by Claimant Name, Veteran Participant ID, File Number or SSN' :
-            ''}
-          onChange={this.onChange}
-          recordSearch={this.onSearch}
-          placeholder="Type to search..."
-          onClearSearch={this.onClearSearch}
-          isSearchAhead
-          value={this.state.searchText} />
-      </div>
-      <div className="section-hearings-list" style={{ clear: 'both' }}>
-        <TaskTableUnconnected
-          {...this.state.predefinedColumns}
-          getKeyForRow={(row, object) => object.id}
-          onHistoryUpdate={this.props.onHistoryUpdate}
-          customColumns={this.getTableColumns()}
-          tasks={[]}
-          taskPagesApiEndpoint={this.props.baseTasksUrl}
-          useTaskPagesApi
-          tabPaginationOptions={this.props.tabPaginationOptions} />
+      <div className="non-comp-queue-table-wrapper">
+        <div className="cf-search-ahead-parent cf-push-right cf-noncomp-search">
+          <SearchBar
+            id="searchBar"
+            size="small"
+            title={this.props.featureToggles.decisionReviewQueueSsnColumn ?
+              'Search by Claimant Name, Veteran Participant ID, File Number or SSN' :
+              ''}
+            onChange={this.onChange}
+            recordSearch={this.onSearch}
+            placeholder="Type to search..."
+            onClearSearch={this.onClearSearch}
+            isSearchAhead
+            value={this.state.searchText} />
+        </div>
+        <div className="section-hearings-list" style={{ clear: 'both' }}>
+          <TaskTableUnconnected
+            {...this.state.predefinedColumns}
+            getKeyForRow={(row, object) => object.id}
+            onHistoryUpdate={this.props.onHistoryUpdate}
+            customColumns={this.getTableColumns()}
+            tasks={[]}
+            taskPagesApiEndpoint={this.props.baseTasksUrl}
+            useTaskPagesApi
+            tabPaginationOptions={this.props.tabPaginationOptions} />
+        </div>
       </div>
     </React.Fragment>;
   };

--- a/client/app/styles/_noncomp.scss
+++ b/client/app/styles/_noncomp.scss
@@ -131,3 +131,16 @@
   margin-top: 20px;
   clear: right;
 }
+
+.non-comp-queue-table-wrapper {
+  position: relative;
+
+  .cf-noncomp-search {
+    position: absolute;
+    right: 0;
+    z-index: 99999;
+  }
+  .cf-pagination-pages {
+    padding-top: 50px;
+  }
+}

--- a/client/app/styles/_noncomp.scss
+++ b/client/app/styles/_noncomp.scss
@@ -141,6 +141,6 @@
     z-index: 99999;
   }
   .cf-pagination-pages {
-    padding-top: 50px;
+    padding-top: 65px;
   }
 }

--- a/client/app/styles/_table.scss
+++ b/client/app/styles/_table.scss
@@ -13,6 +13,10 @@
   }
 }
 
+.cf-table-wrapper {
+  overflow-x: auto;
+}
+
 .cf-table-wrapper:focus {
   outline: none;
 }
@@ -55,6 +59,13 @@
 // ===========================*
 // Pagination
 // ============================*/
+
+.cf-pagination {
+  position: sticky;
+  right: 0;
+  left: 0;
+  bottom: 0;
+}
 
 .cf-pagination-summary {
   float: left;


### PR DESCRIPTION
Resolves [APPEALS-24042](https://jira.devops.va.gov/browse/APPEALS-24042)

# Description
Added the ability to scroll horizontally on tables when the table's width exceeds the page's bounds. This is most likely to occur on lower resolution screens or when the user uses the browser's zooming-in feature. When that happens a scroll bar appears at the bottom of the parent div of the table. The pagination controls are unaffected and remain in place.

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Data is table is visible at any level of zoom
- [x] Table is completely usable at any level of zoom
- [x] Pagination controls remain unaffected and usable

## Testing Plan
1. Login as VHAPOUSER and navigate to a Program Office queue
2. Use the browser's zoom-in feature to zoom in to a level in which the table is wider than the bounds of the page
3. Verify that a horizontal scroll bar appears just below the table and usable
4. Verify that the pagination controls are visible and usable

# Frontend
## User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
![24042_Before](https://github.com/department-of-veterans-affairs/caseflow/assets/110493538/57984b26-8d10-4090-8834-2e6d433a35df) | ![24042_After](https://github.com/department-of-veterans-affairs/caseflow/assets/110493538/6e8c20f2-1798-41f5-8841-e783e84f1fc1)
