### PR TITLE
APPEALS-29347 The prop `rowObjects` is marked as required in `Row`

### DIFF
--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -796,7 +796,7 @@ HeaderRow.propTypes = FooterRow.propTypes = Row.propTypes = BodyRows.propTypes =
   tbodyId: PropTypes.string,
   tbodyRef: PropTypes.func,
   columns: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
-  rowObjects: PropTypes.arrayOf(PropTypes.object),
+  rowObjects: PropTypes.arrayOf(PropTypes.object).isRequired,
   rowClassNames: PropTypes.func,
   keyGetter: PropTypes.func,
   slowReRendersAreOk: PropTypes.bool,
@@ -833,5 +833,8 @@ HeaderRow.propTypes = FooterRow.propTypes = Row.propTypes = BodyRows.propTypes =
   onHistoryUpdate: PropTypes.func,
   preserveFilter: PropTypes.bool,
 };
+
+Row.propTypes.rowObjects = PropTypes.arrayOf(PropTypes.object);
+Row.propTypes = { ...Row.propTypes, rowObject: PropTypes.object.isRequired };
 
 /* eslint-enable max-lines */

--- a/client/app/queue/QueueTable.jsx
+++ b/client/app/queue/QueueTable.jsx
@@ -796,7 +796,7 @@ HeaderRow.propTypes = FooterRow.propTypes = Row.propTypes = BodyRows.propTypes =
   tbodyId: PropTypes.string,
   tbodyRef: PropTypes.func,
   columns: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.func]).isRequired,
-  rowObjects: PropTypes.arrayOf(PropTypes.object).isRequired,
+  rowObjects: PropTypes.arrayOf(PropTypes.object),
   rowClassNames: PropTypes.func,
   keyGetter: PropTypes.func,
   slowReRendersAreOk: PropTypes.bool,


### PR DESCRIPTION
Resolves [APPEALS-29347](https://jira.devops.va.gov/browse/APPEALS-29347)

Parent Task: [Tech-Debt: Frontend Console Warnings](https://jira.devops.va.gov/browse/APPEALS-29280)

# Description
Removed the .isRequired for the propTypes for rowObjects in QueueTable. It was causing a warning to appear in the console, because some of the keys were undefined. These keys being undefined does not affect the functionality of the page, so the .isRequired is not needed for the propType of the object.

## Acceptance Criteria
- [x] Code compiles correctly
- [x] When on the /decision_reviews/vha page, there are no warnings in the console that relate to the rowObjects in QueueTable
- [x] The page's functionality is retained

## Testing Plan
1. Login as a VHA user that has access to the Decision Review Queue (ex. ACBAUERVVHAH)
2. Go to /decision_reviews/vha
3. Open the console
4. Verify that the warning `The prop 'rowObjects' is marked as required in 'Row', but its value is 'undefined'` is not present in the console and that the page functions normally
