### PR TITLE
Dooley/uat-stuck-jobs

### DIFF
--- a/app/jobs/bgs_share_error_fix_job.rb
+++ b/app/jobs/bgs_share_error_fix_job.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+class BgsShareErrorFixJob < CaseflowJob
+  ERROR_TEXT = "ShareError"
+  STUCK_JOB_REPORT_SERVICE = StuckJobReportService.new
+
+  def perform
+    clear_hlr_errors if hlrs_with_errors.present?
+    clear_rius_errors if rius_with_errors.present?
+    clear_bge_errors if bges_with_errors.present?
+  end
+
+  def resolve_error_on_records(object_type)
+    ActiveRecord::Base.transaction do
+      object_type.clear_error!
+    rescue StandardError => error
+      log_error(error)
+      STUCK_JOB_REPORT_SERVICE.append_errors(object_type.class.name, object_type.id, error)
+    end
+  end
+
+  def clear_rius_errors
+    STUCK_JOB_REPORT_SERVICE.append_record_count(rius_with_errors.count, ERROR_TEXT)
+    rius_with_errors.each do |riu|
+      epe = EndProductEstablishment.find_by(
+        id: riu.review_id
+      )
+      return if epe.established_at.blank?
+
+      resolve_error_on_records(riu)
+      STUCK_JOB_REPORT_SERVICE.append_single_record(riu.class.name, riu.id)
+    end
+    STUCK_JOB_REPORT_SERVICE.append_record_count(rius_with_errors.count, ERROR_TEXT)
+  end
+
+  def clear_hlr_errors
+    STUCK_JOB_REPORT_SERVICE.append_record_count(hlrs_with_errors.count, ERROR_TEXT)
+
+    hlrs_with_errors.each do |hlr|
+      epe = EndProductEstablishment.find_by(
+        veteran_file_number: hlr.veteran_file_number
+      )
+      return if epe.established_at.blank?
+
+      resolve_error_on_records(hlr)
+      STUCK_JOB_REPORT_SERVICE.append_single_record(hlr.class.name, hlr.id)
+    end
+    STUCK_JOB_REPORT_SERVICE.append_record_count(hlrs_with_errors.count, ERROR_TEXT)
+  end
+
+  def clear_bge_errors
+    STUCK_JOB_REPORT_SERVICE.append_record_count(bges_with_errors.count, ERROR_TEXT)
+
+    bges_with_errors.each do |bge|
+      return if bge.end_product_establishment.established_at.blank?
+
+      resolve_error_on_records(bge)
+      STUCK_JOB_REPORT_SERVICE.append_single_record(bge.class.name, bge.id)
+    end
+    STUCK_JOB_REPORT_SERVICE.append_record_count(bges_with_errors.count, ERROR_TEXT)
+  end
+
+  def hlrs_with_errors
+    HigherLevelReview.where("establishment_error ILIKE?", "%#{ERROR_TEXT}%")
+  end
+
+  def rius_with_errors
+    RequestIssuesUpdate.where("error ILIKE?", "%#{ERROR_TEXT}%")
+  end
+
+  def bges_with_errors
+    BoardGrantEffectuation.where("decision_sync_error ILIKE?", "%#{ERROR_TEXT}%")
+  end
+end

--- a/app/jobs/bgs_share_error_fix_job.rb
+++ b/app/jobs/bgs_share_error_fix_job.rb
@@ -25,7 +25,7 @@ class BgsShareErrorFixJob < CaseflowJob
       epe = EndProductEstablishment.find_by(
         id: riu.review_id
       )
-      return if epe.established_at.blank?
+      next if epe.established_at.blank?
 
       resolve_error_on_records(riu)
       STUCK_JOB_REPORT_SERVICE.append_single_record(riu.class.name, riu.id)
@@ -40,7 +40,7 @@ class BgsShareErrorFixJob < CaseflowJob
       epe = EndProductEstablishment.find_by(
         veteran_file_number: hlr.veteran_file_number
       )
-      return if epe.established_at.blank?
+      next if epe.established_at.blank?
 
       resolve_error_on_records(hlr)
       STUCK_JOB_REPORT_SERVICE.append_single_record(hlr.class.name, hlr.id)
@@ -52,7 +52,7 @@ class BgsShareErrorFixJob < CaseflowJob
     STUCK_JOB_REPORT_SERVICE.append_record_count(bges_with_errors.count, ERROR_TEXT)
 
     bges_with_errors.each do |bge|
-      return if bge.end_product_establishment.established_at.blank?
+      next if bge.end_product_establishment.established_at.blank?
 
       resolve_error_on_records(bge)
       STUCK_JOB_REPORT_SERVICE.append_single_record(bge.class.name, bge.id)

--- a/app/jobs/claim_date_dt_fix_job.rb
+++ b/app/jobs/claim_date_dt_fix_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class ClaimDateDtFixJob < CaseflowJob
+  ERROR_TEXT = "ClaimDateDt"
+
+  def perform
+    stuck_job_report_service = StuckJobReportService.new
+
+    return if decision_docs_with_errors.blank?
+
+    stuck_job_report_service.append_record_count(decision_docs_with_errors.count, ERROR_TEXT)
+
+    decision_docs_with_errors.each do |single_decision_document|
+      return unless single_decision_document.processed_at.present? &&
+                    single_decision_document.uploaded_to_vbms_at.present?
+
+      stuck_job_report_service.append_single_record(single_decision_document.class.name, single_decision_document.id)
+
+      ActiveRecord::Base.transaction do
+        single_decision_document.clear_error!
+      rescue StandardError => error
+        log_error(error)
+        stuck_job_report_service.append_errors(single_decision_document.class.name, single_decision_document.id, error)
+      end
+    end
+
+    stuck_job_report_service.append_record_count(decision_docs_with_errors.count, ERROR_TEXT)
+
+    stuck_job_report_service.write_log_report(ERROR_TEXT)
+  end
+
+  def decision_docs_with_errors
+    DecisionDocument.where("error ILIKE ?", "%#{ERROR_TEXT}%")
+  end
+end

