### PR TITLE
jcroteau/APPEALS-29633 Fix Deprecation Warning: `ActiveRecord::Result#to_hash` has been renamed to `to_a`. `to_hash` [pre Rails 6.1]

### DIFF
--- a/app/controllers/organizations/task_summary_controller.rb
+++ b/app/controllers/organizations/task_summary_controller.rb
@@ -31,7 +31,7 @@ class Organizations::TaskSummaryController < OrganizationsController
       format.json do
         render json: {
           members: json_users(organization.users),
-          task_counts: result.to_hash.to_json
+          task_counts: result.to_a.to_json
         }
       end
     end

--- a/app/models/vacols/case_assignment.rb
+++ b/app/models/vacols/case_assignment.rb
@@ -159,7 +159,7 @@ class VACOLS::CaseAssignment < VACOLS::Record
           conn.exec_query(sanitize_sql_array([query, vacols_ids]))
         end
 
-        result.to_hash.reduce({}) do |memo, row|
+        result.to_a.reduce({}) do |memo, row|
           memo[(row["bfkey"]).to_s] = (row["n"] > 0)
           memo
         end

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -210,7 +210,7 @@ class VACOLS::CaseDocket < VACOLS::Record
       group by PRIORITY, READY
     SQL
 
-    connection.exec_query(query).to_hash
+    connection.exec_query(query).to_a
   end
   # rubocop:enable Metrics/MethodLength
 
@@ -220,7 +220,7 @@ class VACOLS::CaseDocket < VACOLS::Record
       where VLJ is null or #{ineligible_judges_sattyid_cache}
     SQL
 
-    connection.exec_query(query).to_hash.count
+    connection.exec_query(query).to_a.size
   end
 
   def self.not_genpop_priority_count
@@ -229,7 +229,7 @@ class VACOLS::CaseDocket < VACOLS::Record
       where VLJ is not null
     SQL
 
-    connection.exec_query(query).to_hash.count
+    connection.exec_query(query).to_a.size
   end
 
   def self.nod_count
@@ -311,7 +311,7 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     fmtd_query = sanitize_sql_array([query, num])
 
-    appeals = conn.exec_query(fmtd_query).to_hash
+    appeals = conn.exec_query(fmtd_query).to_a
     appeals.map { |appeal| appeal["bfdloout"] }
   end
 
@@ -330,7 +330,7 @@ class VACOLS::CaseDocket < VACOLS::Record
                                       num
                                     ])
 
-    appeals = conn.exec_query(fmtd_query).to_hash
+    appeals = conn.exec_query(fmtd_query).to_a
     appeals.map { |appeal| appeal["bfd19"] }
   end
 
@@ -349,7 +349,7 @@ class VACOLS::CaseDocket < VACOLS::Record
                                       num
                                     ])
 
-    appeals = conn.exec_query(fmtd_query).to_hash
+    appeals = conn.exec_query(fmtd_query).to_a
     appeals.map { |appeal| appeal["bfd19"] }
   end
 
@@ -361,7 +361,7 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     fmtd_query = sanitize_sql_array([query, 1])
 
-    connection.exec_query(fmtd_query).to_hash.first&.fetch("bfdloout")
+    connection.exec_query(fmtd_query).to_a.first&.fetch("bfdloout")
   end
 
   def self.age_of_oldest_priority_appeal_by_docket_date
@@ -372,7 +372,7 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     fmtd_query = sanitize_sql_array([query, 1])
 
-    connection.exec_query(fmtd_query).to_hash.first&.fetch("bfd19")
+    connection.exec_query(fmtd_query).to_a.first&.fetch("bfd19")
   end
 
   def self.nonpriority_decisions_per_year
@@ -411,7 +411,7 @@ class VACOLS::CaseDocket < VACOLS::Record
   end
 
   def self.priority_ready_appeal_vacols_ids
-    connection.exec_query(SELECT_PRIORITY_APPEALS).to_hash.map { |appeal| appeal["bfkey"] }
+    connection.exec_query(SELECT_PRIORITY_APPEALS).to_a.map { |appeal| appeal["bfkey"] }
   end
 
   def self.ready_to_distribute_appeals
@@ -420,7 +420,7 @@ class VACOLS::CaseDocket < VACOLS::Record
     SQL
 
     fmtd_query = sanitize_sql_array([query])
-    connection.exec_query(fmtd_query).to_hash
+    connection.exec_query(fmtd_query).to_a
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ParameterLists, Metrics/MethodLength
@@ -504,11 +504,11 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     conn.transaction do
       if dry_run
-        conn.exec_query(query).to_hash
+        conn.exec_query(query).to_a
       else
         conn.execute(LOCK_READY_APPEALS) unless FeatureToggle.enabled?(:acd_disable_legacy_lock_ready_appeals)
 
