### PR TITLE
APPEALS-29634 Fix Deprecation Warning: update_attributes is deprecated and will be removed from Rails 6.1

### DIFF
--- a/app/models/concerns/case_review_concern.rb
+++ b/app/models/concerns/case_review_concern.rb
@@ -23,7 +23,7 @@ module CaseReviewConcern
 
   def associate_with_appeal
     # Populate appeal_* column values based on original implementation that uses `task_id`
-    update_attributes(
+    update(
       appeal_id: appeal_through_task_id&.id,
       appeal_type: appeal_through_task_id&.class&.name
     )

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -7,18 +7,18 @@ module DisallowedDeprecations
   class ::DisallowedDeprecationError < StandardError; end
 
   # Regular expressions for Rails 5.2 deprecation warnings that we have addressed in the codebase
-  RAILS_5_2_FIXED_DEPRECATION_WARNING_REGEXES = [
+  RAILS_6_0_FIXED_DEPRECATION_WARNING_REGEXES = [
     /Dangerous query method \(method whose arguments are used as raw SQL\) called with non\-attribute argument\(s\)/
   ].freeze
 
   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
-    /update_attributes!*\(/
+    /update_attributes is deprecated and will be removed from Rails 6\.1/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection
   DISALLOWED_DEPRECATION_WARNING_REGEXES = [
-    *RAILS_5_2_FIXED_DEPRECATION_WARNING_REGEXES,
+    *RAILS_6_0_FIXED_DEPRECATION_WARNING_REGEXES,
     *RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES
   ].freeze
 

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -11,9 +11,15 @@ module DisallowedDeprecations
     /Dangerous query method \(method whose arguments are used as raw SQL\) called with non\-attribute argument\(s\)/
   ].freeze
 
+   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
+  RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
+     /update_attributes!*\(/
+  ].freeze
+
   # Regular expressions for deprecation warnings that should raise an exception on detection
   DISALLOWED_DEPRECATION_WARNING_REGEXES = [
-    *RAILS_5_2_FIXED_DEPRECATION_WARNING_REGEXES
+    *RAILS_5_2_FIXED_DEPRECATION_WARNING_REGEXES,
+    *RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES
   ].freeze
 
   # @param message [String] deprecation warning message to be checked against disallow list

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -6,7 +6,7 @@
 module DisallowedDeprecations
   class ::DisallowedDeprecationError < StandardError; end
 
-  # Regular expressions for Rails 5.2 deprecation warnings that we have addressed in the codebase
+  # Regular expressions for Rails 6.0 deprecation warnings that we have addressed in the codebase
   RAILS_6_0_FIXED_DEPRECATION_WARNING_REGEXES = [
     /Dangerous query method \(method whose arguments are used as raw SQL\) called with non\-attribute argument\(s\)/
   ].freeze

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -11,9 +11,9 @@ module DisallowedDeprecations
     /Dangerous query method \(method whose arguments are used as raw SQL\) called with non\-attribute argument\(s\)/
   ].freeze
 
-   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
+  # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
-     /update_attributes!*\(/
+    /update_attributes!*\(/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-29634](https://jira.devops.va.gov/browse/APPEALS-29634)

# Description
## Background
### Deprecation Warning
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead)
Deprecation Horizon: Rails 6.1
#### Affected locations
* Found in CI / Test
    The following locations have already been identified via CI / Test errors:
    called from `associate_with_appeal` at `app/models/concerns/case_review_concern.rb:26`


* Found by Code Search
    Codebase was searched for other potentially affected locations 
    RegEx:  `/update_attributes!*\(/`
    
No additional affected locations were found.

#### Proposed Solution
For each affected location, exercise the code with the associated RSpec test, or, if such a test doesn't exist, find a way to exercise it from the Rails console, and confirm that the location triggers the deprecation warning when executed. If confirmed, replace the call to `ActiveRecord::Persistence #update_attributes` with alias `#update`, and exercise the code again to confirm that the deprecation warning is no longer emitted.

Also, please add a regex for the deprecation warning to the `DisallowedDeprecations` array:
https://github.com/department-of-veterans-affairs/caseflow/blob/faebbf69589e773ce239ece6dd2deb2315b29857/app/services/deprecation_warnings/disallowed_deprecations.rb#L10-L12

## Testing Plan
- Jira Test Issue: https://jira.devops.va.gov/browse/APPEALS-31295

### Local Development Environment

#### Allowed Deprecation Warning does NOT raise exception

- [x] From local `development` Rails console, manually issue a deprecation warning
```ruby
ActiveSupport::Deprecation.warn("test")
```
- [x] Confirm that an exception is **NOT** raised
#### Disallowed Deprecation Warning raises exception

- [x] From local `development` Rails console, manually issue the deprecation warning
```ruby
ActiveSupport::Deprecation.warn("update_attributes is deprecated and will be removed from Rails 6.1")
```
- [x] Confirm that exception `DisallowedDeprecationError` is raised
### CI / Test Environment

#### Deprecation Warning is no longer emitted

- [x] Confirm that all relevant specs pass
    
### UAT
- [x] From the caseflow UAT Rails console, manually issue the deprecation warning
```ruby
ActiveSupport::Deprecation.warn("update_attributes is deprecated and will be removed from Rails 6.1")
```
- [x] Check Sentry for Caseflow UAT and confirm that an issue for `DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1` was created
- [x] Check Sentry for Caseflow UAT and confirm that an issue for exception `DisallowedDeprecationError` was **NOT** created
- [x] Check the DSVA Slack channel `#appeals-deprecation-alerts` and confirm that a new alert was created for `DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1`

### Prod Verification
- [ ] From the caseflow Prod Rails console, manually issue the deprecation warning
```ruby
ActiveSupport::Deprecation.warn("update_attributes is deprecated and will be removed from Rails 6.1")
```
- [ ] Check Sentry for Caseflow Prod and confirm that a new issue for `DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1` was created
- [ ] Check Sentry for Caseflow Prod and confirm that an issue for exception `DisallowedDeprecationError` was **NOT** created
- [ ] Check the DSVA Slack channel `#appeals-deprecation-alerts` and confirm that a new alert was created for `DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1`


# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

## Monitoring, Logging, Auditing, Error, and Exception Handling Checklist

### Monitoring
- [ ] Are performance metrics (e.g., response time, throughput) being tracked?
- [ ] Are key application components monitored (e.g., database, cache, queues)?
- [ ] Is there a system in place for setting up alerts based on performance thresholds?

### Logging
- [ ] Are logs being produced at appropriate log levels (debug, info, warn, error, fatal)?
- [ ] Are logs structured (e.g., using log tags) for easier querying and analysis?
- [ ] Are sensitive data (e.g., passwords, tokens) redacted or omitted from logs?
- [ ] Is log retention and rotation configured correctly?
- [ ] Are logs being forwarded to a centralized logging system if needed?

### Auditing
- [ ] Are user actions being logged for audit purposes?
- [ ] Are changes to critical data being tracked ?
- [ ] Are logs being securely stored and protected from tampering or exposing protected data?

### Error Handling
- [ ] Are errors being caught and handled gracefully?
- [ ] Are appropriate error messages being displayed to users?
- [ ] Are critical errors being reported to an error tracking system (e.g., Sentry, ELK)?
- [ ] Are unhandled exceptions being caught at the application level ?

### Exception Handling
- [ ] Are custom exceptions defined and used where appropriate?
- [ ] Is exception handling consistent throughout the codebase?
- [ ] Are exceptions logged with relevant context and stack trace information?
- [ ] Are exceptions being grouped and categorized for easier analysis and resolution?