--- a/app/jobs/claim_date_dt_fix_job.rb
+++ b/app/jobs/claim_date_dt_fix_job.rb
@@ -11,8 +11,8 @@ class ClaimDateDtFixJob < CaseflowJob
     stuck_job_report_service.append_record_count(decision_docs_with_errors.count, ERROR_TEXT)
 
     decision_docs_with_errors.each do |single_decision_document|
-      return unless single_decision_document.processed_at.present? &&
-                    single_decision_document.uploaded_to_vbms_at.present?
+      next unless single_decision_document.processed_at.present? &&
+                  single_decision_document.uploaded_to_vbms_at.present?
 
       stuck_job_report_service.append_single_record(single_decision_document.class.name, single_decision_document.id)
 

--- a/app/jobs/claim_not_established_fix_job.rb
+++ b/app/jobs/claim_not_established_fix_job.rb
@@ -13,7 +13,7 @@ class ClaimNotEstablishedFixJob < CaseflowJob
     decision_docs_with_errors.each do |single_decision_document|
       file_number = single_decision_document.veteran.file_number
       epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
-      return unless validate_epe(epe)
+      next unless validate_epe(epe)
 
       stuck_job_report_service.append_single_record(single_decision_document.class.name, single_decision_document.id)
 

--- a/app/jobs/claim_not_established_fix_job.rb
+++ b/app/jobs/claim_not_established_fix_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class ClaimNotEstablishedFixJob < CaseflowJob
+  ERROR_TEXT = "Claim not established."
+  EPECODES = %w[030 040 930 682].freeze
+
+  def perform
+    stuck_job_report_service = StuckJobReportService.new
+    return if decision_docs_with_errors.blank?
+
+    stuck_job_report_service.append_record_count(decision_docs_with_errors.count, ERROR_TEXT)
+
+    decision_docs_with_errors.each do |single_decision_document|
+      file_number = single_decision_document.veteran.file_number
+      epe = EndProductEstablishment.find_by(veteran_file_number: file_number)
+      return unless validate_epe(epe)
+
+      stuck_job_report_service.append_single_record(single_decision_document.class.name, single_decision_document.id)
+
+      ActiveRecord::Base.transaction do
+        single_decision_document.clear_error!
+      rescue StandardError => error
+        log_error(error)
+        stuck_job_report_service.append_errors(single_decision_document.class.name, single_decision_document.id,
+                                               error)
+      end
+    end
+
+    stuck_job_report_service.append_record_count(decision_docs_with_errors.count, ERROR_TEXT)
+    stuck_job_report_service.write_log_report(ERROR_TEXT)
+  end
+
+  def decision_docs_with_errors
+    DecisionDocument.where("error ILIKE ?", "%#{ERROR_TEXT}%")
+  end
+
+  def validate_epe(epe)
+    epe_code = epe&.code&.slice(0, 3)
+    EPECODES.include?(epe_code) && epe&.established_at.present?
+  end
+end

--- a/app/jobs/dta_sc_creation_failed_fix_job.rb
+++ b/app/jobs/dta_sc_creation_failed_fix_job.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+class DtaScCreationFailedFixJob < CaseflowJob
+  ERROR_TEXT = "DTA SC Creation Failed"
+
+  def perform
+    stuck_job_report_service = StuckJobReportService.new
+    return if hlrs_with_errors.blank?
+
+    stuck_job_report_service.append_record_count(hlrs_with_errors.count, ERROR_TEXT)
+
+    hlrs_with_errors.each do |hlr|
+      return unless SupplementalClaim.find_by(
+        decision_review_remanded_id: hlr.id,
+        decision_review_remanded_type: "HigherLevelReview"
+      )
+
+      stuck_job_report_service.append_single_record(hlr.class.name, hlr.id)
+
+      ActiveRecord::Base.transaction do
+        hlr.clear_error!
+      rescue StandardError => error
+        log_error(error)
+        stuck_job_report_service.append_error(hlr.class.name, hlr.id, error)
+      end
+    end
+
+    stuck_job_report_service.append_record_count(hlrs_with_errors.count, ERROR_TEXT)
+    stuck_job_report_service.write_log_report(ERROR_TEXT)
+  end
+
+  def hlrs_with_errors
+    HigherLevelReview.where("establishment_error ILIKE ?", "%#{ERROR_TEXT}%")
+  end
+end

--- a/app/jobs/dta_sc_creation_failed_fix_job.rb
+++ b/app/jobs/dta_sc_creation_failed_fix_job.rb
@@ -10,7 +10,7 @@ class DtaScCreationFailedFixJob < CaseflowJob
     stuck_job_report_service.append_record_count(hlrs_with_errors.count, ERROR_TEXT)
 
     hlrs_with_errors.each do |hlr|
