### PR TITLE
APPEALS-29342 | Fix `SearchableDropdown` propType issue

### DIFF
--- a/client/app/components/SearchableDropdown.jsx
+++ b/client/app/components/SearchableDropdown.jsx
@@ -428,7 +428,7 @@ SearchableDropdown.propTypes = {
   searchable: PropTypes.bool,
   selfManageValueState: PropTypes.bool,
   styling: PropTypes.object,
-  value: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.array]),
+  value: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.array, PropTypes.number]),
 };
 
 /* eslint-disable no-undefined */


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-29342

## Parent task: https://jira.devops.va.gov/browse/APPEALS-29280

Parent Task Description:
Throughout the app we have many instances of console warnings coming from React. As a developer team we should try to reduce these warning and errors where possible.

While some of these aren't really all that important for the performance of the app I believe it has value in reducing what I call "Warning  Complacency" where we become complacent with having warnings in the app which can lead to more important warnings and errors getting lost in the noise of other minor warnings.

# Description
We want to add `number` as a PropType for the value prop for the `SearchableDropdown` component.

Without this propType we were receiving console warnings coming from the `TestUsers` use of `SearchableDropdown` where the value was of type number.

There most likely are other instances of this that are resolved by this change.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The console warning at `/test/users` is gone


