### PR TITLE
APPEALS-36594 | Fix Rubocop offenses for files in spec/workflows

### DIFF
--- a/spec/workflows/docket_switch_task_handler_spec.rb
+++ b/spec/workflows/docket_switch_task_handler_spec.rb
@@ -43,8 +43,25 @@ describe DocketSwitch::TaskHandler, :all_dbs do
   let(:granted_request_issue_ids) { [] }
   let!(:old_docket_stream_tasks) do
     [
-      create(:translation_task, appeal: old_docket_stream, parent: create(:translation_task, appeal: old_docket_stream, parent: old_docket_stream.root_task, assigned_to: translation_organization)),
-      create(:foia_task, appeal: old_docket_stream, parent: create(:translation_task, parent: old_docket_stream.root_task, assigned_to: other_organization))
+      create(
+        :translation_task,
+        appeal: old_docket_stream,
+        parent: create(
+          :translation_task,
+          appeal: old_docket_stream,
+          parent: old_docket_stream.root_task,
+          assigned_to: translation_organization
+        )
+      ),
+      create(
+        :foia_task,
+        appeal: old_docket_stream,
+        parent: create(
+          :translation_task,
+          parent: old_docket_stream.root_task,
+          assigned_to: other_organization
+        )
+      )
     ]
   end
   let!(:translation_organization) { Translation.singleton }

--- a/spec/workflows/post_decision_motion_updater_spec.rb
+++ b/spec/workflows/post_decision_motion_updater_spec.rb
@@ -234,6 +234,7 @@ describe PostDecisionMotionUpdater, :all_dbs do
     Appeal.find_by(stream_docket_number: appeal.docket_number, stream_type: Constants.AMA_STREAM_TYPES.vacate)
   end
 
+  # rubocop:disable Metrics/AbcSize
   def verify_vacate_stream
     expect(vacate_stream).to_not be_nil
     expect(vacate_stream.claimant.participant_id).to eq(appeal.claimant.participant_id)
@@ -253,6 +254,7 @@ describe PostDecisionMotionUpdater, :all_dbs do
     motion = PostDecisionMotion.first
     expect(motion.appeal).to eq(vacate_stream)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def verify_decision_issues_created
     motion = PostDecisionMotion.first


### PR DESCRIPTION
Main Jira: https://jira.devops.va.gov/browse/APPEALS-35680
Secondary Jira: https://jira.devops.va.gov/browse/APPEALS-36564

# Description
Resolves Rubocop offenses for files in spec/workflows:
`docket_switch_task_handler_spec.rb`
`post_decision_motion_updater_spec.rb`

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Tests pass

