### PR TITLE
APPEALS-24894 | Add cron job to priority sync

### DIFF
--- a/app/jobs/ep_priority_sync_job.rb
+++ b/app/jobs/ep_priority_sync_job.rb
@@ -23,6 +23,7 @@ class EpPrioritySyncJob < CaseflowJob
       # no Raven report. We'll try again later.
       Rails.logger.error error
     rescue StandardError => error
+      # BOOM 💥
       capture_exception(error: error)
     end
   end

--- a/app/jobs/ep_priority_sync_job.rb
+++ b/app/jobs/ep_priority_sync_job.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+# Runs the priority sync for cancelled and cleared EPs
+class EpPrioritySyncJob < CaseflowJob
+  queue_with_priority :low_priority
+  application_attr :intake
+
+  BATCH_SIZE = 50
+
+  def perform(batch_limit = BATCH_SIZE)
+    RequestStore.store[:current_user] = User.system_user
+
+    begin
+      ep_syncer = WarRoom::ReportLoadEndProductSync.new
+      synced_cleared_eps = ep_syncer.run_for_cleared_eps(batch_limit)
+      synced_cancelled_eps = ep_syncer.run_for_cancelled_eps(batch_limit)
+
+      Raven.capture_message \
+        "EP Priority Sync Job: #{DateTime.now}" \
+        "Cancelled EPs Attempted/Synced: #{batch_limit}/#{synced_cancelled_eps}" \
+        "Cleared EPs Attempted/Synced: #{batch_limit}/#{synced_cleared_eps}"
+    rescue Errno::ETIMEDOUT => error
+      # no Raven report. We'll try again later.
+      Rails.logger.error error
+    rescue StandardError => error
+      capture_exception(error: error)
+    end
+  end
+end

--- a/lib/helpers/report_load_end_product_sync.rb
+++ b/lib/helpers/report_load_end_product_sync.rb
@@ -35,12 +35,14 @@ module WarRoom
 
       @error_log = []
       @run_log = []
+      synced_count = 0
 
       error_ids = get_error_ids
 
       eps_queried = get_cleared_eps(batch_limit, error_ids, conn)
       eps_queried.each do |x|
         call_priority_sync(x["reference_id"], conn)
+        synced_count += 1
       end
 
       error_csv = build_csv(@error_log)
@@ -50,6 +52,7 @@ module WarRoom
       final_metrics
 
       conn.close
+      synced_count
     end
 
     # Priority sync for cancelled EPs
@@ -59,12 +62,14 @@ module WarRoom
 
       @error_log = []
       @run_log = []
+      synced_count = 0
 
       error_ids = get_error_ids
 
       eps_queried = get_cancelled_eps(batch_limit, error_ids, conn)
       eps_queried.each do |x|
         call_priority_sync(x["reference_id"], conn)
+        synced_count += 1
       end
 
       error_csv = build_csv(@error_log)
@@ -74,6 +79,7 @@ module WarRoom
       final_metrics
 
       conn.close
+      synced_count
     end
 
 


### PR DESCRIPTION
Resolves [Add cron job to priority sync](https://jira.devops.va.gov/browse/APPEALS-24894)

# Description
This is a dev supporting PR that implements a cron job that will run the priority sync job every hour. It will process 50 at a time so we are not overloading any services. This job syncs all cancelled and cleared EPs between Caseflow and VBMS. It is a crucial job that needs to run at least once a week in a large batch size of usually 500 plus. 

Containing this in a job that runs every hour with a total of 50 means we can sync 1,200 per day or 8,400 per week. This satisfies the amount that we should run every week and makes it so no developer intervention is needed to process this job. 


## Acceptance Criteria
- [x] Code compiles correctly
