### PR TITLE
Will/appeals 35023 pr 3

### DIFF
--- a/app/controllers/api/v3/base_controller.rb
+++ b/app/controllers/api/v3/base_controller.rb
@@ -9,6 +9,19 @@ class Api::V3::BaseController < Api::ApplicationController
     end
   end
 
+  rescue_from StandardError do |error|
+    Raven.capture_exception(error, extra: raven_extra_context)
+
+    render json: {
+      "errors": [
+        "status": "500",
+        "title": "Unknown error occured",
+        "detail": "Message: There was a server error. "\
+                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
+      ]
+    }, status: :internal_server_error
+  end
+
   protect_from_forgery with: :null_session
 
   def render_errors(errors)

--- a/app/controllers/api/v3/issues/ama/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/ama/veterans_controller.rb
@@ -8,19 +8,6 @@ class Api::V3::Issues::Ama::VeteransController < Api::V3::BaseController
     api_released?(:api_v3_ama_issues)
   end
 
-  rescue_from StandardError do |error|
-    Raven.capture_exception(error, extra: raven_extra_context)
-
-    render json: {
-      "errors": [
-        "status": "500",
-        "title": "Unknown error occured",
-        "detail": "Message: There was a server error. "\
-                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
-      ]
-    }, status: :internal_server_error
-  end
-
   def show
     veteran = find_veteran
     page = init_page

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -2,7 +2,8 @@
 
 # :reek:InstanceVariableAssumption
 class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
-  DEFAULT_UPPER_BOUND_PER_PAGE = ENV["REQUEST_ISSUE_DEFAULT_UPPER_BOUND_PER_PAGE"].to_i # The max amount of Issues that can be paginated on a single page
+  # The max amount of Issues that can be paginated on a single page
+  DEFAULT_UPPER_BOUND_PER_PAGE = ENV["REQUEST_ISSUE_DEFAULT_UPPER_BOUND_PER_PAGE"].to_i
   include ApiV3FeatureToggleConcern
 
   before_action do
@@ -34,19 +35,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
 
   def file_number
     @file_number ||= request.headers["X-VA-FILE-NUMBER"].presence
-  end
-
-  rescue_from StandardError do |error|
-    Raven.capture_exception(error, extra: raven_extra_context)
-
-    render json: {
-      "errors": [
-        "status": "500",
-        "title": "Unknown error occured",
-        "detail": "Message: There was a server error. "\
-                  "Use the error uuid to submit a support ticket: #{Raven.last_event_id}"
-      ]
-    }, status: :internal_server_error
   end
 
   rescue_from Caseflow::Error::InvalidFileNumber, BGS::ShareError do |error|

--- a/app/controllers/api/v3/issues/vacols/veterans_controller.rb
+++ b/app/controllers/api/v3/issues/vacols/veterans_controller.rb
@@ -21,7 +21,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
   end
 
   def veteran
-    vet_file_number = file_number
     @veteran ||= find_veteran
   end
 
@@ -43,7 +42,6 @@ class Api::V3::Issues::Vacols::VeteransController < Api::V3::BaseController
 
     render_veteran_not_found
   end
-
 
   def show
     page = ActiveRecord::Base.sanitize_sql(params[:page].to_i) if params[:page]

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -1176,6 +1176,13 @@ class LegacyAppeal < CaseflowRecord
     # build Legacy Appeal records for each one if they don't already exist
     def veteran_has_appeals_in_vacols?(veteran_file_number)
       fetch_appeals_by_file_number(veteran_file_number).any?
+    rescue NoMethodError
+      cases = MetricsService.record("VACOLS: appeals_by_vbms_id",
+                                    service: :vacols,
+                                    name: "appeals_by_vbms_id") do
+        VACOLS::Case.where(bfcorlid: convert_file_number_to_vacols(veteran_file_number))
+      end
+      cases.any?
     end
 
     private

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -1176,7 +1176,7 @@ class LegacyAppeal < CaseflowRecord
     # build Legacy Appeal records for each one if they don't already exist
     def veteran_has_appeals_in_vacols?(veteran_file_number)
       fetch_appeals_by_file_number(veteran_file_number).any?
-    rescue NoMethodError
+    rescue StandardError
       cases = MetricsService.record("VACOLS: appeals_by_vbms_id",
                                     service: :vacols,
                                     name: "appeals_by_vbms_id") do

--- a/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
+++ b/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
@@ -34,6 +34,10 @@ class Api::V3::Issues::Ama::RequestIssueSerializer
     object.decision_review.claimant.participant_id
   end
 
