### PR TITLE
APPEALS-24709

### DIFF
--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -127,15 +127,14 @@ class Fakes::BGSService
     # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
     if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
       epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
-      return unless epe.vbms_ext_claim
+      if epe.vbms_ext_claim
+        vbms_status = epe.vbms_ext_claim.level_status_code
 
-      vbms_status = epe.vbms_ext_claim.level_status_code
-      records.values.each do |record|
-        record[:status_type_code] = vbms_status
+        records.values.each do |record|
+          record[:status_type_code] = vbms_status
 
-        # checks that there is a benefit_claim_id present
-        unless record[:benefit_claim_id] do
-          record[:benefit_claim_id] = epe.reference_id
+          # checks that there is a benefit_claim_id present
+          record[:benefit_claim_id] = epe.reference_id unless record[:benefit_claim_id]
         end
       end
     end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -123,9 +123,9 @@ class Fakes::BGSService
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}
 
-    epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
+    if ActiveRecord::Base.connection.table_exists? "vbms_ext_claims"
+      epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
 
-    if VbmsExtClaim.table_exists?
       if epe.vbms_ext_claim
         records.values.each do |record|
           vbms_status = epe.vbms_ext_claim.level_status_code
@@ -135,6 +135,7 @@ class Fakes::BGSService
           record[:benefit_claim_id] = epe.reference_id
         end
       end
+
     end
 
     records.values

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -125,7 +125,7 @@ class Fakes::BGSService
 
     # if the table isn't standing, this will prevent a 'nil class' error
     # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
-    if ActiveRecord::Base.connection.data_source_exists? "vbms_ext_claim"
+    if VbmsExtClaim.table_exists?
       epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
 
       if epe.vbms_ext_claim

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -125,10 +125,10 @@ class Fakes::BGSService
 
     # if the table isn't standing, this will prevent a 'nil class' error
     # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
-    if VbmsExtClaim.table_exists?
+    if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
       epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
 
-      if epe.vbms_ext_claim
+      if VbmsExtClaim.find_by(claim_id: epe.reference_id)
         vbms_status = epe.vbms_ext_claim.level_status_code
 
         records.values.each do |record|

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -122,23 +122,6 @@ class Fakes::BGSService
   def get_end_products(file_number)
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}
-
-    # if the table isn't standing, this will prevent a 'nil class' error
-    # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
-    if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
-      epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
-      if epe.vbms_ext_claim
-        vbms_status = epe.vbms_ext_claim.level_status_code
-
-        records.values.each do |record|
-          record[:status_type_code] = vbms_status
-
-          # checks that there is a benefit_claim_id present
-          record[:benefit_claim_id] = epe.reference_id unless record[:benefit_claim_id]
-        end
-      end
-    end
-
     records.values
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -129,11 +129,11 @@ class Fakes::BGSService
       if epe.vbms_ext_claim
         vbms_status = epe.vbms_ext_claim.level_status_code
         record[:status_type_code] = vbms_status
-      end
 
-      # EP benefit_claim_id needs to match the EPE's reference_id
-      unless record[:benefit_claim_id]
-        record[:benefit_claim_id] = epe.reference_id
+        # EP benefit_claim_id needs to match the EPE's reference_id
+        unless record[:benefit_claim_id]
+          record[:benefit_claim_id] = epe.reference_id
+        end
       end
     end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -140,7 +140,6 @@ class Fakes::BGSService
     records.values
   end
 
-
   # Util method for further filtering a veteran's EPs by code, modifier, payee code, or claim date.
   # Each parameter is optional; if omitted or set to nil, it won't be used for filtering.
   def select_end_products(file_number, code: nil, modifier: nil, payee_code: nil, claim_date: nil)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -125,13 +125,13 @@ class Fakes::BGSService
 
     epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
 
-    records.values.each do |record|
+    if VbmsExtClaim.table_exists?
       if epe.vbms_ext_claim
-        vbms_status = epe.vbms_ext_claim.level_status_code
-        record[:status_type_code] = vbms_status
+        records.values.each do |record|
+          vbms_status = epe.vbms_ext_claim.level_status_code
+          record[:status_type_code] = vbms_status
 
-        # EP benefit_claim_id needs to match the EPE's reference_id
-        unless record[:benefit_claim_id]
+          # EP benefit_claim_id needs to match the EPE's reference_id
           record[:benefit_claim_id] = epe.reference_id
         end
       end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -123,8 +123,8 @@ class Fakes::BGSService
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}
 
-    if ActiveRecord::Base.connection.table_exists? "vbms_ext_claims"
-      vbms_status_sync(records)
+    if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
+      vbms_status_sync(records, file_number)
     end
 
     records.values
@@ -809,15 +809,15 @@ class Fakes::BGSService
     }
   end
 
-  def vbms_status_sync(records)
+  def vbms_status_sync(records, file_number)
     epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
     return unless epe.vbms_ext_claim
 
-    vbms_status = epe.vbms_ext_claim.level_status_code
-    sync(records, vbms_status)
+    sync(records, epe)
   end
 
