### PR TITLE
APPEALS/24143 - Fix flakey test for case_details_spec.rb

### DIFF
--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -218,11 +218,8 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
       end
 
       context "when request header contains nonexistent Veteran file number" do
-        it "returns 404 error", skip: "flake" do
-          appeal = create(:appeal, claimants: [build(:claimant, participant_id: "CLAIMANT_WITH_PVA_AS_VSO")])
-          create(:supplemental_claim, veteran_file_number: appeal.veteran_file_number)
-
-          request.headers["HTTP_CASE_SEARCH"] = "123"
+        it "returns 404 error" do
+          request.headers["HTTP_CASE_SEARCH"] = "123456789"
 
           expect_any_instance_of(Fakes::BGSService).to_not receive(:fetch_poas_by_participant_id)
 

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -453,7 +453,7 @@ RSpec.describe HearingsController, type: :controller do
         expect(response.status).to eq 200
       end
 
-      it "should return a 200 and update aod if provided", :aggregate_failures, skip: "flake AOD present" do
+      it "should return a 200 and update aod if provided", :aggregate_failures do
         params = {
           id: ama_hearing.external_id,
           advance_on_docket_motion: {

--- a/spec/controllers/organizations/users_controller_spec.rb
+++ b/spec/controllers/organizations/users_controller_spec.rb
@@ -274,7 +274,7 @@ describe Organizations::UsersController, :postgres, type: :controller do
     let!(:params) { { organization_url: org.url, id: user.id } }
 
     let(:org) { create(:judge_team, :has_judge_team_lead_as_admin) }
-    let!(:user) do
+    let(:user) do
       create(:user).tap do |user|
         org.add_user(user)
       end
@@ -300,7 +300,9 @@ describe Organizations::UsersController, :postgres, type: :controller do
       end
     end
 
-    context "when user is the judge in the organization", skip: "Flake" do
+    context "when user is the judge in the organization" do
+      let(:user) { org.admin }
+
       it "returns an error" do
         subject
 

--- a/spec/feature/hearings/daily_docket/build_hearsched_spec.rb
+++ b/spec/feature/hearings/daily_docket/build_hearsched_spec.rb
@@ -72,10 +72,10 @@ feature "Hearing Schedule Daily Docket for Build HearSched", :all_dbs do
     let!(:hearing) { create(:hearing, :with_tasks) }
     let!(:postponed_hearing_day) { create(:hearing_day, scheduled_for: Date.new(2019, 3, 3)) }
 
-    scenario "User can update fields", skip: "flake" do
+    scenario "User can update fields" do
       visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
       find("textarea", id: "#{hearing.external_id}-notes").click.send_keys("This is a note about the hearing!")
-      find("label", text: "9:00 am").click
+      find("label", text: "9:00 AM Eastern Time (US & Canada)").click
       find("label", text: "Transcript Requested").click
       click_button("Save")
       expect(page).to have_content("You have successfully updated")
@@ -87,7 +87,7 @@ feature "Hearing Schedule Daily Docket for Build HearSched", :all_dbs do
       expect(page).to have_content("No Show")
       expect(page).to have_content("This is a note about the hearing!", wait: 10) # flake
       expect(find_field("Transcript Requested", visible: false)).to be_checked
-      expect(find_field("9:00 am", visible: false)).to be_checked
+      expect(find_field("9:00 AM", visible: false)).to be_checked
     end
   end
 

--- a/spec/feature/queue/case_details_spec.rb
+++ b/spec/feature/queue/case_details_spec.rb
@@ -153,7 +153,7 @@ RSpec.feature "Case details", :all_dbs do
         expect(details_link.text).to eq(COPY::CASE_DETAILS_HEARING_DETAILS_LINK_COPY)
       end
 
-      context "the user has a VSO role", skip: "re-enable when pagination is fixed" do
+      context "the user has a VSO role" do
         let!(:vso) { create(:vso, name: "VSO", role: "VSO", url: "vso-url", participant_id: "8054") }
         let!(:vso_user) { create(:user, :vso_role) }
         let!(:vso_task) { create(:ama_vso_task, :in_progress, assigned_to: vso, appeal: appeal) }

--- a/spec/models/appeal_series_issues_spec.rb
+++ b/spec/models/appeal_series_issues_spec.rb
@@ -68,7 +68,27 @@ describe AppealSeriesIssues, :all_dbs do
   end
 
   let(:combined_issues) do
-    AppealSeriesIssues.new(appeal_series: series).all.sort_by { |issue_hash| issue_hash[:diagnostic_code] }
+    AppealSeriesIssues.new(appeal_series: series).all
+  end
+
+  let(:combined_issues_array) do
+    [
+      {
+        description: "Service connection, limitation of thigh motion (flexion)",
+        diagnosticCode: "5252",
+        active: true,
+        lastAction: :remand,
+        date: 6.months.ago.to_date
+      },
+      {
+        description: "New and material evidence to reopen claim for service connection,"\
+          " shoulder or arm muscle injury",
+        diagnosticCode: "5301",
+        active: false,
+        lastAction: :allowed,
+        date: 6.months.ago.to_date
+      }
+    ]
   end
 
   context "#all" do
@@ -77,18 +97,7 @@ describe AppealSeriesIssues, :all_dbs do
     context "when an issue spans a remand" do
       it "combines issues together" do
         expect(subject.length).to eq(2)
-        expect(subject.first[:description]).to eq(
-          "Service connection, limitation of thigh motion (flexion)"
-        )
-        expect(subject.first[:active]).to be_truthy
-        expect(subject.first[:lastAction]).to eq(:remand)
-        expect(subject.first[:date]).to eq(6.months.ago.to_date)
-        expect(subject.last[:description]).to eq(
-          "New and material evidence to reopen claim for service connection, shoulder or arm muscle injury"
-        )
-        expect(subject.last[:active]).to be_falsey
-        expect(subject.last[:lastAction]).to eq(:allowed)
-        expect(subject.last[:date]).to eq(6.months.ago.to_date)
+        expect(subject).to match_array(combined_issues_array)
       end
 
       context "when there is a draft decision" do
@@ -105,9 +114,7 @@ describe AppealSeriesIssues, :all_dbs do
 
         it "does not show the draft disposition" do
           expect(subject.length).to eq(2)
-          expect(subject.first[:active]).to be_truthy
-          expect(subject.first[:date]).to eq(6.months.ago.to_date)
-          expect(subject.first[:lastAction]).to eq(:remand)
+          expect(subject).to match_array(combined_issues_array)
         end
       end
     end
@@ -116,7 +123,7 @@ describe AppealSeriesIssues, :all_dbs do
       let(:appeals) { [original] }
 
       it "is marked as active" do
-        expect(subject.first[:active]).to be_truthy
+        expect(subject).to match_array(combined_issues_array)
       end
     end
 
@@ -124,6 +131,7 @@ describe AppealSeriesIssues, :all_dbs do
       let(:original_issues) { [] }
 
       it "returns issues" do
+        expect(subject.length).to eq(1)
         expect(subject.first[:description]).to eq("Service connection, limitation of thigh motion (flexion)")
       end
     end
@@ -151,7 +159,15 @@ describe AppealSeriesIssues, :all_dbs do
       end
 
       it "does not show as a last_action" do
-        expect(subject.first[:lastAction]).to eq(:remand)
+        expect(subject.length).to eq(3)
+        other_hash = {
+          description: "Other",
+          diagnosticCode: nil,
+          active: false,
+          lastAction: nil,
+          date: nil
+        }
+        expect(subject).to match_array(combined_issues_array.push(other_hash))
       end
     end
 
@@ -161,8 +177,13 @@ describe AppealSeriesIssues, :all_dbs do
       end
 
       it "appears as the last action" do
-        expect(subject.first[:lastAction]).to eq(:cavc_remand)
-        expect(subject.first[:date]).to eq(1.month.ago.to_date)
+        expect(subject.length).to eq(2)
+        expect(subject).to include(
+          a_hash_including(
+            lastAction: :cavc_remand,
+            date: 1.month.ago.to_date
+          )
+        )
       end
     end
   end

--- a/spec/models/task_filter_spec.rb
+++ b/spec/models/task_filter_spec.rb
@@ -381,7 +381,7 @@ describe TaskFilter, :all_dbs do
           ["col=#{Constants.QUEUE_CONFIG.COLUMNS.APPEAL_TYPE.name}&val=#{case_types['1']}|#{case_types['2']}"]
         end
 
-        it "returns tasks with Original or Supplemental case types", skip: "flakey" do
+        it "returns tasks with Original or Supplemental case types" do
           expect(subject.map(&:id)).to match_array(tasks_type_original.map(&:id) + tasks_type_supplemental.map(&:id))
         end
       end


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-24143

# Description
In the process of maintaining a better testing suite we are attempting to remove all rspec tests that are skipped.

### Actions made:
This specific instance there was a skip that is no longer needed as the test does not fail when ran. Upon further research it looks like the pagination has been fixed and now allows the test to work correctly. I tried for a while to find the commit/PR that resolved the pagination issue but could not find it.

I've also ran the Github CI a few times and it does not seem to fail there. So we should keep an eye out on this test flaking out in the future but for now I feel confident in pushing it.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Test `the user has a VSO role`  in `case_details_spec.rb` passes 


## Screenshots
<img width="1388" alt="Screenshot 2023-07-07 at 9 34 59 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/1141d60d-4370-40cf-abaa-b36d873f8813">

