### PR TITLE
APPEALS-35131 "Generate Task Report" button is not displaying after dispositioning a claim

### DIFF
--- a/app/views/decision_reviews/show.html.erb
+++ b/app/views/decision_reviews/show.html.erb
@@ -21,7 +21,8 @@
       loadingPowerOfAttorney: {
         loading: false,
         error: false
-      }
+      },
+      isBusinessLineAdmin: business_line.user_is_admin?(current_user)
     }
   }) %>
 <% end %>


### PR DESCRIPTION
Resolves [APPEALS-35131: "Generate Task Report" button is not displaying after dispositioning a claim](https://jira.devops.va.gov/browse/APPEALS-35131)

# Description
Added `isBusinessLineAdmin: business_line.user_is_admin?(current_user)` to app/views/decision_reviews/show.html.erb

## Acceptance Criteria
- [x] Code compiles correctly
- [x] "Generate Task Report" button is still rendered on the screen after a claim disposition is completed if the user is a vha admin

## Testing Plan
1. Log in as VHAADMIN2
2. Go to VHA decision review queue
3. Go to any claim on the in progress tasks tab
4. Submit a disposition with any status and date
5. After clicking the "Complete" button, the page redirects back to the decision review queue and the button is there

# Frontend
## User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
<img width="1226" alt="APPEALS-35131_Before" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110493538/154e7f8c-06b1-447b-93cf-c0d4c764a3a1">|<img width="1236" alt="APPEALS-35131_After" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110493538/55e59a30-4a62-4cef-b9e4-cb4ca07f80b5">


