### PR TITLE
Removed redundant test because a more complete test for this exists i…

### DIFF
--- a/spec/controllers/appeals_controller_spec.rb
+++ b/spec/controllers/appeals_controller_spec.rb
@@ -1026,22 +1026,6 @@ RSpec.describe AppealsController, :all_dbs, type: :controller do
         subject
         expect(response).to be_successful
       end
-
-      it "creates an IssuesUpdateTask for each updated MST or PACT issue" do
-        #Note: there are 4 issues on the appeal, but since there are no edits to request_issue1, we only expect 3 tasks to be created.
-        allow_any_instance_of(AppealsController).to receive(:appeal).and_return(appeal)
-        allow(Organization).to receive(:find_by_url).and_return(organization)
-
-        subject
-        expect(IssuesUpdateTask.count).to eq(3)
-        expect(IssuesUpdateTask.first.instructions[0].include?("Special Issues: MST")).to eq (true)
-        expect(IssuesUpdateTask.first.instructions[0].include?("MST reason note")).to eq (true)
-        expect(IssuesUpdateTask.second.instructions[0].include?("Special Issues: PACT")).to eq (true)
-        expect(IssuesUpdateTask.second.instructions[0].include?("PACT reason note")).to eq (true)
-        expect(IssuesUpdateTask.third.instructions[0].include?("Special Issues: MST, PACT")).to eq (true)
-        expect(IssuesUpdateTask.third.instructions[0].include?("MST note")).to eq (true)
-        expect(IssuesUpdateTask.third.instructions[0].include?("Pact note")).to eq (true)
-      end
     end
   end
 end


### PR DESCRIPTION
Resolves [23984](https://jira.devops.va.gov/browse/APPEALS-24984)

# Description
There was a old test in the appeals_controller_spec that was testing IssueUpdateTask. This test wasn't specific to the appeals controller and seemed to be built into the wrong place. I began to move it to issue_update_task_spec.rb where I noticed that some nearly identical tests were created, but more thorough and complete than this one ever was. I have removed the old test from the appeals controller and haven't revised anything inside the IssueUpdateTask spec because they were much more thorough and covered the original requirements for testing this that I deleted.

At least one test will fail if the environment does not have wkhtmltopdf installed.

## Acceptance Criteria
- [ X] Code compiles correctly

Passing unit test:
<img width="1099" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/0348cfbf-9477-4f41-aa0f-4cc83cbbcda1">