### PR TITLE
Min/APPEALS-31484

### DIFF
--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -71,8 +71,8 @@ class VaDotGovAddressValidator
       # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
       return "RO49" if closest_regional_office_facility_id_is_el_paso?
+      return "RO58" if appellant_lives_in_phillipines?
       return "RO71" if !appellant_lives_in_usa?
-      return "RO56" if appellant_lives_in_phillipines?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -71,6 +71,7 @@ class VaDotGovAddressValidator
       # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
       return "RO49" if closest_regional_office_facility_id_is_el_paso?
+      return "RO71" if veteran_lives_in_usa?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -71,8 +71,8 @@ class VaDotGovAddressValidator
       # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
       return "RO49" if closest_regional_office_facility_id_is_el_paso?
-      return "RO71" if !veteran_lives_in_usa?
-      return "RO56" if veteran_lives_in_phillipines?
+      return "RO71" if !appellant_lives_in_usa?
+      return "RO56" if appellant_lives_in_phillipines?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -46,7 +46,7 @@ class VaDotGovAddressValidator
 
     update_closest_regional_office
     destroy_existing_available_hearing_locations!
-    create_available_hearing_locations if closest_regional_office != "RO71"
+    create_available_hearing_locations
     { status: :matched_available_hearing_locations }
   end
 
@@ -70,7 +70,7 @@ class VaDotGovAddressValidator
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
       return "RO49" if closest_regional_office_facility_id_is_el_paso?
       return "RO58" if appellant_lives_in_phillipines?
-      return "RO71" if !appellant_lives_in_usa?
+      return "RO11" if !appellant_lives_in_usa?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -46,8 +46,7 @@ class VaDotGovAddressValidator
 
     update_closest_regional_office
     destroy_existing_available_hearing_locations!
-    create_available_hearing_locations
-
+    create_available_hearing_locations if closest_regional_office != "RO71"
     { status: :matched_available_hearing_locations }
   end
 
@@ -66,7 +65,6 @@ class VaDotGovAddressValidator
   def closest_regional_office
     @closest_regional_office ||= begin
       return unless closest_ro_response.success?
-
       # Note: In `ro_facility_ids_to_geomatch`, the San Antonio facility ID and Elpaso facility Id is passed
       # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?

--- a/app/services/va_dot_gov_address_validator.rb
+++ b/app/services/va_dot_gov_address_validator.rb
@@ -71,7 +71,8 @@ class VaDotGovAddressValidator
       # as a valid RO for any veteran living in Texas.
       return "RO62" if closest_regional_office_facility_id_is_san_antonio?
       return "RO49" if closest_regional_office_facility_id_is_el_paso?
-      return "RO71" if veteran_lives_in_usa?
+      return "RO71" if !veteran_lives_in_usa?
+      return "RO56" if veteran_lives_in_phillipines?
 
       RegionalOffice
         .cities

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -84,10 +84,10 @@ module VaDotGovAddressValidator::Validations
   end
 
   def veteran_lives_in_usa?
-    %w[USA US].include? appeal.veteran&.address&.country
+    %w[USA US].include? address.country
   end
 
   def veteran_lives_in_phillipines?
-    %w[PH RP PI].include? appeal.veteran&.address&.country
+    %w[PH RP PI].include? address.country
   end
 end

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -56,7 +56,7 @@ module VaDotGovAddressValidator::Validations
                         error_handler.handle(state_code_error)
                       elsif !closest_ro_response.success?
                         error_handler.handle(closest_ro_response.error)
-                      elsif !available_hearing_locations_response.success?
+                      elsif closest_regional_office != "RO71" && !available_hearing_locations_response.success?
                         error_handler.handle(available_hearing_locations_response.error)
                       end
   end
@@ -84,7 +84,9 @@ module VaDotGovAddressValidator::Validations
   end
 
   def appellant_lives_in_usa?
-    %w[USA US].include? address.country
+    return true if address.country.nil?
+
+    %w[USA US].include? address.country unless address.country.nil?
   end
 
   def appellant_lives_in_phillipines?

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -82,4 +82,8 @@ module VaDotGovAddressValidator::Validations
   def veteran_lives_in_texas?
     state_code == "TX"
   end
+
+  def veteran_lives_in_usa?
+    %w[USA US].include? valid_addess[:country_code]
+  end
 end

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -84,6 +84,10 @@ module VaDotGovAddressValidator::Validations
   end
 
   def veteran_lives_in_usa?
