### PR TITLE
aaron/APPEALS-29591

### DIFF
--- a/app/jobs/populate_end_product_sync_queue_job.rb
+++ b/app/jobs/populate_end_product_sync_queue_job.rb
@@ -51,7 +51,9 @@ class PopulateEndProductSyncQueueJob < CaseflowJob
       on end_product_establishments.reference_id = vbms_ext_claim."CLAIM_ID"::varchar
       where (end_product_establishments.synced_status <> vbms_ext_claim."LEVEL_STATUS_CODE" or end_product_establishments.synced_status is null)
         and vbms_ext_claim."LEVEL_STATUS_CODE" in ('CLR','CAN')
-        and end_product_establishments.id not in (select end_product_establishment_id from priority_end_product_sync_queue)
+        and end_product_establishments.id not in (select end_product_establishment_id
+                                                  from priority_end_product_sync_queue
+                                                  where end_product_establishments.id = priority_end_product_sync_queue.end_product_establishment_id)
       limit #{BATCH_LIMIT};
     SQL
 

--- a/app/models/priority_queues/priority_end_product_sync_queue.rb
+++ b/app/models/priority_queues/priority_end_product_sync_queue.rb
@@ -46,16 +46,8 @@ class PriorityEndProductSyncQueue < CaseflowRecord
   # for later manual review.
   def declare_record_stuck!
     update!(status: Constants.PRIORITY_EP_SYNC.stuck)
-    stuck_record = CaseflowStuckRecord.create!(stuck_record: self,
-                                               error_messages: error_messages,
-                                               determined_stuck_at: Time.zone.now)
-    msg = "StuckRecordAlert::SyncFailed End Product Establishment ID: #{end_product_establishment_id}."
-    Raven.capture_message(msg, level: "error", extra: { caseflow_stuck_record_id: stuck_record.id,
-                                                        batch_process_type: batch_process.class.name,
-                                                        batch_id: batch_id,
-                                                        queue_type: self.class.name,
-                                                        queue_id: id,
-                                                        end_product_establishment_id: end_product_establishment_id,
-                                                        determined_stuck_at: stuck_record.determined_stuck_at })
+    CaseflowStuckRecord.create!(stuck_record: self,
+                                error_messages: error_messages,
+                                determined_stuck_at: Time.zone.now)
   end
 end

--- a/spec/models/priority_queues/priority_end_product_sync_queue_spec.rb
+++ b/spec/models/priority_queues/priority_end_product_sync_queue_spec.rb
@@ -171,20 +171,6 @@ describe PriorityEndProductSyncQueue, :postgres do
         found_record = CaseflowStuckRecord.find_by(stuck_record: record)
         expect(record.caseflow_stuck_records).to include(found_record)
       end
-
-      it "a message will be sent to Sentry" do
-        expect(Raven).to have_received(:capture_message)
-          .with("StuckRecordAlert::SyncFailed End Product Establishment ID: #{record.end_product_establishment_id}.",
-                extra: {
-                  batch_id: record.batch_id,
-                  batch_process_type: record.batch_process.class.name,
-                  caseflow_stuck_record_id: record.caseflow_stuck_records.first.id,
-                  determined_stuck_at: anything,
-                  end_product_establishment_id: record.end_product_establishment_id,
-                  queue_type: record.class.name,
-                  queue_id: record.id
-                }, level: "error")
-      end
     end
   end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-29591](https://jira.devops.va.gov/browse/APPEALS-29591)

# Description
As a developer, I need to remove the sentry alert that occurs when a record is placed into the Caseflow_stuck_records table and optimize the sql query that the PopulateEndProductSyncQueueJob uses.

## Acceptance Criteria
- [x] Remove sentry alerts when a record is placed within the caseflow_stuck_records table.
- [x] Update SQL query in PopulateEndProductSyncQueueJob to be more performant.  