### PR TITLE
reject remove task

### DIFF
--- a/app/controllers/correspondence_tasks_controller.rb
+++ b/app/controllers/correspondence_tasks_controller.rb
@@ -66,6 +66,18 @@ class CorrespondenceTasksController < TasksController
     root_task.cancel_task_and_child_subtasks
   end
 
+  def completed_package
+    remove_package_task = RemovePackageTask.find_by(appeal_id: params[:id], type: RemovePackageTask.name)
+    remove_package_task.update!(
+      assigned_to: current_user,
+      status: Constants.TASK_STATUSES.completed,
+      instructions: params[:instructions]
+    )
+
+    review_package_task = ReviewPackageTask.find_by(appeal_id: params[:id], type: ReviewPackageTask.name)
+    review_package_task.update!(status: Constants.TASK_STATUSES.in_progress)
+  end
+
   private
 
   def task_to_create

--- a/client/app/queue/correspondence/component/RemovePackageModal.jsx
+++ b/client/app/queue/correspondence/component/RemovePackageModal.jsx
@@ -71,10 +71,36 @@ class RemovePackageModal extends React.Component {
     }
   }
 
+  completePackage = async () => {
+    try {
+      const data = {
+        correspondence_id: this.props.correspondence_id,
+        instructions: []
+      };
+
+      data.instructions.push(this.state.reasonReject);
+
+      ApiUtil.post(`/queue/correspondence/${this.props.correspondence_id}/completed_package`, { data }).
+        then(() => {
+          this.setState({
+            updateCancelSuccess: true
+          });
+          this.props.updateLastAction('InProgressReviewPackage');
+        });
+
+    } catch (error) {
+      console.error(error);
+    }
+  }
+
   render() {
     const { onCancel } = this.props;
     const submit = () => {
-      this.removePackage();
+      if (this.state.reasonForRemove === 'Approve request') {
+        this.removePackage();
+      } else {
+        this.completePackage();
+      }
     };
 
     const removeReasonOptions = [

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -300,6 +300,7 @@ Rails.application.routes.draw do
     post '/correspondence/:correspondence_uuid/current_step', to: 'correspondence#current_step', as: :queue_correspondence_intake_current_step
     post '/correspondence/:correspondence_uuid/correspondence_intake_task', to: 'correspondence_tasks#create_correspondence_intake_task'
     post '/correspondence/:id/remove_package', to: 'correspondence_tasks#remove_package'
+    post '/correspondence/:id/completed_package', to: 'correspondence_tasks#completed_package'
     get '/correspondence/:correspondence_uuid/intake', to: 'correspondence#intake'
     get '/correspondence/:correspondence_uuid/review_package', to: 'correspondence#review_package'
     get '/correspondence/edit_document_type_correspondence', to: 'correspondence#document_type_correspondence'

--- a/spec/controllers/correspondence_tasks_controller_spec.rb
+++ b/spec/controllers/correspondence_tasks_controller_spec.rb
@@ -95,18 +95,34 @@ RSpec.describe CorrespondenceTasksController, :all_dbs, type: :controller do
         task_creation_params.merge!(type: "removePackage", instructions: ["please remove task, thanks"])
         post :create_package_action_task, params: task_creation_params
         expect(response).to have_http_status(:ok)
-        remove_package_task = RemovePackageTask.find_by(appeal_id: correspondence.id, type: RemovePackageTask.name)
         task_creation_params[:id] = correspondence.id
         post :remove_package, params: task_creation_params
+      end
 
-        it "creates remove package task successfully" do
-          expect(response).to have_http_status(:ok)
-          remove_package_task = RemovePackageTask.find_by(appeal_id: correspondence.id, type: RemovePackageTask.name)
-          expect(remove_package_task.status).to eq(Constants.TASK_STATUSES.canceled)
-          parent = CorrespondenceTask.find_by(appeal_id: correspondence.id, type: CorrespondenceTask.name)
-          expect(parent.status).to eq(Constants.TASK_STATUSES.on_hold)
-          expect(parent.children.status).to eq(Constants.TASK_STATUSES.on_hold)
-        end
+      it "creates remove package task successfully" do
+        remove_package_task = RemovePackageTask.find_by(appeal_id: correspondence.id, type: RemovePackageTask.name)
+        expect(remove_package_task.status).to eq(Constants.TASK_STATUSES.cancelled)
+        review_package_task = ReviewPackageTask.find_by(appeal_id: correspondence.id, type: ReviewPackageTask.name)
+        expect(review_package_task.status).to eq(Constants.TASK_STATUSES.cancelled)
+      end
+    end
+  end
+
+  describe "POST #reject_package" do
+    context "Reject Delete correspondence package from Caseflow" do
+      before do
+        task_creation_params.merge!(type: "removePackage", instructions: ["please remove task, thanks"])
+        post :create_package_action_task, params: task_creation_params
+        expect(response).to have_http_status(:ok)
+        task_creation_params[:id] = correspondence.id
+        post :completed_package, params: task_creation_params
+      end
+
+      it "reject remove package task successfully" do
+        remove_package_task = RemovePackageTask.find_by(appeal_id: correspondence.id, type: RemovePackageTask.name)
+        expect(remove_package_task.status).to eq(Constants.TASK_STATUSES.completed)
+        review_package_task = ReviewPackageTask.find_by(appeal_id: correspondence.id, type: ReviewPackageTask.name)
+        expect(review_package_task.status).to eq(Constants.TASK_STATUSES.in_progress)
       end
     end
   end


### PR DESCRIPTION
Resolves: [APPEALS-29193](https://jira.devops.va.gov/browse/APPEALS-29193), [APPEALS-29205](https://jira.devops.va.gov/browse/APPEALS-29205), [APPEALS-34996](https://jira.devops.va.gov/browse/APPEALS-34996), [APPEALS-35592](https://jira.devops.va.gov/browse/APPEALS-35592), [APPEALS-35593](https://jira.devops.va.gov/browse/APPEALS-35593), [APPEALS-29194](https://jira.devops.va.gov/browse/APPEALS-29194),
[APPEALS-34916](https://jira.devops.va.gov/browse/APPEALS-34916), [APPEALS-36343](https://jira.devops.va.gov/browse/APPEALS-36343), [APPEALS-37496](https://jira.devops.va.gov/browse/APPEALS-37496), [APPEALS-37530](https://jira.devops.va.gov/browse/APPEALS-37530), [APPEALS-36673](https://jira.devops.va.gov/browse/APPEALS-36673)

# Description
As a Mail Supervisor user I need to be able to reject or accept a Remove Package request so that I am complete the removal process.
 
## Acceptance Criteria
- [ ] Code compiles correctly

If Confirm is clicked on the modal the following happens
1. If Approve Request was selected
  - The Remove Package Task is updated, assigned to the user, and all tasks are cancelled
2. If Reject Request was selected
  - The Remove Package Task is assigned to the user, and given a status of completed
  - Reject reason is stored as instructions
  - The Review Package Task is given a status of “in progress”
  - The user is taken back to the Correspondence Queue (/queue/correspondence)

## Testing Plan

1. Login as a Mail team user `MAIL_TEAM_SUPERVISOR_MAIL_INTAKE_USER (VACO)`
2. From the App selector, select and click on `Queue`
3. In Your cases page, click on `Switch views` and select `Correspondence Cases`
4. Now you have to see the `Correspondence Cases` page
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/507b9ab6-4423-4a21-83b2-d82154d9d41a)

5. Select a package that was previously selected to remove, the review package page has to looks like that this
![image (18)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/beb633ae-1ef3-49ca-ab2e-8aedbcaaf24f)

![image (23)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/de28aa25-8bad-4304-b001-f77615853600)

6. click on `Review removal request` button a modal windows has to show up
![image (19)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/aa32fed9-fc13-4278-9cda-bf1d92b4ddde)

7. In the Modal windows we have two options when you click on the first radio button the button `confirm` is enable
![image (20)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/3d449bc1-4b8b-4ff9-ab1d-90d0bea0070b)


8. When clicking on the `Confirm` button the application redirects to the correspondence cases list and shows a banner
![image (22)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/8ca99887-468c-4c32-b303-271818f104ae)

![image (24)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/bbebdd9f-597c-41cf-aecf-7aa1a31d9e58)

9. In the second option you need to fill a text area up, to enable the button `confirm`
![image (21)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/2506dab8-eeb9-4111-8d35-1486ac4b0076)

![image (25)](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/77d65c51-c5e2-42cd-81de-a2f8ce63fa92)

