### PR TITLE
colocated tasks in on hold tab fixed

### DIFF
--- a/app/models/queue_tabs/on_hold_tasks_tab.rb
+++ b/app/models/queue_tabs/on_hold_tasks_tab.rb
@@ -39,7 +39,9 @@ class OnHoldTasksTab < QueueTab
   def legacy_colocated_task_ids_assigned_by_assignee
     colocated_tasks = ColocatedTask.open.order(:created_at)
       .where(assigned_by: assignee, assigned_to_type: Organization.name, appeal_type: LegacyAppeal.name)
-
+      .select do |task|
+        task&.parent&.type&.is_a?(ColocatedTask)
+      end
     colocated_tasks.group_by(&:appeal_id).map { |_appeal_id, tasks| tasks.first.id }
   end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-30703](https://jira.devops.va.gov/browse/APPEALS-30703)

# Description
If the parent is not a colocated task, these tasks will not be added to the on hold tasks tab

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Remove colocated tasks from on hold tasks tab for judges queue

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

BEFORE
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/05c8b890-214c-444a-803b-651b825c0d77)

AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/4f1ea63a-201e-4f6f-a8af-62314fbec181)


