### PR TITLE
Remove `disable_claim_establishment` FeatureToggle - APPEALS/19822

### DIFF
--- a/app/jobs/decision_review_process_job.rb
+++ b/app/jobs/decision_review_process_job.rb
@@ -7,9 +7,6 @@ class DecisionReviewProcessJob < CaseflowJob
   application_attr :intake
 
   def perform(thing_to_establish)
-    # Temporarily stop establishing claims due to VBMS bug
-    return if FeatureToggle.enabled?(:disable_claim_establishment, user: RequestStore.store[:current_user])
-
     @decision_review = thing_to_establish
 
     # If establishment is for a RequestIssuesUpdate, use the user on the update

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -474,30 +474,6 @@ feature "Higher-Level Review", :all_dbs do
     end
   end
 
-  context "when disabling claim establishment is enabled" do
-    before { FeatureToggle.enable!(:disable_claim_establishment) }
-    after { FeatureToggle.disable!(:disable_claim_establishment) }
-
-    it "completes intake and prevents edit" do
-      start_higher_level_review(veteran_no_ratings)
-      visit "/intake"
-      click_intake_continue
-      click_intake_add_issue
-      add_intake_nonrating_issue(
-        category: "Active Duty Adjustments",
-        description: "Description for Active Duty Adjustments",
-        date: profile_date.mdY
-      )
-      click_intake_finish
-
-      expect(page).to have_content("#{Constants.INTAKE_FORM_NAMES.higher_level_review} has been submitted.")
-
-      click_on "correct the issues"
-
-      expect(page).to have_content("Review not editable")
-    end
-  end
-
   it "Shows a review error when something goes wrong" do
     start_higher_level_review(veteran_no_ratings)
     visit "/intake"

--- a/spec/jobs/decision_review_process_job_spec.rb
+++ b/spec/jobs/decision_review_process_job_spec.rb
@@ -49,15 +49,6 @@ describe DecisionReviewProcessJob do
     expect(establishment_subject.error).to be_nil
   end
 
-  context "when disable_claim_establishment feature toggle is enabled" do
-    before { FeatureToggle.enable!(:disable_claim_establishment) }
-    after { FeatureToggle.disable!(:disable_claim_establishment) }
-
-    it "does not attempt establishment" do
-      expect(subject).to eq(nil)
-    end
-  end
-
   context "transient VBMS error" do
     let(:vbms_error) do
       VBMS::HTTPError.new("500", "FAILED FOR UNKNOWN REASONS")

--- a/spec/models/higher_level_review_intake_spec.rb
+++ b/spec/models/higher_level_review_intake_spec.rb
@@ -195,30 +195,6 @@ describe HigherLevelReviewIntake, :all_dbs do
       )
     end
 
-    context "when disable_claim_establishment is enabled" do
-      before { FeatureToggle.enable!(:disable_claim_establishment) }
-      after { FeatureToggle.disable!(:disable_claim_establishment) }
-
-      it "does not submit claims to VBMS" do
-        subject
-
-        expect(intake).to be_success
-        expect(intake.detail.establishment_submitted_at).to eq(Time.zone.now)
-        expect(ratings_end_product_establishment).to_not be_nil
-        expect(ratings_end_product_establishment.established_at).to eq(nil)
-        expect(Fakes::VBMSService).not_to have_received(:establish_claim!)
-        expect(Fakes::VBMSService).not_to have_received(:create_contentions!)
-        expect(Fakes::VBMSService).not_to have_received(:associate_rating_request_issues!)
-        expect(intake.detail.request_issues.count).to eq 1
-        expect(intake.detail.request_issues.first).to have_attributes(
-          contested_rating_issue_reference_id: "reference-id",
-          contested_issue_description: "decision text",
-          rating_issue_associated_at: nil
-        )
-        expect(HigherLevelReview.processable.count).to eq 1
-      end
-    end
-
     context "when benefit type is pension" do
       let(:benefit_type) { "pension" }
       let(:pension_rating_ep_establishment) do


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-19822

# Description

The disable_claim_establishment FeatureToggle is a defunct feature flag that resides in our codebase. It is currently enabled by default by `enable_features_dev.rb` in local and demo environments, and this causes an error to display whenever attempting to edit issues on claim reviews.

We would like to remove this FeatureToggle entirely in order to reduce code complexity, as well as to prevent this error from occurring.

As a part of this we will also remove the tests

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The user does not receive an error when creating a new appeal and attempting to edit the issue (can be seen in videos below.)

## Note:
It seems that the error only goes away when creating a new appeal after the FeatureToggle has been removed. Any appeals that have been created prior will have an error. Not sure if this is worth discussing or not.

# Frontend
## User Facing Changes
![Screenshot 2023-07-18 at 11 22 32 AM](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/b4f681f7-eec8-4198-9864-4012ea2862c1)
User will no longer receive this error when attempting to edit an issue. Can be better viewed in videos below.


### BEFORE

https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/2f4308f8-a788-4831-bd20-991599658b5c


### AFTER

https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/60a07af0-5633-4483-825f-1ca3d6d57121


