### PR TITLE
Craig/appeals 24719

### DIFF
--- a/client/test/app/queue/ColocatedTaskListView.test.js
+++ b/client/test/app/queue/ColocatedTaskListView.test.js
@@ -31,7 +31,8 @@ const WrapperComponent = ({ children }) => (
   </MemoryRouter>
 );
 
-// Date constructor uses zero-based offset for months — this is 2021-03-17
+// Date constructor uses zero-based offset for months — this is 2021-03-17. The time (11:30pm) is to ensure
+// that the crossover between days doesn't affect the front end calculations for when tasks were assigned
 const fakeDate = new Date(2021, 2, 17, 23, 30, 0, 0);
 
 beforeAll(() => {

--- a/client/test/app/queue/ColocatedTaskListView.test.js
+++ b/client/test/app/queue/ColocatedTaskListView.test.js
@@ -32,7 +32,7 @@ const WrapperComponent = ({ children }) => (
 );
 
 // Date constructor uses zero-based offset for months — this is 2021-03-17
-const fakeDate = new Date(2021, 2, 17, 12);
+const fakeDate = new Date(2021, 2, 17, 23, 30, 0, 0);
 
 beforeAll(() => {
   // Ensure consistent handling of dates across tests

--- a/client/test/data/queue/taskLists/index.js
+++ b/client/test/data/queue/taskLists/index.js
@@ -18,7 +18,7 @@ const getAmaTaskTemplate = ({ id = 1 } = {}) => ({
     placed_on_hold_at: null,
     on_hold_duration: null,
     status: null,
-    assigned_at: formatISO(sub(new Date(), { hours: 47 })),
+    assigned_at: formatISO(sub(new Date(), { days: 2 })),
     closest_regional_office: null,
     assigned_to: {
       css_id: null,

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -467,7 +467,7 @@ RSpec.describe HearingsController, type: :controller do
         patch :update, as: :json, params: params
         expect(response.status).to eq 200
         ama_hearing.reload
-        expect(ama_hearing.advance_on_docket_motion.person.id).to eq ama_hearing.appeal.appellant.id
+        expect(ama_hearing.advance_on_docket_motion.person.id).to eq ama_hearing.appeal.appellant.person.id
         expect(ama_hearing.advance_on_docket_motion.reason).to eq Constants.AOD_REASONS.age
         expect(ama_hearing.advance_on_docket_motion.granted).to eq true
       end

--- a/spec/models/dispatch/task_spec.rb
+++ b/spec/models/dispatch/task_spec.rb
@@ -56,7 +56,7 @@ describe Dispatch::Task, :postgres do
     let!(:unassigned_task) { FakeTask.create!(aasm_state: :unassigned, prepared_at: Date.yesterday) }
     let!(:reviewed_task) { FakeTask.create!(aasm_state: :reviewed, prepared_at: Date.yesterday) }
 
-    it { is_expected.to eq([unassigned_task, reviewed_task]) }
+    it { is_expected.to match_array [unassigned_task, reviewed_task] }
   end
 
   context ".completed_on" do
@@ -79,7 +79,7 @@ describe Dispatch::Task, :postgres do
     end
 
     # .sort added in case ActiveRecord returns tasks out of order in subject
-    it { is_expected.to eq([task_completed_this_morning, task_completed_tonight].sort) }
+    it { is_expected.to match_array [task_completed_this_morning, task_completed_tonight] }
   end
 
   context ".completed_success" do


### PR DESCRIPTION
Resolves [APPEALS-24719](https://jira.devops.va.gov/browse/APPEALS-24719)

# Description
- Modify test data to set task `assigned_at` to 2 days ago instead of 47 hours ago, which was causing problems running the test with times between 11pm-12am
- Modify test config to use 11:30pm as the time to ensure that the problem is resolved

## Acceptance Criteria
- [ ] Code compiles correctly
