### PR TITLE
Will/appeals 35023

### DIFF
--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -7,27 +7,10 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   #
   # Response: Update corresponding Notification status
   def notifications_update
-    if required_params[:notification_type] == "email"
-      email_update
-    elsif required_params[:notification_type] == "sms"
-      sms_update
-    end
+    send "#{required_params[:notification_type]}_update"
   end
 
   private
-
-  # Purpose: Log error in Rails logger and gives 500 error
-  #
-  # Params:  Notification type string, either "email" or "SMS"
-  #
-  # Response: json error message with uuid and 500 error
-  def log_error(notification_type)
-    uuid = SecureRandom.uuid
-    error_msg = "An #{notification_type} notification with id #{required_params[:id]} could not be found. " \
-                "Error ID: #{uuid}"
-    Rails.logger.error(error_msg)
-    render json: { message: error_msg }, status: :internal_server_error
-  end
 
   # Purpose: Finds and updates notification if type is email
   #
@@ -35,13 +18,8 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   #
   # Response: Update corresponding email Notification status
   def email_update
-    # find notification through external id
-    notif = Notification.find_by(email_notification_external_id: required_params[:id])
-    # log external id if notification doesn't exist
-    return log_error(required_params[:notification_type]) unless notif
+    redis.set("email_update:#{required_params[:id]}:#{required_params[:status]}", 0)
 
-    # update notification if it exists
-    notif.update!(email_notification_status: required_params[:status])
     render json: { message: "Email notification successfully updated: ID " + required_params[:id] }
   end
 
@@ -51,13 +29,8 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   #
   # Response: Update corresponding SMS Notification status
   def sms_update
-    # find notification through external id
-    notif = Notification.find_by(sms_notification_external_id: required_params[:id])
-    # log external id if notification doesn't exist
-    return log_error(required_params[:notification_type]) unless notif
+    redis.set("sms_update:#{required_params[:id]}:#{required_params[:status]}", 0)
 
-    # update notification if it exists
-    notif.update!(sms_notification_status: params[:status])
     render json: { message: "SMS notification successfully updated: ID " + required_params[:id] }
   end
 
@@ -65,5 +38,9 @@ class Api::V1::VaNotifyController < Api::ApplicationController
     id_param, notification_type_param, status_param = params.require([:id, :notification_type, :status])
 
     { id: id_param, notification_type: notification_type_param, status: status_param }
+  end
+
+  def redis
+    @redis ||= Redis.new(url: Rails.application.secrets.redis_url_cache)
   end
 end

--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -9,6 +9,19 @@ class Api::V3::BaseController < Api::ApplicationController
     end
   end
 
+  rescue_from StandardError do |error|
+    Raven.capture_exception(error, extra: raven_extra_context)
+
+    render json: {
+      "errors": [
+        "status": "500",
+        "title": "Unknown error occured",
+        "detail": "Message: There was a server error. "\
+                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
+      ]
+    }, status: :internal_server_error
+  end
+
   protect_from_forgery with: :null_session
 
   def render_errors(errors)

--- a/app/controllers/api/v3/issues/ama/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/ama/veterans_controller.rb
@@ -8,19 +8,6 @@ class Api::V3::Issues::Ama::VeteransController < Api::V3::BaseController
     api_released?(:api_v3_ama_issues)
   end
 
-  rescue_from StandardError do |error|
-    Raven.capture_exception(error, extra: raven_extra_context)
-
-    render json: {
-      "errors": [
-        "status": "500",
-        "title": "Unknown error occured",
-        "detail": "Message: There was a server error. "\
-                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
-      ]
-    }, status: :internal_server_error
-  end
-
   def show
     veteran = find_veteran
     page = init_page

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -2,7 +2,8 @@
 
 # :reek:InstanceVariableAssumption
 class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
