### PR TITLE
Ryan/appeals 29959

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -169,12 +169,12 @@ class DocumentsTable extends React.Component {
  }
 
  executeRecieptFilter = () => {
-  this.props.setRecieptDateFilter(this.state.recieptFilter,
-    { fromDate: this.state.fromDate,
-      toDate: this.state.toDate,
-      onDate: this.state.onDate});
+   this.props.setRecieptDateFilter(this.state.recieptFilter,
+     { fromDate: this.state.fromDate,
+       toDate: this.state.toDate,
+       onDate: this.state.onDate });
 
-      this.toggleRecieptDataDropdownFilterVisibility();
+   this.toggleRecieptDataDropdownFilterVisibility();
  }
 
  isRecieptFilterButtonEnabled = () => {
@@ -375,6 +375,13 @@ class DocumentsTable extends React.Component {
         'descending'
     }`;
 
+    // conditionally rendered to give dropdown elements and their errors a solid line on their left indicating errors
+    const inputErrorStyle = {
+      borderLeft: '5px solid red',
+      marginLeft: '-2px',
+      paddingLeft: '5px'
+    };
+
     return [
       {
         cellClass: 'last-read-column',
@@ -469,27 +476,35 @@ class DocumentsTable extends React.Component {
                         dateDropdownMap[this.state.recieptFilter].displayText}
                       defaultValue="On this date"
                     />
-                    {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.FROM) &&
+                    <div>
+                      <div style={this.state.fromDateErrors.length === 0 ? {} : inputErrorStyle}>
+                        {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.FROM) &&
                   this.state.fromDateErrors.map((error, index) =>
                     <p id={index} key={index} style={{ color: 'red' }}>{error}</p>)}
-                    {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.FROM) &&
+                        {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.FROM) &&
                   <DateSelector value={this.state.fromDate} type="date" name="From"
                     onChange={this.validateDateFrom} />}
+                      </div>
 
-                    {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.TO) &&
+                      <div style={this.state.toDateErrors.length === 0 ? {} : inputErrorStyle}>
+                        {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.TO) &&
                   this.state.toDateErrors.map((error) =>
                     <p style={{ color: 'red' }}>{error}</p>)}
-                    {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.TO) &&
+                        {(this.state.recieptFilter === recieptDateFilterStates.BETWEEN || this.state.recieptFilter === recieptDateFilterStates.TO) &&
                   <DateSelector value={this.state.toDate} type="date" name="To"
                     onChange={this.validateDateTo} />}
+                      </div>
 
-                    {this.state.recieptFilter === recieptDateFilterStates.UNINITIALIZED && <DateSelector readOnly type="date" name="Receipt date"
-                      onChange={this.validateDateIsAfter} comment="This is a read only component used as a dummy" />}
+                      <div style={this.state.onDateErrors.length === 0 ? {} : inputErrorStyle}>
+                      {this.state.recieptFilter === recieptDateFilterStates.UNINITIALIZED && <DateSelector readOnly type="date" name="Receipt date"
+                        onChange={this.validateDateIsAfter} comment="This is a read only component used as a dummy" />}
 
-                    {(this.state.recieptFilter === recieptDateFilterStates.ON) && this.state.onDateErrors.map((error) =>
-                      <p style={{ color: 'red' }}>{error}</p>)}
-                    {this.state.recieptFilter === recieptDateFilterStates.ON && <DateSelector value={this.state.onDate} type="date"
-                      name="On this date" onChange={this.setOnDate} />}
+                      {(this.state.recieptFilter === recieptDateFilterStates.ON) && this.state.onDateErrors.map((error) =>
+                        <p style={{ color: 'red' }}>{error}</p>)}
+                      {this.state.recieptFilter === recieptDateFilterStates.ON && <DateSelector value={this.state.onDate} type="date"
+                        name="On this date" onChange={this.setOnDate} />}
+                        </div>
+                    </div>
 
                     <div style={{ width: '100%', display: 'flex' }}>
                       <span style={{ height: '1px', position: 'absolute', width: '100%', backgroundColor: 'gray' }}></span>


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Receipt Date Error Message Needs Red Ride Line to the Left of the Error Message](https://jira.devops.va.gov/browse/APPEALS-29959)

# Description
The receiptdate picker needed error indicators that would display a red line next to the inputs and their error messages, so the user has an additional visual cue.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan

1. Log into Caseflow as a user that can access reader (BVADWISE works)
2. Navigate to reader
3. open the receiptdate picker and choose the first category, "between these dates".
4. set an invalid date for both to and from, and verify that the red line appears next to each.
5. give one of the two dates a correct date to make the red line go away.
6. Change the filter to "before this date" and repeat the process to get the red line to appear.
7. Change the filter to "after this date" and repeat the process to get the red line to appear.
8. Change the filter to "on this date" and repeat the process to get the red line to appear.


# Frontend
## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 <img width="252" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/b394e5de-84d4-4b1b-9cc2-a40a385caa3c">| 
<img width="322" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/12c989e3-ec3d-4327-8014-56c981547500">