### PR TITLE
fixes multiple ui errors with task instructions

### DIFF
--- a/client/app/queue/components/TaskRows.jsx
+++ b/client/app/queue/components/TaskRows.jsx
@@ -355,7 +355,7 @@ class TaskRows extends React.PureComponent {
 
     return (
       <React.Fragment key={`${task.uniqueId} fragment`}>
-        {task.instructions[1] && (<React.Fragment key={`${task.uniqueId} div`}>
+        {task.instructions[1] && task.type === 'JudgeAssignTask' && (<React.Fragment key={`${task.uniqueId} div`}>
           <div
             key={`${task.uniqueId} instructions`}
             style={divStyles}
@@ -366,7 +366,7 @@ class TaskRows extends React.PureComponent {
           </div>
         </React.Fragment>
         )}
-        {task.assigneeName && !(task.type === ('AttorneyTask' || 'AttorneyRewriteTask')) &&
+        {task.assigneeName && task.type !== 'AttorneyTask' && task.type !== 'AttorneyRewriteTask' &&
         (<React.Fragment key={`${task.uniqueId} div`}>
           <div
             key={`${task.uniqueId} instructions`}
@@ -385,7 +385,7 @@ class TaskRows extends React.PureComponent {
               style={divStyles}
               className="task-instructions"
             >
-              <b>{COPY.LEGACY_APPEALS_VLJ_DETAILS_INSTRUCTIONS}</b>
+              <b>{task.type !== 'JudgeDecisionReviewTask' && COPY.LEGACY_APPEALS_VLJ_DETAILS_INSTRUCTIONS}</b>
               <ReactMarkdown>{formatBreaks(task.instructions[0])}</ReactMarkdown>
             </div>
           </React.Fragment>


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-30901](https://jira.devops.va.gov/browse/APPEALS-30901)

# Description
On first assignment of a JudgeDecisionReviewTask, the task instructions now correctly show only the attorney notes header
Refactored task instructions conditionals to satisfy JS and make them more consistent
Reason field in task instructions now only appears for JudgeAssignTask

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Task instructions follows all figma and AC requirements in both active tasks and case timeline

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go from scenario 1 to scenario 7 with the same case, and verify all instructions fields are correct

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

First assignment of JudgeDecisionReviewTask
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/f6164743-c884-441f-9ed1-81597edc3978)

Multiple Reassignments on JudgeDecisionReviewTask
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/f2fb240a-7a20-406d-8632-673417cf6f9b)

AttorneyTask only showing details
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/702c7110-91dd-4cf5-9cc0-d23150690586)


