### PR TITLE
MattT/APPEALS-24860: Add JWT Support to Package Manager Service

### DIFF
--- a/app/services/concerns/jwt_generator.rb
+++ b/app/services/concerns/jwt_generator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module JwtGenerator
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    # Purpose: Remove any illegal characters and keeps source at proper format
+    #
+    # Params: string
+    #
+    # Return: sanitized string
+    def base64url(source)
+      encoded_source = Base64.encode64(source)
+      encoded_source = encoded_source.sub(/=+$/, "")
+      encoded_source = encoded_source.tr("+", "-")
+      encoded_source = encoded_source.tr("/", "_")
+      encoded_source
+    end
+  end
+end

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -182,7 +182,6 @@ class ExternalApi::PacmanService
       request.open_timeout = 30
       request.read_timeout = 30
       request.body = body.to_json unless body.nil?
-      # not sure how user validation will be handled
       request.auth.ssl.ssl_version  = :TLSv1_2
       request.auth.ssl.ca_cert_file = ENV["SSL_CERT_FILE"]
       request.headers = headers.merge("X-Forwarded-User": generate_token)

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -137,9 +137,11 @@ class ExternalApi::PacmanService
 
     def jwt_payload
       current_epoch_timestamp = DateTime.now.strftime("%Q").to_i / 1000.floor
+
       {
         iat: current_epoch_timestamp,
         iss: ENV["PACMAN_API_TOKEN_ISSUER"],
+        aud: ENV["PACMAN_API_TOKEN_ISSUER"],
         samlToken: ENV["PACMAN_API_SAML_TOKEN"],
         externalSystemSource: ENV["PACMAN_API_SYS_ACCOUNT"]
       }
@@ -173,11 +175,10 @@ class ExternalApi::PacmanService
       stringified_data = jwt_payload.to_json.encode("UTF-8")
       encoded_data = base64url(stringified_data)
       token = "#{encoded_header}.#{encoded_data}"
-      signature = OpenSSL::HMAC.digest("SHA256", ENV["PACMAN_API_TOKEN_SECRET"], token)
-      signature = base64url(signature)
+      signature = OpenSSL::HMAC.digest("SHA512", ENV["PACMAN_API_TOKEN_SECRET"], token)
 
       # Signed Token
-      "#{token}.#{signature}"
+      "#{token}.#{base64url(signature)}"
     end
 
     # Purpose: Build and send the request to the server

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -145,6 +145,19 @@ class ExternalApi::PacmanService
       }
     end
 
+    # Purpose: Remove any illegal characters and keeps source at proper format
+    #
+    # Params: string
+    #
+    # Return: sanitized string
+    def base64url(source)
+      encoded_source = Base64.encode64(source)
+      encoded_source = encoded_source.sub(/=+$/, "")
+      encoded_source = encoded_source.tr("+", "-")
+      encoded_source = encoded_source.tr("/", "_")
+      encoded_source
+    end
+
     # Purpose: Generate the JWT token
     #
     # Params: none

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -144,7 +144,7 @@ class ExternalApi::PacmanService
         iat: current_epoch_timestamp,
         iss: ENV["PACMAN_API_TOKEN_ISSUER"],
         aud: ENV["PACMAN_API_TOKEN_ISSUER"],
-        samlToken: ENV["PACMAN_API_SAML_TOKEN"],
+        samlToken: ENV["PACMAN_API_SAML_TOKEN"]&.encode("UTF-8"),
         externalSystemSource: ENV["PACMAN_API_SYS_ACCOUNT"]
       }
     end

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -5,6 +5,8 @@ require "base64"
 require "digest"
 
 class ExternalApi::PacmanService
+  include JwtGenerator
+
   BASE_URL = ENV["PACMAN_API_URL"]
   SEND_DISTRIBUTION_ENDPOINT = "/package-manager-service/distribution"
   SEND_PACKAGE_ENDPOINT = "/package-manager-service/communication-package"
@@ -145,19 +147,6 @@ class ExternalApi::PacmanService
         samlToken: ENV["PACMAN_API_SAML_TOKEN"],
         externalSystemSource: ENV["PACMAN_API_SYS_ACCOUNT"]
       }
-    end
-
-    # Purpose: Remove any illegal characters and keeps source at proper format
-    #
-    # Params: string
-    #
-    # Return: sanitized string
-    def base64url(source)
-      encoded_source = Base64.encode64(source)
-      encoded_source = encoded_source.sub(/=+$/, "")
-      encoded_source = encoded_source.tr("+", "-")
-      encoded_source = encoded_source.tr("/", "_")
-      encoded_source
     end
 
     # Purpose: Generate the JWT token

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -135,6 +135,38 @@ class ExternalApi::PacmanService
       }]
     end
 
+    def jwt_payload
+      current_epoch_timestamp = DateTime.now.strftime("%Q").to_i / 1000.floor
+      {
+        iat: current_epoch_timestamp,
+        iss: ENV["PACMAN_API_TOKEN_ISSUER"],
+        samlToken: ENV["PACMAN_API_SAML_TOKEN"],
+        externalSystemSource: ENV["PACMAN_API_SYS_ACCOUNT"]
+      }
+    end
+
+    # Purpose: Generate the JWT token
+    #
+    # Params: none
+    #
+    # Return: token needed for authorization
+    def generate_token
+      header = {
+        alg: ENV["PACMAN_API_TOKEN_ALG"]
+      }
+
+      stringified_header = header.to_json.encode("UTF-8")
+      encoded_header = base64url(stringified_header)
+      stringified_data = jwt_payload.to_json.encode("UTF-8")
+      encoded_data = base64url(stringified_data)
+      token = "#{encoded_header}.#{encoded_data}"
+      signature = OpenSSL::HMAC.digest("SHA256", ENV["PACMAN_API_TOKEN_SECRET"], token)
+      signature = base64url(signature)
+
+      # Signed Token
+      "#{token}.#{signature}"
+    end
+
     # Purpose: Build and send the request to the server
     #
     # Params: general requirements for HTTP request