-  def sync(records, vbms_status)
+  def sync(records, epe)
+    vbms_status = epe.vbms_ext_claim.level_status_code
     records.values.each do |record|
       record[:status_type_code] = vbms_status
     end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -122,6 +122,25 @@ class Fakes::BGSService
   def get_end_products(file_number)
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}
+
+    # if the table isn't standing, this will prevent a 'nil class' error
+    # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
+    if ActiveRecord::Base.connection.data_source_exists? "vbms_ext_claim"
+      epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
+
+      if epe.vbms_ext_claim
+        vbms_status = epe.vbms_ext_claim.level_status_code
+
+        records.values.each do |record|
+          record[:status_type_code] = vbms_status
+
+          # checks that there is a benefit_claim_id present
+          record[:benefit_claim_id] = epe.reference_id unless record[:benefit_claim_id]
+        end
+      end
+
+    end
+
     records.values
   end
 

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -128,7 +128,7 @@ class Fakes::BGSService
     if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
       epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
 
-      if VbmsExtClaim.find_by(claim_id: epe.reference_id)
+      if epe&.vbms_ext_claim
         vbms_status = epe.vbms_ext_claim.level_status_code
 
         records.values.each do |record|

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -126,19 +126,7 @@ class Fakes::BGSService
     # if the table isn't standing, this will prevent a 'nil class' error
     # if it standing, we will attempt to sync EP, EPE, and VbmsExtClaim statuses
     if ActiveRecord::Base.connection.table_exists? "vbms_ext_claim"
-      epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
-
-      if epe&.vbms_ext_claim
-        vbms_status = epe.vbms_ext_claim.level_status_code
-
-        records.values.each do |record|
-          record[:status_type_code] = vbms_status
-
-          # checks that there is a benefit_claim_id present
-          record[:benefit_claim_id] = epe.reference_id unless record[:benefit_claim_id]
-        end
-      end
-
+      vbms_status_sync(records, file_number)
     end
 
     records.values
@@ -823,35 +811,31 @@ class Fakes::BGSService
     }
   end
 
-  # # we only want to sync statuses if the EPE belongs to a VbmsExtClaim record
-  # def vbms_status_sync(records, file_number)
-  #   epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
-  #   return unless epe.vbms_ext_claim
+  # we only want to sync statuses if the EPE belongs to a VbmsExtClaim record
+  def vbms_status_sync(records, file_number)
+    epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
+    sync(records, epe) if epe&.vbms_ext_claim
+  end
 
-  #   sync(records, epe)
-  # end
+  # 'records' returns an object of objects
+  # incase there are multiple nested objects,
+  # all of them must be iterated over and updated
+  def sync(records, epe)
+    vbms_status = epe.vbms_ext_claim.level_status_code
+    records.values.each do |record|
+      record[:status_type_code] = vbms_status
 
-  # # 'records' returns an object of objects
-  # # incase there are multiple nested objects,
-  # # all of them must be iterated over and updated
-  # def sync(records, epe)
-  #   vbms_status = epe.vbms_ext_claim.level_status_code
-  #   records.values.each do |record|
-  #     record[:status_type_code] = vbms_status
+      # checks that there is a benefit_claim_id present
+      epe_claim_id_sync(record)
+    end
+  end
 
-  #     # checks that there is a benefit_claim_id present
-  #     epe_claim_id_sync(record)
-  #   end
-  # end
-
-  # # while running rspec on factory EPEs, an EP is generated without a claim_id
-  # # causing `epe.sync!` to result in an error
-  # # to bypass the nil value, we manually set the EP's benefit_claim_id
-  # def epe_claim_id_sync(record)
-  #   return if record[:benefit_claim_id]
-
-  #   record[:benefit_claim_id] = epe.reference_id
-  # end
+  # while running rspec on factory EPEs, an EP is generated without a claim_id
+  # causing `epe.sync!` to result in an error
+  # to bypass the nil value, we manually set the EP's benefit_claim_id
+  def epe_claim_id_sync(record)
+    record[:benefit_claim_id] = epe.reference_id unless record[:benefit_claim_id]
+  end
   # rubocop:enable Metrics/MethodLength
 end
 # rubocop:enable Metrics/ClassLength


### PR DESCRIPTION
Resolves [APPEALS-24709](https://jira.devops.va.gov/browse/APPEALS-24709)

# Description
Update BGS Faker File to return LEVEL_STATUS_CODE that is shown in VBMS_EXT_CLAIM table when RESULT is called on an END PRODUCT ESTABLISHMENT.

## Acceptance Criteria
- [x] When calling the 'result' method on EndProductEstablishment records, the EP generated has a status_type_code value that matches it's associated VbmsExtClaim's level_status_code value
- [x] When calling the 'sync!' method on EndProductEstablishment records, its synced_status value matches it's associated VbmsExtClaim's level_status_code value
- [x] No errors occur if the VbmsExtClaim table isn't standing or if a particular EPE doesn't belong to a VbmsExtClaim record

## Testing Plan
1. [Test Steps](https://jira.devops.va.gov/browse/APPEALS-25022)
2. [Test Execution](https://jira.devops.va.gov/browse/APPEALS-25081)
3. [Test Details](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-25081&testIssueKey=APPEALS-25022)

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

