### PR TITLE
APPEALS-36592 | Fix rubocop offenses in `spec/serializer`

### DIFF
--- a/spec/serializers/conference_link_serializer_spec.rb
+++ b/spec/serializers/conference_link_serializer_spec.rb
@@ -13,7 +13,6 @@ describe ConferenceLinkSerializer, :all_dbs do
   let(:hearing_day) { create(:hearing_day) }
   let(:conference_link) { create(:conference_link, hearing_day_id: hearing_day.id) }
 
-
   context "Converting conference link to hash" do
     subject { described_class.new(conference_link) }
     before do


### PR DESCRIPTION
Parent Jira: https://jira.devops.va.gov/browse/APPEALS-35680
Secondary Jira: https://jira.devops.va.gov/browse/APPEALS-36592

# Description
Fix rubocop offenses in the spec/serializer directory

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Codeclimate passes
- [ ] Tests pass

