### PR TITLE
jcroteau/APPEALS-29103 - Remove invalid ActiveRecord callback argument

### DIFF
--- a/app/models/board_grant_effectuation.rb
+++ b/app/models/board_grant_effectuation.rb
@@ -14,7 +14,7 @@ class BoardGrantEffectuation < CaseflowRecord
   belongs_to :end_product_establishment
 
   validates :granted_decision_issue, presence: true
-  before_save :hydrate_from_granted_decision_issue, on: :create
+  before_save :hydrate_from_granted_decision_issue
 
   END_PRODUCT_CODES = {
     rating: "030BGR",


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-29103

# Description

> ## Background
> 
> Rails 6.0 introduces a breaking change by adding strict argument checking to ActiveRecord callbacks. This change was not found previously on reviews of Rails release notes or changelogs:
> 
> - [Add strict argument checking to ActiveRecord callbacks #30919](https://github.com/rails/rails/pull/30919)
> 
> Currently, on Rails versions prior to 6.0, invalid keys are being ignored on AR callbacks. For example, a `before_save` with the invalid `on: :create` option will execute before _**every save**_, not just before the initial create.
> 
> ## Problem Statement
> 
> When Caseflow is upgraded to Rails 6.0, the application will fail to load with the following error:
> 
> ```bash
> An error occurred while loading ./spec/models/board_grant_effectuation_spec.rb.
> Failure/Error: before_save :hydrate_from_granted_decision_issue, on: :create
> ArgumentError:
>   Unknown key: :on. Valid keys are: :if, :unless, :prepend
> # ./app/models/board_grant_effectuation.rb:17:in `<class:BoardGrantEffectuation>'
> ```
> 
> While this issue was found to break [some other gems](https://github.com/rails/rails/pull/30919#issuecomment-339856225), the only potentially affected gem we depend on is `paper_trail` (which was fixed in [this PR](https://github.com/paper-trail-gem/paper_trail/pull/1001). Our version of `paper_trail` (10.3.1) has a fix already in place.
> 
> A RegEx search across the Caseflow project (including dependencies) found only one occurrence of affected code:
> 
> - RegEx Search: `/(before|after|around)_save.*(on:|:on)/`
> - Result: `app/models/board_grant_effectuation.rb` (Line 17)
>   - `before_save :hydrate_from_granted_decision_issue, on: :create`
> 
> This affected line has been in place since 2019, so if this were a bug, it's gone unnoticed for many years now (and is, thus, probably not a bug).
> 
> ## Proposed Solution
> 
> Simply remove the `on: :create` option from the affected line mentioned above. This will not change the existing behavior, since the option is currently ignored anyways.

## Acceptance Criteria
- [x] The relevant tests still pass.

## Testing Plan
This PR will be deployed simultaneously with https://github.com/department-of-veterans-affairs/caseflow/pull/19261 and covered by regression testing of that PR.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added