### PR TITLE
APPEALS-36571 | Resolve Rubocop offenses in the app/mailers dir

### DIFF
--- a/app/mailers/dispatch_mailer.rb
+++ b/app/mailers/dispatch_mailer.rb
@@ -4,6 +4,7 @@
 # DispatchMailer will:
 # - Generate emails from the templates in app/views/dispatch_mailer
 ##
+# rubocop:disable Rails/ApplicationMailer
 class DispatchMailer < ActionMailer::Base
   default from: "Board of Veterans' Appeals <BoardofVeteransAppealsHearings@messages.va.gov>"
   layout "dispatch_mailer"
@@ -23,3 +24,4 @@ class DispatchMailer < ActionMailer::Base
     @appeal.appellant_or_veteran_name
   end
 end
+# rubocop:enable Rails/ApplicationMailer

--- a/app/mailers/hearing_email_status_mailer.rb
+++ b/app/mailers/hearing_email_status_mailer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/ApplicationMailer
 class HearingEmailStatusMailer < ActionMailer::Base
   default from: "Board of Veterans' Appeals <BoardofVeteransAppealsHearings@messages.va.gov>"
   layout "hearing_email_status_mailer"
@@ -31,3 +32,4 @@ class HearingEmailStatusMailer < ActionMailer::Base
     "#{@hearing_type} #{@email_type} email failed to send to #{@email_address}"
   end
 end
+# rubocop:enable Rails/ApplicationMailer

--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -11,6 +11,7 @@
 # - Generate email subjects based on the type of email.
 # - Create the calendar invites that get attached to the emails.
 ##
+# rubocop:disable Rails/ApplicationMailer
 class HearingMailer < ActionMailer::Base
   default from: "Board of Veterans' Appeals <BoardofVeteransAppealsHearings@messages.va.gov>"
   layout "hearing_mailer"
@@ -175,3 +176,4 @@ class HearingMailer < ActionMailer::Base
     email_recipient_info.title == HearingEmailRecipient::RECIPIENT_TITLES[:judge]
   end
 end
+# rubocop:enable Rails/ApplicationMailer

--- a/app/mailers/membership_request_mailer.rb
+++ b/app/mailers/membership_request_mailer.rb
@@ -7,7 +7,7 @@
 # - Notify requestor upon successful membership request submission
 # - Notify requestor upon change of status of membership request
 # - Notify admins upon successful membership request submission
-
+# rubocop:disable Rails/ApplicationMailer
 class MembershipRequestMailer < ActionMailer::Base
   helper MembershipRequestHelper
   default from: "VHA Benefit Appeals <vhabenefitappeals@messages.va.gov>"
@@ -57,3 +57,4 @@ class MembershipRequestMailer < ActionMailer::Base
     mail(to: @recipient&.email, subject: COPY::VHA_MEMBERSHIP_REQUEST_SUBJECT_LINE_REQUESTOR_DENIED)
   end
 end
+# rubocop:enable Rails/ApplicationMailer

--- a/app/mailers/test/hearings_profile_mailer.rb
+++ b/app/mailers/test/hearings_profile_mailer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Rails/ApplicationMailer
 class Test::HearingsProfileMailer < ActionMailer::Base
   default from: "Board of Veterans' Appeals <BoardofVeteransAppealsHearings@messages.va.gov>"
 
@@ -15,3 +16,4 @@ class Test::HearingsProfileMailer < ActionMailer::Base
     )
   end
 end
+# rubocop:enable Rails/ApplicationMailer


### PR DESCRIPTION
Parent Jira: https://jira.devops.va.gov/browse/APPEALS-35680
Secondary Jira: https://jira.devops.va.gov/browse/APPEALS-36571

# Description
Resolve Rubocop offenses in the app/mailers directory.
We have no base ApplicationMailer so this rubocop rule doesn't apply to us. Because of this I just disabled the rule in place.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Codeclimate passes
- [ ] Tests pass