@@ -148,10 +180,12 @@ class ExternalApi::PacmanService
       request.read_timeout = 30
       request.body = body.to_json unless body.nil?
       # not sure how user validation will be handled
-      request.headers = headers.merge(Bearer: ENV["PACMAN_API_KEY"])
+      request.auth.ssl.ssl_version  = :TLSv1_2
+      request.auth.ssl.ca_cert_file = ENV["SSL_CERT_FILE"]
+      request.headers = headers.merge("X-Forwarded-User": generate_token)
       sleep 1
 
-      MetricsService.record("pacman service #{method.to_s.upcase} request to #{url}",
+      MetricsService.record("Pacman Service #{method.to_s.upcase} request to #{url}",
                             service: :pacman,
                             name: endpoint) do
         case method

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -10,8 +10,7 @@ class ExternalApi::PacmanService
   SEND_PACKAGE_ENDPOINT = "/package-manager-service/communication-package"
   GET_DISTRIBUTION_ENDPOINT = "/package-manager-service/distribution/"
   HEADERS = {
-    "Content-Type": "application/json", Accept: "application/json",
-    "TOKEN": ENV["PACMAN_API_KEY"]
+    "Content-Type": "application/json", Accept: "application/json"
   }.freeze
 
   class << self

--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -164,7 +164,7 @@ class ExternalApi::PacmanService
     #
     # Params: none
     #
-    # Return: token needed for authorization
+    # Return: token needed for authentication
     def generate_token
       header = {
         alg: ENV["PACMAN_API_TOKEN_ALG"]

--- a/app/services/external_api/va_notify_service.rb
+++ b/app/services/external_api/va_notify_service.rb
@@ -4,6 +4,8 @@ require "json"
 require "base64"
 require "digest"
 class ExternalApi::VANotifyService
+  include JwtGenerator
+
   BASE_URL = ENV["VA_NOTIFY_API_URL"]
   CLIENT_SECRET = ENV["VA_NOTIFY_API_KEY"]
   SERVICE_ID = ENV["VA_NOTIFY_SERVICE_ID"]
@@ -98,19 +100,6 @@ class ExternalApi::VANotifyService
       signature = base64url(signature)
       signed_token = "#{token}.#{signature}"
       signed_token
-    end
-
-    # Purpose: Remove any illegal characters and keeps source at proper format
-    #
-    # Params: string
-    #
-    # Return: sanitized string
-    def base64url(source)
-      encoded_source = Base64.encode64(source)
-      encoded_source = encoded_source.sub(/=+$/, "")
-      encoded_source = encoded_source.tr("+", "-")
-      encoded_source = encoded_source.tr("/", "_")
-      encoded_source
     end
 
     # Purpose: Build an email request object

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,7 +98,12 @@ Rails.application.configure do
   # Notifications page eFolder link
   ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage.bip.va.gov"
 
-  ENV["PACMAN_API_URL"] ||= "https://pacman-uat.stage.bip.va.gov/"
+  ENV["PACMAN_API_SAML_TOKEN"] ||= "our-saml-token"
+  ENV["PACMAN_API_TOKEN_SECRET"] ||= "client-secret"
+  ENV["PACMAN_API_TOKEN_ALG"] ||= "HS512"
+  ENV["PACMAN_API_TOKEN_ISSUER"] ||= "issuer-of-our-token"
+  ENV["PACMAN_API_SYS_ACCOUNT"] ||= "CSS_ID_OF_OUR_ACCOUNT"
+  ENV["PACMAN_API_URL"] ||= "https://pacman-uat.dev.bip.va.gov/"
 
   if ENV["WITH_TEST_EMAIL_SERVER"]
     config.action_mailer.delivery_method = :smtp

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -114,6 +114,10 @@ Rails.application.configure do
   ENV['TEST_VACOLS_HOST'] ||= "localhost"
 
   # Pacman environment variables
-  ENV["PACMAN_API_URL"] ||= "https://pacman-uat.stage.bip.va.gov"
-  ENV["PACMAN_API_KEY"] ||= "secret-key"
+  ENV["PACMAN_API_TOKEN_ALG"] ||= "HS512"
+  ENV["PACMAN_API_URL"] ||= "https://pacman-uat.dev.bip.va.gov"
+  ENV["PACMAN_API_SAML_TOKEN"] ||= "our-saml-token"
+  ENV["PACMAN_API_TOKEN_SECRET"] ||= "client-secret"
+  ENV["PACMAN_API_TOKEN_ISSUER"] ||= "issuer-of-our-token"
+  ENV["PACMAN_API_SYS_ACCOUNT"] ||= "CSS_ID_OF_OUR_ACCOUNT"
 end


### PR DESCRIPTION
Resolves [APPEALS-24860](https://jira.devops.va.gov/browse/APPEALS-24860)

# Description
Allow for `ExternalApi::PacmanService` to generate JWTs containing the SAML token provided to us, and have those JWTs be signed by the provided client secret.

## Acceptance Criteria
- [ ] Utilizing a provided SAML token and client secret, the ExternalApi::PacmanService class has functionality to generate JWTs for authentication with the Pacman API.
   - [ ] JWTs will go in the headers of requests under the key "X-Forwarded-User".
   - [ ] JWTs will be signed by the provided client secret.

## Testing Plan
1. WIP