### PR TITLE
APPEALS-29280 | Fix PropType warning for CaseDetailsLoadingScreen

### DIFF
--- a/client/app/queue/CaseDetailsLoadingScreen.jsx
+++ b/client/app/queue/CaseDetailsLoadingScreen.jsx
@@ -130,7 +130,7 @@ const mapDispatchToProps = (dispatch) => bindActionCreators({
 }, dispatch);
 
 CaseDetailsLoadingScreen.propTypes = {
-  children: PropTypes.array,
+  children: PropTypes.element,
   appealId: PropTypes.string,
   userId: PropTypes.number,
   onReceiveTasks: PropTypes.func,


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-29281

# Description
This is a tech-debt subtask for the tech debt epic https://jira.devops.va.gov/browse/APPEALS-29280.

Throughout the app we have many instances of console warnings coming from React. As a developer team we should try to reduce these warning and errors where possible.

More info can be found in the linked epic.


## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The PropType warning should be gone for `CaseDetailsLoadingScreen` at `queue/appeals/{appeal-id}`

