### PR TITLE
explicitly require base.rb to avoid namespace errors for seed files

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,6 +3,8 @@
 require "database_cleaner"
 
 # because db/seeds is not in the autoload path, we must load them explicitly here
+# base.rb needs to be loaded first because the other seeds inherit from it
+require Rails.root.join("db/seeds/base.rb").to_s
 Dir[Rails.root.join("db/seeds/*.rb")].sort.each { |f| require f }
 
 class SeedDB

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -41,6 +41,8 @@ end
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 # because db/seeds is not in the autoload path, we must load them explicitly here
+# base.rb needs to be loaded first because the other seeds inherit from it
+require Rails.root.join("db/seeds/base.rb").to_s
 Dir[Rails.root.join("db/seeds/**/*.rb")].sort.each { |f| require f }
 
 # The TZ variable controls the timezone of the browser in capybara tests, so we always define it.


### PR DESCRIPTION
# Description
Add require statement to explicitly require the seeds/base.rb file prior to loading the other seed files since they inherit from base

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Rspec tests can be run locally
