### PR TITLE
filters unique tasks by external appeal ID

### DIFF
--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -137,7 +137,10 @@ export const legacyJudgeTasksAssignedToUser = createSelector(
 
 const workTasksByAssigneeCssIdSelector = createSelector(
   [tasksByAssigneeCssIdSelector],
-  (tasks) => workTasksSelector(tasks)
+  (tasks) =>
+    workTasksSelector(tasks).
+      filter((task, i, arr) => arr.map((id) => (id.externalAppealId)).
+        indexOf(task.externalAppealId) === i),
 );
 
 const workTasksByAssigneeOrgSelector = createSelector(


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-29898](https://jira.devops.va.gov/browse/APPEALS-29898)

# Description
Added filter to workTasks selector to only return unique externalAppealId's so we do not get 'duplicate' tasks in the assign case page

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Judge Assign Page no longer shows multiple tasks with the same external appeal Id in their Assign Queue

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

BEFORE
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/990b31fa-a4b1-416c-a1c4-80c23940f00d)


AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/862272ea-13ea-43fd-b504-60886bf2f4ef)

