### PR TITLE
HunJerBAH/APPEALS-25276

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -432,6 +432,11 @@ class AppealsController < ApplicationController
 
   def create_legacy_issue_update_task(before_issue, current_issue)
     user = RequestStore[:current_user]
+
+    # close out any tasks that might be open
+    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task[0].delete unless open_issue_task.empty?
+
     task = IssuesUpdateTask.create!(
       appeal: appeal,
       parent: appeal.root_task,

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -434,7 +434,9 @@ class AppealsController < ApplicationController
     user = RequestStore[:current_user]
 
     # close out any tasks that might be open
-    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task = Task.where(
+      assigned_to: SpecialIssueEditTeam.singleton
+    ).where(status: "assigned").where(appeal: appeal)
     open_issue_task[0].delete unless open_issue_task.empty?
 
     task = IssuesUpdateTask.create!(

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -59,6 +59,13 @@ class IssuesController < ApplicationController
   private
 
   def create_legacy_issue_update_task(before_issue)
+
+    # close out any tasks that might be open
+    open_issue_task = Task.where(
+      assigned_to: SpecialIssueEditTeam.singleton
+    ).where(status: "assigned").where(appeal: appeal)
+    open_issue_task[0].delete unless open_issue_task.empty?
+
     user = current_user
     task = IssuesUpdateTask.create!(
       appeal: appeal,

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -123,7 +123,9 @@ module IssueUpdater
     root_task = RootTask.find_or_create_by!(appeal: appeal)
 
     # close out any tasks that might be open
-    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task = Task.where(
+      assigned_to: SpecialIssueEditTeam.singleton
+    ).where(status: "assigned").where(appeal: appeal)
     open_issue_task[0].delete unless open_issue_task.empty?
 
     task = IssuesUpdateTask.create!(

--- a/app/models/concerns/issue_updater.rb
+++ b/app/models/concerns/issue_updater.rb
@@ -122,6 +122,10 @@ module IssueUpdater
   def create_issue_update_task(original_issue, decision_issue)
     root_task = RootTask.find_or_create_by!(appeal: appeal)
 
+    # close out any tasks that might be open
+    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task[0].delete unless open_issue_task.empty?
+
     task = IssuesUpdateTask.create!(
       appeal: appeal,
       parent: root_task,

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -333,9 +333,11 @@ class RequestIssuesUpdate < CaseflowRecord
 
   def create_issue_update_task(change_type, before_issue, after_issue = nil)
     transaction do
-    # close out any tasks that might be open
-    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
-    open_issue_task[0].delete unless open_issue_task.empty?
+      # close out any tasks that might be open
+      open_issue_task = Task.where(
+        assigned_to: SpecialIssueEditTeam.singleton
+      ).where(status: "assigned").where(appeal: before_issue.decision_review)
+      open_issue_task[0].delete unless open_issue_task.empty?
 
       task = IssuesUpdateTask.create!(
         appeal: before_issue.decision_review,

--- a/app/models/request_issues_update.rb
+++ b/app/models/request_issues_update.rb
@@ -333,6 +333,10 @@ class RequestIssuesUpdate < CaseflowRecord
 
   def create_issue_update_task(change_type, before_issue, after_issue = nil)
     transaction do
+    # close out any tasks that might be open
+    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task[0].delete unless open_issue_task.empty?
+
       task = IssuesUpdateTask.create!(
         appeal: before_issue.decision_review,
         parent: RootTask.find_by(appeal: before_issue.decision_review),

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -207,16 +207,12 @@ class InitialTasksFactory
   end
 
   def create_establishment_task
-    # close out any tasks that might be open on the appeal
-    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
-    open_issue_task[0].delete unless open_issue_task.empty?
-
     task = EstablishmentTask.create!(
       appeal: @appeal,
       parent: @root_task,
       assigned_by: RequestStore[:current_user],
       assigned_to: SpecialIssueEditTeam.singleton,
-      completed_by: RequestStore[:current_user],
+      completed_by: RequestStore[:current_user]
     )
     task.format_instructions(@appeal.request_issues)
     task.completed!

--- a/app/workflows/initial_tasks_factory.rb
+++ b/app/workflows/initial_tasks_factory.rb
@@ -207,6 +207,10 @@ class InitialTasksFactory
   end
 
   def create_establishment_task
+    # close out any tasks that might be open on the appeal
+    open_issue_task = Task.where(assigned_to: SpecialIssueEditTeam.singleton).where(status: "assigned")
+    open_issue_task[0].delete unless open_issue_task.empty?
+
     task = EstablishmentTask.create!(
       appeal: @appeal,
       parent: @root_task,


### PR DESCRIPTION
Resolves [APPEALS-25276](https://jira.devops.va.gov/browse/APPEALS-25276)

# Description
If the MST/PACT status on an appeal is edited but fails for some reason before the IssuesUpdateTask or EstablishmentTask is closed out, the open task prevents any further MST/PACT edits from being created. This fix deletes any outstanding tasks that are "assigned" due to being incomplete on the appeal. 

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan

1. Navigate to caseflow and sign in as a BVA Intake user.
2. Intake a new appeal by going through the intake process. On the add Issues page, select MST/PACT on a new issue and add it to the intake.
3. When you complete the intake process, navigate to the appeal's case details page. Copy the UUID of the appeal from the URL.
4. Open up the rails console. Create an IssueUpdateTask by running these commands

**RequestStore[:current_user] = User.find_by(css_id: 'BVADWISE')
appeal = Appeal.find_by_uuid( uuid-from-url-goes-here)
task = IssuesUpdateTask.create!(
      appeal: appeal,
      parent: appeal.root_task,
      assigned_to: SpecialIssueEditTeam.singleton,
      assigned_by: RequestStore[:current_user],
      completed_by: RequestStore[:current_user]
    )**
5. Navigate back to caseflow and go to the edit issues page of the appeal you created.
6. Edit the MST/PACT status of the issue and click save.
7. You should not get an error message. The new task created for the MST/PACT change should show in the case timeline.
