### PR TITLE
hotfix/APPEALS-37621

### DIFF
--- a/app/models/serializers/work_queue/appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_search_serializer.rb
@@ -8,6 +8,10 @@ class WorkQueue::AppealSearchSerializer
 
   attribute :contested_claim, &:contested_claim?
 
+  attribute :closest_regional_office
+
+  attribute :closest_regional_office_label
+
   attribute :issues do |object|
     object.request_issues.active_or_decided_or_withdrawn.includes(:remand_reasons).map do |issue|
       {

--- a/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
@@ -9,6 +9,10 @@ class WorkQueue::LegacyAppealSearchSerializer
   attribute :assigned_attorney
   attribute :assigned_judge
 
+  attribute :closest_regional_office
+
+  attribute :closest_regional_office_label
+
   attribute :issues do |object|
     object.issues.map do |issue|
       WorkQueue::LegacyIssueSerializer.new(issue).serializable_hash[:data][:attributes]

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -577,6 +577,9 @@ export const prepareAppealForSearchStore = (appeals) => {
       veteranGender: appeal.attributes.veteran_gender,
       veteranAddress: appeal.attributes.veteran_address,
       veteranParticipantId: appeal.attributes.veteran_participant_id,
+      closestRegionalOffice: appeal.attributes.closest_regional_office,
+      closestRegionalOfficeLabel:
+        appeal.attributes.closest_regional_office_label,
       externalId: appeal.attributes.external_id,
       status: appeal.attributes.status,
       decisionDate: appeal.attributes.decision_date,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-37621](https://jira.devops.va.gov/browse/APPEALS-37621)

# Description
Caseflow IDT API V2 should return (and up until now has returned) the "closest_regional_office_label" which is used for purposes of transcript generation.  It is no longer returning that  field and as a result we cannot process hearing transcript Work Orders to get the hearings transcribed

## Acceptance Criteria
- [ ] Code compiles correctly