-  DEFAULT_UPPER_BOUND_PER_PAGE = ENV["REQUEST_ISSUE_DEFAULT_UPPER_BOUND_PER_PAGE"].to_i # The max amount of Issues that can be paginated on a single page
+  # The max amount of Issues that can be paginated on a single page
+  DEFAULT_UPPER_BOUND_PER_PAGE = ENV["REQUEST_ISSUE_DEFAULT_UPPER_BOUND_PER_PAGE"].to_i
   include ApiV3FeatureToggleConcern
 
   before_action do
@@ -20,7 +21,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
   end
 
   def veteran
-    vet_file_number = file_number
     @veteran ||= find_veteran
   end
 
@@ -55,7 +55,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
 
     render_veteran_not_found
   end
-
 
   def show
     page = ActiveRecord::Base.sanitize_sql(params[:page].to_i) if params[:page]

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -36,19 +36,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
     @file_number ||= request.headers["X-VA-FILE-NUMBER"].presence
   end
 
-  rescue_from StandardError do |error|
-    Raven.capture_exception(error, extra: raven_extra_context)
-
-    render json: {
-      "errors": [
-        "status": "500",
-        "title": "Unknown error occured",
-        "detail": "Message: There was a server error. "\
-                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
-      ]
-    }, status: :internal_server_error
-  end
-
   rescue_from Caseflow::Error::InvalidFileNumber, BGS::ShareError do |error|
     Raven.capture_exception(error, extra: raven_extra_context)
     Rails.logger.error "Unable to find Veteran, please review the entered params: #{error}"

--- a/app/jobs/process_notification_status_updates_job.rb
+++ b/app/jobs/process_notification_status_updates_job.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+class ProcessNotificationStatusUpdatesJob < CaseflowJob
+  queue_with_priority :low_priority
+
+  def perform
+    RequestStore[:current_user] = User.system_user
+
+    redis = Redis.new(url: Rails.application.secrets.redis_url_cache)
+
+    processed_count = 0
+
+    # prefer scan so we only load a single record into memory,
+    # dumping the whole list could cause performance issues when job runs
+    redis.scan_each(match: "*_update:*") do |key|
+      break if processed_count >= 1000
+
+      begin
+        raw_notification_type, uuid, status = key.split(":")
+
+        notification_type = extract_notification_type(raw_notification_type)
+
+        fail InvalidNotificationStatusFormat if [notification_type, uuid, status].any?(&:nil?)
+
+        rows_updated = Notification.select(Arel.star).where(
+          Notification.arel_table["#{notification_type}_notification_external_id".to_sym].eq(uuid)
+        ).update_all("#{notification_type}_notification_status" => status)
+
+        fail StandardError, "No notification matches UUID #{uuid}" if rows_updated.zero?
+      rescue StandardError => error
+        log_error(error)
+      ensure
+        # cleanup keys - do first so we don't reporcess any failed keys
+        redis.del key
+        processed_count += 1
+      end
+    end
+  end
+
+  private
+
+  def extract_notification_type(raw_notification_type)
+    raw_notification_type.split("_").first
+  end
+end

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -1176,6 +1176,13 @@ class LegacyAppeal < CaseflowRecord
     # build Legacy Appeal records for each one if they don't already exist
     def veteran_has_appeals_in_vacols?(veteran_file_number)
       fetch_appeals_by_file_number(veteran_file_number).any?
+    rescue NoMethodError
+      cases = MetricsService.record("VACOLS: appeals_by_vbms_id",
+                                    service: :vacols,
+                                    name: "appeals_by_vbms_id") do
+        VACOLS::Case.where(bfcorlid: convert_file_number_to_vacols(veteran_file_number))
+      end
+      cases.any?
     end
 
     private

--- a/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
+++ b/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
@@ -34,6 +34,10 @@ class Api::V3::Issues::Ama::RequestIssueSerializer
     object.decision_review.claimant.participant_id
   end
 
