### PR TITLE
APPEALS-26881: MST and PACT Feature Toggle Update

### DIFF
--- a/app/models/tasks/judge_decision_review_task.rb
+++ b/app/models/tasks/judge_decision_review_task.rb
@@ -35,6 +35,10 @@ class JudgeDecisionReviewTask < JudgeTask
   private
 
   def ama_judge_actions
-    Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h
+    # bypass special issues page if mst/pact enabled
+    return Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h if
+      FeatureToggle.enabled?(:mst_identification) || FeatureToggle.enabled?(:pact_identification)
+
+    Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SPECIAL_ISSUES.to_h
   end
 end

--- a/app/models/tasks/judge_dispatch_return_task.rb
+++ b/app/models/tasks/judge_dispatch_return_task.rb
@@ -6,7 +6,7 @@
 class JudgeDispatchReturnTask < JudgeTask
   def additional_available_actions(_user)
     [
-      Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h,
+      ama_issue_checkout,
       Constants.TASK_ACTIONS.JUDGE_DISPATCH_RETURN_TO_ATTORNEY.to_h,
       Constants.TASK_ACTIONS.CANCEL_TASK.to_h
     ]
@@ -14,5 +14,13 @@ class JudgeDispatchReturnTask < JudgeTask
 
   def self.label
     COPY::JUDGE_DISPATCH_RETURN_TASK_LABEL
+  end
+
+  def ama_issue_checkout
+    # bypass special issues page if mst/pact enabled
+    return Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT.to_h if
+      FeatureToggle.enabled?(:mst_identification) || FeatureToggle.enabled?(:pact_identification)
+
+    Constants.TASK_ACTIONS.JUDGE_AMA_CHECKOUT_SPECIAL_ISSUES.to_h
   end
 end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -877,7 +877,11 @@ class TaskActionRepository # rubocop:disable Metrics/ClassLength
     def select_ama_review_decision_action(task)
       return Constants.TASK_ACTIONS.REVIEW_VACATE_DECISION.to_h if task.appeal.vacate?
 
-      Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h
+      # route to decision if mst/pact toggles are enabled.
+      return Constants.TASK_ACTIONS.REVIEW_AMA_DECISION.to_h if
+        FeatureToggle.enabled?(:mst_identification) || FeatureToggle.enabled?(:pact_identification)
+
+      Constants.TASK_ACTIONS.REVIEW_AMA_DECISION_SP_ISSUES.to_h
     end
 
     def select_withdraw_hearing_copy(appeal)

--- a/client/app/constants/SpecialIssueFilters.js
+++ b/client/app/constants/SpecialIssueFilters.js
@@ -1,6 +1,6 @@
 import { enabledSpecialIssues } from './SpecialIssueEnabler.js';
 