-    %w[USA US].include? valid_addess[:country_code]
+    %w[USA US].include? appeal.veteran&.address&.country
+  end
+
+  def veteran_lives_in_phillipines?
+    %w[PH RP PI].include? appeal.veteran&.address&.country
   end
 end

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -83,11 +83,11 @@ module VaDotGovAddressValidator::Validations
     state_code == "TX"
   end
 
-  def veteran_lives_in_usa?
+  def appellant_lives_in_usa?
     %w[USA US].include? address.country
   end
 
-  def veteran_lives_in_phillipines?
+  def appellant_lives_in_phillipines?
     %w[PH RP PI].include? address.country
   end
 end

--- a/app/services/va_dot_gov_address_validator/validations.rb
+++ b/app/services/va_dot_gov_address_validator/validations.rb
@@ -56,7 +56,7 @@ module VaDotGovAddressValidator::Validations
                         error_handler.handle(state_code_error)
                       elsif !closest_ro_response.success?
                         error_handler.handle(closest_ro_response.error)
-                      elsif closest_regional_office != "RO71" && !available_hearing_locations_response.success?
+                      elsif !available_hearing_locations_response.success?
                         error_handler.handle(available_hearing_locations_response.error)
                       end
   end

--- a/spec/services/geomatch_service_spec.rb
+++ b/spec/services/geomatch_service_spec.rb
@@ -84,7 +84,6 @@ describe GeomatchService do
         subject
 
         legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
-
         expect(legacy_appeal).not_to be_nil
         expect(legacy_appeal.closest_regional_office).not_to be_nil
         expect(legacy_appeal.available_hearing_locations).not_to be_empty
@@ -97,8 +96,8 @@ describe GeomatchService do
 
           legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
           expect(legacy_appeal).not_to be_nil
-          expect(legacy_appeal.closest_regional_office).not_to be_nil
-          expect(legacy_appeal.available_hearing_locations).not_to be_empty
+          expect(legacy_appeal.closest_regional_office).to eq("RO71")
+          expect(legacy_appeal.available_hearing_locations).to eq([])
         end
       end
 
@@ -109,7 +108,7 @@ describe GeomatchService do
 
           legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
           expect(legacy_appeal).not_to be_nil
-          expect(legacy_appeal.closest_regional_office).not_to be_nil
+          expect(legacy_appeal.closest_regional_office).to eq("RO58")
           expect(legacy_appeal.available_hearing_locations).not_to be_empty
         end
       end