+  attribute :claim_id do |object|
+    object&.end_product_establishment&.reference_id
+  end
+
   attribute :decision_issues do |object|
     object.decision_issues.map do |di|
       {

--- a/app/services/api/v3/issues/vacols/vbms_vacols_dto_builder.rb
+++ b/app/services/api/v3/issues/vacols/vbms_vacols_dto_builder.rb
@@ -9,7 +9,7 @@ class Api::V3::Issues::Vacols::VbmsVacolsDtoBuilder
     @veteran_participant_id = veteran.participant_id&.to_s
     @veteran_file_number = veteran.file_number&.to_s
     @vacols_issue_count = total_vacols_issue_count
-    @offset = per_page || RequestIssue.default_per_page #LegacyIssues will be consistent with AMA RequestIssues
+    @offset = per_page || RequestIssue.default_per_page # LegacyIssues will be consistent with AMA RequestIssues
     @vacols_issues = serialized_vacols_issues
     @total_number_of_pages = (@vacols_issue_count / @offset.to_f).ceil
     @hash_response = build_hash_response
@@ -27,8 +27,8 @@ class Api::V3::Issues::Vacols::VbmsVacolsDtoBuilder
   def serialized_vacols_issues(page = @page, offset = @offset)
     vacols_issues = []
     v_ids = LegacyAppeal.fetch_appeals_by_file_number(@veteran_file_number).map(&:vacols_id)
-    v_ids.each do |i|
-      vacols_issues.push(AppealRepository.issues(i))
+    v_ids.each do |id|
+      vacols_issues.push(AppealRepository.issues(id))
     end
 
     serialized_data = Api::V3::Issues::Vacols::VacolsIssueSerializer.new(

--- a/config/application.rb
+++ b/config/application.rb
@@ -155,5 +155,12 @@ module CaseflowCertification
       TOPLEVEL_BINDING.eval("self").extend FinderConsoleMethods
     end
     # :nocov:
+
+    # Unregister `sprockets-rails` source mapping postprocessor to avoid conflicts with source map generation provided
+    # by `react_on_rails`+`webpack`. The addition of this postprocessor in `sprockets-rails` `3.4.0` was causing
+    # corruption of the `webpack-bundle.js` file, thus breaking feature specs in local development environments.
+    config.assets.configure do |env|
+      env.unregister_postprocessor("application/javascript", ::Sprockets::Rails::SourcemappingUrlProcessor)
+    end
   end
 end

--- a/config/initializers/scheduled_jobs.rb
+++ b/config/initializers/scheduled_jobs.rb
@@ -49,5 +49,6 @@ SCHEDULED_JOBS = {
     "legacy_notification_efolder_sync_job" => LegacyNotificationEfolderSyncJob,
     "change_hearing_request_type_task_cancellation_job" => ChangeHearingRequestTypeTaskCancellationJob,
     "cannot_delete_contention_remediation_job" => CannotDeleteContentionRemediationJob,
-    "contention_not_found_remediation_job" => ContentionNotFoundRemediationJob
+    "contention_not_found_remediation_job" => ContentionNotFoundRemediationJob,
+    "process_notification_status_updates_job" => ProcessNotificationStatusUpdatesJob
 }.freeze

--- a/db/migrate/20231016132819_add_notification_id_and_status_indexes.rb
+++ b/db/migrate/20231016132819_add_notification_id_and_status_indexes.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+class AddNotificationIdAndStatusIndexes < Caseflow::Migration
+  disable_ddl_transaction!
+
+  def change
+    add_index :notifications,
+              :email_notification_external_id,
+              algorithm: :concurrently
+
+    add_index :notifications,
+              :email_notification_status,
+              algorithm: :concurrently
+
+    add_index :notifications,
+              :sms_notification_external_id,
+              algorithm: :concurrently
+
+    add_index :notifications,
+              :sms_notification_status,
+              algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1336,7 +1336,11 @@ ActiveRecord::Schema.define(version: 2023_10_18_115254) do
     t.string "sms_notification_status", comment: "Status of SMS/Text Notification"
     t.datetime "updated_at", comment: "TImestamp of when Notification was Updated"
     t.index ["appeals_id", "appeals_type"], name: "index_appeals_notifications_on_appeals_id_and_appeals_type"
+    t.index ["email_notification_external_id"], name: "index_notifications_on_email_notification_external_id"
+    t.index ["email_notification_status"], name: "index_notifications_on_email_notification_status"
     t.index ["participant_id"], name: "index_participant_id"
+    t.index ["sms_notification_external_id"], name: "index_notifications_on_sms_notification_external_id"
+    t.index ["sms_notification_status"], name: "index_notifications_on_sms_notification_status"
   end
 
   create_table "organizations", force: :cascade do |t|

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -462,6 +462,7 @@ module Caseflow::Error
   class VANotifyInternalServerError < VANotifyApiError; end
   class VANotifyRateLimitError < VANotifyApiError; end
   class EmptyQueueError < StandardError; end
+  class InvalidNotificationStatusFormat < StandardError; end
 
   # Pacman errors
   class PacmanApiError < StandardError

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 describe Api::V1::VaNotifyController, type: :controller do
-  before do
-    Seeds::NotificationEvents.new.seed!
-  end
+  include ActiveJob::TestHelper
+
+  before { Seeds::NotificationEvents.new.seed! }
+
   let(:api_key) { ApiKey.create!(consumer_name: "API Consumer").key_string }
   let!(:appeal) { create(:appeal) }
   let!(:notification_email) do
@@ -69,8 +70,10 @@ describe Api::V1::VaNotifyController, type: :controller do
     it "updates status of notification" do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_email
-      notification_email.reload
-      expect(notification_email.email_notification_status).to eq("created")
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(notification_email.reload.email_notification_status).to eq("created")
     end
   end
 
@@ -84,8 +87,10 @@ describe Api::V1::VaNotifyController, type: :controller do
     it "updates status of notification" do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_sms
-      notification_sms.reload
-      expect(notification_sms.sms_notification_status).to eq("created")
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(notification_sms.reload.sms_notification_status).to eq("created")
     end
   end
 
@@ -128,10 +133,16 @@ describe Api::V1::VaNotifyController, type: :controller do
       }
     end
 
-    it "updates status of notification" do
+    it "Update job raises error if UUID is passed in for a non-existant notification" do
+      expect_any_instance_of(ProcessNotificationStatusUpdatesJob).to receive(:log_error) do |_job, error|
+        expect(error.message).to eq("No notification matches UUID #{payload_fake.dig(:id)}")
+      end
+
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_fake
-      expect(response.status).to eq(500)
+      expect(response.status).to eq(200)
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
     end
   end
 end

--- a/spec/jobs/process_notification_status_updates_job_spec.rb
+++ b/spec/jobs/process_notification_status_updates_job_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+describe ProcessNotificationStatusUpdatesJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:redis) do
+    # Creates a fresh Redis connection before each test and deletes all keys in the store
+    Redis.new(url: Rails.application.secrets.redis_url_cache).tap(&:flushall)
+  end
+
+  context ".perform" do
+    before { Seeds::NotificationEvents.new.seed! }
+
+    subject(:job) { ProcessNotificationStatusUpdatesJob.perform_later }
+
+    let(:new_status) { "test_status" }
+    let(:appeal) { create(:appeal, veteran_file_number: "500000102", receipt_date: 6.months.ago.to_date.mdY) }
+    let(:email_notification) do
+      create(:notification, appeals_id: appeal.uuid,
+                            appeals_type: "Appeal",
+                            event_date: 6.days.ago,
+                            event_type: "Quarterly Notification",
+                            notification_type: "Email",
+                            email_notification_external_id: SecureRandom.uuid)
+    end
+    let(:sms_notification) do
+      create(:notification, appeals_id: appeal.uuid,
+                            appeals_type: "Appeal",
+                            event_date: 6.days.ago,
+                            event_type: "Hearing scheduled",
+                            sms_notification_external_id: SecureRandom.uuid,
+                            notification_type: "SMS")
+    end
+
+    it "has one message in queue" do
+      expect { job }.to change(ActiveJob::Base.queue_adapter.enqueued_jobs, :size).by(1)
+    end
+
+    it "processes email notifications from redis cache" do
+      expect(email_notification.email_notification_status).to_not eq(new_status)
+
+      create_cache_entries(email_notification)
+
+      expect(redis.keys.grep(/email_update:/).count).to eq(1)
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(redis.keys.grep(/email_update:/).count).to eq(0)
+      expect(email_notification.reload.email_notification_status).to eq(new_status)
+    end
+
+    it "processes sms notifications from redis cache" do
+      expect(sms_notification.sms_notification_status).to_not eq(new_status)
+
+      create_cache_entries(sms_notification)
+
+      expect(redis.keys.grep(/sms_update:/).count).to eq(1)
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(redis.keys.grep(/sms_update:/).count).to eq(0)
+      expect(sms_notification.reload.sms_notification_status).to eq(new_status)
+    end
+
+    it "processes a mix of email and sms notifications from redis cache" do
+      create_cache_entries(sms_notification, email_notification)
+
+      expect(redis.keys.grep(/(sms|email)_update:/).count).to eq(2)
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(redis.keys.grep(/(sms|email)_update:/).count).to eq(0)
+      expect(email_notification.reload.email_notification_status).to eq(new_status)
+      expect(sms_notification.reload.sms_notification_status).to eq(new_status)
+    end
+
+    it "an error is raised if a UUID doesn't match with a notification record, but the job isn't halted" do
+      expect_any_instance_of(ProcessNotificationStatusUpdatesJob).to receive(:log_error) do |_job, error|
+        expect(error.message).to eq("No notification matches UUID not-going-to-match")
+      end.exactly(:once)
+
+      # This notification update will cause an error
+      redis.set("sms_update:not-going-to-match:#{new_status}", 0)
+
+      # This notification update should be fine
+      create_cache_entries(email_notification)
+
+      expect(redis.keys.grep(/(sms|email)_update:/).count).to eq(2)
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+
+      expect(sms_notification.reload.sms_notification_status).to be_nil
+      expect(email_notification.reload.email_notification_status).to eq(new_status)
+
+      expect(redis.keys.grep(/(sms|email)_update:/).count).to eq(0)
+    end
+  end
+
+  private
+
+  def create_cache_entries(*keys)
+    keys.each do |key|
+      notification_type = key.notification_type.downcase
+      external_id = key.send("#{notification_type}_notification_external_id".to_sym)
+
+      redis.set("#{notification_type}_update:#{external_id}:#{new_status}", 0)
+    end
+  end
+end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -1163,6 +1163,16 @@ describe LegacyAppeal, :all_dbs do
     end
   end
 
