### PR TITLE
Revert "hotfix/APPEALS-32912: Status: Review for VHA workflow should not affect unidentified issues without a decision Date"

### DIFF
--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -57,7 +57,7 @@ export default class IssuesList extends React.Component {
     const isIssueWithdrawn = issue.withdrawalDate || issue.withdrawalPending;
 
     // Do not show the Add Decision Date action if the issue is pending or is fully withdrawn
-    if ((!issue.date || issue.editedDecisionDate) && !isIssueWithdrawn && !issue.isUnidentified) {
+    if ((!issue.date || issue.editedDecisionDate) && !isIssueWithdrawn) {
       options.push(
         {
           displayText: issue.editedDecisionDate ? 'Edit decision date' : 'Add decision date',
@@ -97,8 +97,7 @@ export default class IssuesList extends React.Component {
           );
 
           const isIssueWithdrawn = issue.withdrawalDate || issue.withdrawalPending;
-          const showNoDecisionDateBanner = !issue.date && !isIssueWithdrawn &&
-            !issue.isUnidentified;
+          const showNoDecisionDateBanner = !issue.date && !isIssueWithdrawn;
 
           return <div className="issue-container" key={`issue-container-${issue.index}`}>
             <div

--- a/spec/feature/intake/add_issues_spec.rb
+++ b/spec/feature/intake/add_issues_spec.rb
@@ -407,6 +407,9 @@ feature "Intake Add Issues Page", :all_dbs do
     let(:decision_date) { 50.days.ago.to_date.mdY }
     let(:untimely_days) { 2.years.ago.to_date.mdY }
 
+    before { FeatureToggle.enable!(:unidentified_issue_decision_date) }
+    after { FeatureToggle.disable!(:unidentified_issue_decision_date) }
+
     scenario "unidentified issue decision date on add issue page" do
       start_higher_level_review(veteran_no_ratings)
       visit "/intake"

--- a/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
+++ b/spec/feature/intake/vha_hlr_sc_enter_no_decision_date_spec.rb
@@ -396,37 +396,4 @@ feature "Vha Higher-Level Review and Supplemental Claims Enter No Decision Date"
       it_behaves_like "Vha HLR/SC adding issue without decision date to existing claim review"
     end
   end
-
-  context "adding an unidentified issue without a decision date" do
-    let(:intake_type) do
-      start_higher_level_review(veteran, benefit_type: "vha")
-    end
-
-    it "should not show no decision date banner or edit decision date issue option" do
-      intake_type
-      visit "/intake"
-      click_intake_continue
-      click_intake_add_issue
-      click_intake_no_matching_issues
-
-      fill_in "Transcribe the issue as it's written on the form", with: "unidentified issue"
-      click_on("Add this issue", class: "add-issue")
-
-      expect(page).to_not have_content(COPY::VHA_NO_DECISION_DATE_BANNER)
-      click_intake_finish
-
-      expect(page).to have_content("Veterans Health Administration")
-      click_on veteran.name.to_s
-
-      # Grab the new HLR and visit the edit page
-      hlr = Intake.last.detail
-      issue_id = hlr.request_issues.first.id
-
-      expect(page).to have_content("Edit Issues")
-
-      within "#issue-#{issue_id}" do
-        expect(page).to have_no_selector("select option", text: "Add decision date")
-      end
-    end
-  end
 end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#19742