-      return unless SupplementalClaim.find_by(
+      next unless SupplementalClaim.find_by(
         decision_review_remanded_id: hlr.id,
         decision_review_remanded_type: "HigherLevelReview"
       )

--- a/app/jobs/sc_dta_for_appeal_fix_job.rb
+++ b/app/jobs/sc_dta_for_appeal_fix_job.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+class ScDtaForAppealFixJob < CaseflowJob
+  ERRORTEXT = "Can't create a SC DTA for appeal"
+
+  def records_with_errors
+    DecisionDocument.where("error ILIKE ?", "%#{ERRORTEXT}%")
+  end
+
+  def sc_dta_for_appeal_fix
+    stuck_job_report_service = StuckJobReportService.new
+    return if records_with_errors.blank?
+
+    # count of records with errors before fix
+    stuck_job_report_service.append_record_count(records_with_errors.count, ERRORTEXT)
+
+    records_with_errors.each do |decision_doc|
+      claimant = decision_doc.appeal.claimant
+
+      return unless claimant.payee_code.nil?
+
+      if claimant.type == "VeteranClaimant"
+        claimant.update!(payee_code: "00")
+      elsif claimant.type == "DependentClaimant"
+        claimant.update!(payee_code: "10")
+      end
+      stuck_job_report_service.append_single_record(decision_doc.class.name, decision_doc.id)
+      clear_error_on_record(decision_doc)
+    end
+
+    # record count with errors after fix
+    stuck_job_report_service.append_record_count(records_with_errors.count, ERRORTEXT)
+    stuck_job_report_service.write_log_report(ERRORTEXT)
+  end
+
+  def clear_error_on_record(decision_doc)
+    ActiveRecord::Base.transaction do
+      decision_doc.clear_error!
+    rescue StandardError => error
+      log_error(error)
+      stuck_job_report_service.append_errors(decision_doc.class.name, decision_doc.id, error)
+    end
+  end
+end

--- a/app/jobs/sc_dta_for_appeal_fix_job.rb
+++ b/app/jobs/sc_dta_for_appeal_fix_job.rb
@@ -17,7 +17,7 @@ class ScDtaForAppealFixJob < CaseflowJob
     records_with_errors.each do |decision_doc|
       claimant = decision_doc.appeal.claimant
 
-      return unless claimant.payee_code.nil?
+      next unless claimant.payee_code.nil?
 
       if claimant.type == "VeteranClaimant"
         claimant.update!(payee_code: "00")

--- a/app/services/stuck_job_report_service.rb
+++ b/app/services/stuck_job_report_service.rb
@@ -7,11 +7,12 @@
 # The logs also contain the Id of the record that has been updated
 
 class StuckJobReportService
-  BUCKET_NAME = "data-remediation-output"
-  attr_reader :logs
+  # BUCKET_NAME = "data-remediation-output-#{Rails.deploy_env}"
+  attr_reader :logs, :bucket_name
 
   def initialize
     @logs = ["#{Time.zone.now} ********** Remediation Log Report **********"]
+    @bucket_name = "data-remediation-output-#{Rails.deploy_env}"
   end
 
   # Logs the Id and the object that is being updated
@@ -20,7 +21,8 @@ class StuckJobReportService
   end
 
   def append_error(class_name, id, error)
-    logs.push("\n#{Time.zone.now} Record Type: #{class_name} - Record ID: #{id}. Encountered #{error}, record not updated.")
+    logs.push("\n#{Time.zone.now} Record Type: #{class_name}"\
+      " - Record ID: #{id}. Encountered #{error}, record not updated.")
   end
 
   # Gets the record count of the record type passed in.
@@ -43,8 +45,8 @@ class StuckJobReportService
     file_name = "#{create_file_name}-logs/#{create_file_name}-log-#{Time.zone.now}"
     s3client = aws_client
     s3resource = Aws::S3::Resource.new(client: s3client)
-    s3bucket = s3resource.bucket(BUCKET_NAME)
 
+    s3bucket = s3resource.bucket(bucket_name)
     s3bucket.object(file_name).upload_file(filepath, acl: "private", server_side_encryption: "AES256")
   end
 

--- a/app/services/stuck_job_report_service.rb
+++ b/app/services/stuck_job_report_service.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# StuckJobReportService is a generic shared class that creates the logs
+# sent to S3. The logs give the count before the remediation and
+# the count after the remediation.
+
+# The logs also contain the Id of the record that has been updated
+
+class StuckJobReportService
+  BUCKET_NAME = "data-remediation-output"
+  attr_reader :logs
+
+  def initialize
+    @logs = ["#{Time.zone.now} ********** Remediation Log Report **********"]
+  end
+
+  # Logs the Id and the object that is being updated
+  def append_single_record(class_name, id)
+    logs.push("\n#{Time.zone.now} Record Type: #{class_name} - Record ID: #{id}.")
+  end
+
+  def append_error(class_name, id, error)
+    logs.push("\n#{Time.zone.now} Record Type: #{class_name} - Record ID: #{id}. Encountered #{error}, record not updated.")
+  end
+
+  # Gets the record count of the record type passed in.
+  def append_record_count(records_with_errors_count, text)
+    logs.push("\n#{Time.zone.now} #{text}::Log - Total number of Records with Errors: #{records_with_errors_count}")
+  end
+
+  def write_log_report(error_text)
+    temporary_file = Tempfile.new("cdc-log.txt")
+    filepath = temporary_file.path
+    temporary_file.write(logs)
+    temporary_file.flush
+    create_file_name = error_text.split.join("-").downcase
+    upload_logs_to_s3(filepath, create_file_name)
+
+    temporary_file.close!
+  end
+
+  def upload_logs_to_s3(filepath, create_file_name)
+    file_name = "#{create_file_name}-logs/#{create_file_name}-log-#{Time.zone.now}"
+    s3client = aws_client
+    s3resource = Aws::S3::Resource.new(client: s3client)
+    s3bucket = s3resource.bucket(BUCKET_NAME)
+
+    s3bucket.object(file_name).upload_file(filepath, acl: "private", server_side_encryption: "AES256")
+  end
+
+  def aws_client
+    if Rails.env.test?
+      Aws::S3::Client.new(stub_responses: true) # Use stub responses for tests
+    else
+      Aws::S3::Client.new # Use actual AWS client for production or other environments
+    end
+  end
+end

--- a/app/services/stuck_job_report_service.rb
+++ b/app/services/stuck_job_report_service.rb
@@ -7,7 +7,6 @@
 # The logs also contain the Id of the record that has been updated
 
 class StuckJobReportService
-  # BUCKET_NAME = "data-remediation-output-#{Rails.deploy_env}"
   attr_reader :logs, :bucket_name
 
   def initialize

--- a/app/services/stuck_job_report_service.rb
+++ b/app/services/stuck_job_report_service.rb
@@ -11,7 +11,7 @@ class StuckJobReportService
 
   def initialize
     @logs = ["#{Time.zone.now} ********** Remediation Log Report **********"]
-    @bucket_name = "data-remediation-output-#{Rails.deploy_env}"
+    @bucket_name = (Rails.deploy_env == :prod) ? "data-remediation-output" : "data-remediation-output-#{Rails.deploy_env}"
   end
 
   # Logs the Id and the object that is being updated
@@ -29,12 +29,12 @@ class StuckJobReportService
     logs.push("\n#{Time.zone.now} #{text}::Log - Total number of Records with Errors: #{records_with_errors_count}")
   end
 
-  def write_log_report(error_text)
+  def write_log_report(report_text)
     temporary_file = Tempfile.new("cdc-log.txt")
     filepath = temporary_file.path
     temporary_file.write(logs)
     temporary_file.flush
-    create_file_name = error_text.split.join("-").downcase
+    create_file_name = report_text.split.join("-").downcase
     upload_logs_to_s3(filepath, create_file_name)
 
     temporary_file.close!

--- a/app/services/stuck_job_report_service.rb
+++ b/app/services/stuck_job_report_service.rb
@@ -7,11 +7,13 @@
 # The logs also contain the Id of the record that has been updated
 
 class StuckJobReportService
-  attr_reader :logs, :bucket_name
+  attr_reader :logs, :folder_name
+
+  S3_FOLDER_NAME = "data-remediation-output"
 
   def initialize
     @logs = ["#{Time.zone.now} ********** Remediation Log Report **********"]
-    @bucket_name = (Rails.deploy_env == :prod) ? "data-remediation-output" : "data-remediation-output-#{Rails.deploy_env}"
+    @folder_name = (Rails.deploy_env == :prod) ? S3_FOLDER_NAME : "#{S3_FOLDER_NAME}-#{Rails.deploy_env}"
   end
 
   # Logs the Id and the object that is being updated
@@ -30,30 +32,12 @@ class StuckJobReportService
   end
 
   def write_log_report(report_text)
-    temporary_file = Tempfile.new("cdc-log.txt")
-    filepath = temporary_file.path
-    temporary_file.write(logs)
-    temporary_file.flush
     create_file_name = report_text.split.join("-").downcase
-    upload_logs_to_s3(filepath, create_file_name)
-
-    temporary_file.close!
+    upload_logs_to_s3(create_file_name)
   end
 
-  def upload_logs_to_s3(filepath, create_file_name)
+  def upload_logs_to_s3(create_file_name)
     file_name = "#{create_file_name}-logs/#{create_file_name}-log-#{Time.zone.now}"
-    s3client = aws_client
-    s3resource = Aws::S3::Resource.new(client: s3client)
-
-    s3bucket = s3resource.bucket(bucket_name)
-    s3bucket.object(file_name).upload_file(filepath, acl: "private", server_side_encryption: "AES256")
-  end
-
-  def aws_client
-    if Rails.env.test?
-      Aws::S3::Client.new(stub_responses: true) # Use stub responses for tests
-    else
-      Aws::S3::Client.new # Use actual AWS client for production or other environments
-    end
+    S3Service.store_file("#{folder_name}/#{file_name}", logs)
   end
 end

--- a/spec/jobs/bgs_share_error_fix_job_spec.rb
+++ b/spec/jobs/bgs_share_error_fix_job_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+describe BgsShareErrorFixJob, :postgres do
+  let(:share_error) { "BGS::ShareError" }
+  let(:file_number) { "123456789" }
+  let!(:hlr) do
+    create(:higher_level_review,
+           establishment_error: share_error,
+           veteran_file_number: file_number)
+  end
+  let!(:epe) do
+    create(:end_product_establishment,
+           source: hlr,
+           established_at: Time.zone.now,
+           veteran_file_number: file_number)
+  end
+
+  subject { described_class.new }
+
+  context "BGS::ShareError" do
+    context "HLR" do
+      context "when the error exists on HigherLevelReview"
+      describe "when EPE has established_at date" do
+        it "clears the BGS::ShareError on the HLR" do
+          subject.perform
+          expect(hlr.reload.establishment_error).to be_nil
+        end
+      end
+      describe "when EPE does not have established_at date" do
+        it "does not clear the BGS::ShareError on the HLR" do
+          epe.update(established_at: nil)
+          subject.perform
+          expect(hlr.reload.establishment_error).to eq(share_error)
+        end
+      end
+      context "when the hlr does not have the BGS::ShareError" do
+        it "does not attempt to clear the error" do
+          hlr.update(establishment_error: nil)
+          subject.perform
+          expect(hlr.reload.establishment_error).to eq(nil)
+        end
+      end
+    end
+
+    context "RIU" do
+      let!(:hlr_2) { create(:higher_level_review) }
+
+      let!(:riu) do
+        create(:request_issues_update,
+               error: share_error,
+               review_id: 65,
+               review_type: hlr_2)
+      end
+      let!(:epe_2) do
+        create(:end_product_establishment,
+               id: riu.review_id,
+               established_at: Time.zone.now,
+               veteran_file_number: 3_231_213_123)
+      end
+
+      context "when the error exists on  RIU"
+      describe "when EPE has established_at date" do
+        it "clears the BGS::ShareError on the RIU" do
+          subject.perform
+          expect(riu.reload.error).to be_nil
+        end
+      end
+      describe "when EPE does not have established_at date" do
+        it "does not clear the BGS::ShareError on the RIU" do
+          epe_2.update(established_at: nil)
+          subject.perform
+          expect(riu.reload.error).to eq(share_error)
+        end
+      end
+      context "when the RIU does not have the BGS::ShareError" do
+        it "does not attempt to clear the error" do
+          riu.update(error: nil)
+          subject.perform
+          expect(riu.reload.error).to eq(nil)
+        end
+      end
+    end
+
+    context "BGE" do
+      let!(:epe_3) do
+        create(:end_product_establishment,
+               established_at: Time.zone.now, veteran_file_number: 88_888_888)
+      end
+      let!(:bge) do
+        create(:board_grant_effectuation,
+               end_product_establishment_id: epe_3.id,
+               decision_sync_error: share_error)
+      end
+
+      context "when the error exists on BGE"
+      describe "when EPE has established_at date" do
+        it "clear_error!" do
+          subject.perform
+          expect(bge.reload.decision_sync_error).to be_nil
+        end
+      end
+      describe "if EPE does not have established_at" do
+        it "clears the BGS::ShareError on the BGE" do
+          epe_3.update(established_at: nil)
+          subject.perform
+          expect(bge.reload.decision_sync_error).to eq(share_error)
+        end
+      end
+      context "when the BGE does not have the BGS::ShareError" do
+        it "does not attempt to clear the error" do
+          bge.update(decision_sync_error: nil)
+          subject.perform
+          expect(bge.reload.decision_sync_error).to eq(nil)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/claim_date_dt_fix_job_spec.rb
+++ b/spec/jobs/claim_date_dt_fix_job_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+describe ClaimDateDtFixJob, :postres do
+  let(:claim_date_dt_error) { "ClaimDateDt" }
+
+  let!(:decision_doc_with_error) do
+    create(
+      :decision_document,
+      error: claim_date_dt_error,
+      processed_at: 7.days.ago,
+      uploaded_to_vbms_at: 7.days.ago
+    )
+  end
+
+  subject { described_class.new("decision_document", "ClaimDateDt") }
+
+  before do
+    create_list(:decision_document, 5)
+    create_list(:decision_document, 2, error: claim_date_dt_error, processed_at: 7.days.ago,
+                                       uploaded_to_vbms_at: 7.days.ago)
+  end
+
+  context "when error, processed_at and uploaded_to_vbms_at are populated" do
+    it "clears the error field" do
+      expect(subject.decision_docs_with_errors.count).to eq(3)
+      subject.perform
+
+      expect(decision_doc_with_error.reload.error).to be_nil
+      expect(subject.decision_docs_with_errors.count).to eq(0)
+    end
+  end
+
+  context "when either uploaded_to_vbms_at or processed_at are nil" do
+    describe "when upladed_to_vbms_at is nil" do
+      it "does not clear the error field" do
+        decision_doc_with_error.update(uploaded_to_vbms_at: nil)
+
+        expect(decision_doc_with_error.error).to eq("ClaimDateDt")
+
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).not_to be_nil
+      end
+    end
+
+    describe "when processed_at is nil" do
+      it "does not clear the error field" do
+        decision_doc_with_error.update(processed_at: nil)
+        expect(decision_doc_with_error.error).to eq("ClaimDateDt")
+
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).not_to be_nil
+      end
+    end
+  end
+end

