### PR TITLE
APPEALS-4958 - Add key prop to `TaskRows` timeline components

### DIFF
--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -532,6 +532,7 @@ class TaskRows extends React.PureComponent {
               timeline,
               taskList,
               index,
+              key: `${timelineEvent?.type}-${index}`
             });
           }
 


### PR DESCRIPTION
Resolves  https://jira.devops.va.gov/browse/APPEALS-4958
The Jira task mentions adding a key for `DecisionDateTimeLine` but it is needed for all of the timeline components inside the `TaskRows` component.

The timeline components are:
``` jsx
    const componentMap = {
      decisionDate: DecisionDateTimeLine,
      nodDateUpdate: NodDateUpdateTimeline,
      substitutionDate: SubstituteAppellantTimelineEvent,
      substitutionProcessed: SubstitutionProcessedTimelineEvent
    };
```

As these are all mapped they all throw the React key error when displayed and should all be updated, not just `DecisionDateTimeLine`

# Description
This is a tech-debt task and should not change any functionality.

The timeline components were missing a key prop which was throwing a React error `Warning: Each child in a list should have a unique "key" prop.`

In an effort to reduce errors and increase performance we have added in these component keys.

Further reading on why React keys are important:
https://dev.to/francodalessio/understanding-the-importance-of-the-key-prop-in-react-3ag7

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The key warnings are gone

## Testing Plan - At `queue/appeals/{appeal-id}`
1. Switch user to BVAAABSHIRE
2. Go to Queue and select an AMA Appeal (e.g. Bob SmithMayer)
- [ ] The "Case Timeline" section should display as expected
- [ ] Inside the browser dev tools there should be no key warning for "Task Rows". (There may be other warnings not related to this that can become there own Jira tickets)

## QA/Dev notes:
This error will show up in the browser Dev Tools (Message me if you need help with this)

The key prop itself will not show up on the element tree in the dev tools but that is okay as according to the [React docs](https://legacy.reactjs.org/docs/lists-and-keys.html#keys-must-only-be-unique-among-siblings) "Keys serve as a hint to React but they don’t get passed to your components."
I did not realize this prior to this task so I was looking for the key where it wouldn't be. So all we need for this task is just see if the error/warning went away.

 ### BEFORE

![Untitled](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/9d8cc486-d11b-40f9-8761-64032782064c)

### AFTER
![Untitled1](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/67e6d0af-865c-48ca-a6c3-219315a48934)


