### PR TITLE
[DO NOT MERGE] Rails 5.2.Z - Raise on deprecation warnings in test env

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -44,7 +44,7 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
-  config.active_support.deprecation = :stderr
+  config.active_support.deprecation = :raise
 
   unless ENV['RAILS_ENABLE_TEST_LOG']
     config.logger = Logger.new(nil)


### PR DESCRIPTION
This is just an exploratory branch based off of https://github.com/department-of-veterans-affairs/caseflow/pull/19104 to see what deprecation warnings will emerge from the test suite.