--- a/spec/jobs/claim_not_established_fix_job_spec.rb
+++ b/spec/jobs/claim_not_established_fix_job_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+describe ClaimNotEstablishedFixJob, :postgres do
+  let(:claim_not_established_error) { "Claim not established." }
+  let!(:veteran_file_number) { "111223333" }
+  let!(:veteran) { create(:veteran, file_number: veteran_file_number) }
+  let(:appeal) { create(:appeal, veteran_file_number: veteran_file_number) }
+
+  let!(:decision_doc_with_error) do
+    create(
+      :decision_document,
+      error: claim_not_established_error,
+      processed_at: 7.days.ago,
+      uploaded_to_vbms_at: 7.days.ago,
+      appeal: appeal
+    )
+  end
+
+  let!(:epe) do
+    create(
+      :end_product_establishment,
+      code: "030BGRNR",
+      source: decision_doc_with_error,
+      veteran_file_number: veteran_file_number,
+      established_at: Time.zone.now
+    )
+  end
+
+  context "#claim_not_established" do
+    subject { described_class.new("decision_document", claim_not_established_error) }
+
+    context "when code and established_at are present on epe" do
+      it "clears the error field when epe code  is 030" do
+        epe.update(code: "030")
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).to be_nil
+      end
+
+      it "clears the error field when epe code  is 040" do
+        epe.update(code: "040")
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).to be_nil
+      end
+
+      it "clears the error field when epe code  is 930" do
+        epe.update(code: "930")
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).to be_nil
+      end
+
+      it "clears the error field when epe code  is 682" do
+        epe.update(code: "682")
+        subject.perform
+
+        expect(decision_doc_with_error.reload.error).to be_nil
+      end
+    end
+
+    context "When either code or established_at are missing on epe" do
+      describe "when code and established_at are nil" do
+        it "does not clear error on decision_document" do
+          epe.update(code: nil)
+          epe.update(established_at: nil)
+          subject.perform
+
+          expect(decision_doc_with_error.reload.error).to eq(claim_not_established_error)
+        end
+      end
+      describe "when code is nil" do
+        it "does not clear error on decision_document" do
+          epe.update(code: nil)
+          subject.perform
+
+          expect(decision_doc_with_error.reload.error).to eq(claim_not_established_error)
+        end
+      end
+
+      describe "when established_at is nil" do
+        it "does not clear error on decision_document" do
+          epe.update(established_at: nil)
+          subject.perform
+
+          expect(decision_doc_with_error.reload.error).to eq(claim_not_established_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/dta_sc_creation_failed_fix_job_spec.rb
+++ b/spec/jobs/dta_sc_creation_failed_fix_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe DtaScCreationFailedFixJob, :postgres do
+  let(:dta_error) { "DTA SC creation failed" }
+  let!(:veteran_file_number) { "111223333" }
+  let!(:veteran) { create(:veteran, file_number: veteran_file_number) }
+
+  let!(:hlr) { create(:higher_level_review, veteran_file_number: veteran_file_number, establishment_error: dta_error) }
+  let!(:sc) { create(:supplemental_claim, veteran_file_number: veteran_file_number, decision_review_remanded: hlr) }
+
+  context "#dta_sc_creation_failed_fix" do
+    subject { described_class.new("higher_level_review", dta_error) }
+
+    context "When SC has decision_review_remanded_id and decision_review_remanded_type" do
+      it "clears the error field on related HLR" do
+        subject.perform
+        expect(hlr.reload.establishment_error).to be_nil
+      end
+    end
+
+    context "When either decision_review_remanded_id or decision_review_remanded_type values are nil" do
+      describe "when decision_review_remanded_id is nil" do
+        it "does not clear error field on related HLR" do
+          sc.update(decision_review_remanded_id: nil)
+          subject.perform
+          expect(hlr.reload.establishment_error).to eql(dta_error)
+        end
+      end
+
+      describe "when decision_review_remanded_type is nil" do
+        it "does not clear error field on related HLR" do
+          sc.update(decision_review_remanded_type: nil)
+          subject.perform
+          expect(hlr.reload.establishment_error).to eql(dta_error)
+        end
+      end
+    end
+  end
+end

--- a/spec/jobs/sc_dta_for_appeal_fix_job_spec.rb
+++ b/spec/jobs/sc_dta_for_appeal_fix_job_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+describe ScDtaForAppealFixJob, :postgres do
+  let(:sc_dta_for_appeal_error) { "Can't create a SC DTA for appeal" }
+  let!(:veteran_file_number) { "111223333" }
+  let!(:veteran_file_number_2) { "999999999" }
+
+  # let!(:veteran) { create(:veteran, file_number: veteran_file_number) }
+  let(:appeal) { create(:appeal, veteran_file_number: veteran_file_number) }
+  let(:appeal_2) { create(:appeal, veteran_file_number: veteran_file_number_2) }
+  let!(:decision_doc_with_error) do
+    create(
+      :decision_document,
+      error: sc_dta_for_appeal_error,
+      appeal: appeal
+    )
+  end
+
+  let!(:decision_doc_with_error_2) do
+    create(
+      :decision_document,
+      error: sc_dta_for_appeal_error,
+      appeal: appeal_2
+    )
+  end
+
+  before do
+    create_list(:decision_document, 5)
+  end
+
+  subject { described_class.new }
+
+  context "#sc_dta_for_appeal_fix" do
+    context "when payee_code is nil" do
+      before do
+        decision_doc_with_error.appeal.claimant.update(payee_code: nil)
+      end
+      # we need to manipulate the claimant.type for these describes
+      describe "claimant.type is VeteranClaimant" do
+        it "updates payee_code to 00" do
+          decision_doc_with_error_2.appeal.claimant.update(payee_code: nil)
+
+          subject.sc_dta_for_appeal_fix
+          expect(decision_doc_with_error.appeal.claimant.payee_code).to eq("00")
+          expect(decision_doc_with_error_2.appeal.claimant.payee_code).to eq("00")
+        end
+
+        it "clears error column" do
+          subject.sc_dta_for_appeal_fix
+          expect(decision_doc_with_error.reload.error).to be_nil
+        end
+      end
+
+      describe "claimant.type is DependentClaimant" do
+        it "updates payee_code to 10" do
+          decision_doc_with_error.appeal.claimant.update(type: "DependentClaimant")
+          subject.sc_dta_for_appeal_fix
+          expect(decision_doc_with_error.appeal.claimant.payee_code).to eq("10")
+        end
+
+        it "clears error column" do
+          decision_doc_with_error.appeal.claimant.update(type: "DependentClaimant")
+          subject.sc_dta_for_appeal_fix
+          expect(decision_doc_with_error.reload.error).to be_nil
+        end
+      end
+    end
+
+    context "when payee_code is populated" do
+      it "does not update payee_code" do
+        expect(decision_doc_with_error.appeal.claimant.payee_code).to eq("00")
+        subject.sc_dta_for_appeal_fix
+        expect(decision_doc_with_error.appeal.claimant.payee_code).to eq("00")
+      end
+      it "does not clear error field" do
+        subject.sc_dta_for_appeal_fix
+        expect(decision_doc_with_error.error).to eq(sc_dta_for_appeal_error)
+      end
+    end
+  end
+end

--- a/spec/services/stuck_job_report_service_spec.rb
+++ b/spec/services/stuck_job_report_service_spec.rb
@@ -4,6 +4,9 @@ describe StuckJobReportService, :postres do
   ERROR_TEXT = "Descriptive Error Name"
   FAILED_TRANSACTION_ERROR = "great error"
   STUCK_JOB_NAME = "VBMS::UnknownUser"
+  BUCKET_NAME = "data-remediation-output"
+  CREATE_FILE_NAME = "descriptive-error-name"
+  FILEPATH = "/var/folders/fc/8gwfm4251qlb2nzgn3g4kldm0000gp/T/cdc-log.txt20230831-49789-qkyx0t"
 
   before do
     Timecop.freeze
@@ -61,6 +64,21 @@ describe StuckJobReportService, :postres do
       expect(subject.logs[1]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
       expect(subject.logs[5]).to include("Record Type: Decision Document - Record ID: 4. Encountered great error, record not updated.")
       expect(subject.logs[6]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
+    end
+
+    describe "names the S3 bucket correctly"
+    it "names uat bucket" do
+      allow(Rails).to receive(:deploy_env).and_return(:uat)
+
+      subject.upload_logs_to_s3(FILEPATH, CREATE_FILE_NAME)
+      expect(subject.bucket_name).to eq("data-remediation-output-uat")
+    end
+
+    it "names prod bucket" do
+      allow(Rails).to receive(:deploy_env).and_return(:prod)
+
+      subject.upload_logs_to_s3(FILEPATH, CREATE_FILE_NAME)
+      expect(subject.bucket_name).to eq("data-remediation-output-prod")
     end
   end
 end

--- a/spec/services/stuck_job_report_service_spec.rb
+++ b/spec/services/stuck_job_report_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+describe StuckJobReportService, :postres do
+  ERROR_TEXT = "Descriptive Error Name"
+  FAILED_TRANSACTION_ERROR = "great error"
+  STUCK_JOB_NAME = "VBMS::UnknownUser"
+
+  before do
+    Timecop.freeze
+  end
+
+  fake_data = [
+    {
+      class_name: "Decision Document",
+      id: 1
+    },
+    {
+      class_name: "Decision Document",
+      id: 2
+    },
+    {
+      class_name: "Decision Document",
+      id: 3
+    },
+    {
+      class_name: "Decision Document",
+      id: 4
+    }
+  ]
+
+  subject { described_class.new }
+
+  context "StuckJobReportService" do
+    it "writes the job report" do
+      subject.append_record_count(4, STUCK_JOB_NAME)
+
+      fake_data.map do |data|
+        subject.append_single_record(data[:class_name], data[:id])
+      end
+
+      subject.append_record_count(0, STUCK_JOB_NAME)
+      subject.write_log_report(ERROR_TEXT)
+
+      expect(subject.logs[0]).to include("#{Time.zone.now} ********** Remediation Log Report **********")
+      expect(subject.logs[1]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
+      expect(subject.logs[5]).to include("Record Type: Decision Document - Record ID: 4.")
+      expect(subject.logs[6]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 0")
+    end
+
+    it "writes error log report" do
+      subject.append_record_count(4, STUCK_JOB_NAME)
+
+      fake_data.map do |data|
+        subject.append_error(data[:class_name], data[:id], FAILED_TRANSACTION_ERROR)
+      end
+
+      subject.append_record_count(4, STUCK_JOB_NAME)
+      subject.write_log_report(ERROR_TEXT)
+
+      expect(subject.logs[0]).to include("#{Time.zone.now} ********** Remediation Log Report **********")
+      expect(subject.logs[1]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
+      expect(subject.logs[5]).to include("Record Type: Decision Document - Record ID: 4. Encountered great error, record not updated.")
+      expect(subject.logs[6]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
+    end
+  end
+end

--- a/spec/services/stuck_job_report_service_spec.rb
+++ b/spec/services/stuck_job_report_service_spec.rb
@@ -71,15 +71,15 @@ describe StuckJobReportService, :postres do
     it "names uat bucket" do
       allow(Rails).to receive(:deploy_env).and_return(:uat)
 
-      subject.upload_logs_to_s3(FILEPATH, CREATE_FILE_NAME)
-      expect(subject.bucket_name).to eq("data-remediation-output-uat")
+      subject.upload_logs_to_s3(CREATE_FILE_NAME)
+      expect(subject.folder_name).to eq("data-remediation-output-uat")
     end
 
     it "names prod bucket" do
       allow(Rails).to receive(:deploy_env).and_return(:prod)
 
-      subject.upload_logs_to_s3(FILEPATH, CREATE_FILE_NAME)
-      expect(subject.bucket_name).to eq("data-remediation-output")
+      subject.upload_logs_to_s3(CREATE_FILE_NAME)
+      expect(subject.folder_name).to eq("data-remediation-output")
     end
   end
 end

--- a/spec/services/stuck_job_report_service_spec.rb
+++ b/spec/services/stuck_job_report_service_spec.rb
@@ -62,7 +62,8 @@ describe StuckJobReportService, :postres do
 
       expect(subject.logs[0]).to include("#{Time.zone.now} ********** Remediation Log Report **********")
       expect(subject.logs[1]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
-      expect(subject.logs[5]).to include("Record Type: Decision Document - Record ID: 4. Encountered great error, record not updated.")
+      expect(subject.logs[5]).to include("Record Type: Decision Document - Record ID: 4. Encountered great error,"\
+        " record not updated.")
       expect(subject.logs[6]).to include("#{STUCK_JOB_NAME}::Log - Total number of Records with Errors: 4")
     end
 
@@ -78,7 +79,7 @@ describe StuckJobReportService, :postres do
       allow(Rails).to receive(:deploy_env).and_return(:prod)
 
       subject.upload_logs_to_s3(FILEPATH, CREATE_FILE_NAME)
-      expect(subject.bucket_name).to eq("data-remediation-output-prod")
+      expect(subject.bucket_name).to eq("data-remediation-output")
     end
   end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Execute Testing in UAT for Claimdatedt](https://jira.devops.va.gov/browse/APPEALS-27039)
Resolves [Execute Testing in UAT for DTA SC Creation Failed](https://jira.devops.va.gov/browse/APPEALS-27070)
Resolves [Execute Testing in UAT for Claim not established](https://jira.devops.va.gov/browse/APPEALS-26958)
Resolves [Execute Testing in UAT for BGS::ShareError](https://jira.devops.va.gov/browse/APPEALS-27604)
Resolves [Execute Testing in UAT for Can't create a SC DTA for Appeal](https://jira.devops.va.gov/browse/APPEALS-27064)


# Description
Introduces five stuck job remediations and a service to log the changes they make. Descriptions of the stuck jobs listed below

## Introduces a job to handle the ClaimDateDt error:
- The job will search for all decision documents stamped with the ClaimDateDt error, then verify that both `uploaded_to_vbms_at` and `processed_at` are populated. The error will be cleared only if both columns have values present 
- During the intake process, a Decision Document is sent to be established in VBMS. The date that was entered in Caseflow is not valid in VBMS because VBMS cannot accept dates in the future. The SyncReviewsJob will catch these errors and retry them. However, the error column is never cleared and the Decision Document is still stamped with this error message. 
- Resolves [Execute Testing in UAT for Claimdatedt](https://jira.devops.va.gov/browse/APPEALS-27039)

---

## Introduces a job to handle the DTA SC creation failed error:
- The job will search for all HigherLevelReviews stamped with the DTA SC creation failed error
	- For each HigherLevelReview, we search for the associated SupplementalClaim
	- The SupplementalClaim should have a `decision_review_remanded_id` field that matches the ID of the HigherLevelReview
	- Additionally, the SupplementalClaim will have `decision_review_remanded_type` equal to `"HigherLevelReview"`
	- If this SupplementalClaim exists then it has already successfully been created, and we call `clear_error!` on the HigherLevelReview 
- The DTA SC Creation Failed error occurs on a HigherLevelReview but indicates that a descendant SupplementalClaim was not created when it should have been. It appears that this error is largely, if not entirely, a self-healing issue
	- At one point in the process, the creation of the SupplementalClaim did fail, however Caseflow will retry several times before giving up. It appears that these subsequent attempts have a high success rate
- Resolves [Execute Testing in UAT for DTA SC Creation Failed](https://jira.devops.va.gov/browse/APPEALS-27070)

---

## Introduces a job to handle the Claim not established error:

- The job will search for all decision documents stamped with the Claim not established error.
	- To perform a data clean-up on these records we gather the affected Decision Documents, locate the related End Product Establishment for each by way of the veteran_file_number, and check for a populated `established_at` field *and* the presence of any of the `EPECODES` show in the array 
	- If both of these conditions are met, clear the error message
- When a grant has been made on a veteran's appeal, an End Product Establishment is created in Caseflow and sent to VBMS to be established. This occasionally fails and the Claim not established error is saved to the corresponding Decision Document's error column
	- Under normal circumstances, Caseflow is prepared for this failure and will automatically retry to establish in VBMS
	- However, after a successful retry the error field of the Decision Document is never updated and the message remains
- Resolves [Execute Testing in UAT for Claim not established](https://jira.devops.va.gov/browse/APPEALS-26958)

---
## Introduces a job to handle the BGS::ShareError error:

The BGS::ShareError occurs on three different classes:
- HigherLevelReview
- RequestIssuesUpdate
- BoardGrantEffecuations

There is a failure in pulling information from VBMS which creates the initial error. When Caseflow reruns the fetch and eventually succeeds an EndProductEstablishment with an established_at column with the date/time of establishment recorded will prove the success of this record. The errors on these three records however will remain.
Completing a data clean-up for this error is quite simple
- Resolves [Execute Testing in UAT for BGS::ShareError](https://jira.devops.va.gov/browse/APPEALS-27604)

---

## Introduces a job to handle the Can't create a SC DTA for appeal error:
This Job clears the `Can't create a SC DTA for appeal` error that is on the Decision Document. 
The process follow is as follows.

The logic checks that the payee_code on the claimant. related to the decision document is nil. If it is, it then checks the claimant Type. if the type is "veteran" we set the payee_code to  00. If the claimant type is DependentClaimant, we set the payee_code to 10.

We then clear error on the decision document object. 
Logs are also written to S3.
- Resolves [Execute Testing in UAT for Can't create a SC DTA for Appeal](https://jira.devops.va.gov/browse/APPEALS-27064)

---
## Introduces a service to handle logging for the remediations above:
- The StuckJobReportService generates logs for the previously listed remediations
	- Displays the total count of erroneous records both before and after the remediation is run
	- Documents the individual records as they are processed
	- Notes any record that failed to remediate
	- Sends the report to the appropriate S3 Bucket

---

# Acceptance Criteria

- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

## Storybook Story
*For Frontend (Presentation) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

# Backend
## Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] For queries using raw sql was an explain plan run by System Team
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

## Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
  * [ ] Check that calls are wrapped in MetricService record block
* [ ] Check that all configuration is coming from ENV variables
  * [ ] Listed all new ENV variables in description
  * [ ] Worked with or notified System Team that new ENV variables need to be set
* [ ] Update Fakes
* [ ] For feature branches: Was this tested in Caseflow UAT

# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

## Monitoring, Logging, Auditing, Error, and Exception Handling Checklist

### Monitoring
- [ ] Are performance metrics (e.g., response time, throughput) being tracked?
- [ ] Are key application components monitored (e.g., database, cache, queues)?
- [ ] Is there a system in place for setting up alerts based on performance thresholds?

### Logging
- [ ] Are logs being produced at appropriate log levels (debug, info, warn, error, fatal)?
- [ ] Are logs structured (e.g., using log tags) for easier querying and analysis?
- [ ] Are sensitive data (e.g., passwords, tokens) redacted or omitted from logs?
- [ ] Is log retention and rotation configured correctly?
- [ ] Are logs being forwarded to a centralized logging system if needed?

### Auditing
- [ ] Are user actions being logged for audit purposes?
- [ ] Are changes to critical data being tracked ?
- [ ] Are logs being securely stored and protected from tampering or exposing protected data?

### Error Handling
- [ ] Are errors being caught and handled gracefully?
- [ ] Are appropriate error messages being displayed to users?
- [ ] Are critical errors being reported to an error tracking system (e.g., Sentry, ELK)?
- [ ] Are unhandled exceptions being caught at the application level ?

### Exception Handling
- [ ] Are custom exceptions defined and used where appropriate?
- [ ] Is exception handling consistent throughout the codebase?
- [ ] Are exceptions logged with relevant context and stack trace information?
- [ ] Are exceptions being grouped and categorized for easier analysis and resolution?

