### PR TITLE
remove search bar from Document Type dropdown

### DIFF
--- a/client/app/reader/DocTagPicker.jsx
+++ b/client/app/reader/DocTagPicker.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 
 import Checkbox from '../components/Checkbox';
 import { css } from 'glamor';
-import SearchBar from '../components/SearchBar';
 
 const TagSelector = (props) => {
   const { tag, handleTagToggle, tagToggleStates } = props;
@@ -71,7 +70,6 @@ const DocTagPicker = ({ tags, tagToggleStates, handleTagToggle,
 
   return (
     <div style={{width: '217px'}}>
-      <SearchBar onChange={updateFilterText} value={filterText} disableClearSearch size="small" />
       <ul {...dropdownFilterViewListStyle} {...tagListStyling}>
         {getFilteredData().map((tag, index) => {
           return <li key={index} {...dropdownFilterViewListItemStyle} {...tagListItemStyling}>


### PR DESCRIPTION
Remove search bar from Document Type dropdown filter.


![image](https://github.com/department-of-veterans-affairs/caseflow/assets/107133331/7147b519-e573-4a63-996e-8289a9acf38c)
