### PR TITLE
appeals 25076

### DIFF
--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -36,7 +36,8 @@ module IssueUpdater
   private
 
   def create_decision_issues!
-    issues.each do |issue_attrs|
+    ordered_issues = issues.sort_by { |issue| issue[:request_issue_ids]&.min }
+    ordered_issues.each do |issue_attrs|
       request_issues = appeal.request_issues.active_or_withdrawn.where(id: issue_attrs[:request_issue_ids])
       next if request_issues.empty?
 
@@ -53,6 +54,7 @@ module IssueUpdater
       )
 
       request_issues.each do |request_issue|
+
         RequestDecisionIssue.create!(decision_issue: decision_issue, request_issue: request_issue)
 
         # compare the MST/PACT status of the orignial issue and decision to create task and record

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -36,7 +36,7 @@ module IssueUpdater
   private
 
   def create_decision_issues!
-    ordered_issues = issues.sort_by { |issue| issue[:request_issue_ids]&.min }
+    ordered_issues = issues.sort_by { |issue| issue[:request_issue_ids]&.first }
     ordered_issues.each do |issue_attrs|
       request_issues = appeal.request_issues.active_or_withdrawn.where(id: issue_attrs[:request_issue_ids])
       next if request_issues.empty?

--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -347,17 +347,17 @@ class TaskRows extends React.PureComponent {
         return (
           <div style={divStyle}>
             <b>{text[0]}:</b>
-            <div style={divStyle}>
-              <div style={{whiteSpace: 'pre-line'}}>
-                {text[2]}
-              </div>
-            </div>
             {text[1] &&
               <React.Fragment>
                 <div style={divStyle}>
                   Benefit type: {text[1]}
                 </div>
               </React.Fragment>}
+            <div style={divStyle}>
+              <div style={{whiteSpace: 'pre-line'}}>
+                {text[2]}
+              </div>
+            </div>
             {text[4] ?
               <React.Fragment>
               <h5 style={hStyle}>Original:</h5>


### PR DESCRIPTION
Resolves #{25076}
[APPEALS-25076](https://jira.devops.va.gov/browse/APPEALS-25076)

# Description
This update ensures that after an attorney or judge completes the add decision workflow, the case timeline is ordered in the correct manner. This ticket also fixes the layout of case timeline AMA issues to place the benefit type before the issue description.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan

1. Establish an Appeal in CF for 10182 with multiple issues
2. Move appeal to the decision review stage
3. Log in as a Judge user
4. Make edits to multiple issues on the Appeals issues related to MST / PACT can remove an MST/PACT designation, add one, or some other edit dealing with MST/PACT so that it will show up on the case timeline
5. Check if the order of issues is correct in the case timeline area.
6. Check the details of each entry in the case timeline is ordered correctly.

Expected Result:
1. Case Timeline showing edits in order user makes them. 
2. Case timeline should also display AMA appeals in the order of (1: Benefit Type, 2: Issue Description)

# Frontend
## User Facing Changes
 
<img width="374" alt="Screenshot 2023-07-10 at 1 36 28 PM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/33578594/abb6f80e-48b8-41ba-bfc6-21d35e916b3e">

