### PR TITLE
hotfix/APPEALS-28989 Frequent End Product Establishment Sync Failures

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -210,10 +210,7 @@ class EndProductEstablishment < CaseflowRecord
     contentions unless result.status_type_code == EndProduct::STATUSES.key("Canceled")
 
     transaction do
-      update!(
-        synced_status: result.status_type_code,
-        last_synced_at: Time.zone.now
-      )
+      update!(synced_status: result.status_type_code)
       status_cancelled? ? handle_cancelled_ep! : sync_source!
       close_request_issues_with_no_decision!
     end
@@ -224,6 +221,11 @@ class EndProductEstablishment < CaseflowRecord
   rescue StandardError => error
     Raven.extra_context(end_product_establishment_id: id)
     raise error
+  ensure
+    # Always update last_synced_at to ensure that SyncReviewsJob does not immediately re-enqueue
+    # End Product Establishments that fail to sync with BGS into the EndProductSyncJob.
+    # This will allow for other End Product Establishments to sync first before re-attempting.
+    update!(last_synced_at: Time.zone.now)
   end
 
   def fetch_dispositions_from_vbms

--- a/spec/models/end_product_establishment_spec.rb
+++ b/spec/models/end_product_establishment_spec.rb
@@ -855,6 +855,13 @@ describe EndProductEstablishment, :postgres do
       it "raises EstablishedEndProductNotFound error" do
         expect { subject }.to raise_error(EndProductEstablishment::EstablishedEndProductNotFound)
       end
+
+      it "last_synced_at updates upon error to ensure SyncReviewsJob allows other EPEs to sync before re-attempt" do
+        expect(end_product_establishment.last_synced_at).to eq(nil)
+        expect { subject }.to raise_error(EndProductEstablishment::EstablishedEndProductNotFound)
+        end_product_establishment.reload
+        expect(end_product_establishment.last_synced_at).to eq(Time.zone.now)
+      end
     end
 
     context "when a matching end product has been established" do
@@ -881,6 +888,13 @@ describe EndProductEstablishment, :postgres do
 
         it "re-raises error" do
           expect { subject }.to raise_error(BGS::ShareError)
+        end
+
+        it "last_synced_at updates upon error to ensure SyncReviewsJob allows other EPEs to sync before re-attempt" do
+          expect(end_product_establishment.last_synced_at).to eq(nil)
+          expect { subject }.to raise_error(BGS::ShareError)
+          end_product_establishment.reload
+          expect(end_product_establishment.last_synced_at).to eq(Time.zone.now)
         end
       end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-28989](https://jira.devops.va.gov/browse/APPEALS-28989)

# Description
It has been identified that the current process to sync Claim Reviews (Higher Level Reviews and Supplemental Claims) is consistently attempting to sync the same End Product Establishments in perpetuity.  This occurs because the last_synced_at column on each failed End Product Establishment is not being updated to the current date/time upon a failed BGS call within the sync.  The primary job that enqueues these End Product Establishments is the Sync Reviews Job. 

## Acceptance Criteria
- [x] Move last_synced_at update to ensure block to guarentee that it will always be updated regardless of errors

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/APPEALS-29089) 
2. Go to [Jira Issue/Test Execution Link](https://jira.devops.va.gov/browse/APPEALS-29094)
3. Go to [Jira Issue/XRAY Link](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-29094&testIssueKey=APPEALS-29089)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added