### PR TITLE
APPEALS-24520: fix flaky tests in spec/feature/cavc_dashboard_spec.rb

### DIFF
--- a/spec/feature/queue/cavc_dashboard_spec.rb
+++ b/spec/feature/queue/cavc_dashboard_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
     it "user cannot see the CAVC Dashboard button on the remand appeal case details page" do
       visit "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
-
+      reload_case_detail_page(cavc_remand.remand_appeal.uuid)
       expect(page).to have_text "CAVC Remand"
       expect(page).not_to have_text "CAVC Dashboard"
     end
@@ -52,7 +52,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
       expect(page).to have_button("Cancel")
       click_button "Cancel"
 
-      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}/"
+      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
     end
 
     it "dashboard save button is disabled until changes made, cancel button shows warning if clicked without saving" do
@@ -71,7 +71,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
       expect(page).to have_button("Continue")
       click_button "Continue"
 
-      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}/"
+      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
       click_button "CAVC Dashboard"
       expect(page).not_to have_content("Abandoned")
     end
@@ -97,7 +97,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
       expect(page).to have_button("Continue")
       click_button "Continue"
-      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}/"
+      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
     end
 
     it "user can edit and save CAVC remand details" do
@@ -167,7 +167,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
       click_button "Save Changes"
 
-      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}/"
+      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
       click_button "CAVC Dashboard"
 
       abandoned = page.all("div.cf-select__value-container", exact_text: "Abandoned")
@@ -183,7 +183,9 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
       go_to_dashboard(cavc_remand.remand_appeal.uuid)
 
-      dropdowns = page.all("div.cf-select__placeholder", exact_text: "Select option")
+      expect(page).to have_text `CAVC appeals for #{cavc_remand.remand_appeal.veteran.name}`
+
+      dropdowns = page.all("div.cf-select__placeholder", exact_text: /Select option/)
       dropdowns.first.click
       page.find("div.cf-select__menu").find("div", exact_text: "Reversed").click
 
@@ -194,6 +196,8 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
       reversed_section.find("span", exact_text: "Treatment records").click
       expect(page).to have_content "Decision Reasons (2)"
       reversed_section.find("div", exact_text: "Decision Reasons (2)").click
+      reversed_section.click
+      expect(page).to have_css('div[aria-expanded="false"]')
 
       dropdowns.last.click
       page.find("div.cf-select__menu").find("div", exact_text: "Vacated and Remanded").click
@@ -214,7 +218,8 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
       v_and_r_section.find("div", exact_text: "Decision Reasons (1)").click
 
       click_button "Save Changes"
-      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}/"
+      reload_case_detail_page(cavc_remand.remand_appeal.uuid)
+      expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
       click_button "CAVC Dashboard"
 
       expect(page).to have_content "Decision Reasons (2)"
@@ -226,5 +231,7 @@ end
 
 def go_to_dashboard(appeal_uuid)
   visit "/queue/appeals/#{appeal_uuid}/"
+  reload_case_detail_page(appeal_uuid)
   click_button "CAVC Dashboard"
+  expect(page).to have_current_path("/queue/appeals/#{appeal_uuid}/cavc_dashboard", ignore_query: true)
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -66,6 +66,10 @@ Capybara.register_driver(:sniffybara_headless) do |app|
   Sniffybara::Driver.current_driver = Sniffybara::Driver.new(app, options)
 end
 
+Capybara::Screenshot.register_filename_prefix_formatter(:rspec) do |example|
+  "screenshot_#{example.description.tr(' ', '-').gsub(/^.*\/spec\//, '')}"
+end
+
 Capybara::Screenshot.register_driver(:parallel_sniffybara) do |driver, path|
   driver.browser.save_screenshot(path)
 end


### PR DESCRIPTION
* testing flaky test

* name screenshot with name from example

* removing bang where not necessary

* Adding a logger to see if we can find why it fails randomly

* spec failure timing issue

* Appeals-24520: fixing the flaky spec for vacant and remand

* replacing refresh if needed method with reload_case_detail_page

* uncommenting let comment

* removing accidental commit

* fixing spec failure

Resolves [APPEALS-24520](https://jira.devops.va.gov/browse/APPEALS-24520) and [APPEALS-24426](https://jira.devops.va.gov/browse/APPEALS-24426)

# Description
- Add refresh method to cavc_dashboard_spec.rb
- Change `let!` to `let` in ama_notification_efolder_sync_job_spec.rb
- Modify capybara config to name feature spec failure screenshots based on test name and description

## Acceptance Criteria
- [ ] Code compiles correctly
