### PR TITLE
Add space to setup command

### DIFF
--- a/WINDOWS_10.md
+++ b/WINDOWS_10.md
@@ -46,7 +46,7 @@
             * `git clone https://<yourtoken>@github.com/department-of-veterans-affairs/caseflow`
             * `cd caseflow`
             * `git checkout kevin/setup-ubuntu`
-            * `cp -r ~/caseflow-setup/caseflow-facols/build_facolslocal/vacols/build_facols `
+            * `cp -r ~/caseflow-setup/caseflow-facols/build_facols local/vacols/build_facols `
             * `cp ~/caseflow-setup/*.zip local/vacols/build_facols/`
             * `rm -rf ~/__MACOSX && rm -rf ~/caseflow-setup && rm -f ~/caseflow-setup.zip`
             * `source scripts/ubuntu_setup.sh`


### PR DESCRIPTION

Adds a space to the command: `cp -r ~/caseflow-setup/caseflow-facols/build_facolslocal/vacols/build_facols` between `build_facols` and `local` in the Windows 10 setup instructions so that is executes properly