### PR TITLE
ASmith/29798: Remove Old "Filtering By" Messages

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -382,8 +382,7 @@ class DocumentsTable extends React.Component {
         header: (
           <div id="categories-header">
             <span id="categories-header-label">
-              Categories{' '}
-              {anyCategoryFiltersAreSet ? 'Filtering by Category' : ''}
+              Categories
             </span>
             <FilterIcon
               label="Filter by category"
@@ -568,7 +567,6 @@ class DocumentsTable extends React.Component {
           <div id="tags-header" className="document-list-header-issue-tags">
             <span id="tag-header-label">
               Issue Tags
-              {anyTagFiltersAreSet ? 'Filtering by Issue Tags' : ''}
             </span>
             <FilterIcon
               label="Filter by tag"


### PR DESCRIPTION
Resolves [Tag Filter Shows "Filter by Issue Tag" within the Column Header when Filtering by Tags](https://jira.devops.va.gov/browse/JIRA-29798)

# Description
Remove unneeded old in-table "Filtering by" messages as these are now handled by a global "Filtering by" message.

**NOTE**: _This appears to be legacy behavior that was added before the global "Filtering by" message, and is not a bug per se. Thus, no tests have been added as part of this PR as we are merely removing old behavior._

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
- [ ] Filter by category and verify the "Categories" column header does not update.
- [ ] Filter by issue tag and verify the "Issue Tags" column header does not update.

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="1476" alt="Screenshot 2023-09-07 at 1 06 03 PM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/56f5a08b-9f6f-40a4-9b4d-aa6e67b0ac41">
|
<img width="1476" alt="Screenshot 2023-09-07 at 1 03 57 PM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/e7654466-da1d-429a-a011-4ede672368ef">
