### PR TITLE
Page Requested by user

### DIFF
--- a/app/jobs/page_requested_by_user_fix_job.rb
+++ b/app/jobs/page_requested_by_user_fix_job.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class PageRequestedByUserFixJob < CaseflowJob
+  ERROR_TEXT = "Page requested by the user is unavailable"
+
+  def initialize
+    @stuck_job_report_service = StuckJobReportService.new
+    super
+  end
+
+  def perform
+    clear_bge_errors if bges_with_errors.present?
+  end
+
+  # :reek:FeatureEnvy
+  def resolve_error_on_records(object_type)
+    object_type.clear_error!
+  rescue StandardError => error
+    log_error(error)
+    @stuck_job_report_service.append_errors(object_type.class.name, object_type.id, error)
+  end
+
+  def clear_bge_errors
+    @stuck_job_report_service.append_record_count(bges_with_errors.count, ERROR_TEXT)
+
+    bges_with_errors.each do |bge|
+      next if bge.end_product_establishment.nil? || bge.end_product_establishment.established_at.blank?
+
+      @stuck_job_report_service.append_single_record(bge.class.name, bge.id)
+      resolve_error_on_records(bge)
+    end
+    @stuck_job_report_service.append_record_count(bges_with_errors.count, ERROR_TEXT)
+    @stuck_job_report_service.write_log_report(ERROR_TEXT)
+  end
+
+  def bges_with_errors
+    BoardGrantEffectuation.where("decision_sync_error ILIKE?", "%#{ERROR_TEXT}%")
+  end
+end

