### PR TITLE
Modify Fake ClaimEvidenceService

### DIFF
--- a/lib/fakes/claim_evidence_service.rb
+++ b/lib/fakes/claim_evidence_service.rb
@@ -1,19 +1,17 @@
 # frozen_string_literal: true
 
 class Fakes::ClaimEvidenceService
-  FAKE_STATUS = "sent"
-
   class << self
     def get_ocr_document(doc_series_id)
-      ocr_data = <<~OCR_DATA
-        Frodo: I can’t do this, Sam.
-
-        Sam: I know. It’s all wrong. By rights we shouldn’t even be here. But we are. It’s like in the great stories, Mr. Frodo. The ones that really mattered. Full of darkness and danger, they were. And sometimes you didn’t want to know the end. Because how could the end be happy? How could the world go back to the way it was when so much bad had happened? But in the end, it’s only a passing thing, this shadow. Even darkness must pass. A new day will come. And when the sun shines it will shine out the clearer. Those were the stories that stayed with you. That meant something, even if you were too small to understand why. But I think, Mr. Frodo, I do understand. I know now. Folk in those stories had lots of chances of turning back, only they didn’t. They kept going. Because they were holding on to something.
-
-        Frodo: What are we holding onto, Sam?
-
-        Sam: That there’s some good in this world, Mr. Frodo... and it’s worth fighting for.
-      OCR_DATA
+      if doc_series_id.even?
+        ocr_data = <<~OCR_DATA
+          The quick brown fox jumps over the lazy dog.
+        OCR_DATA
+      else
+        ocr_data = <<~OCR_DATA
+          The five boxing wizards jump quickly.
+        OCR_DATA
+      end
 
       ocr_data
     end

--- a/lib/fakes/claim_evidence_service.rb
+++ b/lib/fakes/claim_evidence_service.rb
@@ -3,6 +3,8 @@
 class Fakes::ClaimEvidenceService
   class << self
     def get_ocr_document(doc_series_id)
+      doc_series_id = Integer(doc_series_id)
+
       if doc_series_id.even?
         ocr_data = <<~OCR_DATA
           The quick brown fox jumps over the lazy dog.


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Modify ClaimEvidenceAPI Fake](https://jira.devops.va.gov/browse/JIRA-32439)

# Description
Modifies the ClaimEvidenceAPI fake to return different doc data for docs with odd/even IDs.

## Acceptance Criteria
- [ ] Specs pass