+  context "fetch_appeals_by_file_number returns NoMethodError" do
+    before do
+      allow(LegacyAppeal).to receive(:fetch_appeals_by_file_number).and_raise(NoMethodError)
+    end
+
+    it "raises ActiveRecord::RecordNotFound error" do
+      expect { LegacyAppeal.veteran_has_appeals_in_vacols("1234567890") }.to raise_error(NoMethodError)
+    end
+  end
+
   context ".convert_file_number_to_vacols" do
     subject { LegacyAppeal.convert_file_number_to_vacols(file_number) }
 

--- a/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
+++ b/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
@@ -50,6 +50,7 @@ describe Api::V3::Issues::Ama::RequestIssueSerializer, :postgres do
       expect(serialized_request_issue.key?(:caseflow_considers_title_of_active_review)).to eq true
       expect(serialized_request_issue.key?(:caseflow_considers_eligible)).to eq true
       expect(serialized_request_issue.key?(:claimant_participant_id)).to eq true
+      expect(serialized_request_issue.key?(:claim_id)).to eq true
       expect(serialized_request_issue.key?(:decision_issues)).to eq true
 
       serialized_decision_issue = serialized_request_issue[:decision_issues].first


### PR DESCRIPTION
# Description
Adds error handling for a no method error when a veteran is missing data. Also, code climate issues are fixed in this PR.

## Acceptance Criteria
- querying for legacy_appeals_present will now return a no method error instead of a 500 server error.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added
