### PR TITLE
APPEALS-14737 | Fix pagination page persistence bug on `NonComp`

### DIFF
--- a/client/app/nonComp/components/NonCompTabs.jsx
+++ b/client/app/nonComp/components/NonCompTabs.jsx
@@ -86,7 +86,16 @@ const NonCompTabsUnconnected = (props) => {
     filter((key) => props.businessLineConfig.tabs.includes(key)).
     map((key) => ALL_TABS[key]);
 
+  const resetPageNumberOnTabChange = (value) => {
+    // If the user has selected a new tab then we should reset the pagination page to 0
+    // This is to prevent situations where Viewing 31-45 of 1 total gets displayed and blocks user navigation
+    if (value !== getTabByIndex) {
+      tabPaginationOptions.page = 0;
+    }
+  };
+
   return (<TabWindow
+    onChange={((value) => resetPageNumberOnTabChange(value))}
     name="tasks-organization-queue"
     tabs={tabs}
     defaultPage={props.currentTab || getTabByIndex}

--- a/db/seeds/vha_change_history.rb
+++ b/db/seeds/vha_change_history.rb
@@ -319,6 +319,7 @@ module Seeds
       hlr.create_business_line_tasks!
     end
 
+    # :reek:FeatureEnvy
     def create_hlr_with_unidentified_issue_without_decision_date
       hlr = create(:higher_level_review,
                    :with_intake,
@@ -342,6 +343,7 @@ module Seeds
       sc.create_business_line_tasks!
     end
 
+    # :reek:FeatureEnvy
     def create_sc_with_unidentified_issue_without_decision_date
       sc = create(:supplemental_claim,
                   :with_intake,

--- a/spec/feature/non_comp/reviews_spec.rb
+++ b/spec/feature/non_comp/reviews_spec.rb
@@ -898,6 +898,30 @@ feature "NonComp Reviews Queue", :postgres do
     end
   end
 
+  # rubocop:disable Layout/LineLength
+  context "get params should not get appended to URL  when QueueTable is loading and user navigates to Generate report pages." do
+    before do
+      create_list(:higher_level_review_vha_task, 30, assigned_to: non_comp_org)
+      OrganizationsUser.make_user_admin(user, non_comp_org)
+    end
+
+    it "should reset the pagination page when switching tabs" do
+      visit BASE_URL
+      expect(page).to have_content("Veterans Health Administration")
+
+      # Navigate to the next page
+      pagination = page.find(class: "cf-pagination-pages", match: :first)
+      pagination.find("Button", text: "2", match: :first).click
+
+      expect(page).to have_content("Viewing 16-30 of 33 total")
+
+      # Navigate to another tab
+      click_button("Incomplete tasks")
+      expect(page).to have_content("Viewing 1-2 of 2 total")
+    end
+  end
+  # rubocop:enable Layout/LineLength
+
   context "For a non comp org that is not VHA" do
     after { FeatureToggle.disable!(:board_grant_effectuation_task) }
     let(:non_comp_org) { create(:business_line, name: "Non-Comp Org", url: "nco") }


### PR DESCRIPTION
Jira: https://jira.devops.va.gov/browse/APPEALS-14737

Jira Description:
Pagination-related options are ingested from URL query parameters upon initial load of the decision review queue page here in `NonCompTabs.jsx`. The values contained within tabPaginationOptions are not kept up to date with changes in the query parameters, however.

This causes issues to arise if a user navigates to the decision review queue using a URL with query parameters that may be incompatible with one/all tabs.

For example, if a user were to go to the VHA's DR queue via /vha?tab=completed&page=10, because the page number of 10 is placed into tabPagiationOptions and never updated, each time a user switches tabs they'll be taken to the 10th page. If one of the tabs does not have 10 pages worth of tasks, this will cause users to be brought to a blank queue page.

# Description
Pass down a new `checkIfPageChanged` onChange function to the TabWindow component. This new function now updates the `tabPaginationOptions.page ` value whenever a new tab is selected.

Added a feature test to confirm the bug has been removed

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Selecting a new tab resets the page value in the query params to 1
- [ ] Selecting the current tab will persist the current page value

## Testing Plan
At `/decision_reviews/vha`
1. Go to a tab with pagination values and select the highest number page you can
2. Navigate to a tab with less pages and see that the page number resets to the first page
3. Confirm that the page number in the url query params matches.

## Screenshots
Before:
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/beb1ccac-7078-4edf-888f-1f0b3a47f278)

After:
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/98b06959-14cc-48ef-a25a-dce98adcecd3)

