### PR TITLE
Akonhilas/APPEALS-33661

### DIFF
--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -1,11 +1,37 @@
 # frozen_string_literal: true
 
 class ExternalApi::WebexService
+  BASE_URL = "#{ENV['WEBEX_HOST']}#{ENV['WEBEX_DOMAIN']}"
+  AUTH_URL = "/v1/access_token"
+  GRANT_TYPE = "refresh_token"
+  CLIENT_ID = ENV["WEBEX_CLIENT_ID"]
+  CLIENT_SECRET = ENV["WEBEX_CLIENT_SECRET"]
+  REFRESH_TOKEN = ENV["WEBEX_REFRESH_TOKEN"]
+  SCOPE = ""
+  HEADERS = {
+    "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"
+  }.freeze
+
   def create_conference(*)
     fail NotImplementedError
   end
 
   def delete_conference(*)
     fail NotImplementedError
+  end
+
+  # Purpose: Refreshing the access token to access the API
+  # Return: The response body
+  def refresh_access_token
+    url = URI::DEFAULT_PARSER.escape(BASE_URL + GET_TOKEN_ENDPOINT)
+    params = {
+      grant_type: GRANT_TYPE,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      refresh_token: REFRESH_TOKEN
+    }
+    encoded_params = URI.encode_www_form(params)
+    response = Faraday.post(url, encoded_params)
+    response.body
   end
 end

--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ExternalApi::WebexService
-  BASE_URL = "#{ENV['WEBEX_HOST']}#{ENV['WEBEX_DOMAIN']}"
+  BASE_URL = "#{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}"
   AUTH_URL = "/v1/access_token"
   GRANT_TYPE = "refresh_token"
   CLIENT_ID = ENV["WEBEX_CLIENT_ID"]

--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -13,9 +13,6 @@ class ExternalApi::WebexService
     "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"
   }.freeze
 
-  def create_conference(*)
-    fail NotImplementedError
-
   def initialize(host:, port:, aud:, apikey:, domain:, api_endpoint:)
     @host = host
     @port = port
@@ -62,6 +59,22 @@ class ExternalApi::WebexService
     ExternalApi::WebexService::DeleteResponse.new(resp)
   end
 
+  # Purpose: Refreshing the access token to access the API
+  # Return: The response body
+  def refresh_access_token
+    url = URI::DEFAULT_PARSER.escape(BASE_URL + AUTH_URL)
+    params = {
+      grant_type: GRANT_TYPE,
+      client_id: CLIENT_ID,
+      client_secret: CLIENT_SECRET,
+      refresh_token: REFRESH_TOKEN
+    }
+    encoded_params = URI.encode_www_form(params)
+    response = Faraday.post(url, encoded_params)
+    caseflow_res = ExternalApi::WebexService::Response.new(response)
+    caseflow_res.resp unless caseflow_res.error
+  end
+
   private
 
   # :nocov:
@@ -82,21 +95,4 @@ class ExternalApi::WebexService
       HTTPI.post(request)
     end
   end
-
-  # Purpose: Refreshing the access token to access the API
-  # Return: The response body
-  def refresh_access_token
-    url = URI::DEFAULT_PARSER.escape(BASE_URL + AUTH_URL)
-    params = {
-      grant_type: GRANT_TYPE,
-      client_id: CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      refresh_token: REFRESH_TOKEN
-    }
-    encoded_params = URI.encode_www_form(params)
-    response = Faraday.post(url, encoded_params)
-    caseflow_res = ExternalApi::WebexService::Response.new(response)
-    caseflow_res.resp unless caseflow_res.error
-  end
-  # :nocov:
 end

--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -7,7 +7,6 @@ class ExternalApi::WebexService
   CLIENT_ID = ENV["WEBEX_CLIENT_ID"]
   CLIENT_SECRET = ENV["WEBEX_CLIENT_SECRET"]
   REFRESH_TOKEN = ENV["WEBEX_REFRESH_TOKEN"]
-  SCOPE = ""
   HEADERS = {
     "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json"
   }.freeze

--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -22,7 +22,7 @@ class ExternalApi::WebexService
   # Purpose: Refreshing the access token to access the API
   # Return: The response body
   def refresh_access_token
-    url = URI::DEFAULT_PARSER.escape(BASE_URL + GET_TOKEN_ENDPOINT)
+    url = URI::DEFAULT_PARSER.escape(BASE_URL + AUTH_URL)
     params = {
       grant_type: GRANT_TYPE,
       client_id: CLIENT_ID,
@@ -31,6 +31,7 @@ class ExternalApi::WebexService
     }
     encoded_params = URI.encode_www_form(params)
     response = Faraday.post(url, encoded_params)
-    response.body
+    caseflow_res = ExternalApi::WebexService::Response.new(response)
+    caseflow_res.resp unless caseflow_res.error
   end
 end

--- a/app/services/external_api/webex_service/response.rb
+++ b/app/services/external_api/webex_service/response.rb
@@ -55,8 +55,6 @@ class ExternalApi::WebexService::Response
     end
   end
 
-
-  # rerun checks
   def invalid_token
     body = JSON.parse(resp.raw_body)
     if body["error_description"] == "The access token expired"

--- a/app/services/external_api/webex_service/response.rb
+++ b/app/services/external_api/webex_service/response.rb
@@ -53,4 +53,18 @@ class ExternalApi::WebexService::Response
       DEFAULT_ERROR_BODY
     end
   end
+
+  def invalid_token
+    return DEFAULT_ERROR_BODY if resp.raw_body.empty?
+
+    begin
+      body = JSON.parse(resp.raw_body)
+      {
+        message: body["message"],
+        description: body["errors"].first["description"]
+      }
+    rescue JSON::ParserError
+      DEFAULT_ERROR_BODY
+    end
+  end
 end

