### PR TITLE
remove erroneous commas in disabled_flags array

### DIFF
--- a/scripts/enable_features_dev.rb
+++ b/scripts/enable_features_dev.rb
@@ -59,9 +59,9 @@ disabled_flags = %w[
   cavc_dashboard_workflow
   poa_auto_refresh
   interface_version_2
-  cc_vacatur_visibility,
-  acd_disable_legacy_distributions,
-  acd_disable_nonpriority_distributions,
+  cc_vacatur_visibility
+  acd_disable_legacy_distributions
+  acd_disable_nonpriority_distributions
   acd_disable_legacy_lock_ready_appeals
 ]
 


### PR DESCRIPTION
# Description
Removed commas from the `disabled_flags` array in enable_features_dev.rb to prevent them from being enabled in local after a reset or demo

## Acceptance Criteria
- [ ] Code compiles correctly