--- a/spec/services/geomatch_service_spec.rb
+++ b/spec/services/geomatch_service_spec.rb
@@ -77,6 +77,8 @@ describe GeomatchService do
         )
       end
       let(:appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+      let(:non_us_address) { Address.new(country: "MX", country_name: "Mexico", city: "Mexico City") }
+      let(:philippines_address) { Address.new(country: "PI", country_name: "Philippines", city: "Manila") }
 
       it "geomatches for the travel board appeal" do
         subject
@@ -86,6 +88,30 @@ describe GeomatchService do
         expect(legacy_appeal).not_to be_nil
         expect(legacy_appeal.closest_regional_office).not_to be_nil
         expect(legacy_appeal.available_hearing_locations).not_to be_empty
+      end
+
+      context "foreign appeal" do
+        before { appeal.instance_variable_set(:@address, non_us_address) }
+        it "geomatches for a foreign appeal" do
+          subject
+
+          legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
+          expect(legacy_appeal).not_to be_nil
+          expect(legacy_appeal.closest_regional_office).not_to be_nil
+          expect(legacy_appeal.available_hearing_locations).not_to be_empty
+        end
+      end
+
+      context "phillipines appeal" do
+        before { appeal.instance_variable_set(:@address, philippines_address) }
+        it "geomatches for a phillipines appeal" do
+          subject
+
+          legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
+          expect(legacy_appeal).not_to be_nil
+          expect(legacy_appeal.closest_regional_office).not_to be_nil
+          expect(legacy_appeal.available_hearing_locations).not_to be_empty
+        end
       end
     end
   end

--- a/spec/services/geomatch_service_spec.rb
+++ b/spec/services/geomatch_service_spec.rb
@@ -96,8 +96,8 @@ describe GeomatchService do
 
           legacy_appeal = LegacyAppeal.find_by(vacols_id: vacols_case.bfkey)
           expect(legacy_appeal).not_to be_nil
-          expect(legacy_appeal.closest_regional_office).to eq("RO71")
-          expect(legacy_appeal.available_hearing_locations).to eq([])
+          expect(legacy_appeal.closest_regional_office).to eq("RO11")
+          expect(legacy_appeal.available_hearing_locations).not_to be_empty
         end
       end
 

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -36,7 +36,7 @@ describe VaDotGovAddressValidator do
     context "when appellant does not live in the us" do
       let(:ro_facility_id) { nil }
       before { appeal.instance_variable_set(:@address, non_us_address) }
-      it "returns RO71" do
+      it "returns RO11" do
         expect(subject).to eq("RO11")
       end
     end

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -7,7 +7,7 @@ describe VaDotGovAddressValidator do
     let(:mock_response) { HTTPI::Response.new(200, {}, {}.to_json) }
     let(:appeal) { create(:appeal, :with_schedule_hearing_tasks) }
     let(:non_us_address) { Address.new(country: "MX", country_name: "Mexico", city: "Mexico City") }
-    let(:non_us_appeal) { create(:appeal, :with_schedule_hearing_tasks, address: non_us_address) }
+    let(:philippines_address) { Address.new(country: "PI", country_name: "Philippines", city: "Manila") }
     let(:closest_ro_facilities) do
       [
         mock_facility_data(id: ro_facility_id)
@@ -33,11 +33,19 @@ describe VaDotGovAddressValidator do
       end
     end
 
-    context "when veteran does not live in the us" do
+    context "when appellant does not live in the us" do
       let(:ro_facility_id) { nil }
       before { appeal.instance_variable_set(:@address, non_us_address) }
       it "returns RO71" do
         expect(subject).to eq("RO71")
+      end
+    end
+
+    context "when appellant lives in the Philippines" do
+      let(:ro_facility_id) { "vba_358" }
+      before { appeal.instance_variable_set(:@address, philippines_address) }
+      it "returns RO58" do
+        expect(subject).to eq("RO58")
       end
     end
 

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -6,6 +6,8 @@ describe VaDotGovAddressValidator do
   describe "#closest_regional_office" do
     let(:mock_response) { HTTPI::Response.new(200, {}, {}.to_json) }
     let(:appeal) { create(:appeal, :with_schedule_hearing_tasks) }
+    let(:non_us_address) { Address.new(country: "MX", country_name: "Mexico", city: "Mexico City") }
+    let(:non_us_appeal) { create(:appeal, :with_schedule_hearing_tasks, address: non_us_address) }
     let(:closest_ro_facilities) do
       [
         mock_facility_data(id: ro_facility_id)
@@ -28,6 +30,14 @@ describe VaDotGovAddressValidator do
 
       it "returns RO01" do
         expect(subject).to eq("RO01")
+      end
+    end
+
+    context "when veteran does not live in the us" do
+      let(:ro_facility_id) { nil }
+      before { appeal.veteran.instance_variable_set(:@address, non_us_address) }
+      it "returns RO71" do
+        expect(subject).to eq("RO71")
       end
     end
 

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -37,7 +37,7 @@ describe VaDotGovAddressValidator do
       let(:ro_facility_id) { nil }
       before { appeal.instance_variable_set(:@address, non_us_address) }
       it "returns RO71" do
-        expect(subject).to eq("RO71")
+        expect(subject).to eq("RO11")
       end
     end
 

--- a/spec/services/va_dot_gov_address_validator_spec.rb
+++ b/spec/services/va_dot_gov_address_validator_spec.rb
@@ -35,7 +35,7 @@ describe VaDotGovAddressValidator do
 
     context "when veteran does not live in the us" do
       let(:ro_facility_id) { nil }
-      before { appeal.veteran.instance_variable_set(:@address, non_us_address) }
+      before { appeal.instance_variable_set(:@address, non_us_address) }
       it "returns RO71" do
         expect(subject).to eq("RO71")
       end


### PR DESCRIPTION
Resolves [APPEALS-31484](https://jira.devops.va.gov/browse/APPEALS-31484)

# Description
Added in a check for if veteran lives in us that returns the Pittsburgh RO if not

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Adds a method #veteran_lives_in_usa? to check if country code is USA in app/services/va_dot_gov_address_validator/validations.rb similar to #veteran_lives_in_texas?
- [ ] Add a conditional to #closest_regional_office within app/services/va_dot_gov_address_validator.rb
Utilize #veteran_lives_in_usa? to return Pittsburgh RO code for foreign residing veterans (RO71)

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-32417

- [ ] For feature branches merging into master: Was this deployed to UAT?

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other
