### PR TITLE
add timecop to fix tests

### DIFF
--- a/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
+++ b/spec/models/post_send_initial_notification_letter_holding_task_spec.rb
@@ -196,6 +196,8 @@ describe PostSendInitialNotificationLetterHoldingTask do
       )
     end
 
+    before { Timecop.travel(Time.zone.local(2020, 9, 1, 18, 0, 0)) }
+
     context "The TaskTimer for the hold period was not created yet" do
       it "returns the end date period" do
         expect((post_task.timer_ends_at - post_task.created_at.prev_day).to_i / 1.day).to eq(hold_days)


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-31522](https://jira.devops.va.gov/browse/APPEALS-31522)

# Description
Add Timecop to ensure the tests are run at the same system time on every test run.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests not failing
