### PR TITLE
test adding assertion

### DIFF
--- a/spec/feature/hearings/add_hearing_day_spec.rb
+++ b/spec/feature/hearings/add_hearing_day_spec.rb
@@ -359,12 +359,14 @@ RSpec.feature "Add a Hearing Day", :all_dbs do
     end
 
     scenario "select a vlj from the dropdown works" do
-      click_dropdown(name: "vlj", text: judge.full_name, wait: 30)
+      expect(page).to have_content("VLJ")
+      click_dropdown(name: "vlj", text: judge.full_name)
       expect(page).to have_content(judge.full_name)
     end
 
     scenario "select a coordinator from the dropdown works" do
-      click_dropdown(name: "coordinator", text: coordinator.full_name, wait: 30)
+      expect(page).to have_content("Hearing Coordinator")
+      click_dropdown(name: "coordinator", text: coordinator.full_name)
       expect(page).to have_content(coordinator.full_name)
     end
   end

--- a/spec/feature/hearings/assign_hearings_table_spec.rb
+++ b/spec/feature/hearings/assign_hearings_table_spec.rb
@@ -449,6 +449,8 @@ RSpec.feature "Assign Hearings Table" do
         it "filters are correct, and filter as expected" do
           step "navigate to St. Petersburg legacy veterans tab" do
             visit "hearings/schedule/assign"
+            expect(page).to have_content("Regional Office")
+
             click_dropdown(text: "St. Petersburg")
             click_button("Legacy Veterans Waiting", exact: true)
           end

--- a/spec/feature/hearings/assign_hearings_table_spec.rb
+++ b/spec/feature/hearings/assign_hearings_table_spec.rb
@@ -19,6 +19,7 @@ RSpec.feature "Assign Hearings Table" do
   context "No upcoming hearing days" do
     scenario "Show status message for empty upcoming hearing days" do
       visit "hearings/schedule/assign"
+      expect(page).to have_content("Regional Office")
       click_dropdown(text: "Winston-Salem, NC")
       expect(page).to have_content("No upcoming hearing days")
     end

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -218,6 +218,7 @@ RSpec.feature "Convert hearing request type" do
 
           step "go to schedule veterans page" do
             visit "hearings/schedule/assign"
+            expect(page).to have_content("Regional Office")
 
             click_dropdown(text: "Virtual Hearings")
           end

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -272,6 +272,7 @@ RSpec.feature "Convert hearing request type" do
 
         # Check the schedule veterans tab to ensure the hearing is present
         visit "hearings/schedule/assign"
+        expect(page).to have_content("Regional Office")
 
         click_dropdown(text: "Central")
         click_button("AMA Veterans Waiting")
@@ -320,6 +321,7 @@ RSpec.feature "Convert hearing request type" do
 
         # Check the schedule veterans tab to ensure the hearing is present
         visit "hearings/schedule/assign"
+        expect(page).to have_content("Regional Office")
 
         click_dropdown(text: "St. Petersburg, FL")
         click_button("AMA Veterans Waiting")

--- a/spec/feature/hearings/edit_hearing_day_spec.rb
+++ b/spec/feature/hearings/edit_hearing_day_spec.rb
@@ -39,6 +39,7 @@ RSpec.feature "Edit a Hearing Day", :all_dbs do
 
   def navigate_to_docket(hearings = false)
     visit "hearings/schedule"
+    expect(page).to have_content("Add Hearing Day")
     find_link(hearing_day.scheduled_for.strftime("%a %-m/%d/%Y")).click
 
     if hearings == false
@@ -63,6 +64,7 @@ RSpec.feature "Edit a Hearing Day", :all_dbs do
     end
 
     it "can make changes to the VLJ on the docket" do
+      expect(page).to have_content("Select VLJ")
       click_dropdown(name: "vlj", index: 1, wait: 30)
       find("button", text: "Save Changes").click
 
@@ -71,6 +73,7 @@ RSpec.feature "Edit a Hearing Day", :all_dbs do
     end
 
     it "can make changes to the Coordinator on the docket" do
+      expect(page).to have_content("Select Hearing Coordinator")
       click_dropdown(name: "coordinator", text: "#{coordinator.snamef} #{coordinator.snamel}")
       find("button", text: "Save Changes").click
 
@@ -80,6 +83,7 @@ RSpec.feature "Edit a Hearing Day", :all_dbs do
     end
 
     it "can make changes to the Notes on the docket" do
+      expect(page).to have_content("Notes")
       find("textarea", id: "Notes").fill_in(with: sample_notes)
       find("button", text: "Save Changes").click
 

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -692,6 +692,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
 
         scenario "should not see room displayed under Available Hearing Days and Assign Hearing Tabs" do
           visit "hearings/schedule/assign"
+          expect(page).to have_content("Regional Office")
 
           click_dropdown(text: "Denver")
           click_button("AMA Veterans Waiting", exact: true)

--- a/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
+++ b/spec/feature/hearings/schedule_veteran/build_hearsched_spec.rb
@@ -667,6 +667,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
 
         scenario "can schedule a veteran without an error" do
           visit "hearings/schedule/assign"
+          expect(page).to have_content("Regional Office")
 
           click_dropdown(text: "Denver")
           click_button("AMA Veterans Waiting", exact: true)
@@ -736,6 +737,7 @@ RSpec.feature "Schedule Veteran For A Hearing" do
 
         scenario "can schedule a veteran without an error" do
           visit "hearings/schedule/assign"
+          expect(page).to have_content("Regional Office")
 
           click_dropdown(text: "Denver")
           click_button("Legacy Veterans Waiting", exact: true)


### PR DESCRIPTION
# Description
Add Capybara assertion `.to have_content` after some `visit` calls to force the driver to wait until the async calls have completed before interacting with the page.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] No feature tests failing after a `visit` call
