### PR TITLE
APPEALS-34771 Update response for VACOLS issue endpoint.

### DIFF
--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -36,8 +36,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
     @file_number ||= request.headers["X-VA-FILE-NUMBER"].presence
   end
 
-  rescue_from Caseflow::Error::InvalidFileNumber, BGS::ShareError, with: :render_veteran_not_found
-
   rescue_from StandardError do |error|
     Raven.capture_exception(error, extra: raven_extra_context)
 
@@ -50,6 +48,14 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
       ]
     }, status: :internal_server_error
   end
+
+  rescue_from Caseflow::Error::InvalidFileNumber, BGS::ShareError do |error|
+    Raven.capture_exception(error, extra: raven_extra_context)
+    Rails.logger.error "Unable to find Veteran, please review the entered params: #{error}"
+
+    render_veteran_not_found
+  end
+
 
   def show
     page = ActiveRecord::Base.sanitize_sql(params[:page].to_i) if params[:page]

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -36,6 +36,8 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
     @file_number ||= request.headers["X-VA-FILE-NUMBER"].presence
   end
 
+  rescue_from Caseflow::Error::InvalidFileNumber, BGS::ShareError, with: :render_veteran_not_found
+
   rescue_from StandardError do |error|
     Raven.capture_exception(error, extra: raven_extra_context)
 

--- a/spec/requests/api/v3/issues/vacols/veterans_controller_spec.rb
+++ b/spec/requests/api/v3/issues/vacols/veterans_controller_spec.rb
@@ -53,6 +53,17 @@ describe Api::V3::Issues::Vacols::VeteransController, :postgres, type: :request 
           expect(response).to have_http_status(404)
           expect(response.body).to include("No Veteran found for the given identifier")
         end
+
+        it "should return 404 error for non happy paths" do
+          get_vacols_issues(file_number: 87)
+          expect(response).to have_http_status(404)
+
+          get_vacols_issues(file_number: 12345678987654321)
+          expect(response).to have_http_status(404)
+
+          get_vacols_issues(file_number: "fakevet")
+          expect(response).to have_http_status(404)
+        end
       end
 
       context "when a veteran is found" do


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-34771](https://jira.devops.va.gov/browse/APPEALS-34771)

# Description
Added more error catching for invalid veteran file numbers.

404 response with message "veteran not found" will be returned when there are:

1. fewer than 3 integers passed in with the veteran file number
2. more than 9 integers passed in as the veteran file number
3. Non numeric characters passed in as the veteran file number

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Endpoint returns 404 error when veteran cannot be found
- [x] Updated RSPEC

## Testing 
- [x] [Testing Plan](https://jira.devops.va.gov/browse/APPEALS-34513)
- [x] [Test Execution](https://jira.devops.va.gov/browse/APPEALS-34803)