-const specialIssueFilters = (isFeatureToggled) => ({
+const specialIssueFilters = (isFeatureToggled, mstIdentification) => ({
 
   unhandledSpecialIssues() {
     return enabledSpecialIssues(isFeatureToggled).filter((issue) => {
@@ -43,8 +43,14 @@ const specialIssueFilters = (isFeatureToggled) => ({
     return enabledSpecialIssues(isFeatureToggled).filter((issue) => issue.queueSection === 'benefitType');
   },
 
+  // hide mst section on the special issues list if mst_identification feature toggle is enabled
   issuesOnAppealSection () {
-    return enabledSpecialIssues(isFeatureToggled).filter((issue) => issue.queueSection === 'issuesOnAppeal');
+
+    return mstIdentification ?
+      enabledSpecialIssues(isFeatureToggled).filter((issue) =>
+        issue.queueSection === 'issuesOnAppeal' && issue.specialIssue !== 'militarySexualTrauma') :
+      enabledSpecialIssues(isFeatureToggled).filter((issue) =>
+        issue.queueSection === 'issuesOnAppeal');
   },
 
   dicOrPensionSection () {
@@ -52,7 +58,8 @@ const specialIssueFilters = (isFeatureToggled) => ({
   },
 
   amaIssuesOnAppealSection () {
-    return enabledSpecialIssues(isFeatureToggled).filter((issue) => issue.isAmaRelevant && issue.queueSection === 'issuesOnAppeal');
+    return enabledSpecialIssues(isFeatureToggled).filter((issue) =>
+      issue.isAmaRelevant && issue.queueSection === 'issuesOnAppeal');
   }
 });
 

--- a/client/app/constants/SpecialIssues.js
+++ b/client/app/constants/SpecialIssues.js
@@ -347,6 +347,16 @@ export const AMA_SPECIAL_ISSUES = [
     isAmaRelevant: true
   },
   {
+    display: 'Military Sexual Trauma (MST)',
+    queueDisplay: 'Military Sexual Trauma (MST)',
+    specialIssue: 'militarySexualTrauma',
+    snakeCase: 'military_sexual_trauma',
+    unhandled: null,
+    queueSection: 'issuesOnAppeal',
+    queueSectionOrder: 5,
+    isAmaRelevant: true
+  },
+  {
     display: 'Blue Water',
     queueDisplay: 'Blue Water',
     specialIssue: 'blueWater',

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -231,6 +231,8 @@ class QueueApp extends React.PureComponent {
         <SelectSpecialIssuesView
           appealId={appealId}
           taskId={taskId}
+          legacyMstIdentification={this.props.featureToggles.legacy_mst_pact_identification}
+          mstIdentification={this.props.featureToggles.mst_identification}
           prevStep={`/queue/appeals/${appealId}`}
           nextStep={`/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/dispositions`}
         />

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -170,10 +170,16 @@ class SelectDispositionsView extends React.PureComponent {
 
   getPrevStepUrl = () => {
     const {
-      appealId
+      appealId,
+      taskId,
+      checkoutFlow,
+      mstFeatureToggle,
+      pactFeatureToggle
     } = this.props;
 
-    return `/queue/appeals/${appealId}`;
+    // route to case details instead of special issues for MST/PACT
+    return (mstFeatureToggle || pactFeatureToggle) ? `/queue/appeals/${appealId}` :
+      `/queue/appeals/${appealId}/tasks/${taskId}/${checkoutFlow}/special_issues`;
   }
 
   validateForm = () => {
@@ -483,6 +489,8 @@ class SelectDispositionsView extends React.PureComponent {
         pactFeatureToggle={pactFeatureToggle}
         errorMessages={issueErrors}>
         <DecisionIssues
+          mstFeatureToggle={mstFeatureToggle}
+          pactFeatureToggle={pactFeatureToggle}
           decisionIssues={appeal.decisionIssues}
           openDecisionHandler={this.openDecisionHandler}
           openDeleteAddedDecisionIssueHandler={this.openDeleteAddedDecisionIssueHandler} />

--- a/client/app/queue/SelectDispositionsView.jsx
+++ b/client/app/queue/SelectDispositionsView.jsx
@@ -582,7 +582,7 @@ class SelectDispositionsView extends React.PureComponent {
             }
           })}
         />
-        <QueueCheckboxGroup
+        { (mstFeatureToggle || pactFeatureToggle) && <QueueCheckboxGroup
           name={COPY.INTAKE_EDIT_ISSUE_SELECT_SPECIAL_ISSUES}
           options={(mstFeatureToggle || pactFeatureToggle) ? DECISION_SPECIAL_ISSUES : DECISION_SPECIAL_ISSUES_NO_MST_PACT}
           values={specialIssuesValues}
@@ -602,16 +602,16 @@ class SelectDispositionsView extends React.PureComponent {
               id: 'mst_status',
               justification: decisionIssue.mst_justification,
               onJustificationChange: (event) => this.onJustificationChange(event, decisionIssue, 'mst_status'),
-              hasChanged: this.state.decisionIssue.mstOriginalStatus != this.state.decisionIssue.mst_status
+              hasChanged: this.state.decisionIssue.mstOriginalStatus !== this.state.decisionIssue.mst_status
             },
             {
               id: 'pact_status',
               justification: decisionIssue.pact_justification,
               onJustificationChange: (event) => this.onJustificationChange(event, decisionIssue, 'pact_status'),
-              hasChanged: this.state.decisionIssue.pactOriginalStatus != this.state.decisionIssue.pact_status
+              hasChanged: this.state.decisionIssue.pactOriginalStatus !== this.state.decisionIssue.pact_status
             },
           ]}
-        />
+        />}
         <h3>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_DESCRIPTION}</h3>
         <p {...exampleDiv} {...paragraphH3SiblingStyle}>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_EXAMPLE}</p>
         <h3>{COPY.DECISION_ISSUE_MODAL_CONNECTED_ISSUES_TITLE}</h3>

--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -89,19 +89,23 @@ class SelectSpecialIssuesView extends React.PureComponent {
   }
 
   legacySpecialIssuesSections = () => {
+    const mstIdentification = this.props.mstIdentification || this.props.legacyMstIdentification;
+
     return [
       specialIssueFilters(true).noneSection(),
       specialIssueFilters(true).aboutSection(),
       specialIssueFilters(true).residenceSection(),
       specialIssueFilters(true).benefitTypeSection(),
-      specialIssueFilters(true).issuesOnAppealSection(),
-      specialIssueFilters(true).dicOrPensionSection()
+      specialIssueFilters(true, mstIdentification).issuesOnAppealSection(),
+      specialIssueFilters(true).dicOrPensionSection(),
     ];
   };
   amaSpecialIssuesSections = () => {
+    const mstIdentification = this.props.mstIdentification || this.props.legacyMstIdentification;
+
     return [
       specialIssueFilters(true).noneSection(),
-      specialIssueFilters(true).amaIssuesOnAppealSection()
+      specialIssueFilters(true, mstIdentification).amaIssuesOnAppealSection(),
     ];
   };
 
@@ -241,7 +245,9 @@ SelectSpecialIssuesView.propTypes = {
   setSpecialIssues: PropTypes.func,
   clearSpecialIssues: PropTypes.func,
   showErrorMessage: PropTypes.func,
-  specialIssues: PropTypes.object
+  specialIssues: PropTypes.object,
+  mstIdentification: PropTypes.bool,
+  legacyMstIdentification: PropTypes.bool
 };
 
 const mapStateToProps = (state, ownProps) => ({

--- a/client/app/queue/SelectSpecialIssuesView.jsx
+++ b/client/app/queue/SelectSpecialIssuesView.jsx
@@ -134,6 +134,8 @@ class SelectSpecialIssuesView extends React.PureComponent {
   renderSpecialIssuesPage = (appeal, sections, specialIssues) => {
     const {
       error,
+      mstIdentification,
+      legacyMstIdentification,
       ...otherProps
     } = this.props;
     const { allIssuesDisabled } = this.state;
@@ -146,7 +148,8 @@ class SelectSpecialIssuesView extends React.PureComponent {
       <p>
         {this.getPageNote()}
       </p>
-      <Alert type="info" title=" " message={COPY.SPECIAL_ISSUES_BANNER_TEXT} styling={infoBannerStyling} />
+      {(mstIdentification || legacyMstIdentification) &&
+      <Alert type="info" title=" " message={COPY.SPECIAL_ISSUES_BANNER_TEXT} styling={infoBannerStyling} />}
       {error && <Alert type="error" title={error.title} message={error.detail} />}
       <div {...flexContainer}>
         <div {...flexColumn}>

--- a/client/app/queue/components/CaseDetailsIssueList.jsx
+++ b/client/app/queue/components/CaseDetailsIssueList.jsx
@@ -53,6 +53,8 @@ export default function CaseDetailsIssueList(props) {
       mstFeatureToggle={props.featureToggles.mst_identification}
       pactFeatureToggle={props.featureToggles.pact_identification}>
       <DecisionIssues
+        mstFeatureToggle={props.featureToggles.mst_identification}
+        pactFeatureToggle={props.featureToggles.pact_identification}
         decisionIssues={updatedDecisionIssues} />
     </AmaIssueList>;
   }

--- a/client/app/queue/components/DecisionIssues.jsx
+++ b/client/app/queue/components/DecisionIssues.jsx
@@ -72,7 +72,13 @@ const specialIssuesFormatting = (mstStatus, pactStatus) => {
 
 export default class DecisionIssues extends React.PureComponent {
   static generateDecisionIssues = (requestIssue, props) => {
-    const { decisionIssues, openDecisionHandler, openDeleteAddedDecisionIssueHandler, hideDelete, hideEdit } = props;
+    const { decisionIssues,
+      openDecisionHandler,
+      openDeleteAddedDecisionIssueHandler,
+      hideDelete,
+      hideEdit,
+      mstFeatureToggle,
+      pactFeatureToggle } = props;
 
     return decisionIssues.
       filter((decisionIssue) => {
@@ -117,7 +123,9 @@ export default class DecisionIssues extends React.PureComponent {
                   {decisionIssue.description}
                   {decisionIssue.diagnostic_code && <div>Diagnostic code: {decisionIssue.diagnostic_code}</div>}
                   {decisionIssue.benefit_type && <div>Benefit Type: {BENEFIT_TYPES[decisionIssue.benefit_type]}</div>}
-                  <div>Special Issues: {specialIssuesFormatting(decisionIssue.mst_status, decisionIssue.pact_status)}</div>
+                  {(pactFeatureToggle || mstFeatureToggle) &&
+                  <div>Special Issues: {specialIssuesFormatting(decisionIssue.mst_status, decisionIssue.pact_status)}
+                  </div>}
                 </span>
                 <span>{ISSUE_DISPOSITIONS_BY_ID[decisionIssue.disposition]}</span>
               </div>

--- a/client/constants/TASK_ACTIONS.json
+++ b/client/constants/TASK_ACTIONS.json
@@ -171,6 +171,10 @@
     "label": "Ready for Dispatch",
     "value": "dispatch_decision/dispositions"
   },
+  "JUDGE_AMA_CHECKOUT_SPECIAL_ISSUES": {
+    "label": "Ready for Dispatch",
+    "value": "dispatch_decision/special_issues"
+  },
   "JUDGE_CHECKOUT_PULAC_CERULLO_REMINDER": {
     "label": "Ready for Dispatch",
     "value": "modal/check_cavc"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-26881](https://jira.devops.va.gov/browse/APPEALS-26881)

# Description
Updated special issues page routing for MST/PACT depending on the feature toggle. Updated MST showing on special issues page for legacy/ama depending on the feature toggle. 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] AMA decisions route to special issues page when MST/PACT feature toggles are disabled
- [ ] AMA decisions route back to special issues page from Add Decisions page when MST/PACT feature toggles are disabled
- [ ] blue water and burn pit special issues do not show on the Add Decisions modal when MST/PACT feature toggles are disabled
- [ ] "Special Issues: None" does not show on decisions when MST/PACT feature toggles are disabled
- [ ] MST checkbox shows on Legacy Special Issues List when MST/Legacy MST/PACT feature toggles are disabled
- [ ] the MST/PACT special issues banner does not show on the Special Issues List when MST/PACT feature toggles are disabled.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->

**AMA Testing**
1. Sign in as BVAAABSHIRE and navigate to the Judge's Queue
2. Click on an AMA case ready for review to navigate to the case details page. 
3. Click on the task action dropdown and select "Ready for Dispatch"
4. You should arrive on the Special Issues page that displays MST, Blue Water, and Burn Pit. The MST/PACT alert banner should not display on the page.
5. Click an option from the checkboxes and continue. 
6. On the Add Decisions page, click the back button. You should arrive on the Special Issues page again instead of the Case Details page.
7. Click continue to navigate to the Add Decisions page. Click **add decision** and fill out the form. Note that Blue Water, MST/PACT, and Burn Pit checkboxes do not show on the modal. Click continue to add the decision.
8. In the add decision display, there should be no mention of "Special Issues: None". Fill out the rest of decisions and continue. 
9. Fill out the forms to complete the decision. When the decision is completed, you will arrive in the Judge's Queue with a green success banner displaying that the decision was completed. 
10. Click the back arrow on the browser to navigate to the case details page of the case you just resolved. Notice in the decisions that there is no mention of "Special Issues: None" in the decisions.

**Legacy Testing**
1. Sign in as BVAAABSHIRE and navigate to the Judge's Queue. Click on a legacy case to navigate to the case details page
2. Click on the task action dropdown and select "Ready for Dispatch"
3. You should arrive on the Special Issues page that displays all of the special issues. There should be a checkbox for MST in the list. There also should not be a banner for MST/PACT.

**Attorney Testing**
1. Repeat the testing steps above for AMA and Legacy with BVACASPER1 or another attorney user. 

# Frontend
## User Facing Changes

Legacy Special Issues screen with toggles disabled
![image (13)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/cd033831-5b9b-480e-b99c-cc801732c415)

AMA Special Issues screen with toggles disabled
![image (14)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/c58600b6-8d04-4e39-9434-6ed1d1e7ecaa)

AMA Decisions Workflow
![image (15)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/7c5771c2-f015-4e2c-b965-658e188480cd)
![image (16)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/ce416c07-0ddc-46c9-a50d-0d904e78e676)
![image (17)](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/f73d9a8a-8192-4d8a-87d4-d057e027ae2f)
