### PR TITLE
updated require statement in seeds.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "database_cleaner"
+require "database_cleaner-active_record"
 
 # because db/seeds is not in the autoload path, we must load them explicitly here
 # base.rb needs to be loaded first because the other seeds inherit from it


### PR DESCRIPTION
# Description
Changes the require statement in `db/seeds.rb` to account for the gem `database_cleaner` being changed to `database_cleaner-active_record`

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Make reset runs without error

## Testing Plan
1. Run make reset
