### PR TITLE
Move Intake Form Task Types to Constants

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -3,6 +3,7 @@
 class CorrespondenceController < ApplicationController
   before_action :verify_feature_toggle
   before_action :correspondence
+  before_action :auto_texts
 
   def intake
     respond_to do |format|
@@ -144,5 +145,9 @@ class CorrespondenceController < ApplicationController
       correspondenceUuid: correspondence.uuid,
       packageDocumentType: correspondence.correspondence_type_id
     }
+  end
+
+  def auto_texts
+    @auto_texts ||= AutoText.all.pluck(:name)
   end
 end

--- a/app/views/correspondence/intake.html.erb
+++ b/app/views/correspondence/intake.html.erb
@@ -8,6 +8,7 @@
     featureToggles: {
       correspondence_queue: FeatureToggle.enabled?(:correspondence_queue, user: current_user)
     },
-    correspondence: @correspondence
+    correspondence: @correspondence,
+    autoTexts: @auto_texts
   }) %>
 <% end %>

--- a/client/app/queue/QueueApp.jsx
+++ b/client/app/queue/QueueApp.jsx
@@ -670,7 +670,7 @@ class QueueApp extends React.PureComponent {
   );
 
   routedCorrespondenceIntake = (props) => (
-    <CorrespondenceIntake {...props.match.params} />
+    <CorrespondenceIntake autoTexts={this.props.autoTexts} {...props.match.params} />
   );
 
   routedCorrespondenceCase = () => (
@@ -1490,7 +1490,8 @@ QueueApp.propTypes = {
   canEditCavcDashboards: PropTypes.bool,
   canViewCavcDashboards: PropTypes.bool,
   userIsCobAdmin: PropTypes.bool,
-  correspondence: PropTypes.object
+  correspondence: PropTypes.object,
+  autoTexts: PropTypes.array
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/queue/constants.js
+++ b/client/app/queue/constants.js
@@ -11,6 +11,7 @@ import { COLORS as COMMON_COLORS } from '@department-of-veterans-affairs/caseflo
 import COPY from '../../COPY';
 import VACOLS_COLUMN_MAX_LENGTHS from '../../constants/VACOLS_COLUMN_MAX_LENGTHS';
 import LEGACY_APPEAL_TYPES_BY_ID from '../../constants/LEGACY_APPEAL_TYPES_BY_ID';
+import QUEUE_INTAKE_FORM_TASK_TYPES from '../../constants/QUEUE_INTAKE_FORM_TASK_TYPES';
 
 export const COLORS = {
   QUEUE_LOGO_PRIMARY: '#11598D',
@@ -163,6 +164,8 @@ export const LEGACY_APPEAL_TYPES = _.fromPairs(_.zip(
   _.invokeMap(_.keys(LEGACY_APPEAL_TYPES_BY_ID), 'toUpperCase'),
   _.values(LEGACY_APPEAL_TYPES_BY_ID)
 ));
+
+export const INTAKE_FORM_TASK_TYPES = QUEUE_INTAKE_FORM_TASK_TYPES;
 
 export const ISSUE_DESCRIPTION_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.ISSUES.ISSDESC;
 export const ATTORNEY_COMMENTS_MAX_LENGTH = VACOLS_COLUMN_MAX_LENGTHS.DECASS.DEATCOM;

--- a/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
+++ b/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
@@ -107,6 +107,7 @@ export const CorrespondenceIntake = (props) => {
         setUnrelatedTasks={props.setUnrelatedTasks}
         correspondenceUuid={props.correspondence_uuid}
         onContinueStatusChange={handleContinueStatusChange}
+        autoTexts={props.autoTexts}
       />
     }
     {currentStep === 3 &&
@@ -161,7 +162,8 @@ CorrespondenceIntake.propTypes = {
   veteranInformation: PropTypes.object,
   unrelatedTasks: PropTypes.arrayOf(Object),
   setUnrelatedTasks: PropTypes.func,
-  mailTasks: PropTypes.objectOf(PropTypes.bool)
+  mailTasks: PropTypes.objectOf(PropTypes.bool),
+  autoTexts: PropTypes.arrayOf(PropTypes.string)
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
@@ -199,6 +199,7 @@ export const AddAppealRelatedTaskView = (props) => {
                   unlinkAppeal={appealCheckboxOnChange}
                   allTaskTypeOptions={props.allTaskTypeOptions}
                   filterUnavailableTaskTypeOptions={props.filterUnavailableTaskTypeOptions}
+                  autoTexts={props.autoTexts}
                 />
               );
             })}
@@ -213,7 +214,8 @@ AddAppealRelatedTaskView.propTypes = {
   correspondenceUuid: PropTypes.string.isRequired,
   setRelatedTasksCanContinue: PropTypes.func.isRequired,
   filterUnavailableTaskTypeOptions: PropTypes.func.isRequired,
-  allTaskTypeOptions: PropTypes.array.isRequired
+  allTaskTypeOptions: PropTypes.array.isRequired,
+  autoTexts: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default AddAppealRelatedTaskView;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -5,29 +5,6 @@ import ReactSelectDropdown from '../../../../../components/ReactSelectDropdown';
 import Button from '../../../../../components/Button';
 import PropTypes from 'prop-types';
 
-const autotextOptions = [
-  'Address updated in VACOLS',
-  'Decision sent to Senator or Congressman mm/dd/yy',
-  'Interest noted in telephone call of mm/dd/yy',
-  'Interest noted in evidence file regarding current appeal',
-  'Email - responded via email on mm/dd/yy',
-  'Email - written response req; confirmed receipt via email to Congress office on mm/dd/yy',
-  'Possible motion pursuant to BVA decision dated mm/dd/yy',
-  'Motion pursuant to BVA decision dated mm/dd/yy',
-  'Statement in support of appeal by appellant',
-  'Statement in support of appeal by rep',
-  'Medical evidence X-Rays submitted or referred by',
-  'Medical evidence clinical reports submitted or referred by',
-  'Medical evidence examination reports submitted or referred by',
-  'Medical evidence progress notes submitted or referred by',
-  'Medical evidence physician\'s medical statement submitted or referred by',
-  'C&P exam report',
-  'Consent form (specify)',
-  'Withdrawal of issues',
-  'Response to BVA solicitation letter dated mm/dd/yy',
-  'VAF 9 (specify)'
-];
-
 const AddTaskView = (props) => {
   const task = props.task;
   const [modalVisible, setModalVisible] = useState(false);
@@ -59,7 +36,7 @@ const AddTaskView = (props) => {
 
     if (autoTextValues.length > 0) {
       autoTextValues.forEach((id) => {
-        autoTextOutput += `${autotextOptions[id] }\n`;
+        autoTextOutput += `${props.autoTexts[id] }\n`;
       });
     }
     updateTaskContent(autoTextOutput);
@@ -70,7 +47,7 @@ const AddTaskView = (props) => {
     <div key={task.id} style={{ display: 'block', marginRight: '2rem' }}>
       {modalVisible &&
         <CheckboxModal
-          checkboxData={autotextOptions}
+          checkboxData={props.autoTexts}
           toggleModal={handleModalToggle}
           closeHandler={handleModalToggle}
           handleAccept={handleAutotext}
@@ -134,7 +111,8 @@ AddTaskView.propTypes = {
   displayRemoveCheck: PropTypes.bool.isRequired,
   filteredTaskOptions: PropTypes.array.isRequired,
   allTaskTypeOptions: PropTypes.array.isRequired,
-  availableTaskTypeOptions: PropTypes.array.isRequired
+  availableTaskTypeOptions: PropTypes.array.isRequired,
+  autoTexts: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default AddTaskView;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -19,7 +19,7 @@ const mailTasksRight = [
   'Associated with Claims Folder'
 ];
 
-const relatedTaskTypes = INTAKE_FORM_TASK_TYPES.relatedToAppeal; 
+const relatedTaskTypes = INTAKE_FORM_TASK_TYPES.relatedToAppeal;
 const unrelatedTaskTypes = INTAKE_FORM_TASK_TYPES.unrelatedToAppeal;
 
 export const AddTasksAppealsView = (props) => {
@@ -28,7 +28,7 @@ export const AddTasksAppealsView = (props) => {
   const [unrelatedTasksCanContinue, setUnrelatedTasksCanContinue] = useState(true);
 
   const dispatch = useDispatch();
-  
+
   const filterUnavailableTaskTypeOptions = (tasks, options) => {
     let otherMotionCount = 0;
 
@@ -102,6 +102,7 @@ export const AddTasksAppealsView = (props) => {
               setUnrelatedTasksCanContinue={setUnrelatedTasksCanContinue}
               filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
               allTaskTypeOptions={unrelatedTaskTypes}
+              autoTexts={props.autoTexts}
             />
           </div>
         </div>
@@ -114,6 +115,7 @@ export const AddTasksAppealsView = (props) => {
             setRelatedTasksCanContinue={setRelatedTasksCanContinue}
             filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
             allTaskTypeOptions={relatedTaskTypes}
+            autoTexts={props.autoTexts}
           />
         </div>
       </div>
@@ -123,7 +125,8 @@ export const AddTasksAppealsView = (props) => {
 
 AddTasksAppealsView.propTypes = {
   correspondenceUuid: PropTypes.string.isRequired,
-  onContinueStatusChange: PropTypes.func.isRequired
+  onContinueStatusChange: PropTypes.func.isRequired,
+  autoTexts: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default AddTasksAppealsView;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -5,6 +5,7 @@ import Checkbox from '../../../../../components/Checkbox';
 import AddAppealRelatedTaskView from './AddAppealRelatedTaskView';
 import AddUnrelatedTaskView from './AddUnrelatedTaskView';
 import { saveMailTaskState } from '../../../correspondenceReducer/correspondenceActions';
+import { INTAKE_FORM_TASK_TYPES } from '../../../../constants';
 
 const mailTasksLeft = [
   'Change of address',
@@ -18,17 +19,8 @@ const mailTasksRight = [
   'Associated with Claims Folder'
 ];
 
-const taskTypeOptions = [
-  { value: 'CAVC Correspondence', label: 'CAVC Correspondence' },
-  { value: 'Congressional interest', label: 'Congressional interest' },
-  { value: 'Death certificate', label: 'Death certificate' },
-  { value: 'FOIA request', label: 'FOIA request' },
-  { value: 'Other motion', label: 'Other motion' },
-  { value: 'Power of attorney-related', label: 'Power of attorney-related' },
-  { value: 'Privacy act request', label: 'Privacy act request' },
-  { value: 'Privacy complaint', label: 'Privacy complaint' },
-  { value: 'Status inquiry', label: 'Status inquiry' }
-];
+const relatedTaskTypes = INTAKE_FORM_TASK_TYPES.relatedToAppeal; 
+const unrelatedTaskTypes = INTAKE_FORM_TASK_TYPES.unrelatedToAppeal;
 
 export const AddTasksAppealsView = (props) => {
   const mailTasks = useSelector((state) => state.intakeCorrespondence.mailTasks);
@@ -36,8 +28,8 @@ export const AddTasksAppealsView = (props) => {
   const [unrelatedTasksCanContinue, setUnrelatedTasksCanContinue] = useState(true);
 
   const dispatch = useDispatch();
-
-  const filterUnavailableTaskTypeOptions = (tasks) => {
+  
+  const filterUnavailableTaskTypeOptions = (tasks, options) => {
     let otherMotionCount = 0;
 
     const filteredTaskNames = tasks.map((task) => {
@@ -48,7 +40,7 @@ export const AddTasksAppealsView = (props) => {
       return task.type;
     });
 
-    return taskTypeOptions.filter((option) => {
+    return options.filter((option) => {
       // Up to 2 other motion tasks can be created in the workflow
       // so only filter 'other motion' if there are 2 other motion tasks already created
       if (option.value === 'Other motion' && otherMotionCount < 2) {
@@ -109,7 +101,7 @@ export const AddTasksAppealsView = (props) => {
             <AddUnrelatedTaskView
               setUnrelatedTasksCanContinue={setUnrelatedTasksCanContinue}
               filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
-              allTaskTypeOptions={taskTypeOptions}
+              allTaskTypeOptions={unrelatedTaskTypes}
             />
           </div>
         </div>
@@ -121,7 +113,7 @@ export const AddTasksAppealsView = (props) => {
             correspondenceUuid={props.correspondenceUuid}
             setRelatedTasksCanContinue={setRelatedTasksCanContinue}
             filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
-            allTaskTypeOptions={taskTypeOptions}
+            allTaskTypeOptions={relatedTaskTypes}
           />
         </div>
       </div>

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -114,6 +114,7 @@ export const AddUnrelatedTaskView = (props) => {
                 displayRemoveCheck
                 allTaskTypeOptions={props.allTaskTypeOptions}
                 availableTaskTypeOptions={availableTaskTypeOptions}
+                autoTexts={props.autoTexts}
               />
             ))}
           </div>
@@ -136,7 +137,8 @@ export const AddUnrelatedTaskView = (props) => {
 AddUnrelatedTaskView.propTypes = {
   setUnrelatedTasksCanContinue: PropTypes.func.isRequired,
   filterUnavailableTaskTypeOptions: PropTypes.func.isRequired,
-  allTaskTypeOptions: PropTypes.array.isRequired
+  allTaskTypeOptions: PropTypes.array.isRequired,
+  autoTexts: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default AddUnrelatedTaskView;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -63,7 +63,7 @@ export const AddUnrelatedTaskView = (props) => {
   }, [addTasksVisible]);
 
   useEffect(() => {
-    setavailableTaskTypeOptions(props.filterUnavailableTaskTypeOptions(newTasks));
+    setavailableTaskTypeOptions(props.filterUnavailableTaskTypeOptions(newTasks, props.allTaskTypeOptions));
   }, [newTasks]);
 
   const getTasks = () => {

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
@@ -78,6 +78,7 @@ export const ExistingAppealTasksView = (props) => {
               setRelatedTasksCanContinue={props.setRelatedTasksCanContinue}
               allTaskTypeOptions={props.allTaskTypeOptions}
               availableTaskTypeOptions={availableTaskTypeOptions}
+              autoTexts={props.autoTexts}
             />
           );
         })}
@@ -116,7 +117,8 @@ ExistingAppealTasksView.propTypes = {
   setRelatedTasksCanContinue: PropTypes.func.isRequired,
   unlinkAppeal: PropTypes.func.isRequired,
   allTaskTypeOptions: PropTypes.array.isRequired,
-  filterUnavailableTaskTypeOptions: PropTypes.func.isRequired
+  filterUnavailableTaskTypeOptions: PropTypes.func.isRequired,
+  autoTexts: PropTypes.arrayOf(PropTypes.string).isRequired
 };
 
 export default ExistingAppealTasksView;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
@@ -51,7 +51,7 @@ export const ExistingAppealTasksView = (props) => {
   }, [props.newTasks]);
 
   useEffect(() => {
-    setavailableTaskTypeOptions(props.filterUnavailableTaskTypeOptions(getTasksForAppeal()));
+    setavailableTaskTypeOptions(props.filterUnavailableTaskTypeOptions(getTasksForAppeal(), props.allTaskTypeOptions));
   }, [props.newTasks]);
 
   return (

--- a/client/constants/QUEUE_INTAKE_FORM_TASK_TYPES.json
+++ b/client/constants/QUEUE_INTAKE_FORM_TASK_TYPES.json
@@ -1,0 +1,35 @@
+{
+  "unrelatedToAppeal": [
+    { "value": "CAVC Correspondence", "label": "CAVC Correspondence" },
+    { "value": "Congressional interest", "label": "Congressional interest" },
+    { "value": "Death certificate", "label": "Death certificate" },
+    { "value": "FOIA request", "label": "FOIA request" },
+    { "value": "Other motion", "label": "Other motion" },
+    { "value": "Power of attorney-related", "label": "Power of attorney-related" },
+    { "value": "Privacy act request", "label": "Privacy act request" },
+    { "value": "Privacy complaint", "label": "Privacy complaint" },
+    { "value": "Status inquiry", "label": "Status inquiry" }
+  ],
+  "relatedToAppeal": [
+    { "value": "CAVC Correspondence", "label": "CAVC Correspondence" },
+    { "value": "CUE-related", "label": "CUE-related" },
+    { "value": "Change of address", "label": "Change of address" },
+    { "value": "Congressional interest", "label": "Congressional interest" },
+    { "value": "Controlled Correspondence", "label": "Controlled Correspondence" },
+    { "value": "Death certificate", "label": "Death certificate" },
+    { "value": "Docket switch", "label": "Docket switch" },
+    { "value": "Evidence or argument", "label": "Evidence or argument" },
+    { "value": "Extension request", "label": "Extension request" },
+    { "value": "FOIA request", "label": "FOIA request" },
+    { "value": "Hearing-related", "label": "Hearing-related" },
+    { "value": "Motion for reconsideration", "label": "Motion for reconsideration" },
+    { "value": "Motion to Advance on Docket", "label": "Motion to Advance on Docket" },
+    { "value": "Other motion", "label": "Other motion" },
+    { "value": "Power of attorney-related", "label": "Power of attorney-related" },
+    { "value": "Privacy act request", "label": "Privacy act request" },
+    { "value": "Privacy complaint", "label": "Privacy complaint" },
+    { "value": "Returned or undeliverable mail", "label": "Returned or undeliverable mail" },
+    { "value": "Status inquiry", "label": "Status inquiry" },
+    { "value": "Withdrawal of appeal", "label": "Withdrawal of appeal" }
+  ]
+}

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -71,6 +71,7 @@ class SeedDB
     call_and_log_seed_step Seeds::StaticDispatchedAppealsTestData
     call_and_log_seed_step Seeds::AdditionalRemandedAppeals
     call_and_log_seed_step Seeds::AdditionalLegacyRemandedAppeals
+    call_and_log_seed_step Seeds::AutoTexts
   end
 end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Intake Form Step 2.3 Cont: Tasks Related to an Existing Appeal - Autotexts](https://jira.devops.va.gov/browse/APPEALS-34560)

# Description
Moves hard-coded task type options to constants and populates auto-text from backend.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Go to intake form step 2.
2. Verify list of task type options is correct for tasks not related to an appeal.
3. Verify list of task type options is correct for tasks that are related to an appeal.
4. Verify the list of auto-text options is populating (may need to run seed file).
