### PR TITLE
Search Reader Tags Starting at 2 Characters

### DIFF
--- a/client/app/reader/DocTagPicker.jsx
+++ b/client/app/reader/DocTagPicker.jsx
@@ -55,7 +55,7 @@ const DocTagPicker = ({ tags, tagToggleStates, handleTagToggle, defaultSearchTex
   const [filterText, updateFilterText] = useState('');
 
   const getFilteredData = () => {
-    if (filterText.length < 3) {
+    if (filterText.length < 2) {
       return tags;
     }
     const filteredData = tags.filter(


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Tag Filter Search Move to 2 Characters Long](https://jira.devops.va.gov/browse/JIRA-30828)

# Description
Begin searching document tags in the tag filter dropdown starting at 2 characters instead of 3.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
1. Log into Appeals as a user with reader access (`BVADWISE` works).
2. Click the filter icon in the "Issue Tags" column.
3. Type 2 or more characters.
4. Verify that the tags are searched with 2 or more characters entered into the search box. 

# Frontend
## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="1486" alt="before" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/b27e988e-9059-4958-bd3a-d6f9940d338a">
|
<img width="1498" alt="after" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/080a2b54-5d2b-4802-8c01-ef9175c3aca0">