-        appeals = conn.exec_query(query).to_hash
+        appeals = conn.exec_query(query).to_a
         return appeals if appeals.empty?
 
         vacols_ids = appeals.map { |appeal| appeal["bfkey"] }

--- a/app/models/vacols/case_issue.rb
+++ b/app/models/vacols/case_issue.rb
@@ -107,7 +107,7 @@ class VACOLS::CaseIssue < VACOLS::Record
       conn.exec_query(sanitize_sql_array([query, vacols_ids]))
     end
 
-    issues_result.to_hash.reduce({}) do |memo, result|
+    issues_result.to_a.reduce({}) do |memo, result|
       issue_key = result["isskey"].to_s
       memo[issue_key] = (memo[issue_key] || []) << result
       memo

--- a/app/models/vacols/correspondent.rb
+++ b/app/models/vacols/correspondent.rb
@@ -50,7 +50,7 @@ class VACOLS::Correspondent < VACOLS::Record
 
     fmtd_query = sanitize_sql_array([query, last_extract])
 
-    connection.exec_query(fmtd_query).to_hash
+    connection.exec_query(fmtd_query).to_a
   end
 
   # Take in a collection and return a csv friendly format

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -14,7 +14,8 @@ module DisallowedDeprecations
 
   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
-    /update_attributes is deprecated and will be removed from Rails 6\.1/
+    /update_attributes is deprecated and will be removed from Rails 6\.1/,
+    /`ActiveRecord::Result#to_hash` has been renamed to `to_a`/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection

--- a/lib/tasks/doc.rake
+++ b/lib/tasks/doc.rake
@@ -41,7 +41,7 @@ namespace :doc do
     end
 
     def exec_sql(sql)
-      db_connection.exec_query(sql).to_hash
+      db_connection.exec_query(sql).to_a
     end
 
     def db_connection


### PR DESCRIPTION
### 🔴 **Warning:** To be merged into `master` only _with_ or _after_ the Rails 6.0 upgrade (https://github.com/department-of-veterans-affairs/caseflow/pull/19261).

<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves https://jira.devops.va.gov/browse/APPEALS-29633

# Description
## Deprecation Warning
```
DEPRECATION WARNING: `ActiveRecord::Result#to_hash` has been renamed to `to_a`. `to_hash` is deprecated and will be removed in Rails 6.1.
```

**Deprecation Horizon:** Rails 6.1

## Affected locations
### Found in CI / Test

The following locations were identified via [`DisallowedDeprecationError`'s in CI / Test](https://github.com/department-of-veterans-affairs/caseflow/pull/19287):
- called from block (2 levels) in `index` at `app/controllers/organizations/task_summary_controller.rb:34`
- called from `counts_by_priority_and_readiness` at `app/models/vacols/case_docket.rb:182`
- called from `counts_by_priority_and_readiness` at `app/models/vacols/case_docket.rb:201`
- called from `age_of_n_oldest_genpop_priority_appeals` at `app/models/vacols/case_docket.rb:283`
- called from `age_of_oldest_priority_appeal` at `app/models/vacols/case_docket.rb:325`
- called from block in `distribute_appeals` at `app/models/vacols/case_docket.rb:457`
- called from `descriptions` at `app/models/vacols/case_issue.rb:106`
- called at `app/models/concerns/belongs_to_polymorphic_appeal_concern_spec.rb:56`

### Found by Code Search
- Codebase was manually searched for other potentially affected locations.
  - Regular expressions used:
    - `/exec_query[\S\s]*to_hash/`
    - `/\.to_hash/`
      - matches were carefully vetted for calls to `ActiveRecord::Result #to_hash`
- called at `app/models/vacols/case_assignment.rb:162`
- called from `counts_by_priority_and_readiness` at `app/models/vacols/case_docket.rb:192`
- called from `age_of_n_oldest_genpop_priority_appeals` at `app/models/vacols/case_docket.rb:298`
- called from `age_of_oldest_priority_appeal` at `app/models/vacols/case_docket.rb:313`
- called from `age_of_oldest_priority_appeal` at `app/models/vacols/case_docket.rb:336`
- called from `age_of_oldest_priority_appeal` at `app/models/vacols/case_docket.rb:369`
- called from block in `distribute_appeals` at `app/models/vacols/case_docket.rb:453`
- called at `app/models/vacols/correspondent.rb:52`
- called at `lib/tasks/doc.rake:44`

## Solution
Replace calls to `ActiveRecord::Result #to_hash` with `#to_a`. 

_**Note:** This is only a signature change. The result of `ActiveRecord::Result #to_a` is the same as for `#to_hash`._

# Testing Plan
- Jira Test issue: https://jira.devops.va.gov/browse/APPEALS-31147

### 🔴 **Warning:** To be merged into `master` only _with_ or _after_ the Rails 6.0 upgrade (https://github.com/department-of-veterans-affairs/caseflow/pull/19261).