### PR TITLE
Asmith APPEALS/30785 Fix Table Header Styling

### DIFF
--- a/client/app/reader/DocumentsTable.jsx
+++ b/client/app/reader/DocumentsTable.jsx
@@ -411,7 +411,7 @@ class DocumentsTable extends React.Component {
         ariaLabel: 'categories-header-label',
         header: (
           <div id="categories-header">
-            <span id="categories-header-label">
+            <span id="categories-header-label" className="table-header-label">
               Categories
             </span>
             <FilterIcon
@@ -450,13 +450,13 @@ class DocumentsTable extends React.Component {
         header: (
           <div style={{ minWidth: '250px' }}>
             <Button
-              styling={{ 'aria-roledescription': 'sort button' }}
+              styling={{ 'aria-roledescription': 'sort button', style: { display: 'inline' } }}
               name="Receipt Date"
               id="receipt-date-header"
               classNames={['cf-document-list-button-header']}
               onClick={() => this.props.changeSortState('receivedAt')}
             >
-              <span id="receipt-date-header-label">Receipt Date</span>
+              <span id="receipt-date-header-label" className="table-header-label">Receipt Date</span>
               {this.props.docFilterCriteria.sort.sortBy === 'receivedAt' ?
                 sortArrowIcon :
                 notSortedIcon}
@@ -545,12 +545,12 @@ class DocumentsTable extends React.Component {
           <>
             <Button
               id="type-header"
-              styling={{ 'aria-roledescription': 'sort button' }}
+              styling={{ 'aria-roledescription': 'sort button', style: { display: 'inline' } }}
               name="Document Type"
               classNames={['cf-document-list-button-header']}
               onClick={() => this.props.changeSortState('type')}
             >
-              <span id="type-header-label">Document Type</span>
+              <span id="type-header-label" className="table-header-label">Document Type</span>
 
               {this.props.docFilterCriteria.sort.sortBy === 'type' ?
                 sortArrowIcon :
@@ -596,7 +596,7 @@ class DocumentsTable extends React.Component {
         ariaLabel: 'tag-header-label',
         header: (
           <div id="tags-header" className="document-list-header-issue-tags">
-            <span id="tag-header-label">
+            <span id="tag-header-label" className="table-header-label">
               Issue Tags
             </span>
             <FilterIcon
@@ -632,7 +632,7 @@ class DocumentsTable extends React.Component {
       {
         cellClass: 'comments-column',
         header: (
-          <div id="comments-header" className="document-list-header-comments">
+          <div id="comments-header" className="document-list-header-comments table-header-label">
             Comments
           </div>
         ),

--- a/client/app/styles/reader/_document_list.scss
+++ b/client/app/styles/reader/_document_list.scss
@@ -93,6 +93,10 @@
     th > div {
       display: flex;
     }
+
+    .table-header-label {
+      vertical-align: super;
+    }
   }
 
   .cf-document-list-button-header {


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Filter Icon Below the Column Header](https://jira.devops.va.gov/browse/APPEALS-30785)

# Description
Fix Table Header Styling:    
- Move filter icon next to header name.   
- Fix alignment of th labels.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
1. Log in as a user with reader access.
2. Navigate to reader.
3. Verify the changes to the documents table header.

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 
<img width="1832" alt="before" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/33c2ad3c-ab13-4ea5-94dd-389a78a5bf49">
|
<img width="1787" alt="after" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/4e95cadd-f11b-400c-bb82-a95c35b46fd3">