### PR TITLE
APPPEALS-29699 | Remove AddDecisionDate action for withdrawn issues

### DIFF
--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -54,7 +54,10 @@ export default class IssuesList extends React.Component {
       );
     }
 
-    if (!issue.date || issue.editedDecisionDate) {
+    const isIssueWithdrawn = issue.withdrawalDate || issue.withdrawalPending;
+
+    // Do not show the Add Decision Date action if the issue is pending or is fully withdrawn
+    if ((!issue.date || issue.editedDecisionDate) && !isIssueWithdrawn) {
       options.push(
         {
           displayText: issue.editedDecisionDate ? 'Edit decision date' : 'Add decision date',
@@ -93,7 +96,8 @@ export default class IssuesList extends React.Component {
             issue, userCanWithdrawIssues, intakeData.isDtaError
           );
 
-          const showNoDecisionDateBanner = !issue.date;
+          const isIssueWithdrawn = issue.withdrawalDate || issue.withdrawalPending;
+          const showNoDecisionDateBanner = !issue.date && !isIssueWithdrawn;
 
           return <div className="issue-container" key={`issue-container-${issue.index}`}>
             <div


### PR DESCRIPTION
Closes Jira: https://jira.devops.va.gov/browse/APPEALS-29699

# Description
We do not want the ability to add a decision date to a withdrawn issue. So we need to update the conditional to exclude withdrawn issues from having the AddDecisionDate action.

We also will remove the showNoDecisionDateModal for withdrawn issues.
## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Pending withdrawal issues do not show the noDecisionDateBanner and do not have the ability to add/edit a decision date
- [ ] Fully saved withdrawal issues do not show the noDecisionDateBanner and do not have the ability to add/edit a decision date

# Frontend
https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/7f47880f-4e74-4e4e-a581-ff40861efc00




