### PR TITLE
added closing of reciept filter modal after a successful filter.

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -168,6 +168,15 @@ class DocumentsTable extends React.Component {
    };
  }
 
+ executeRecieptFilter = () => {
+  this.props.setRecieptDateFilter(this.state.recieptFilter,
+    { fromDate: this.state.fromDate,
+      toDate: this.state.toDate,
+      onDate: this.state.onDate});
+
+      this.toggleRecieptDataDropdownFilterVisibility();
+ }
+
  isRecieptFilterButtonEnabled = () => {
    if (this.state.recieptFilter === recieptDateFilterStates.BETWEEN && (this.state.toDate === '' || this.state.fromDate === '' ||
   this.state.toDateErrors.length > 0 || this.state.fromDateErrors.length > 0)) {
@@ -486,10 +495,7 @@ class DocumentsTable extends React.Component {
                     <div style={{ width: '100%', display: 'flex' }}>
                       <span style={{ height: '1px', position: 'absolute', width: '100%', backgroundColor: 'gray' }}></span>
                       <div style={{ display: 'flex', marginTop: '10px', marginRight: '10px', marginBottom: '10px', justifyContent: 'end', width: '100%' }}>
-                        <Button disabled={this.isRecieptFilterButtonEnabled()} onClick={() => this.props.setRecieptDateFilter(this.state.recieptFilter,
-                          { fromDate: this.state.fromDate,
-                            toDate: this.state.toDate,
-                            onDate: this.state.onDate })} title="apply filter">
+                        <Button disabled={this.isRecieptFilterButtonEnabled()} onClick={() => this.executeRecieptFilter()} title="apply filter">
                           <span>Apply filter</span>
                         </Button>
                       </div>
@@ -689,4 +695,3 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(DocumentsTable);
-


### PR DESCRIPTION
Resolves [Receipt Date Filter Remain Active After Clicking the Apply Filter Button](https://jira.devops.va.gov/browse/APPEALS-29796)

# Description
Previously, when filtering the reciept date, the modal would not automatically close upon filtering. It now does so after a successful filter.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan

1. Login to Caseflow with BVADWISE.
2. Navigate to the reader portion of Caseflow.
3. Open the receipt date filter and apply any of the searches.
4. The receipt date modal now automatically closes after filtering.

# Frontend
## User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="1344" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/2794b531-0546-43fa-b365-4f2c59ac9134">
|
<img width="1273" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/6803d5e6-f991-4184-b454-6d8859f9fa08">



## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other