### PR TITLE
APPEALS-30940 | Create `IssueDisposition` component for Generate Task Report

### DIFF
--- a/client/app/nonComp/components/ReportPage/Conditions/IssueDisposition.jsx
+++ b/client/app/nonComp/components/ReportPage/Conditions/IssueDisposition.jsx
@@ -1,5 +1,44 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import { Controller, useFormContext } from 'react-hook-form';
+import { get } from 'lodash';
+import * as yup from 'yup';
+import SearchableDropdown from 'app/components/SearchableDropdown';
+import * as ERRORS from 'constants/REPORT_PAGE_VALIDATION_ERRORS';
+import { ISSUE_DISPOSITION_LIST } from 'constants/REPORT_TYPE_CONSTANTS';
 
-export const IssueDisposition = () => {
-  return <div>issue disposition test component please ignore</div>;
+export const issueDispositionSchema = yup.object({
+  issueDispositions: yup.array().min(1, ERRORS.SELECT_ONE_DROPDOWN)
+});
+
+export const IssueDisposition = ({ control, field, name }) => {
+  const { errors } = useFormContext();
+  const fieldName = `${name}.options.issueDispositions`;
+
+  return (
+    <div className="report-page-multi-select-dropdown">
+      <Controller
+        control={control}
+        name={fieldName}
+        defaultValue={field.options.issueDispositions ?? []}
+        render={({ onChange, ref, ...rest }) => (
+          <SearchableDropdown
+            {...rest}
+            errorMessage={get(errors, fieldName)?.message}
+            inputRef={ref}
+            label="Issue Disposition"
+            multi
+            onChange={onChange}
+            options={ISSUE_DISPOSITION_LIST}
+          />
+        )}
+      />
+    </div>
+  );
+};
+
+IssueDisposition.propTypes = {
+  control: PropTypes.object,
+  field: PropTypes.object,
+  name: PropTypes.string,
 };

--- a/client/app/nonComp/components/ReportPage/ReportPageConditions.jsx
+++ b/client/app/nonComp/components/ReportPage/ReportPageConditions.jsx
@@ -9,13 +9,14 @@ import * as yup from 'yup';
 import { daysWaitingSchema } from './Conditions/DaysWaiting';
 import { decisionReviewTypeSchema } from './Conditions/DecisionReviewType';
 import { facilitySchema } from './Conditions/Facility';
+import { issueDispositionSchema } from './Conditions/IssueDisposition';
 import * as ERRORS from 'constants/REPORT_PAGE_VALIDATION_ERRORS';
 
 const conditionOptionSchemas = {
   daysWaiting: daysWaitingSchema,
   decisionReviewType: decisionReviewTypeSchema,
   facility: facilitySchema,
-  issueDisposition: yup.object(),
+  issueDisposition: issueDispositionSchema,
   issueType: yup.object(),
   personnel: personnelSchema
 };

--- a/client/constants/REPORT_TYPE_CONSTANTS.json
+++ b/client/constants/REPORT_TYPE_CONSTANTS.json
@@ -126,7 +126,33 @@
       "label": "Last 365 Days",
       "value": "last_365_days"
     }
-  ]
+  ],
+ "ISSUE_DISPOSITION_LIST": [
+  {
+    "label": "Blank",
+    "value": "blank"
+  },
+  {
+    "label": "Denied",
+    "value": "denied"
+  },
+  {
+    "label": "Dismissed",
+    "value": "dismissed"
+  },
+  {
+    "label": "DTA Error",
+    "value": "dta_error"
+  },
+  {
+    "label": "Granted",
+    "value": "granted"
+  },
+  {
+    "label": "Withdrawn",
+    "value": "withdrawn"
+  }
+]
 }
 
 

--- a/client/test/app/nonComp/pages/ReportPage.test.js
+++ b/client/test/app/nonComp/pages/ReportPage.test.js
@@ -215,6 +215,48 @@ describe('ReportPage', () => {
     });
   });
 
+  describe('Issue Disposition Section', () => {
+    beforeEach(clickOnReportType);
+
+    it('allows you to select issue dispositions', async () => {
+      setup();
+      await navigateToConditionInput('Issue Disposition');
+
+      const dropdown = screen.getByLabelText('Issue Disposition');
+
+      await selectEvent.select(dropdown, ['Granted']);
+      expect(screen.getByText('Granted')).toBeInTheDocument();
+    });
+
+    it('allows to select multiple options from dropdown', async () => {
+      setup();
+      await navigateToConditionInput('Issue Disposition');
+
+      const dropdown = screen.getByLabelText('Issue Disposition');
+
+      await selectEvent.select(dropdown, ['Granted', 'Blank']);
+
+      expect(screen.getByText('Granted')).toBeInTheDocument();
+      expect(screen.getByText('Blank')).toBeInTheDocument();
+    });
+
+    it('selects an option from dropdown, then removes it and renders an error', async () => {
+      setup();
+      await navigateToConditionInput('Issue Disposition');
+
+      const dropdown = screen.getByLabelText('Issue Disposition');
+
+      await selectEvent.select(dropdown, ['Granted']);
+      expect(screen.getByText('Granted')).toBeInTheDocument();
+
+      const clearButton = document.querySelector('.cf-select__indicator.cf-select__clear-indicator');
+
+      userEvent.click(clearButton);
+
+      expect(screen.queryByText('Granted')).not.toBeInTheDocument();
+    });
+  });
+
   it('should have Generate task Report button and Clear Filter button disabled on initial load', () => {
     setup();
 


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-30940
Main Jira effort: https://jira.devops.va.gov/browse/APPEALS-26499

# Description
Create the `IssueDisposition` inputs for Generate Task Report.

## Acceptance Criteria
- [ ] Drop-down options for Issue Disposition include:
        Blank
        Granted
        Denied
        Dismissed
        DTA Error
        Withdrawn
- [ ] User can type to search or select more options from the drop-down selection to include all desired options.
- [ ] User can remove any selected Issue Disposition displayed via the 'X' next to each selection. 
Form validation: 
- [ ] At least one type must be selected if condition is added 

## Testing Plan
1. Log in as VHAADMIN1
2. Go to decision_reviews/vha/report
3. Select Event / Action for Report type
4. Click Add Condition
5. Select Issue Disposition
6. Interact with inputs and check if that works
7. Check validation
8. Click submit and check the dev tools console to see if the correct data was logged

## Screenshots

![Screenshot 2023-11-21 at 1 58 39 PM](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/930f9f13-003b-4202-b041-e72a526d6f1f)

![Screenshot 2023-11-21 at 1 58 57 PM](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/9d39f9a7-5f3d-4847-ac92-ffa7360c39b4)
