### PR TITLE
jcroteau/APPEALS-32061 - Replace `database_cleaner` with `database_cleaner-active_record` [pre Rails 6.1]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :test, :development, :demo do
   gem "capybara"
   gem "capybara-screenshot"
   gem "danger", "~> 6.2.2"
-  gem "database_cleaner"
+  gem "database_cleaner-active_record"
   gem "factory_bot_rails", "~> 5.2"
   gem "faker"
   gem "guard-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,7 +224,10 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    database_cleaner (1.7.0)
+    database_cleaner-active_record (2.1.0)
+      activerecord (>= 5.a)
+      database_cleaner-core (~> 2.0.0)
+    database_cleaner-core (2.0.1)
     ddtrace (0.34.1)
       msgpack
     debase (0.2.4.1)
@@ -742,7 +745,7 @@ DEPENDENCIES
   console_tree_renderer!
   countries
   danger (~> 6.2.2)
-  database_cleaner
+  database_cleaner-active_record
   ddtrace
   debase
   derailed_benchmarks

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -14,26 +14,26 @@ RSpec.configure do |config|
   # IMPORTANT that in all these hook defs, the "caseflow" connection comes last.
 
   config.before(:suite) do
-    DatabaseCleaner[:active_record, { connection: etl }].clean_with(:truncation)
-    DatabaseCleaner[:active_record, { connection: vacols }]
+    DatabaseCleaner[:active_record, { db: etl }].clean_with(:truncation)
+    DatabaseCleaner[:active_record, { db: vacols }]
       .clean_with(:deletion, except: vacols_tables_to_preserve)
-    DatabaseCleaner[:active_record, { connection: caseflow }].clean_with(:truncation)
+    DatabaseCleaner[:active_record, { db: caseflow }].clean_with(:truncation)
   end
 
   config.before(:each) do |example|
     # Allows seeded data to persist for use across threads
     # You will need to manually clean the data once the threads under test close.
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { connection: vacols }].strategy = :transaction
-      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :transaction
+      DatabaseCleaner[:active_record, { db: vacols }].strategy = :transaction
+      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :transaction
     end
   end
 
   config.before(:each, db_clean: :truncation) do |example|
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { connection: vacols }].strategy =
+      DatabaseCleaner[:active_record, { db: vacols }].strategy =
         :deletion, { except: vacols_tables_to_preserve }
-      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :truncation
+      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :truncation
     end
   end
 
@@ -46,42 +46,42 @@ RSpec.configure do |config|
       # Driver is probably for an external browser with an app
       # under test that does *not* share a database connection with the
       # specs, so use truncation strategy.
-      DatabaseCleaner[:active_record, { connection: vacols }].strategy =
+      DatabaseCleaner[:active_record, { db: vacols }].strategy =
         :deletion, { except: vacols_tables_to_preserve }
-      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :truncation
+      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :truncation
     end
   end
 
   config.before(:each) do |example|
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { connection: vacols }].start
-      DatabaseCleaner[:active_record, { connection: caseflow }].start
+      DatabaseCleaner[:active_record, { db: vacols }].start
+      DatabaseCleaner[:active_record, { db: caseflow }].start
     end
   end
 
   config.append_after(:each) do
-    DatabaseCleaner[:active_record, { connection: vacols }].clean
-    DatabaseCleaner[:active_record, { connection: caseflow }].clean
+    DatabaseCleaner[:active_record, { db: vacols }].clean
+    DatabaseCleaner[:active_record, { db: caseflow }].clean
     clean_application!
   end
 
   # ETL is never used in feature tests and there are only a few, so we tag those with :etl
   # ETL db uses deletion strategy everywhere because syncing runs in a transaction.
   config.before(:each, :etl) do
-    DatabaseCleaner[:active_record, { connection: etl }].strategy = :deletion
+    DatabaseCleaner[:active_record, { db: etl }].strategy = :deletion
   end
 
   config.before(:each, :etl, db_clean: :truncation) do
-    DatabaseCleaner[:active_record, { connection: etl }].strategy = :truncation
+    DatabaseCleaner[:active_record, { db: etl }].strategy = :truncation
   end
 
   config.before(:each, :etl) do
     Rails.logger.info("DatabaseCleaner.start ETL")
-    DatabaseCleaner[:active_record, { connection: etl }].start
+    DatabaseCleaner[:active_record, { db: etl }].start
   end
 
   config.append_after(:each, :etl) do
-    DatabaseCleaner[:active_record, { connection: etl }].clean
+    DatabaseCleaner[:active_record, { db: etl }].clean
     Rails.logger.info("DatabaseCleaner.clean ETL")
   end
 end


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-32061

# Description

When we attempt to upgrade to Rails 6.1 and run `bin/rails app:update`, the following error message is raised:

```
rails aborted!
NoMethodError: undefined method `spec' for #<ActiveRecord::ConnectionAdapters::ConnectionPool:0x00007f8b495c3c90>
Did you mean?  inspect
/Users/jeremycroteau/dev/appeals/caseflow/config/environment.rb:5:in `<main>'
Tasks: TOP => active_storage:update => environment
```

This exception is being raised in a few different places, but one of them is in `database_cleaner`: [lib/database_cleaner/active_record/base.rb](https://github.com/DatabaseCleaner/database_cleaner/blob/0dcf095f71db55f4c6e4c1d3a93869df91aa2e13/lib/database_cleaner/active_record/base.rb#L82)

We need to replace `database_cleaner` with [`database_cleaner-active_record`](https://github.com/DatabaseCleaner/database_cleaner-active_record) for compatability with ActiveRecord 6.1.

As part of the update, the options API has changed a little bit. In each place where we use the `connection` option, we will need to use the `db` option instead.

**BEFORE**
```
DatabaseCleaner[:active_record, { connection: whatever }]
```

**AFTER**
```
DatabaseCleaner[:active_record, { db: whatever }]
```

## Testing Plan

Since this affects the running of the test suite only, a passing test suite should be a sufficient test plan.
