### PR TITLE
Craig/appeals 37619

### DIFF
--- a/app/models/organizations/business_line.rb
+++ b/app/models/organizations/business_line.rb
@@ -250,7 +250,7 @@ class BusinessLine < Organization
 
       ActiveRecord::Base.transaction do
         # increase the timeout for the transaction because the query more than the default 30 seconds
-        ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 120000"
+        ActiveRecord::Base.connection.execute "SET LOCAL statement_timeout = 180000"
         ActiveRecord::Base.connection.execute change_history_sql_block
       end
     end

--- a/client/app/nonComp/actions/changeHistorySlice.js
+++ b/client/app/nonComp/actions/changeHistorySlice.js
@@ -1,5 +1,6 @@
 import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import ApiUtil from '../../util/ApiUtil';
+import { getMinutesToMilliseconds } from '../../util/DateUtil';
 
 // Define the initial state
 const initialState = {
@@ -12,7 +13,12 @@ export const downloadReportCSV = createAsyncThunk('changeHistory/downloadReport'
   async ({ organizationUrl, filterData }, thunkApi) => {
     try {
       const postData = ApiUtil.convertToSnakeCase(filterData);
-      const getOptions = { query: postData.filters, headers: { Accept: 'text/csv' }, responseType: 'arraybuffer' };
+      const getOptions = {
+        query: postData.filters,
+        headers: { Accept: 'text/csv' },
+        responseType: 'arraybuffer',
+        timeout: { response: getMinutesToMilliseconds(3) }
+      };
       const response = await ApiUtil.get(`/decision_reviews/${organizationUrl}/report`, getOptions);
 
       // Create a Blob from the array buffer


### PR DESCRIPTION
[APPEALS-37619](https://jira.devops.va.gov/browse/APPEALS-37619)

# Description
- Increase database query timeout to 3 minutes
- Override default ApiUtil timeout to increase timeout to 3 seconds for report generation

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Reports are generated and returned to frontend if backend takes >60 seconds

## Testing Plan
1. In the `decision_reviews_controller.rb` file, add a line to the `generate_report` method's `format.csv do` block that says `sleep(125)`
2. Run the front and back end
3. Go to the report generation page
4. Select 'Event/Action'
5. Open the browser developer tools (Ctrl+F12, Cmd+F12, right click -> inspect)
6. In browser dev tools, go to the Network tab
7. Click "generate task report"
8. Observe the network tab request to `/decision_reviews/vha/report?...`
9. Wait ~125 seconds
10. Verify that the CSV file downloads
11. Verify that the network request in step 8 took >125000 milliseconds but completed successfully
