### PR TITLE
APPEALS-35957 | Fix `Checkbox` component focused border css

### DIFF
--- a/client/app/styles/_commons.scss
+++ b/client/app/styles/_commons.scss
@@ -36,7 +36,7 @@ a:focus,
 [type=radio]:focus + label::before,
 [type=checkbox]:focus + label::before {
   outline: .25rem solid $color-focus-outline;
-  outline-offset: 6px;
+  outline-offset: 3px;
 }
 
 

--- a/db/seeds/vha_change_history.rb
+++ b/db/seeds/vha_change_history.rb
@@ -319,6 +319,7 @@ module Seeds
       hlr.create_business_line_tasks!
     end
 
+    # :reek:FeatureEnvy
     def create_hlr_with_unidentified_issue_without_decision_date
       hlr = create(:higher_level_review,
                    :with_intake,
@@ -342,6 +343,7 @@ module Seeds
       sc.create_business_line_tasks!
     end
 
+    # :reek:FeatureEnvy
     def create_sc_with_unidentified_issue_without_decision_date
       sc = create(:supplemental_claim,
                   :with_intake,


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-35957

# Description
This css fix lowers the Checkbox focused border to 3px. When this was 6px it would extend outside the constraints of the element and cover text of the label element.

#### Note:
There seems to be an inconsistency in the app with our checkboxes. Some have an outline when clicked and some do not. For example the checkboxes at `/vha/help` do not have this outline. I think ideally we should have the consistent throughout the app but that's open for discussion.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The border no longer extends over into the next component
- [ ] The functionality of the Checkbox components remains the same
- [ ] No other styles are effected for the Checkbox component

Before
<img width="141" alt="Screenshot 2023-12-05 at 8 32 03 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/57369582-849f-4e1a-ade8-9aabf0c4ddfd">

After
<img width="141" alt="Screenshot 2023-12-05 at 8 31 22 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/2994a625-e05f-4151-a61b-03de8f1be1cd">
<img width="198" alt="Screenshot 2023-12-05 at 8 34 38 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/fc86ac1d-f67d-4f93-a7dd-2c8bac919b72">

## Testing Plan
The easiest Checkbox component I found we can test this on is in the hearings section. Navigate to `/hearings/schedule/add_hearing_day` and see that the Checkbox looks correct.
