### PR TITLE
lthompson/APPEALS-26137

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -265,6 +265,10 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
     roles.include?("VSO")
   end
 
+  def non_board_employee?
+    vso_employee? || roles.include?("RO ViewHearSched")
+  end
+
   def camo_employee?
     member_of_organization?(VhaCamo.singleton) && FeatureToggle.enabled?(:vha_predocket_workflow, user: self)
   end

--- a/app/serializers/hearings/hearing_day_serializer.rb
+++ b/app/serializers/hearings/hearing_day_serializer.rb
@@ -17,7 +17,9 @@ class HearingDaySerializer
     get_judge_last_name(hearing_day, params)
   end
   attribute :lock
-  attribute :notes
+  attribute :notes do |hearing_day|
+    RequestStore[:current_user]&.vso_employee? ? nil : hearing_day.notes
+  end
   attribute :readable_request_type do |hearing_day, params|
     get_readable_request_type(hearing_day, params)
   end

--- a/app/serializers/hearings/hearing_day_serializer.rb
+++ b/app/serializers/hearings/hearing_day_serializer.rb
@@ -18,7 +18,7 @@ class HearingDaySerializer
   end
   attribute :lock
   attribute :notes do |hearing_day|
-    RequestStore[:current_user]&.vso_employee? ? nil : hearing_day.notes
+    RequestStore[:current_user]&.non_board_employee? ? nil : hearing_day.notes
   end
   attribute :readable_request_type do |hearing_day, params|
     get_readable_request_type(hearing_day, params)

--- a/client/test/app/hearings/components/dailyDocket/DailyDocketEditLink.test.js
+++ b/client/test/app/hearings/components/dailyDocket/DailyDocketEditLink.test.js
@@ -1,0 +1,46 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { MemoryRouter as Router } from 'react-router-dom';
+import DailyDocketEditLink from '../../../../../../client/app/hearings/components/dailyDocket/DailyDocketEditLinks';
+import { Provider } from 'react-redux';
+import { applyMiddleware, createStore, compose } from 'redux';
+import thunk from 'redux-thunk';
+
+const createStoreWithReducer = (initialState) => {
+  const reducer = (state = initialState) => state;
+
+  return createStore(reducer, compose(applyMiddleware(thunk)));
+};
+
+const renderDailyDocket = (props) => {
+  const store = createStoreWithReducer({ components: {} });
+
+  return render(
+    <Provider store={store}>
+      <Router>
+        <DailyDocketEditLink {...props} />
+      </Router>
+    </Provider>
+  );
+};
+
+it('does render docket notes when user is a board employee', async () => {
+  const mockProps = {
+    user: { userIsNonBoardEmployee: false },
+    dailyDocket: { notes: 'There is a note here' },
+  };
+
+  renderDailyDocket(mockProps);
+  expect(await screen.findByText(/Notes:/)).toBeInTheDocument();
+});
+
+it('does not render docket notes when user is a nonBoardEmployee', async () => {
+  const mockProps = {
+    user: { userIsNonBoardEmployee: true },
+    dailyDocket: { notes: 'There is a note here' },
+  };
+
+  renderDailyDocket(mockProps);
+  expect(await screen.queryByText(/Note:\s*This\s*is\s*a\s*note/)).not.toBeInTheDocument();
+});

--- a/client/test/app/hearings/components/dailyDocket/DailyDocketPrinted.test.js
+++ b/client/test/app/hearings/components/dailyDocket/DailyDocketPrinted.test.js
@@ -18,6 +18,16 @@ describe('DailyDocketPrinted', () => {
     expect(await screen.findByText(/VLJ:/)).toBeInTheDocument();
   });
 
