### PR TITLE
Calvin/appeals 24660

### DIFF
--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -98,8 +98,9 @@ class AttorneyTask < Task
   def can_be_moved_by_user?(user)
     return false unless parent.is_a?(JudgeTask)
 
+    # Allows SSC, SCM, VLJ's if legacy
     if appeal.is_a?(LegacyAppeal)
-      return user&.can_act_on_behalf_of_legacy_judges?
+      return parent.assigned_to == user || assigned_by == user || user&.can_act_on_behalf_of_legacy_judges?
     end
 
     # The judge who is assigned the parent review task, the assigning judge, and SpecialCaseMovementTeam members can

--- a/app/models/tasks/attorney_task.rb
+++ b/app/models/tasks/attorney_task.rb
@@ -26,16 +26,17 @@ class AttorneyTask < Task
       Constants.TASK_ACTIONS.CANCEL_AND_RETURN_TASK.to_h
     ].compact
 
-    if appeal.is_a?(LegacyAppeal) && FeatureToggle.enable!(:vlj_legacy_appeal)
-      movement_actions = [
-        Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY_LEGACY.to_h,
-        Constants.TASK_ACTIONS.CANCEL_AND_RETURN_TASK.to_h]
-    else
-      movement_actions = [
-        Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,
-        Constants.TASK_ACTIONS.CANCEL_AND_RETURN_TASK.to_h
-      ]
-    end
+    movement_actions = if appeal.is_a?(LegacyAppeal) && FeatureToggle.enable!(:vlj_legacy_appeal)
+                         [
+                           Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY_LEGACY.to_h,
+                           Constants.TASK_ACTIONS.CANCEL_AND_RETURN_TASK.to_h
+                         ]
+                       else
+                         [
+                           Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,
+                           Constants.TASK_ACTIONS.CANCEL_AND_RETURN_TASK.to_h
+                         ]
+                       end
 
     actions_based_on_assignment(user, atty_actions, movement_actions)
   end
@@ -96,6 +97,10 @@ class AttorneyTask < Task
 
   def can_be_moved_by_user?(user)
     return false unless parent.is_a?(JudgeTask)
+
+    if appeal.is_a?(LegacyAppeal)
+      return user&.can_act_on_behalf_of_legacy_judges?
+    end
 
     # The judge who is assigned the parent review task, the assigning judge, and SpecialCaseMovementTeam members can
     # cancel or reassign this task


### PR DESCRIPTION
Resolves [APPEALS-24660](https://jira.devops.va.gov/browse/APPEALS-24660)

# Description
Added an if statement that checks if a legacy appeal, and the user is a SSC, they will have access to the attorney task actions dropdown

## Acceptance Criteria
Expected Results: Supervisory Senior Council members are on the list of roles that need to be able to move a Legacy appeal in Case-flow

## Testing Plan
Click FAKEUSER in the top right corner and select Switch User to switch to user SPLTAPPLSNOW.
Ensure you are on user SPLTAPPLSNOW before pasting this URL in your browser search bar https://voyager.caseflowdemo.com/queue/appeals/678700013
You should arrive on Veteran Quintin Mohr's Case Details page. Ensure there are two actions dropdown lists. Select the dropdown box at the bottom of the Currently Active
Confirm there are two options
*Re-Assign to Judge
 Assign to Attorney*

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

**BEFORE**
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/99a1f496-8be4-447e-b088-9ebbd8ddb6f6)

**AFTER**
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/6c3a4817-4628-4e25-afb6-816e982bda89)
