### PR TITLE
added uat logic to mimic 500 server error

### DIFF
--- a/app/controllers/api/v3/issues/ama/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/ama/veterans_controller.rb
@@ -56,6 +56,9 @@ class Api::V3::Issues::Ama::VeteransController < Api::V3::BaseController
 
   def find_veteran
     begin
+      # Temporary logic used to induce a 500 Server Error in UAT
+      fail StandardError if params[:participant_id] == "000000000"
+
       Veteran.find_by!(participant_id: params[:participant_id])
     rescue ActiveRecord::RecordNotFound
       render_errors(

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -16,6 +16,9 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
   end
 
   def validate_veteran_presence
+    # Temporary logic used to induce a 500 Server Error in UAT
+    fail StandardError if file_number == "00000001"
+
     render_veteran_not_found unless veteran
   end
 


### PR DESCRIPTION
Resolves [APPEALS-28094](https://jira.devops.va.gov/browse/APPEALS-28094)

# Description
Specific logic to mimic 500 server error for the VACOLS and AMA endpoints in UAT

## Testing Plan
AMA endpoint:
1. Ran server in caseflow using `make run-m1`
2. Made GET request in Postman using `http://127.0.0.1:3000/api/v3/issues/ama/find_by_veteran/000000000`
3. Ensured 500 server error occurred

VACOLS endpoint:
1. Ran server in caseflow using `make run-m1`
2. Made GET request in Postman using `http://127.0.0.1:3000/api/v3/issues/vacols/find_by_veteran`
3. Passed in `00000001` for `X-VA-File-Number` header
4. Ensured 500 server error occurred

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

