### PR TITLE
fixed typo that was causing wrong banner to appear

### DIFF
--- a/client/app/queue/components/AssignToAttorneyWidget.jsx
+++ b/client/app/queue/components/AssignToAttorneyWidget.jsx
@@ -188,7 +188,7 @@ export class AssignToAttorneyWidget extends React.PureComponent {
         return this.props.showSuccessMessage({
           title: sprintf(COPY.ASSIGN_WIDGET_SUCCESS, {
             verb: isReassign ? 'You have successfully reassigned' : 'You have successfully assigned',
-            numCases: selectedTasks.length === 1 && selectedTasks[0].appeal?.appelantFullName ? `${selectedTasks[0].appeal.appellantFullName}'s` : selectedTasks.length,
+            numCases: selectedTasks.length === 1 && selectedTasks[0].appeal?.appellantFullName ? `${selectedTasks[0].appeal.appellantFullName}'s` : selectedTasks.length,
             casePlural: pluralize('cases', selectedTasks.length),
             // eslint-disable-next-line camelcase
             assignee: assignee.full_name


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/JIRA-12345)

# Description
Please explain the changes you made here. 
1. Added an L to appelant. (Fixes typo and now displays correct banner)

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Successful banner shows appellant's name in scenario 4/5

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

BEFORE
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/d505b1e9-6f16-4931-be91-b4c384071db9)

AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/108481161/b025e559-1d9d-4f1d-b9d5-5698c87dd953)
