### PR TITLE
Calvin/appeals 29642-AttorneyRewrite

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -123,11 +123,10 @@ class TasksController < ApplicationController
 
       tasks_hash = json_tasks(tasks.uniq)
       if task.appeal.class == LegacyAppeal
-        assigned_to = if (task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask") &&
-                         !update_params&.[](:reassign)&.[](:assigned_to_id)
-                        User.find(Task.find_by(id: task.parent_id).assigned_to_id)
-                      elsif update_params&.[](:reassign)&.[](:assigned_to_id)
+        assigned_to = if update_params&.[](:reassign)&.[](:assigned_to_id)
                         User.find(update_params[:reassign][:assigned_to_id])
+                      elsif task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask"
+                        User.find(Task.find_by(id: task.parent_id).assigned_to_id)
                       end
         QueueRepository.update_location_to_judge(task.appeal.vacols_id, assigned_to) if assigned_to
       else

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -96,7 +96,7 @@ class TasksController < ApplicationController
     # This should be the JudgeDecisionReviewTask
     parent_task = Task.find_by(id: params[:tasks].first[:parent_id]) if params[:tasks].first[:type] == "AttorneyRewriteTask"
     if parent_task&.appeal&.is_a?(LegacyAppeal)
-      QueueRepository.reassign_case_to_attorney!(
+      QueueRepository.reassign_decass_to_attorney!(
         judge: parent_task.assigned_to,
         attorney: User.find(params[:tasks].first[:assigned_to_id]),
         vacols_id: parent_task.appeal.external_id
@@ -123,12 +123,11 @@ class TasksController < ApplicationController
 
       tasks_hash = json_tasks(tasks.uniq)
       if task.appeal.class == LegacyAppeal
-        assigned_to =
-          if task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask"
-            User.find(Task.find_by(id: task.parent_id).assigned_to_id)
-          elsif update_params&.[](:reassign)&.[](:assigned_to_id)
-            User.find(update_params[:reassign][:assigned_to_id])
-          end
+        assigned_to = if task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask"
+                        User.find(Task.find_by(id: task.parent_id).assigned_to_id)
+                      elsif update_params&.[](:reassign)&.[](:assigned_to_id)
+                        User.find(update_params[:reassign][:assigned_to_id])
+                      end
         QueueRepository.update_location_to_judge(task.appeal.vacols_id, assigned_to) if assigned_to
       else
         modified_task_contested_claim

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -123,8 +123,13 @@ class TasksController < ApplicationController
 
       tasks_hash = json_tasks(tasks.uniq)
       if task.appeal.class == LegacyAppeal
-        assigned_to = (task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask") ? User.find(Task.find_by(id: task.parent_id).assigned_to_id) : User.find(update_params[:reassign][:assigned_to_id])
-        QueueRepository.update_location_to_judge(task.appeal.vacols_id, assigned_to)
+        assigned_to =
+          if task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask"
+            User.find(Task.find_by(id: task.parent_id).assigned_to_id)
+          elsif update_params&.[](:reassign)&.[](:assigned_to_id)
+            User.find(update_params[:reassign][:assigned_to_id])
+          end
+        QueueRepository.update_location_to_judge(task.appeal.vacols_id, assigned_to) if assigned_to
       else
         modified_task_contested_claim
       end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -92,7 +92,6 @@ class TasksController < ApplicationController
     param_groups.each do |task_type, param_group|
       tasks << valid_task_classes[task_type.to_sym].create_many_from_params(param_group, current_user)
     end
-    byebug
     # This should be the JudgeDecisionReviewTask
     parent_task = Task.find_by(id: params[:tasks].first[:parent_id]) if params[:tasks].first[:type] == "AttorneyRewriteTask"
     if parent_task&.appeal&.is_a?(LegacyAppeal)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -92,7 +92,7 @@ class TasksController < ApplicationController
     param_groups.each do |task_type, param_group|
       tasks << valid_task_classes[task_type.to_sym].create_many_from_params(param_group, current_user)
     end
-
+    byebug
     # This should be the JudgeDecisionReviewTask
     parent_task = Task.find_by(id: params[:tasks].first[:parent_id]) if params[:tasks].first[:type] == "AttorneyRewriteTask"
     if parent_task&.appeal&.is_a?(LegacyAppeal)
@@ -123,7 +123,8 @@ class TasksController < ApplicationController
 
       tasks_hash = json_tasks(tasks.uniq)
       if task.appeal.class == LegacyAppeal
-        assigned_to = if task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask"
+        assigned_to = if (task.type == "AttorneyTask" || task.type == "AttorneyRewriteTask") &&
+                         !update_params&.[](:reassign)&.[](:assigned_to_id)
                         User.find(Task.find_by(id: task.parent_id).assigned_to_id)
                       elsif update_params&.[](:reassign)&.[](:assigned_to_id)
                         User.find(update_params[:reassign][:assigned_to_id])

--- a/app/models/attorney_case_review.rb
+++ b/app/models/attorney_case_review.rb
@@ -102,7 +102,7 @@ class AttorneyCaseReview < CaseflowRecord
       ActiveRecord::Base.multi_transaction do
         record = create(params)
         if record.valid?
-          if record.legacy? && record&.task&.type == "AttorneyTask"
+          if record.legacy? && (record&.task&.type == "AttorneyTask" || record&.task&.type == "AttorneyRewriteTask")
             record.update_in_vacols_and_caseflow!
           else
             record.legacy? ? record.update_in_vacols! : record.update_in_caseflow!

--- a/app/repositories/queue_repository.rb
+++ b/app/repositories/queue_repository.rb
@@ -160,6 +160,13 @@ class QueueRepository
       end
     end
 
+    def reassign_decass_to_attorney!(judge:, attorney:, vacols_id:)
+      transaction do
+        attrs = assign_to_attorney_attrs(vacols_id, attorney, judge)
+        create_decass_record(attrs.merge(adding_user: judge.vacols_uniq_id))
+      end
+    end
+
     def any_task_assigned_by_user?(appeal, user)
       VACOLS::Decass.where(defolder: appeal.vacols_id, demdusr: user.vacols_uniq_id).exists?
     end

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -147,7 +147,7 @@ class AssignToView extends React.Component {
     };
 
     if (taskType === 'AttorneyRewriteTask' && task.isLegacy === true) {
-      return this.reassignTask(false, true);
+      return this.reassignTask();
     }
 
     if (isReassignAction) {
@@ -158,12 +158,6 @@ class AssignToView extends React.Component {
       requestSave('/tasks', payload, isPulacCerullo ? pulacCerulloSuccessMessage : assignTaskSuccessMessage).
       then((resp) => {
         this.props.onReceiveAmaTasks(resp.body.tasks.data);
-        if (task.appealType === 'LegacyAppeal') {
-          this.props.legacyReassignToJudge({
-            tasks: [task],
-            assigneeId: this.state.selectedValue
-          }, assignTaskSuccessMessage);
-        }
       }).
       catch(() => {
         // handle the error from the frontend
@@ -341,6 +335,7 @@ class AssignToView extends React.Component {
 
     const action = getAction(this.props);
     const actionData = taskActionData(this.props);
+
     actionData.drop_down_label = COPY.JUDGE_LEGACY_DECISION_REVIEW_TITLE
     const isPulacCerullo = action && action.label === 'Pulac-Cerullo';
 

--- a/client/app/queue/AssignToView.jsx
+++ b/client/app/queue/AssignToView.jsx
@@ -217,12 +217,6 @@ class AssignToView extends React.Component {
       if (task.type === 'JudgeAssignTask') {
         this.props.setOvertime(task.externalAppealId, false);
       }
-      if (task.appealType === 'LegacyAppeal') {
-        this.props.legacyReassignToJudge({
-          tasks: [task],
-          assigneeId: this.state.selectedValue
-        }, successMsg);
-      }
     });
   };
 

--- a/client/app/queue/QueueActions.js
+++ b/client/app/queue/QueueActions.js
@@ -564,7 +564,7 @@ export const reassignTasksToUser = ({
 }) => (dispatch) => Promise.all(tasks.map((oldTask) => {
   let params, url;
 
-  if (oldTask.appealType === 'LegacyAppeal' && oldTask.type === 'AttorneyTask') {
+  if (oldTask.appealType === 'LegacyAppeal' && (oldTask.type === 'AttorneyTask' || oldTask.type === 'AttorneyRewriteTask')) {
     url = `/tasks/${oldTask.taskId}`;
     params = {
       data: {


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-29642](https://jira.devops.va.gov/browse/APPEALS-29642)

# Description

- Added AttorneyRewriteTask to cases where we may need to update both ama and vacols location when doing decision ready for review

- Removed legacyReassignToJudge call from AssignToView as the legacy location is already being updated in the required cases

- This fixes the three priorloc entries, but still seeing two entries for some case movements.  (Think I know why)

- Should fix colocated task issue that craig reese found as it removes the entire block of code that caused the issue

- Fixes cancel and return to judge action, actually updates legacy location now

- Moved subsequent function calls to within the post call to the task controller


## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

Return to attorney only creates one priorloc
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/30825aef-da06-4cc5-9dca-dd9dc752aabe)


