### PR TITLE
APPEALS-37336 | Correct 'Add Condition' Form Validation and Spelling 

### DIFF
--- a/client/app/styles/_noncomp.scss
+++ b/client/app/styles/_noncomp.scss
@@ -174,7 +174,13 @@ $validation-error-color: #cd2026;
 
     .report-page-variable-select {
       width: 40%;
-      margin-right: 1%;
+      margin-right: 2rem;
+
+      // Override the max-width of the SearchableDropdown component so that the validation border fits
+      .cf-select,
+      .cf-select__control {
+        max-width: none;
+      }
     }
 
     .report-page-variable-content {

--- a/client/constants/REPORT_PAGE_VALIDATION_ERRORS.json
+++ b/client/constants/REPORT_PAGE_VALIDATION_ERRORS.json
@@ -1,8 +1,8 @@
 {
   "MISSING_NUMBER": "Please enter a number",
   "MISSING_TIME_RANGE": "Please select a time range",
-  "MISSING_SELECTION": "Plase make a selection",
-  "MISSING_CONDITION": "Plase make a selection or remove this condition",
+  "MISSING_SELECTION": "Please make a selection",
+  "MISSING_CONDITION": "Please make a selection or remove this condition",
   "MAX_DAYS_TOO_SMALL": "Max days must be greater than min days",
   "MISSING_DATE": "Please enter a valid date",
   "END_DATE_SMALL": "End date must be greater than the start date",


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-37336

# Description
1. Fix Report page validation spelling error.
`Plase -> Please`
2. Fix css issue with Add Condition form validation border
Before this fix there was a border width issue for larger screens with the validation border on the SearchableDropdown component.
3. Also we updated the margin-right to better fit now that the width changed around a little bit.


To fix this we override the max-width attribute to none since we don't need any set max-width for this usage of the component.

There may be an ability to pass down the styles as props but since this is needed as a fast fix we can just override it with some css specificity rules. Plus passing stuff down into the SearchableDropdown component may cause other unforeseen issues.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Spelling change is fixed
- [ ] Form validation css appears as intended for small, normal, and large screen sizes.


## Screenshots (Notice large screen size and zoomed out)
Before:
![Screenshot 2023-12-26 at 2 39 06 PM](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/cc294565-fa73-4cb4-93ad-9ec75c614cfb)

After:
![Screenshot 2023-12-26 at 2 39 24 PM](https://github.com/department-of-veterans-affairs/caseflow/assets/51007432/fef3f624-d9e0-40e9-a89b-c75a7127519c)
