### PR TITLE
APPEALS-24145 Fix test scenario "Assigning it to complete the claims establishment"

### DIFF
--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -548,7 +548,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         click_on "Finish routing claim"
 
         expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
         expect(page).to have_content("Success!")
         expect(page).to have_content("Reviewed Full Grant decision")
         expect(page).to have_content("Established EP: 070BVAGR - BVA Grant (070) for Station 351 - Muskogee")
@@ -583,9 +582,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         click_label("confirmNote")
         click_on "Finish routing claim"
 
-        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
         # Confirmation Page
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
         expect(page).to have_content("Success!")
         expect(page).to have_content("Added VBMS Note on Rice Compliance")
 
@@ -641,7 +639,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           click_on "Assign to Claim" # unknown reason sometimes hangs here
 
           expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
           expect(page).to have_content("Success!")
 
           expect(task.reload.outgoing_reference_id).to eq(end_product.claim_id)
@@ -679,9 +676,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         click_label("gulfWarRegistry")
         click_on "Create End Product"
 
-        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
         # Confirmation Page
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
         expect(page).to have_content("Success!")
         expect(page).to have_content("Established EP: 070RMBVAGARC - ARC Remand with BVA Grant for Station 397 - ARC")
         expect(page).to have_content("VACOLS Updated: Changed Location to 98")
@@ -780,7 +776,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         safe_click "#button-Finish-routing-claim"
 
         expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
         expect(page).to have_content("Success!")
         expect(page).to have_content("VACOLS Updated: Changed Location to 50")
         expect(page).to have_content("Added VBMS Note on Rice Compliance")
@@ -838,7 +833,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         click_on "Finish routing claim"
 
         expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
         expect(page).to have_content("Success!")
         expect(task.reload.completion_status).to eq("special_issue_vacols_routed")
       end
@@ -871,7 +865,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           click_on "Create End Product"
 
           expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
-
           expect(page).to have_content("Success!")
 
           expect(Fakes::VBMSService).to have_received(:establish_claim!).with(

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -623,7 +623,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           )
         end
 
-        scenario "Assigning it to complete the claims establishment", skip: "flakey hang" do
+        scenario "Assigning it to complete the claims establishment" do
           visit "/dispatch/establish-claim"
           click_on "Establish next claim"
 
@@ -854,6 +854,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           click_on "Route claim"
           click_on "Create new EP"
           click_on "Create End Product"
+
+          expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
 
           expect(page).to have_content("Success!")
 

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -636,7 +636,7 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
           expect(page).to have_content("Route Claim")
           expect(page).to have_selector(:link_or_button, "Assign to Claim")
-          click_on "Assign to Claim" # unknown reason sometimes hangs here
+          click_on "Assign to Claim"
 
           expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
           expect(page).to have_content("Success!")

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -141,6 +141,9 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
       end
 
       visit "/dispatch/work-assignments"
+
+      expect(page).to have_current_path("/dispatch/work-assignments")
+
       expect(page).to have_content("1.\nJanet Smith\n0 0 1 1 3")
       expect(page).to have_content("2.\nJune Smith\n1 0 0 1 2")
       expect(page).to have_content("3.\nJeffers Smith\n0 1 0 1 2")
@@ -544,6 +547,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         click_label("confirmNote")
         click_on "Finish routing claim"
 
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
+
         expect(page).to have_content("Success!")
         expect(page).to have_content("Reviewed Full Grant decision")
         expect(page).to have_content("Established EP: 070BVAGR - BVA Grant (070) for Station 351 - Muskogee")
@@ -577,6 +582,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
 
         click_label("confirmNote")
         click_on "Finish routing claim"
+
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
 
         # Confirmation Page
         expect(page).to have_content("Success!")
@@ -633,6 +640,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
           expect(page).to have_selector(:link_or_button, "Assign to Claim")
           click_on "Assign to Claim" # unknown reason sometimes hangs here
 
+          expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
+
           expect(page).to have_content("Success!")
 
           expect(task.reload.outgoing_reference_id).to eq(end_product.claim_id)
@@ -669,6 +678,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         # Test text, radio button, & checkbox inputs
         click_label("gulfWarRegistry")
         click_on "Create End Product"
+
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
 
         # Confirmation Page
         expect(page).to have_content("Success!")
@@ -768,6 +779,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
 
         safe_click "#button-Finish-routing-claim"
 
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
+
         expect(page).to have_content("Success!")
         expect(page).to have_content("VACOLS Updated: Changed Location to 50")
         expect(page).to have_content("Added VBMS Note on Rice Compliance")
@@ -823,6 +836,8 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
         expect(page).to have_content("50")
 
         click_on "Finish routing claim"
+
+        expect(page).to have_current_path("/dispatch/establish-claim/#{task.id}")
 
         expect(page).to have_content("Success!")
         expect(task.reload.completion_status).to eq("special_issue_vacols_routed")

--- a/spec/feature/dispatch/establish_claim_spec.rb
+++ b/spec/feature/dispatch/establish_claim_spec.rb
@@ -142,8 +142,6 @@ RSpec.feature "Establish Claim - ARC Dispatch", :all_dbs do
 
       visit "/dispatch/work-assignments"
 
-      expect(page).to have_current_path("/dispatch/work-assignments")
-
       expect(page).to have_content("1.\nJanet Smith\n0 0 1 1 3")
       expect(page).to have_content("2.\nJune Smith\n1 0 0 1 2")
       expect(page).to have_content("3.\nJeffers Smith\n0 1 0 1 2")


### PR DESCRIPTION
Resolves [Fix flaky/skipped tests in feature/dispatch/establish_claim_spec.rb](https://jira.devops.va.gov/browse/APPEALS-24145)

# Description
Removed a skip: "flakey hang" and added some assertions

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Spec executes without failure

## Testing Plan
1. run `CI=true make one-test ./spec/feature/dispatch/establish_claim_spec.rb` in the console