+  attribute :claim_id do |object|
+    object&.end_product_establishment&.reference_id
+  end
+
   attribute :decision_issues do |object|
     object.decision_issues.map do |di|
       {

--- a/app/services/api/v3/issues/vacols/vbms_vacols_dto_builder.rb
+++ b/app/services/api/v3/issues/vacols/vbms_vacols_dto_builder.rb
@@ -4,7 +4,7 @@
 class Api::V3::Issues::Vacols::VbmsVacolsDtoBuilder
   attr_reader :hash_response, :vacols_issue_count
 
-  def initialize(veteran, page, per_page = nil)
+  def initialize(veteran, page, per_page)
     @page = page
     @veteran_participant_id = veteran.participant_id&.to_s
     @veteran_file_number = veteran.file_number&.to_s
@@ -27,8 +27,8 @@ class Api::V3::Issues::Vacols::VbmsVacolsDtoBuilder
   def serialized_vacols_issues(page = @page, offset = @offset)
     vacols_issues = []
     v_ids = LegacyAppeal.fetch_appeals_by_file_number(@veteran_file_number).map(&:vacols_id)
-    v_ids.each do |i|
-      vacols_issues.push(AppealRepository.issues(i))
+    v_ids.each do |id|
+      vacols_issues.push(AppealRepository.issues(id))
     end
 
     serialized_data = Api::V3::Issues::Vacols::VacolsIssueSerializer.new(

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2990,16 +2990,16 @@ describe LegacyAppeal, :all_dbs do
       context "length greater than 9" do
         let(:veteran_file_number) { "1234567890" }
 
-        it "raises ActiveRecord::RecordNotFound error" do
-          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        it "raises Caseflow::Error::InvalidFileNumber error" do
+          expect { subject }.to raise_error(Caseflow::Error::InvalidFileNumber)
         end
       end
 
       context "length less than 3" do
         let(:veteran_file_number) { "12" }
 
-        it "raises ActiveRecord::RecordNotFound error" do
-          expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+        it "raises Caseflow::Error::InvalidFileNumber error" do
+          expect { subject }.to raise_error(Caseflow::Error::InvalidFileNumber)
         end
       end
     end

--- a/spec/models/legacy_appeal_spec.rb
+++ b/spec/models/legacy_appeal_spec.rb
@@ -2960,6 +2960,16 @@ describe LegacyAppeal, :all_dbs do
       create(:case, bfcorlid: "123456789S")
     end
 
+    context "fetch_appeals_by_file_number returns NoMethodError" do
+      before do
+        allow(LegacyAppeal).to receive(:fetch_appeals_by_file_number).and_raise(NoMethodError)
+      end
+
+      it "raises ActiveRecord::RecordNotFound error" do
+        expect { LegacyAppeal.veteran_has_appeals_in_vacols("1234567890") }.to raise_error(NoMethodError)
+      end
+    end
+
     context "when appeals are returned from VACOLS for the given file_number" do
       let(:veteran_file_number) { "123456789" }
 

--- a/spec/requests/api/v3/issues/vacols/veterans_controller_spec.rb
+++ b/spec/requests/api/v3/issues/vacols/veterans_controller_spec.rb
@@ -58,7 +58,7 @@ describe Api::V3::Issues::Vacols::VeteransController, :postgres, type: :request 
           get_vacols_issues(file_number: 87)
           expect(response).to have_http_status(404)
 
-          get_vacols_issues(file_number: 12345678987654321)
+          get_vacols_issues(file_number: 123_456_789_876_543_21)
           expect(response).to have_http_status(404)
 
           get_vacols_issues(file_number: "fakevet")

--- a/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
+++ b/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
@@ -51,6 +51,7 @@ describe Api::V3::Issues::Ama::RequestIssueSerializer, :postgres do
       expect(serialized_request_issue.key?(:caseflow_considers_eligible)).to eq true
       expect(serialized_request_issue.key?(:claimant_participant_id)).to eq true
       expect(serialized_request_issue.key?(:decision_issues)).to eq true
+      expect(serialized_request_issue.key?(:claim_id)).to eq true
 
       serialized_decision_issue = serialized_request_issue[:decision_issues].first
       expect(serialized_decision_issue.key?(:id)).to eq true

--- a/spec/serializers/api/v3/issues/vacols/vacols_issue_serializer_spec.rb
+++ b/spec/serializers/api/v3/issues/vacols/vacols_issue_serializer_spec.rb
@@ -39,7 +39,8 @@ describe Api::V3::Issues::Vacols::VacolsIssueSerializer, :postgres do
       expect(serialized_vacols_issue[:vacols_id]).to eq issue.id
       expect(serialized_vacols_issue[:vacols_sequence_id]).to eq issue.vacols_sequence_id
       expect(serialized_vacols_issue[:eligible_for_soc_opt_in]).to eq issue.eligible_for_opt_in?
-      expect(serialized_vacols_issue[:eligible_for_soc_opt_in_with_exemption]).to eq issue.eligible_for_opt_in?(covid_flag: true)
+      expect(serialized_vacols_issue[:eligible_for_soc_opt_in_with_exemption])
+        .to eq issue.eligible_for_opt_in?(covid_flag: true)
       expect(serialized_vacols_issue[:description]).to eq issue.friendly_description
       expect(serialized_vacols_issue[:disposition]).to eq issue.disposition
       expect(serialized_vacols_issue[:close_date]).to eq issue.close_date


### PR DESCRIPTION
Resolves [APPEALS-35023](https://jira.devops.va.gov/browse/APPEALS-35023)

# Description
As a developer, I need to add additional error handling to AMA Issues API. When querying for legacy_appeals_present, it occasionally results in a NoMethodError. I also need add a transient attribute to the request issue serializer that returns the claim_id (EPE reference_id), remove any code climate issues present, and ensure that we have 100% code coverage.

## Acceptance Criteria

- [x] Query tied to legacy_appeals_present needs to include error handling in situations where a NoMethodError occurs.  
- [x] Add transient attribute called claim_id to the AMA Request Issues serializer.  This attribute should be populated by the correlated End Product Establishment field of reference_id.  
- [x] Resolve any outstanding Code Climate Issues.
- [x] Ensure 100% RSPEC code coverage for APIs

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [x] run command: bundle exec rspec spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb   to verify claim_id is present 
- [x] run command: bundle exec rspec spec/models/legacy_appeal_spec.rb to confirm no method error is returned
- [x] Test plan: https://jira.devops.va.gov/browse/APPEALS-35675
- [x] Test execution: https://jira.devops.va.gov/browse/APPEALS-35678
- [x] XRAY: https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-35678&testIssueKey=APPEALS-35675

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
