### PR TITLE
[APPEALS- 29700] Update banner language after issue update

### DIFF
--- a/app/controllers/claim_review_controller.rb
+++ b/app/controllers/claim_review_controller.rb
@@ -153,15 +153,17 @@ class ClaimReviewController < ApplicationController
   end
 
   def vha_flash_message
-    issues_without_decision_date = (request_issues_update.after_issues - request_issues_update.edited_issues)
-      .select do |issue|
-        issue.decision_date.blank?
-      end
+    issues_without_decision_date = (request_issues_update.after_issues -
+                                request_issues_update.edited_issues -
+                                request_issues_update.removed_or_withdrawn_issues)
+      .select { |issue| issue.decision_date.blank? && !issue.withdrawn? }
 
     if issues_without_decision_date.empty?
       vha_established_message
-    else
+    elsif request_issues_update.edited_issues.any?
       vha_edited_decision_date_message
+    else
+      review_edited_message
     end
   end
 

--- a/client/app/intake/pages/addIssues/addIssues.jsx
+++ b/client/app/intake/pages/addIssues/addIssues.jsx
@@ -259,7 +259,8 @@ class AddIssuesPage extends React.Component {
 
       // if an new issue was added or an issue was edited
       const newOrChangedIssue =
-        issues.filter((issue) => !issue.id || issue.editedDescription || issue.editedDecisionDate || issue.correctionType).length > 0;
+        issues.filter((issue) => !issue.id || issue.editedDescription ||
+          issue.editedDecisionDate || issue.correctionType).length > 0;
 
       if (issueCountChanged || partialWithdrawal || newOrChangedIssue) {
         return true;

--- a/client/app/intake/pages/addIssues/addIssues.jsx
+++ b/client/app/intake/pages/addIssues/addIssues.jsx
@@ -366,7 +366,11 @@ class AddIssuesPage extends React.Component {
 
     if (editPage && haveIssuesChanged()) {
       // flash a save message if user is on the edit page & issues have changed
-      const issuesChangedBanner = <p>When you finish making changes, click "Save" to continue.</p>;
+      const establishText =
+        intakeData.benefitType === 'vha' && _.every(intakeData.addedIssues, (issue) => issue.decisionDate) ?
+          'Establish' :
+          'Save';
+      const issuesChangedBanner = <p>{`When you finish making changes, click ${establishText} to continue.`}</p>;
 
       fieldsForFormType = fieldsForFormType.concat({
         field: '',

--- a/client/app/intake/pages/addIssues/addIssues.jsx
+++ b/client/app/intake/pages/addIssues/addIssues.jsx
@@ -259,7 +259,7 @@ class AddIssuesPage extends React.Component {
 
       // if an new issue was added or an issue was edited
       const newOrChangedIssue =
-        issues.filter((issue) => !issue.id || issue.editedDescription || issue.correctionType).length > 0;
+        issues.filter((issue) => !issue.id || issue.editedDescription || issue.editedDecisionDate || issue.correctionType).length > 0;
 
       if (issueCountChanged || partialWithdrawal || newOrChangedIssue) {
         return true;
@@ -366,11 +366,12 @@ class AddIssuesPage extends React.Component {
 
     if (editPage && haveIssuesChanged()) {
       // flash a save message if user is on the edit page & issues have changed
-      const establishText =
-        intakeData.benefitType === 'vha' && _.every(intakeData.addedIssues, (issue) => issue.decisionDate) ?
-          'Establish' :
-          'Save';
-      const issuesChangedBanner = <p>{`When you finish making changes, click ${establishText} to continue.`}</p>;
+      const isAllIssuesReadyToBeEstablished = _.every(intakeData.addedIssues, (issue) => (
+        issue.withdrawalDate || issue.withdrawalPending) || issue.decisionDate
+      );
+
+      const establishText = intakeData.benefitType === 'vha' && isAllIssuesReadyToBeEstablished ? 'Establish' : 'Save';
+      const issuesChangedBanner = <p>{`When you finish making changes, click "${establishText}" to continue.`}</p>;
 
       fieldsForFormType = fieldsForFormType.concat({
         field: '',

--- a/client/app/intakeEdit/components/EditButtons.jsx
+++ b/client/app/intakeEdit/components/EditButtons.jsx
@@ -136,7 +136,9 @@ class SaveButtonUnconnected extends React.Component {
 
     let saveButtonText;
 
-    if (benefitType === 'vha' && _.every(addedIssues, (issue) => issue.decisionDate)) {
+    if (benefitType === 'vha' && _.every(addedIssues, (issue) => (
+      issue.withdrawalDate || issue.withdrawalPending) || issue.decisionDate
+    )) {
       saveButtonText = COPY.CORRECT_REQUEST_ISSUES_ESTABLISH;
     } else {
       saveButtonText = withdrawReview ? COPY.CORRECT_REQUEST_ISSUES_WITHDRAW : COPY.CORRECT_REQUEST_ISSUES_SAVE;

--- a/db/seeds/sanitized_json/appeal-119577.json
+++ b/db/seeds/sanitized_json/appeal-119577.json
@@ -6096,7 +6096,7 @@
     },
     {
       "id": 222,
-      "type": "BusinessLine",
+      "type": "VhaBusinessLine",
       "name": "Veterans Health Administration",
       "role": null,
       "url": "vha",

--- a/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
+++ b/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
@@ -300,6 +300,10 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
       expect(page).to have_button("Establish", disabled: false)
       expect(page).to_not have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
 
+      within "#issue-#{third_issue_id}" do
+        expect(page).to_not have_content("Select action")
+      end
+
       click_button "Establish"
 
       expect(page).to have_content(COPY::CORRECT_REQUEST_ISSUES_CHANGED_MODAL_TITLE)

--- a/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
+++ b/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
@@ -15,8 +15,17 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
                               last_name: "Merica")
   end
 
+  let(:changed_issue_banner_save_text) do
+    "When you finish making changes, click \"Save\" to continue."
+  end
+
+  let(:changed_issue_banner_establish_text) do
+    "When you finish making changes, click \"Establish\" to continue."
+  end
+
   before do
     VhaBusinessLine.singleton.add_user(current_user)
+    CaseReview.singleton.add_user(current_user)
     current_user.save
     User.authenticate!(user: current_user)
   end
@@ -126,6 +135,8 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
         click_on("Save")
       end
 
+      expect(page).to have_content(changed_issue_banner_establish_text)
+
       # Check that the Edit Issues save button is now Establish, the decision date is added, and the banner is gone
       expect(page).to_not have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
       expect(page).to have_content("Decision date: #{another_past_date}")
@@ -203,6 +214,20 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
         date: nil
       )
 
+      click_intake_add_issue
+      add_intake_nonrating_issue(
+        category: "CHAMPVA",
+        description: "CHAMPVA issue",
+        date: nil
+      )
+
+      click_intake_add_issue
+      add_intake_nonrating_issue(
+        category: "Clothing Allowance",
+        description: "Clothes for dependent",
+        date: nil
+      )
+
       expect(page).to have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
 
       click_button "Save"
@@ -219,19 +244,58 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
       # Go back to the Edit issues page
       click_link task.appeal.veteran.name.to_s
 
-      # Next we want to remove that issue and check the task status and message again.
       expect(page).to have_button("Save", disabled: true)
 
       expect(page).to have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
 
-      # Remove the issue
-      request_issue_id = task.appeal.request_issues.reload.find { |issue| issue.decision_date.blank? }.id
+      # Add a decision date, remove an issue, and withdraw an issue
+      new_issues = task.appeal.request_issues.reload.select { |issue| issue.decision_date.blank? }
+      request_issue_id = new_issues.first.id
+      second_issue_id = new_issues.second.id
+      third_issue_id = new_issues.third.id
 
       within "#issue-#{request_issue_id}" do
+        first("select").select("Add decision date")
+      end
+
+      fill_in "decision-date", with: (Time.zone.now - 1.week).strftime("%m/%d/%Y")
+
+      within ".cf-modal-controls" do
+        expect(page).to have_button("Save", disabled: false)
+        click_on("Save")
+      end
+
+      expect(page).to have_content(changed_issue_banner_save_text)
+
+      click_button "Save"
+
+      expect(page).to have_content(edit_decision_date_success_message_text)
+      expect(current_url).to include("/decision_reviews/vha?tab=incomplete")
+      expect(task.reload.status).to eq("on_hold")
+
+      # Go back to the Edit issues page
+      click_link task.appeal.veteran.name.to_s
+
+      expect(page).to have_button("Save", disabled: true)
+      expect(page).to have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
+
+      within "#issue-#{second_issue_id}" do
         first("select").select("Remove issue")
       end
 
       click_on("Yes, remove issue")
+
+      expect(page).to have_content(changed_issue_banner_save_text)
+      expect(page).to have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
+
+      within "#issue-#{third_issue_id}" do
+        first("select").select("Withdraw issue")
+      end
+
+      expect(page).to have_content(changed_issue_banner_establish_text)
+      expect(page).to have_button("Establish", disabled: true)
+
+      fill_in "withdraw-date", with: (Time.zone.now - 1.week).strftime("%m/%d/%Y")
 
       expect(page).to have_button("Establish", disabled: false)
       expect(page).to_not have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
@@ -285,8 +349,12 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
       task.appeal
     end
 
-    let(:edit_save_success_message_text) do
+    let(:edit_decision_date_success_message_text) do
       "You have successfully updated an issue's decision date"
+    end
+
+    let(:edit_save_success_message_text) do
+      "You have successfully added 3 issues."
     end
 
     context "an existing Higher-Level Review" do


### PR DESCRIPTION
Resolves [Update banner language after issue update](https://jira.devops.va.gov/browse/APPEALS-29700)

# Description
Updated the text in banner, that is shown to a user after updating an issue. The text in the banner now reads "Establish" instead of "Save" which is consistent with the text on the button at the bottom of the screen

Also the context on line 301 of `spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb` will fail until the changes from https://github.com/department-of-veterans-affairs/caseflow/pull/19375 are merged in

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Banner text reads "When you finish making changes, click Establish to continue." after updating issues 

## Testing Plan
1. Intaking a HLR with VHA benefit type
2. Add 2 issues both without a decision date
3. Save the HLR
4. Click on the HLR 
5. For one of the issues select add decision date from the select actions dropdown
6. For the other issue select remove issue
7. Click the "Yes, save" button in the modal
8. The banner should read "When you finish making changes, click Establish to continue."
9. The button at the bottom of the page should say "Establish"
10. Refresh the page
11. For one of the issues select add decision date from the select actions dropdown
12. For the other issue select withdraw issue
13. The banner should read "When you finish making changes, click Establish to continue."
14. The button at the bottom of the page should say "Establish"

# Frontend

https://github.com/department-of-veterans-affairs/caseflow/assets/110493538/6853f0cb-a30b-420d-b317-79ce2eadf645



