### PR TITLE
changed staff create to find by or create

### DIFF
--- a/lib/generators/vacols/staff.rb
+++ b/lib/generators/vacols/staff.rb
@@ -59,8 +59,7 @@ class Generators::Vacols::Staff
 
     def create(attrs = {})
       merged_attrs = staff_attrs.merge(attrs)
-
-      VACOLS::Staff.create(merged_attrs)
+      VACOLS::Staff.find_or_create_by(merged_attrs)
     end
   end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/JIRA-12345)

# Description
Fixes staff generator so now it does not create a new staff record if one is already found containing the same attrs.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Staff generator does not create new staff record if the staff record is already in vacols

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue
Staff count before generation: 3481
Staff count after generation: 3481

Scenario 1
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/3620150e-d6c4-46c0-a8a8-e7e2880a2308)

Scenario 3
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/7d7ea7c9-3053-4ee5-8e2a-f19b8747ecdd)

Scenario 4
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/a736d2f8-e2ea-49a8-82e8-3dea5e3cf303)



