### PR TITLE
[DOCUMENTATION] - Fix .zshrc file settings in `MAC_M1.md`

### DIFF
--- a/MAC_M1.md
+++ b/MAC_M1.md
@@ -155,7 +155,8 @@ developer”
 2. Add the following lines, if any of these are already set make sure to comment previous settings:
 
 ```
-export PATH=/usr/local/homebrew/bin:/opt/homebrew/bin:${PATH} eval "$(/usr/local/homebrew/bin/rbenv init -)"
+export PATH=/usr/local/homebrew/bin:/opt/homebrew/bin:${PATH}
+eval "$(/usr/local/homebrew/bin/rbenv init -)"
 eval "$(/usr/local/homebrew/bin/nodenv init -)"
 # Add Postgres environment variables for CaseFlow
 export POSTGRES_HOST=localhost


### PR DESCRIPTION
# Description

There needed to be a new line in between each command that will be put inside the `/.zshrc` file. Without this line the terminal will not start up correctly.

The user would receive this error:
`/Users/<username>/.zshrc:export:1: not valid in this context: export PATH`

This would cause a few issues with rbenv and jest as well as causing vscode extensions to fail