--- a/spec/jobs/page_requested_by_user_fix_job_spec.rb
+++ b/spec/jobs/page_requested_by_user_fix_job_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+describe PageRequestedByUserFixJob, :postgres do
+  let(:page_error) { "Page requested by the user is unavailable" }
+  let(:file_number) { "123456789" }
+
+  let!(:epe) do
+    create(:end_product_establishment,
+           established_at: Time.zone.now,
+           veteran_file_number: file_number)
+  end
+
+  let!(:bge) do
+    create(:board_grant_effectuation,
+           end_product_establishment_id: epe.id,
+           decision_sync_error: page_error)
+  end
+  let!(:bge_2) do
+    build(:board_grant_effectuation,
+          end_product_establishment_id: nil,
+          decision_sync_error: page_error)
+  end
+
+  subject { described_class.new }
+
+  context "Board Grant Effectuation error clear" do
+    context "when the error exists on BGE"
+    describe "when EPE has established_at date" do
+      it "clear_error!" do
+        subject.perform
+        expect(bge.reload.decision_sync_error).to be_nil
+      end
+    end
+    describe "if EPE does not have established_at" do
+      it "clears the Page requested by the user is unavailable on the BGE" do
+        epe.update(established_at: nil)
+        subject.perform
+        expect(bge.reload.decision_sync_error).to eq(page_error)
+      end
+    end
+    describe "if EPE does not exist" do
+      it "does not clear the error" do
+        subject.perform
+        expect(bge_2.decision_sync_error).to eq(page_error)
+      end
+    end
+    context "when the BGE does not have the Page requested by the user is unavailable" do
+      it "does not attempt to clear the error" do
+        bge.update(decision_sync_error: nil)
+        subject.perform
+        expect(bge.reload.decision_sync_error).to eq(nil)
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Analysis of "Page requested by user is unavailable"](https://jira.devops.va.gov/browse/JIRA-12345)
Resolves [Write the Script for Page requested by the user is unavailable, please contact system administrator](https://jira.devops.va.gov/browse/APPEALS-29155)

# Description

### Stuck Job - Page requested by the user is unavailable
```
Savon::HTTPError: HTTP error (302): <HTML><HEAD><TITLE> Page Unavailable </TITLE> </HEAD>
<BODY> Page requested by the user is unavailable, please contact system administrator. </BODY></HTML>
```
- Root Cause Analysis
	- The <span style="color: red">HTTP status code 302</span> refers to a "Found" or "Moved Temporarily" response. This status code is used when the requested resource has been temporarily moved to a different location.
	- The error is initially hit in the method <span style="color: #CC00FF">fetch_veteran_info</span> which takes a param of <span style="color: hotpink">vbms_id</span>. 
	- This information would indicate a Server/VBMS/Cacheing Error that is ultimately resolved once Caseflow(<span style="color: #CC00FF">fetch_veteran_info</span>) reruns and makes a successful VBMS call.

### Detailed Synopsis
- The <span style="color: red">Page requested by the user is unavailable</span> error occurs on <span style="color: orange">BoardGrantEffecuations</span>.
- There is a failure in pulling information from VBMS which creates the initial error. When Caseflow reruns the fetch and eventually succeeds, an <span style="color: orange">EndProductEstablishment</span> with and <span style="color: darkcyan">established_at</span> column with the date/time of establishment recorded will prove the success of this record. The errors on <span style="color: orange">BoardGrantEffecuations</span> records however will remain. 
- This was likely a cacheing issue (<span style="color: red">HTTP status code 302</span>) that initially failed and was established once the process was retried with cached info (<span style="color: hotpink">vet id/vbms_id</span>).
	- This hypothesis was confirmed through Metabase.
		- The BGE was connected to the Appeal which allowed us to retrieve the Caseflow page that was "unavailable" using the Appeal UUID.
		- The current existence of these pages along with the records <span style="color: orange">EndProductEstablishment</span> confirms that a completing a <span style="color: darkcyan">data clean-up</span> for this error is the necessary remediation 

### Testing and Remediation Steps
- In order to complete a <span style="color: darkcyan">data clean-up</span> and clear the <span style="color: red">errors</span> that remain, we locate the <span style="color: red">Page requested by the user is unavailable</span> on each of the records.
	- From here we can locate <span style="color: orange">EndProductEstablishment</span> connected to each record.
	- Our methods will return if an <span style="color: orange">EndProductEstablishment</span> does not exist.

```Ruby
def clear_bge_errors
	STUCK_JOB_REPORT_SERVICE.append_record_count(bges_with_errors.count, ERROR_TEXT)
	bges_with_errors.each do |bge|
		return if bge.end_product_establishment.established_at.blank?
		resolve_error_on_records(bge)
		STUCK_JOB_REPORT_SERVICE.append_single_record(bge.class.name, bge.id)
	end
	STUCK_JOB_REPORT_SERVICE.append_record_count(bges_with_errors.count, ERROR_TEXT)
end
```

-  Each of our methods call <span style="color: #FF6666">STUCK_JOB_REPORT_SERVICE</span>, which is declared as a global variable at the top of <span style="color: #00FFFF">PageRequestedByUserFixJob</span>.
	- <span style="color: #FF6666">STUCK_JOB_REPORT_SERVICE</span> calls on a new instance of the service class <span style="color: #00FF33">StuckJobReportService</span>, which is used to create <span style="color: darkcyan">logs</span> for AWS. 
	- Our methods also call an additional method, <span style="color: #CC00FF">resolve_error_on_records</span>.
```Ruby
def resolve_error_on_records(object_type)
	ActiveRecord::Base.transaction do
		object_type.clear_error!
	rescue StandardError => error
		log_error(error)
		STUCK_JOB_REPORT_SERVICE.append_errors(object_type.class.name, object_type.id, error)
	end
end
```
- <span style="color: #CC00FF">resolve_error_on_records</span>, takes an class object and runs <span style="color: #CC00FF">clear_error!</span> on the object if its <span style="color: darkcyan">established_at</span> column is defined.
	- Additionally, the method can be rescued. The error that it hits for whatever reason is logged as well as added to AWS <span style="color: darkcyan">logs</span>. 
- Lastly, we have our <span style="color: #CC00FF">perform</span> method which allows the <span style="color: #CC00FF">resolve_error_on_records</span> method to execute if the <span style="color: red">Page requested by the user is unavailable</span> is found on any of the three records.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

## Storybook Story
*For Frontend (Presentation) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

# Backend
## Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] For queries using raw sql was an explain plan run by System Team
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

## Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
  * [ ] Check that calls are wrapped in MetricService record block
* [ ] Check that all configuration is coming from ENV variables
  * [ ] Listed all new ENV variables in description
  * [ ] Worked with or notified System Team that new ENV variables need to be set
* [ ] Update Fakes
* [ ] For feature branches: Was this tested in Caseflow UAT

# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

## Monitoring, Logging, Auditing, Error, and Exception Handling Checklist

### Monitoring
- [ ] Are performance metrics (e.g., response time, throughput) being tracked?
- [ ] Are key application components monitored (e.g., database, cache, queues)?
- [ ] Is there a system in place for setting up alerts based on performance thresholds?

### Logging
- [ ] Are logs being produced at appropriate log levels (debug, info, warn, error, fatal)?
- [ ] Are logs structured (e.g., using log tags) for easier querying and analysis?
- [ ] Are sensitive data (e.g., passwords, tokens) redacted or omitted from logs?
- [ ] Is log retention and rotation configured correctly?
- [ ] Are logs being forwarded to a centralized logging system if needed?

### Auditing
- [ ] Are user actions being logged for audit purposes?
- [ ] Are changes to critical data being tracked ?
- [ ] Are logs being securely stored and protected from tampering or exposing protected data?

### Error Handling
- [ ] Are errors being caught and handled gracefully?
- [ ] Are appropriate error messages being displayed to users?
- [ ] Are critical errors being reported to an error tracking system (e.g., Sentry, ELK)?
- [ ] Are unhandled exceptions being caught at the application level ?

### Exception Handling
- [ ] Are custom exceptions defined and used where appropriate?
- [ ] Is exception handling consistent throughout the codebase?
- [ ] Are exceptions logged with relevant context and stack trace information?
- [ ] Are exceptions being grouped and categorized for easier analysis and resolution?

