### PR TITLE
APPEALS-30972 | Change appealId PropType to number for POA button

### DIFF
--- a/client/app/queue/PowerOfAttorneyDetail.jsx
+++ b/client/app/queue/PowerOfAttorneyDetail.jsx
@@ -185,7 +185,10 @@ PowerOfAttorneyNameUnconnected.propTypes = PowerOfAttorneyDetailUnconnected.prop
     alertType: PropTypes.string,
     powerOfAttorney: PropTypes.object
   }),
-  appealId: PropTypes.string,
+  appealId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ]),
   appellantType: PropTypes.string,
   vha: PropTypes.bool
 };

--- a/client/app/queue/components/PoaRefresh.jsx
+++ b/client/app/queue/components/PoaRefresh.jsx
@@ -57,5 +57,8 @@ PoaRefresh.propTypes = {
   powerOfAttorney: PropTypes.shape({
     poa_last_synced_at: PropTypes.string
   }),
-  appealId: PropTypes.string
+  appealId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ])
 };

--- a/client/app/queue/components/PoaRefreshButton.jsx
+++ b/client/app/queue/components/PoaRefreshButton.jsx
@@ -59,5 +59,8 @@ export const PoaRefreshButton = ({ appealId }) => {
 };
 
 PoaRefreshButton.propTypes = {
-  appealId: PropTypes.string
+  appealId: PropTypes.oneOfType([
+    PropTypes.number,
+    PropTypes.string
+  ])
 };


### PR DESCRIPTION
Resolves  https://jira.devops.va.gov/browse/APPEALS-30972

Throughout the app we have many instances of console warnings coming from React. As a developer team we should try to reduce these warning and errors where possible.

While some of these aren't really all that important for the performance of the app I believe it has value in reducing what I call "Warning Complacency" where we become complacent with having warnings in the app which can lead to more important warnings and errors getting lost in the noise of other minor warnings.

# Description

The POA refresh button components are expecting the appealId to come through as type string but it only comes through as type number.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The console warnings are gone
- [ ] The Refresh POA functionality continues to work as expected


At `[http://127.0.0.1:3000/decision_reviews/vha/tasks/\](http://127.0.0.1:3000/decision_reviews/vha/tasks/){appealId}`

## QA
- [ ] Ensure that the Refresh POA logic continues to work the same


![image](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/b7425e23-d73c-4e47-bba5-934151ec2688)

Original PR:
https://github.com/department-of-veterans-affairs/caseflow/pull/16299