### PR TITLE
remove date, no necessary any more

### DIFF
--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -303,8 +303,7 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
         allow(QueueRepository).to receive(:reassign_case_to_attorney!).with(
           judge: user,
           attorney: attorney,
-          vacols_id: @appeal.vacols_id,
-          created_in_vacols_date: "2018-04-18".to_date
+          vacols_id: @appeal.vacols_id
         ).and_return(true)
 
         expect(@appeal.overtime?).to be true
@@ -334,8 +333,7 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
           allow(QueueRepository).to receive(:reassign_case_to_attorney!).with(
             judge: user,
             attorney: attorney,
-            vacols_id: @appeal.vacols_id,
-            created_in_vacols_date: "2018-04-18".to_date
+            vacols_id: @appeal.vacols_id
           ).and_return(true)
           today = Time.utc(2018, 4, 18)
           yesterday = Time.utc(2018, 4, 17)


### PR DESCRIPTION
Description 

remove date from `legacy_tasks_controller_spec.rb`,  no necessary any more!


![image (7)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/efd1931b-297d-4e4a-a71d-233f312f76aa)
