### PR TITLE
AlecK/APPEALS-36789/Setup

### DIFF
--- a/MAC_INTEL.md
+++ b/MAC_INTEL.md
@@ -77,7 +77,7 @@
 
 19. Run `scripts/dev_env_setup_step2.sh` script (may take a while to run)
 
-20. Run `gem install bundler`
+20. Run `gem install bundler -v $(grep -A 1 "BUNDLED WITH" Gemfile.lock | tail -n 1)`
 
 21. Navigate to `~/appeals/caseflow/local/vacols` in terminal (type: `cd ~/appeals/caseflow/local/vacols`)
 

--- a/WINDOWS_10.md
+++ b/WINDOWS_10.md
@@ -45,7 +45,7 @@
             * `mkdir appeals && cd appeals`
             * `git clone https://<yourtoken>@github.com/department-of-veterans-affairs/caseflow`
             * `cd caseflow`
-            * `git checkout kevin/setup-ubuntu`
+            * `git checkout dev-supporting/setup-ubuntu`
             * `cp -r ~/caseflow-setup/caseflow-facols/build_facols local/vacols/build_facols `
             * `cp ~/caseflow-setup/*.zip local/vacols/build_facols/`
             * `rm -rf ~/__MACOSX && rm -rf ~/caseflow-setup && rm -f ~/caseflow-setup.zip`

--- a/WINDOWS_11.md
+++ b/WINDOWS_11.md
@@ -58,7 +58,7 @@ Run each line is a separate command, run them one at a time
 11. Enter your git token where <yourtoken> is below:
     * ```git clone https://<yourtoken>@github.com/department-of-veterans-affairs/caseflow```
     * ```cd caseflow```
-    * ```git checkout kevin/setup-ubuntu```
+    * ```git checkout dev-supporting/setup-ubuntu```
     * ```cp -r ~/caseflow-setup/caseflow-facols/build_facols local/vacols/build_facols```
     * ```cp ~/caseflow-setup/*.zip local/vacols/build_facols/```
     * ```rm -rf ~/__MACOSX && rm -rf ~/caseflow-setup && rm -f ~/caseflow-setup.zip```
@@ -78,7 +78,7 @@ Run each line is a separate command, run them one at a time
 
 16. Open new terminal in VS Code. Trash old terminal.
 
-17. In new terminal run: ```git checkout kevin/setup-ubuntu```
+17. In new terminal run: ```git checkout dev-supporting/setup-ubuntu```
 
 18. ```cd ~/appeals/caseflow```
 


### PR DESCRIPTION
Resolves parts of [APPEALS-36789](https://jira.devops.va.gov/browse/APPEALS-36789)

# Description
This PR updates the instructions for Intel based Macs to ensure compatibility with variable versions of bundler. Windows requires changes to its setup script, which can be found in this [pull request](https://github.com/department-of-veterans-affairs/caseflow/pull/20300). There are changes to the windows setup instructions that adjust the checkout branch, as the one currently stated doesn't exist / wasn't updated with the name change. 

## Acceptance Criteria
- Caseflow instructions are updated to facilitate any version of bundler