### PR TITLE
Hotfix/APPEALS-24901: Remove Incorrect Encoding of Pacman URLs

### DIFF
--- a/app/services/external_api/pacman_service.rb
+++ b/app/services/external_api/pacman_service.rb
@@ -177,8 +177,7 @@ class ExternalApi::PacmanService
     # Return: service_response: JSON from Pacman or error
     # :reek:LongParameterList
     def send_pacman_request(headers: {}, endpoint:, method: :get, body: nil)
-      url = ERB::Util.url_encode(BASE_URL + endpoint)
-      request = HTTPI::Request.new(url)
+      request = HTTPI::Request.new(BASE_URL + endpoint)
       request.open_timeout = 30
       request.read_timeout = 30
       request.body = body.to_json unless body.nil?


### PR DESCRIPTION
Resolves [APPEALS-24901](https://jira.devops.va.gov/browse/APPEALS-24901)

## Description

Incorrect use of ERB::Util.url_encode() within the ExternalApi::PacmanService's send_pacman_request method is causing the forward slashes in the URL to be incorrectly encoded.

Since we do not use any URL query parameters while interacting with any Pacman routes we can simply remove the use of the ERB::Util.url_encode() method.