### PR TITLE
Rspec fixes

### DIFF
--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -66,6 +66,14 @@ class TasksForAppeal
     end
   end
 
+  def tasks_includes_colocated_task?
+    appeal.tasks
+      .includes(*task_includes)
+      .select do |task|
+      (task.is_a?(IhpColocatedTask) || task.is_a?(ColocatedTask))
+    end
+  end
+
   def all_tasks_except_for_decision_review_tasks
     appeal.tasks.not_decisions_review.includes(*task_includes)
   end
@@ -92,7 +100,7 @@ class TasksForAppeal
   def hide_legacy_tasks?
     active_tasks = all_tasks_except_for_decision_review_tasks.active
     legacy_tasks = legacy_appeal_tasks
-    (active_tasks && legacy_tasks) ? true : false
+    (active_tasks && legacy_tasks && !tasks_includes_colocated_task?) ? true : false
   end
 
   def task_includes

--- a/app/workflows/tasks_for_appeal.rb
+++ b/app/workflows/tasks_for_appeal.rb
@@ -66,12 +66,8 @@ class TasksForAppeal
     end
   end
 
-  def tasks_includes_colocated_task?
-    appeal.tasks
-      .includes(*task_includes)
-      .select do |task|
-      (task.is_a?(IhpColocatedTask) || task.is_a?(ColocatedTask))
-    end
+  def only_root_task?
+    !appeal.tasks.active.where(type: RootTask.name).empty?
   end
 
   def all_tasks_except_for_decision_review_tasks
@@ -100,7 +96,7 @@ class TasksForAppeal
   def hide_legacy_tasks?
     active_tasks = all_tasks_except_for_decision_review_tasks.active
     legacy_tasks = legacy_appeal_tasks
-    (active_tasks && legacy_tasks && !tasks_includes_colocated_task?) ? true : false
+    (active_tasks && legacy_tasks && !only_root_task?) ? true : false
   end
 
   def task_includes

--- a/spec/feature/queue/attorney_checkout_flow_spec.rb
+++ b/spec/feature/queue/attorney_checkout_flow_spec.rb
@@ -99,7 +99,7 @@ RSpec.feature "Attorney checkout flow", :all_dbs do
 
       click_on "Save"
 
-      expect(page).to have_content "Text box field is required"
+      expect(page).to have_content "This field is required"
       fill_in "Text Box", with: decision_issue_text
 
       find(".cf-select__control", text: "Select disposition").click

--- a/spec/feature/queue/judge_checkout_flow_spec.rb
+++ b/spec/feature/queue/judge_checkout_flow_spec.rb
@@ -58,7 +58,7 @@ RSpec.feature "Judge checkout flow", :all_dbs do
       # Change JudgeDecisionReviewTask status so that "Ready for Dispatch" action is available
       jdr_task.update(status: :assigned)
       appeal.request_issues.update_all(closed_at: nil)
-      visit "queue/appeals/#{appeal.uuid}"
+      visit "queue/appeals/#{appeal.external_id}"
       # Below is needed so that the frontend will load the actions dropdown before the jdr task's status changes
       expect(page).to have_content("Actions", wait: 10)
 

--- a/spec/feature/queue/special_case_movement_task_spec.rb
+++ b/spec/feature/queue/special_case_movement_task_spec.rb
@@ -93,7 +93,7 @@ RSpec.feature "SpecialCaseMovementTask", :all_dbs do
 
         # Validate before moving on
         click_on "Continue"
-        expect(page).to have_content(COPY::INSTRUCTIONS_ERROR_FIELD_REQUIRED)
+        expect(page).to have_content(COPY::FORM_ERROR_FIELD_REQUIRED)
         find("label", text: "Death dismissal").click
         fill_in("cancellationInstructions", with: "Instructions for cancellation")
         click_on "Continue"


### PR DESCRIPTION
Resolves [APPEALS-24579](https://jira.devops.va.gov/browse/APPEALS-24579)
[APPEALS-24580](https://jira.devops.va.gov/browse/APPEALS-24580)

# Description
Changed task_for_appeals.rb logic to hiding legacy tasks, returns false when including a colocated task

## Acceptance Criteria
- [x] Code compiles correctly

Rspec passing

tasks_controller_spec.rb
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/01eb14af-90f9-4bba-a1ba-39cffc3efde9)

judge_checkout_flow_spec.rb
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/d69accee-cdcf-41fe-8167-61edc36ea3d3)


attorney_checkout_flow_spec.rb
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/2107f502-8b2a-4017-adeb-f2a8f49d5f96)

Legacy tasks are hidden in case details if there are any active ama tasks that are not the root task