+  it('renders docket notes when user is a board employee', async () => {
+    const mockProps = {
+      user: { userIsNonBoardEmployee: false },
+      docket: { notes: 'There is a note here' }
+    };
+
+    renderDailyDocketPrinted(mockProps);
+    expect(await screen.findByText(/Notes:/)).toBeInTheDocument();
+  });
+
   it('does not render tag VLJ when user is a VSO employee', () => {
     const mockProps = {
       user: { userIsNonBoardEmployee: true },
@@ -27,5 +37,15 @@ describe('DailyDocketPrinted', () => {
 
     renderDailyDocketPrinted(mockProps);
     expect(screen.queryByText(/VLJ:/)).not.toBeInTheDocument();
+  });
+
+  it('does not render docket notes when user is a nonBoardEmployee', async () => {
+    const mockProps = {
+      user: { userIsNonBoardEmployee: true },
+      docket: { notes: 'There is a note here' },
+    };
+
+    renderDailyDocketPrinted(mockProps);
+    expect(await screen.queryByText(/Note:\s*This\s*is\s*a\s*note/)).not.toBeInTheDocument();
   });
 });

--- a/spec/feature/hearings/daily_docket/ro_viewhearsched_spec.rb
+++ b/spec/feature/hearings/daily_docket/ro_viewhearsched_spec.rb
@@ -5,18 +5,15 @@ RSpec.feature "Hearing Schedule Daily Docket for RO ViewHearSched", :all_dbs do
   let!(:current_user) { User.authenticate!(css_id: "BVATWARNER", roles: ["RO ViewHearSched"]) }
   let!(:hearing) { create(:hearing, :with_tasks) }
 
-  scenario "User can only update notes" do
+  scenario "User cannot view docket notes" do
     visit "hearings/schedule/docket/" + hearing.hearing_day.id.to_s
     expect(page).to_not have_button("Print all Hearing Worksheets")
     expect(page).to_not have_content("Edit Hearing Day")
     expect(page).to_not have_content("Lock Hearing Day")
     expect(page).to_not have_content("Hearing Details")
+    expect(page).to_not have_content("Notes")
     expect(page).to have_field("Transcript Requested", disabled: true, visible: false)
-    expect(find(".dropdown-#{hearing.external_id}-disposition")).to have_css(".cf-select__control--is-disabled")
-    fill_in "Notes", with: "This is a note about the hearing!"
-    click_button("Save")
 
     expect(page).to have_content("You have successfully updated", wait: 10)
-    expect(page).to have_content("This is a note about the hearing!")
   end
 end

--- a/spec/feature/hearings/daily_docket/ro_viewhearsched_spec.rb
+++ b/spec/feature/hearings/daily_docket/ro_viewhearsched_spec.rb
@@ -13,7 +13,5 @@ RSpec.feature "Hearing Schedule Daily Docket for RO ViewHearSched", :all_dbs do
     expect(page).to_not have_content("Hearing Details")
     expect(page).to_not have_content("Notes")
     expect(page).to have_field("Transcript Requested", disabled: true, visible: false)
-
-    expect(page).to have_content("You have successfully updated", wait: 10)
   end
 end

--- a/spec/feature/hearings/daily_docket/vso_spec.rb
+++ b/spec/feature/hearings/daily_docket/vso_spec.rb
@@ -12,5 +12,6 @@ RSpec.feature "Hearing Schedule Daily Docket for VSO", :all_dbs do
     expect(page).to_not have_content("Edit Hearing Day")
     expect(page).to_not have_content("Lock Hearing Day")
     expect(page).to_not have_content("Hearing Details")
+    expect(page).to_not have_content("Notes")
   end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-26137](https://jira.devops.va.gov/browse/APPEALS-26137)

# Description
- Added method to User.rb to check if the current_user was a non board employee ("VSO" or "RO ViewHearSched" users) and use that to either display or not display docket notes
- Created and updated unit tests (DailyDocketEditLink.test.js, DailyDocketPrinted.test.js)
- Updated feature tests (vso_spec.rb, ro_viewhearsched_spec.rb)

## Acceptance Criteria
- [x] HearingDaySerializer is updated to check if the current_user has the "VSO"or "RO ViewHearSched" user roles 
- [x] If the current_user does have the "VSO" or "RO ViewHearSched" roles the return value of notes should be nil
- [x] If the current_user does not have the "VSO" or "RO ViewHearSched" roles the return value of notes should be the value contained in the notes column for the hearing day being serialized (existing behavior)

Whenever accessing the Daily Docket page (/hearings/schedule/docket/<hearing_day.id>):
As a VSO/RO user:
- [x] Docket notes should not be visible, no matter if the hearing day has any or not.
As a non-VSO/RO user/Board employee:
- [x] If docket notes exist on the hearing day, then the docket notes should be visible.

Whenever accessing the Daily Docket printout (/hearings/schedule/docket/<hearing_day.id>/print - Accessed by clicking the "Download & Print Page" button on the Daily Docket page):
As a VSO/RO user:
- [x] Docket notes should not be visible, no matter if the hearing day has any or not.
As a non-VSO/RO user/Board employee:
- [x] If docket notes exist on the hearing day, then the docket notes should be visible.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added