--- a/app/services/external_api/webex_service/response.rb
+++ b/app/services/external_api/webex_service/response.rb
@@ -55,6 +55,8 @@ class ExternalApi::WebexService::Response
     end
   end
 
+
+  # rerun checks
   def invalid_token
     body = JSON.parse(resp.raw_body)
     if body["error_description"] == "The access token expired"

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -423,6 +423,8 @@ module Caseflow::Error
     attr_accessor :descriptions
   end
 
+  class WebexInvalidTokenError < ConferenceCreationError; end
+
   class WorkModeCouldNotUpdateError < StandardError; end
 
   class VirtualHearingConversionFailed < SerializableError

--- a/spec/jobs/virtual_hearings/create_conference_job_spec.rb
+++ b/spec/jobs/virtual_hearings/create_conference_job_spec.rb
@@ -109,6 +109,7 @@ describe VirtualHearings::CreateConferenceJob do
         conference_id = "#{virtual_hearing.hearing.docket_number}#{virtual_hearing.hearing.id}"
         conference_id = conference_id.delete "-"
         subject.perform_now
+        byebug
         expect(virtual_hearing.conference_id).to eq(conference_id.to_i)
       end
     end

--- a/spec/services/external_api/webex_service_spec.rb
+++ b/spec/services/external_api/webex_service_spec.rb
@@ -37,22 +37,24 @@ describe ExternalApi::WebexService do
     it "returns an invalid token error" do
       allow(Faraday).to receive(:post).and_return(example_401_response)
       expect { subject.refresh_access_token }.to raise_error(Caseflow::Error::WebexInvalidTokenError)
-  let(:host) { "fake-broker." }
-  let(:port) { "0000" }
-  let(:aud) { "1234abcd" }
-  let(:apikey) { SecureRandom.uuid.to_s }
-  let(:domain) { "gov.fake.com" }
-  let(:api_endpoint) { "/api/v2/fake" }
+    end
+    let(:host) { "fake-broker." }
+    let(:port) { "0000" }
+    let(:aud) { "1234abcd" }
+    let(:apikey) { SecureRandom.uuid.to_s }
+    let(:domain) { "gov.fake.com" }
+    let(:api_endpoint) { "/api/v2/fake" }
 
-  let(:webex_service) do
-    ExternalApi::WebexService.new(
-      host: host,
-      domain: domain,
-      api_endpoint: api_endpoint,
-      aud: aud,
-      apikey: apikey,
-      port: port
-    )
+    let(:webex_service) do
+      ExternalApi::WebexService.new(
+        host: host,
+        domain: domain,
+        api_endpoint: api_endpoint,
+        aud: aud,
+        apikey: apikey,
+        port: port
+      )
+    end
   end
 
   describe "webex requests" do

--- a/spec/services/external_api/webex_service_spec.rb
+++ b/spec/services/external_api/webex_service_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+describe ExternalApi::WebexService do
+  before do
+    subject { ExternalApi::WebexService.new }
+    stub_const("ENV", "WEBEX_HOST" => "fake.api")
+    stub_const("ENV", "WEBEX_DOMAIN" => ".webex.com")
+    stub_const("ENV", "WEBEX_CLIENT_ID" => "fake_id")
+    stub_const("ENV", "WEBEX_CLIENT_SECRET" => "fake_secret")
+    stub_const("ENV", "WEBEX_REFRESH_TOKEN" => "fake_token")
+  end
+
+  describe "OAuth" do
+    let(:example_auth_response_body) do
+      { "access_token": "fake_token",
+        "refresh_token": "fake_token",
+        "expires_in": "99999999",
+        "refresh_token_expires_in": "99999999" }
+    end
+    header = { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" }
+    let(:example_auth_response) { HTTPI::Response.new(200, header, example_auth_response_body.to_json) }
+    let(:caseflow_auth_response) { ExternalApi::WebexService::Response.new(example_auth_response) }
+    it "refreshes access token" do
+      allow(Faraday).to receive(:post).and_return(example_auth_response)
+      expect(subject.refresh_access_token).to eq(caseflow_auth_response.resp)
+    end
+  end
+
+  context "error" do
+    let(:example_expired_refresh_token_response) do
+      { "error": "invalid_token",
+        "error_description": "The access token expired" }
+    end
+    header = { "Content-Type": "application/x-www-form-urlencoded", Accept: "application/json" }
+    let(:example_401_response) { HTTPI::Response.new(401, header, example_expired_refresh_token_response.to_json) }
+    let(:caseflow_401_response) { ExternalApi::WebexService::Response.new(example_401_response) }
+    it "returns an invalid token error" do
+      allow(Faraday).to receive(:post).and_return(example_401_response)
+      expect { subject.refresh_access_token }.to raise_error(Caseflow::Error::WebexInvalidTokenError)
+    end
+  end
+end


### PR DESCRIPTION
Resolves [APPEALS-33661](https://jira.devops.va.gov/browse/APPEALS-33661)

# Description
New methods made in webex_service.rb and response.rb for refreshing token and error detection

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] GetRefreshToken
- [ ] authUrl= '/v1/access_token'
- [ ] grant_type = 'refresh_token'
- [ ] client_id = ENV["WEBEX_CLIENT_ID"]
- [ ] client_secret =  ENV["WEBEX_CLIENT_SECRET"]
- [ ] refresh_token =  ENV["WEBEX_REFRESH_TOKEN"]
- [ ] invalid_token

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-34033

- [ ] For feature branches merging into master: Was this deployed to UAT?

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other