### PR TITLE
add KNAPSACK_PRO_FIXED_QUEUE_SPLIT to workflow.yml

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -72,6 +72,7 @@ jobs:
           KNAPSACK_PRO_CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
           KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
           KNAPSACK_PRO_LOG_LEVEL: info
+          KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
           WD_INSTALL_DIR: .webdrivers
           CI: true
           REDIS_URL_CACHE: redis://redis:6379/0/cache/

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,6 +61,7 @@ RSpec.configure do |config|
   # Allows us to use shorthand FactoryBot methods.
   config.include FactoryBot::Syntax::Methods
 
+  # allows test suite to only run tests tagged with :focus for specific testing
   config.filter_run_when_matching :focus
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -61,8 +61,7 @@ RSpec.configure do |config|
   # Allows us to use shorthand FactoryBot methods.
   config.include FactoryBot::Syntax::Methods
 
-  config.filter_run focus: true
-  config.run_all_when_everything_filtered = true
+  config.filter_run_when_matching :focus
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.


### PR DESCRIPTION
# Description
- Adds `KNAPSACK_PRO_FIXED_QUEUE_SPLIT=true` to the .workflow.yml file for Github Actions to enable re-running individual CI nodes in GHA jobs.
- Updates config option in spec_helper.rb due to the previous config option being deprecated and causing Knapsack Pro problems

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Individual CI nodes can be re-run via Github Actions and correctly run the Rspec tests from that node.

## Testing
- [x] Go to Actions run for this PR (Click checks above, then click on "Rspec Jest Lint Workflow")
- [x] In the top right of the page, find the button which says "Latest 2"
- [x] Click that button, then open "Attempt 1" in a new tab
- [ ] Compare the failing nodes on Attempt 1 with those in Latest 2 and verify that the same number of tests were run on each node of Attempt 1 and Latest 2
- [ ] If desired, click "Re-run Jobs" and then click "Re-run failing jobs". This will re-run the failing nodes and you when finished, you can verify the same data in the above step for each of the attempts that has been made
