### PR TITLE
Fix error in modal windows

### DIFF
--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1426,6 +1426,7 @@
   "CORRESPONDENCE_TITLE_REMOVE_PACKAGE": "Reason for removal:",
   "CORRRESPONDENCE_LABEL_OPTION_REMOVE_PACKAGE": " Choose whether to approve the request for removal or reject it.",
   "CORRRESPONDENCE_TEXT_REMOVE_PACKAGE": "\nThis is the reason for removal provided by the general user.",
+  "CORRRESPONDENCE_SECOND_TEXT_REMOVE_PACKAGE": "\nThis is the reason for removal provided by the user that submitted the request.",
   "CORRESPONDENCE_TITLE_REMOVE_PACKAGE_REASON_REJECT": "Provide a reason for rejection",
   "CORRESPONDENCE_TITLE_REMOVE_PACKAGE_BANNER": "You have successfully removed a mail package for %s",
   "CORRESPONDENCE_MESSAGE_REMOVE_PACKAGE_BANNER": "The package has been removed from Caseflow and must be manually uploaded again from the Centralized Mail Portal, if it needs to be processed.",

--- a/client/app/queue/correspondence/component/RemovePackageModal.jsx
+++ b/client/app/queue/correspondence/component/RemovePackageModal.jsx
@@ -23,7 +23,8 @@ class RemovePackageModal extends React.Component {
       reasonForRemove: null,
       disabledSaveButton: true,
       reasonReject: '',
-      updateCancelSuccess: false
+      updateCancelSuccess: false,
+      textToShow: StringUtil.nl2br(COPY.CORRRESPONDENCE_TEXT_REMOVE_PACKAGE)
 
     };
   }
@@ -31,9 +32,12 @@ class RemovePackageModal extends React.Component {
   handleSelect(reasonForRemove) {
     if (reasonForRemove === 'Approve request') {
       this.setState({ reasonForRemove,
-        disabledSaveButton: false });
+        disabledSaveButton: false,
+        textToShow: StringUtil.nl2br(COPY.CORRRESPONDENCE_TEXT_REMOVE_PACKAGE)
+      });
     } else {
       this.setState({ reasonForRemove,
+        textToShow: StringUtil.nl2br(COPY.CORRRESPONDENCE_SECOND_TEXT_REMOVE_PACKAGE),
         disabledSaveButton: true });
     }
   }
@@ -94,7 +98,7 @@ class RemovePackageModal extends React.Component {
       >
         <p>
           <span style= {{ fontWeight: 'bold' }}>{sprintf(COPY.CORRESPONDENCE_TITLE_REMOVE_PACKAGE)}</span>
-          {StringUtil.nl2br(COPY.CORRRESPONDENCE_TEXT_REMOVE_PACKAGE)}
+          {this.state.textToShow}
         </p>
 
         <RadioField
@@ -111,6 +115,7 @@ class RemovePackageModal extends React.Component {
                 name={sprintf(COPY.CORRESPONDENCE_TITLE_REMOVE_PACKAGE_REASON_REJECT)}
                 onChange={this.reasonChange}
                 value={this.state.reasonReject}
+                placeholder= "This is an example of a reason"
               />
         }
 

--- a/spec/feature/queue/correspondence/review_package_spec.rb
+++ b/spec/feature/queue/correspondence/review_package_spec.rb
@@ -97,6 +97,7 @@ RSpec.feature("The Correspondence Review Package page") do
         radio_choices = page.all(".cf-form-radio-option > label")
         expect(radio_choices[0]).to have_content("Approve request")
         expect(radio_choices[1]).to have_content("Reject request")
+        expect(page).to have_content(COPY::CORRRESPONDENCE_TEXT_REMOVE_PACKAGE)
         expect(page).to have_button("Cancel")
         expect(page).to have_button("Confirm", disabled: true)
         expect(page).not_to have_field("Provide a reason for rejection")
@@ -106,6 +107,7 @@ RSpec.feature("The Correspondence Review Package page") do
         expect(page).to have_button("Review removal request")
         click_button "Review removal request"
         page.all(".cf-form-radio-option > label")[0].click
+        expect(page).to have_content(COPY::CORRRESPONDENCE_TEXT_REMOVE_PACKAGE)
       end
 
       it "remove Package" do


### PR DESCRIPTION
Resolves: [APPEALS-29193](https://jira.devops.va.gov/browse/APPEALS-29193), [APPEALS-29205](https://jira.devops.va.gov/browse/APPEALS-29205), [APPEALS-34996](https://jira.devops.va.gov/browse/APPEALS-34996), [APPEALS-35592](https://jira.devops.va.gov/browse/APPEALS-35592), [APPEALS-35593](https://jira.devops.va.gov/browse/APPEALS-35593), [APPEALS-29194](https://jira.devops.va.gov/browse/APPEALS-29194),
[APPEALS-34916](https://jira.devops.va.gov/browse/APPEALS-34916), [APPEALS-36343](https://jira.devops.va.gov/browse/APPEALS-36343), [APPEALS-37496](https://jira.devops.va.gov/browse/APPEALS-37496)

# Description
Review request modal not displaying text as per wireframe

## Testing Plan
When `approve request`
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/938bcd2c-e99a-410c-bafd-81d44f4fa365)

When `Reject request`
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/ff35ed35-fc3a-442d-8e28-fd8940cfe2d9)





