### PR TITLE
jcroteau/APPEALS-33955 - Unregister `sprockets-rails` source mapping postprocessor

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -155,5 +155,12 @@ module CaseflowCertification
       TOPLEVEL_BINDING.eval("self").extend FinderConsoleMethods
     end
     # :nocov:
+
+    # Unregister `sprockets-rails` source mapping postprocessor to avoid conflicts with source map generation provided
+    # by `react_on_rails`+`webpack`. The addition of this postprocessor in `sprockets-rails` `3.4.0` was causing
+    # corruption of the `webpack-bundle.js` file, thus breaking feature specs in local development environments.
+    config.assets.configure do |env|
+      env.unregister_postprocessor("application/javascript", ::Sprockets::Rails::SourcemappingUrlProcessor)
+    end
   end
 end


### PR DESCRIPTION
Precautionary Revert PR: https://github.com/department-of-veterans-affairs/caseflow/pull/19962

Resolves https://jira.devops.va.gov/browse/APPEALS-33955

# Description
## Value Statement

As a developer, I need to fix local execution of feature specs after the Rails 5.2.8 upgrade, so that I can restore development workflows that necessitate running feature specs.

## Acceptance Criteria
- Feature specs run normally in local development environments without having to first precompile assets
- Tests still pass in CI
- Assets are still served successfully in UAT / Production
- Development is notified once fix is in place ( [Slack thread](https://benefits-int-delivery.slack.com/archives/C02KREHBTPC/p1698425838794519) )

## Background
After the Rails 5.2.8 upgrade, Craig Reese noticed that feature specs were failing in local dev environments:

**Craig Reese ( [Slack thread](https://benefits-int-delivery.slack.com/archives/C02KREHBTPC/p1698425838794519) ):**
> Our **local feature tests** are broken on the latest version of master. When running any feature tests, the “Skip to content” link is all that displays. You can work around this by doing the following _before_ running a feature test:
> ```
> make clean 
> bundle exec rake assets:precompile
> ```
> After building the assets with the above command (bundle exec rake assets:precompile), feature tests will work on your local machine. Tests in GHA are working because they use that command to compile assets.

It was also observed that the following JS error was being logged to the browser console when feature specs were failing locally:

```
Uncaught SyntaxError: Invalid or unexpected token (at webpack-bundle-055906bc7fc18d6161c967e406d4d1e4bb3b1c23ce631aece223b3aece60cbab.js:31000:6)
```

We narrowed down the source of the issue to a change during the `sprockets-rails` gem update from `3.2.2` to `3.4.2`.  When stepping through the intervening versions one-by-one, the feature specs begin to fail at version `3.4.0`, [which introduces a source mapping post-processor to the asset pipeline](https://github.com/rails/sprockets-rails/compare/v3.3.0...v3.4.0).  
   
This is only an issue in local dev environments, since we run `bundle exec rake assets:precompile` in CI / UAT / Production environments, which seems to "fix" the problem. The running hypothesis is that this is because the `react_on_rails` gem hooks into this task and runs its own build steps, which involves using webpack to compile the `webpack-bundle.js` file (and also includes generating source maps). See `config/initializers/react_on_rails.rb` and `client/webpack.config.js` for more details.

## Proposed Solution(s)
There are at least two ways of resolving this issue:

1. Downgrade and lock `sprockets-rails` to version `3.3.0`
  - **Pros:** Easy
  - **Cons:** We may be forced to upgrade `sprockets-rails` to `3.4.0+` in the future, in which case we will have to find an alternative solution to this same problem once again.

2. Leave `sprockets-rails` at `3.4.2` and unregister the source mapping processor from the asset pipeline
    ```
    # config/application.rb  
    
    config.assets.configure do |env|
      env.unregister_postprocessor("application/javascript", ::Sprockets::Rails::SourcemappingUrlProcessor)
    end
    ```
  - **Pros:** Allows us to upgrade `sprockets-rails` into the future
  - **Cons:** We will have to add and maintain one more piece of configuration, which will also add some coupling with `sprockets-rails` internals


## Testing Plan
### In Local Development Environment

- Clear out precompiled assets (if any):
    ```
    make clean
    ```
- Run a feature spec:
    ```
    bundle exec rspec spec/feature/login_spec.rb
    ```
- Expect that the test launches the browser and executes the test successfully.

### In UAT/ProdTest Environment
#### Check that Source Maps are generated correctly
- Using the Chrome browser, login to Caseflow
- Open Chrome DevTools > Sources, click on the "three dots" at the top of the file tree and enable "Group by Authored/Deployed".
- There should be a file tree under the "Authored" section representing the original client application file tree (w/ un-processed JS files, etc).
- Under the "Authored" section, select a `.js` file. At the bottom of the editor, there should be a link to the corresponding deployed file (eg. `webpack-bundle-837498t98345tn349.js`)

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
