### PR TITLE
disabling rubocop checks for sync lock

### DIFF
--- a/app/models/concerns/sync_lock.rb
+++ b/app/models/concerns/sync_lock.rb
@@ -6,6 +6,7 @@ module SyncLock
   extend ActiveSupport::Concern
   LOCK_TIMEOUT = ENV["SYNC_LOCK_MAX_DURATION"]
 
+  # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   def hlr_sync_lock
     if decision_review.is_a?(HigherLevelReview) && block_given?
       redis = Redis.new(url: Rails.application.secrets.redis_url_cache)


### PR DESCRIPTION
turning off rubocop checks for hlr_sync_lock

