### PR TITLE
Fix action dropdown When user is a Judge

### DIFF
--- a/app/models/legacy_tasks/attorney_legacy_task.rb
+++ b/app/models/legacy_tasks/attorney_legacy_task.rb
@@ -6,7 +6,6 @@ class AttorneyLegacyTask < LegacyTask
     # assignment in the VACOLS.DECASS table. task_id is created using the created_at field from the VACOLS.DECASS table
     # so we use the absence of this value to indicate that there is no case assignment and return no actions.
     return [] unless task_id
-
     if current_user&.can_act_on_behalf_of_judges? && FeatureToggle.enabled?(:vlj_legacy_appeal) &&
        (appeal.case_record.reload.bfcurloc == "57" || appeal.case_record.reload.bfcurloc == "CASEFLOW")
       [
@@ -18,7 +17,8 @@ class AttorneyLegacyTask < LegacyTask
         Constants.TASK_ACTIONS.SPECIAL_CASE_MOVEMENT_LEGACY.to_h
       ]
     elsif (current_user&.judge_in_vacols? || current_user&.can_act_on_behalf_of_judges?) &&
-          FeatureToggle.enabled?(:vlj_legacy_appeal)
+          FeatureToggle.enabled?(:vlj_legacy_appeal) &&
+          !(%w[81 33 57 CASEFLOW].include?(appeal.case_record.reload.bfcurloc))
       [
         Constants.TASK_ACTIONS.REASSIGN_TO_JUDGE.to_h,
         Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY_LEGACY.to_h


### PR DESCRIPTION
Resolves [APPEALS-24904](https://jira.devops.va.gov/browse/APPEALS-24904), [APPEALS-27506](https://jira.devops.va.gov/browse/APPEALS-27506) [APPEALS-27966](https://jira.devops.va.gov/browse/APPEALS-27966)

# Description
When the appeal is still in Scenario1 or scenario2, if a login like a judge I don't have the dropdown with the options
- Reassign to judge 
 - Assign to attorney

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] When the appeal is still in Scenario1 or Scenario2, if a login like a judge I don't have the dropdown with the options (Reassign to judge and Assign to attorney)

## Testing Plan

**Scenario1 and Scenario2**
1 - Login to Moon Walkers Demo Environment/ Voyager Demo Environment
2 -Change user to [BVARDUNKLE (VACO)](https://mw.caseflowdemo.com/queue/appeals/082250264#BVARDUNKLE%20(VACO))
3 -You can see the action dropdown, to "Cancel blocking tasks and advance to judge" (scenario1) or "Advance to judge" (scenario2) 

![scenario11](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/be97601b-963b-4293-abed-c616b421937b)

![scenario22](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/babed968-5467-4c45-a2d4-8f624d571405)


4 -Change the user to any judge, for example, BVABECKER
5 -You can not see the action dropdown, to cancel and advances to judge (scenario1) or Advances to judge (scenario2) 
![scenario1](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/2f09eec5-86bc-4eb6-acfe-4f9de8015afe)

![scenario2](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/a7798bbb-695f-4e82-a048-5355527032ec)
