### PR TITLE
jcroteau/APPEALS-35706 - Rollback `database_cleaner` gem update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,7 +99,7 @@ group :test, :development, :demo do
   gem "capybara"
   gem "capybara-screenshot"
   gem "danger", "~> 6.2.2"
-  gem "database_cleaner-active_record"
+  gem "database_cleaner"
   gem "factory_bot_rails", "~> 5.2"
   gem "faker"
   gem "guard-rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,10 +224,7 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
-    database_cleaner-active_record (2.1.0)
-      activerecord (>= 5.a)
-      database_cleaner-core (~> 2.0.0)
-    database_cleaner-core (2.0.1)
+    database_cleaner (1.7.0)
     date (3.3.3)
     ddtrace (0.34.1)
       msgpack
@@ -757,7 +754,7 @@ DEPENDENCIES
   console_tree_renderer!
   countries
   danger (~> 6.2.2)
-  database_cleaner-active_record
+  database_cleaner
   ddtrace
   debase
   derailed_benchmarks

--- a/spec/support/database_cleaner.rb
+++ b/spec/support/database_cleaner.rb
@@ -14,26 +14,26 @@ RSpec.configure do |config|
   # IMPORTANT that in all these hook defs, the "caseflow" connection comes last.
 
   config.before(:suite) do
-    DatabaseCleaner[:active_record, { db: etl }].clean_with(:truncation)
-    DatabaseCleaner[:active_record, { db: vacols }]
+    DatabaseCleaner[:active_record, { connection: etl }].clean_with(:truncation)
+    DatabaseCleaner[:active_record, { connection: vacols }]
       .clean_with(:deletion, except: vacols_tables_to_preserve)
-    DatabaseCleaner[:active_record, { db: caseflow }].clean_with(:truncation)
+    DatabaseCleaner[:active_record, { connection: caseflow }].clean_with(:truncation)
   end
 
   config.before(:each) do |example|
     # Allows seeded data to persist for use across threads
     # You will need to manually clean the data once the threads under test close.
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { db: vacols }].strategy = :transaction
-      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :transaction
+      DatabaseCleaner[:active_record, { connection: vacols }].strategy = :transaction
+      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :transaction
     end
   end
 
   config.before(:each, db_clean: :truncation) do |example|
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { db: vacols }].strategy =
+      DatabaseCleaner[:active_record, { connection: vacols }].strategy =
         :deletion, { except: vacols_tables_to_preserve }
-      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :truncation
+      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :truncation
     end
   end
 
@@ -46,42 +46,42 @@ RSpec.configure do |config|
       # Driver is probably for an external browser with an app
       # under test that does *not* share a database connection with the
       # specs, so use truncation strategy.
-      DatabaseCleaner[:active_record, { db: vacols }].strategy =
+      DatabaseCleaner[:active_record, { connection: vacols }].strategy =
         :deletion, { except: vacols_tables_to_preserve }
-      DatabaseCleaner[:active_record, { db: caseflow }].strategy = :truncation
+      DatabaseCleaner[:active_record, { connection: caseflow }].strategy = :truncation
     end
   end
 
   config.before(:each) do |example|
     unless example.metadata[:bypass_cleaner]
-      DatabaseCleaner[:active_record, { db: vacols }].start
-      DatabaseCleaner[:active_record, { db: caseflow }].start
+      DatabaseCleaner[:active_record, { connection: vacols }].start
+      DatabaseCleaner[:active_record, { connection: caseflow }].start
     end
   end
 
   config.append_after(:each) do
-    DatabaseCleaner[:active_record, { db: vacols }].clean
-    DatabaseCleaner[:active_record, { db: caseflow }].clean
+    DatabaseCleaner[:active_record, { connection: vacols }].clean
+    DatabaseCleaner[:active_record, { connection: caseflow }].clean
     clean_application!
   end
 
   # ETL is never used in feature tests and there are only a few, so we tag those with :etl
   # ETL db uses deletion strategy everywhere because syncing runs in a transaction.
   config.before(:each, :etl) do
-    DatabaseCleaner[:active_record, { db: etl }].strategy = :deletion
+    DatabaseCleaner[:active_record, { connection: etl }].strategy = :deletion
   end
 
   config.before(:each, :etl, db_clean: :truncation) do
-    DatabaseCleaner[:active_record, { db: etl }].strategy = :truncation
+    DatabaseCleaner[:active_record, { connection: etl }].strategy = :truncation
   end
 
   config.before(:each, :etl) do
     Rails.logger.info("DatabaseCleaner.start ETL")
-    DatabaseCleaner[:active_record, { db: etl }].start
+    DatabaseCleaner[:active_record, { connection: etl }].start
   end
 
   config.append_after(:each, :etl) do
-    DatabaseCleaner[:active_record, { db: etl }].clean
+    DatabaseCleaner[:active_record, { connection: etl }].clean
     Rails.logger.info("DatabaseCleaner.clean ETL")
   end
 end


### PR DESCRIPTION
Resolves: https://jira.devops.va.gov/browse/APPEALS-35706

# Description
After the changes made in https://github.com/department-of-veterans-affairs/caseflow/pull/19740, the `db:seed` task was failing with the following error, so let's rollback the `database_cleaner` changes until we can debug and resolve:


>     PG::FeatureNotSupported: ERROR: cannot truncate a table
>     referenced in a foreign key constraint
> 
>     DETAIL: Table "priority_end_product_sync_queue_audit"
>     references "batch_processes".


## Acceptance Criteria
- [ ] Task `make reset` (which runs `db:seed`, among other things) runs successfully in local dev environment.

## Testing Plan
- [ ] Run `make reset` and ensure it finishes successfully.