### PR TITLE
adding new bulk scripts (#20450)

### DIFF
--- a/Makefile.example
+++ b/Makefile.example
@@ -170,6 +170,11 @@ audit: ## Create caseflow_audit schema, tables, and triggers in postgres
 	bundle exec rails r db/scripts/audit/triggers/create_vbms_uploaded_documents_audit_trigger.rb
 	bundle exec rails r db/scripts/audit/triggers/create_priority_end_product_sync_queue_audit_trigger.rb
 
+consolidated_db_scripts: ## Create caseflow_audit schema, tables, and triggers in postgres
+	bundle exec rails r db/scripts/audit/tables/create_bulk_audit_script.rb
+	bundle exec rails r db/scripts/audit/functions/create_bulk_function_script.rb
+	bundle exec rails r db/scripts/audit/triggers/create_bulk_trigger_script.rb
+
 audit-remove: ## Remove caseflow_audit schema, tables and triggers in postgres
 	bundle exec rails r db/scripts/audit/remove_caseflow_audit_schema.rb
 
@@ -238,12 +243,9 @@ fresh:  ## https://github.com/imsky/git-fresh - updates local master to match or
 reset: reset-dbs seed-dbs enable-feature-flags ## Resets databases and enable feature flags
 
 reset-dbs: ## Resets Caseflow and ETL database schemas
-	make audit-remove
-	make external-db-remove
 	DB=etl bundle exec rake db:drop db:create db:schema:load
 	bundle exec rake db:drop db:create db:schema:load
-	make audit
-	make external-db-create
+	make consolidated_db_scripts
 
 seed-vbms-ext-claim: ## Seed only vbms_ext_claim
 	bundle exec rake db:seed:vbms_ext_claim

--- a/db/scripts/audit/functions/create_bulk_function_script.rb
+++ b/db/scripts/audit/functions/create_bulk_function_script.rb
@@ -1,0 +1,459 @@
+# frozen_string_literal: true
+
+require "pg"
+
+begin
+  conn = CaseflowRecord.connection
+
+  # add_row_to_appeal_states_audit_table_function
+  conn.execute(
+    "create or replace function caseflow_audit.add_row_to_appeal_states_audit() returns trigger
+    as
+    $add_row$
+    begin
+      if (TG_OP = 'DELETE') then
+        insert into caseflow_audit.appeal_states_audit
+        select
+          nextval('caseflow_audit.appeal_states_audit_id_seq'::regclass),
+          'D',
+          OLD.id,
+          OLD.appeal_cancelled,
+          OLD.appeal_docketed,
+          OLD.appeal_id,
+          OLD.appeal_type,
+          OLD.created_at,
+          OLD.created_by_id,
+          OLD.decision_mailed,
+          OLD.hearing_postponed,
+          OLD.hearing_scheduled,
+          OLD.hearing_withdrawn,
+          OLD.privacy_act_complete,
+          OLD.privacy_act_pending,
+          OLD.scheduled_in_error,
+          OLD.updated_at,
+          OLD.updated_by_id,
+          OLD.vso_ihp_complete,
+          OLD.vso_ihp_pending;
+      elsif (TG_OP = 'UPDATE') then
+        insert into caseflow_audit.appeal_states_audit
+        select
+          nextval('caseflow_audit.appeal_states_audit_id_seq'::regclass),
+          'U',
+          NEW.id,
+          NEW.appeal_cancelled,
+          NEW.appeal_docketed,
+          NEW.appeal_id,
+          NEW.appeal_type,
+          NEW.created_at,
+          NEW.created_by_id,
+          NEW.decision_mailed,
+          NEW.hearing_postponed,
+          NEW.hearing_scheduled,
+          NEW.hearing_withdrawn,
+          NEW.privacy_act_complete,
+          NEW.privacy_act_pending,
+          NEW.scheduled_in_error,
+          NEW.updated_at,
+          NEW.updated_by_id,
+          NEW.vso_ihp_complete,
+          NEW.vso_ihp_pending;
+      elsif (TG_OP = 'INSERT') then
+        insert into caseflow_audit.appeal_states_audit
+        select
+          nextval('caseflow_audit.appeal_states_audit_id_seq'::regclass),
+          'I',
+          NEW.id,
+          NEW.appeal_cancelled,
+          NEW.appeal_docketed,
+          NEW.appeal_id,
+          NEW.appeal_type,
+          NEW.created_at,
+          NEW.created_by_id,
+          NEW.decision_mailed,
+          NEW.hearing_postponed,
+          NEW.hearing_scheduled,
+          NEW.hearing_withdrawn,
+          NEW.privacy_act_complete,
+          NEW.privacy_act_pending,
+          NEW.scheduled_in_error,
+          NEW.updated_at,
+          NEW.updated_by_id,
+          NEW.vso_ihp_complete,
+          NEW.vso_ihp_pending;
+      end if;
+      return null;
+    end;
+    $add_row$
+    language plpgsql;"
+  )
+
+  # add_row_to_vbms_communication_packages_audit_table_function
+  conn.execute(
+    "create or replace function caseflow_audit.add_row_to_vbms_communication_packages_audit() returns trigger
+    as
+    $add_row$
+    begin
+      if (TG_OP = 'DELETE') then
+        insert into caseflow_audit.vbms_communication_packages_audit
+        select
+          nextval('caseflow_audit.vbms_communication_packages_audit_id_seq'::regclass),
+          'D',
+          OLD.id,
+          OLD.file_number,
+          OLD.copies,
+          OLD.status,
+          OLD.comm_package_name,
+          OLD.created_at,
+          OLD.updated_at,
+          OLD.document_mailable_via_pacman_id,
+          OLD.document_mailable_via_pacman_type,
+          OLD.created_by_id,
+          OLD.updated_by_id,
+          OLD.uuid;
+      elsif (TG_OP = 'UPDATE') then
+        insert into caseflow_audit.vbms_communication_packages_audit
+        select
+          nextval('caseflow_audit.vbms_communication_packages_audit_id_seq'::regclass),
+          'U',
+          NEW.id,
+          NEW.file_number,
+          NEW.copies,
+          NEW.status,
+          NEW.comm_package_name,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.document_mailable_via_pacman_id,
+          NEW.document_mailable_via_pacman_type,
+          NEW.created_by_id,
+          NEW.updated_by_id,
+          NEW.uuid;
+      elsif (TG_OP = 'INSERT') then
+        insert into caseflow_audit.vbms_communication_packages_audit
+        select
+          nextval('caseflow_audit.vbms_communication_packages_audit_id_seq'::regclass),
+          'I',
+          NEW.id,
+          NEW.file_number,
+          NEW.copies,
+          NEW.status,
+          NEW.comm_package_name,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.document_mailable_via_pacman_id,
+          NEW.document_mailable_via_pacman_type,
+          NEW.created_by_id,
+          NEW.updated_by_id,
+          NEW.uuid;
+      end if;
+      return null;
+    end;
+    $add_row$
+    language plpgsql;"
+  )
+
+  # add_row_to_vbms_distributions_audit_table_function
+
+  conn.execute(
+    "create or replace function caseflow_audit.add_row_to_vbms_distributions_audit() returns trigger
+    as
+    $add_row$
+    begin
+      if (TG_OP = 'DELETE') then
+        insert into caseflow_audit.vbms_distributions_audit
+        select
+          nextval('caseflow_audit.vbms_distributions_audit_id_seq'::regclass),
+          'D',
+          OLD.id,
+          OLD.recipient_type,
+          OLD.name,
+          OLD.first_name,
+          OLD.middle_name,
+          OLD.last_name,
+          OLD.participant_id,
+          OLD.poa_code,
+          OLD.claimant_station_of_jurisdiction,
+          OLD.created_at,
+          OLD.updated_at,
+          OLD.vbms_communication_package_id,
+          OLD.created_by_id,
+          OLD.updated_by_id,
+          OLD.uuid;
+      elsif (TG_OP = 'UPDATE') then
+        insert into caseflow_audit.vbms_distributions_audit
+        select
+          nextval('caseflow_audit.vbms_distributions_audit_id_seq'::regclass),
+          'U',
+          NEW.id,
+          NEW.recipient_type,
+          NEW.name,
+          NEW.first_name,
+          NEW.middle_name,
+          NEW.last_name,
+          NEW.participant_id,
+          NEW.poa_code,
+          NEW.claimant_station_of_jurisdiction,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.vbms_communication_package_id,
+          NEW.created_by_id,
+          NEW.updated_by_id,
+          NEW.uuid;
+      elsif (TG_OP = 'INSERT') then
+        insert into caseflow_audit.vbms_distributions_audit
+        select
+          nextval('caseflow_audit.vbms_distributions_audit_id_seq'::regclass),
+          'I',
+          NEW.id,
+          NEW.recipient_type,
+          NEW.name,
+          NEW.first_name,
+          NEW.middle_name,
+          NEW.last_name,
+          NEW.participant_id,
+          NEW.poa_code,
+          NEW.claimant_station_of_jurisdiction,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.vbms_communication_package_id,
+          NEW.created_by_id,
+          NEW.updated_by_id,
+          NEW.uuid;
+      end if;
+      return null;
+    end;
+    $add_row$
+    language plpgsql;"
+  )
+
+  # add_row_to_vbms_distribution_destinations_audit_table_function
+
+  conn.execute(
+    "create or replace function caseflow_audit.add_row_to_vbms_distribution_destinations_audit() returns trigger
+    as
+    $add_row$
+    begin
+      if (TG_OP = 'DELETE') then
+        insert into caseflow_audit.vbms_distribution_destinations_audit
+        select
+          nextval('caseflow_audit.vbms_distribution_destinations_audit_id_seq'::regclass),
+          'D',
+          OLD.id,
+          OLD.destination_type,
+          OLD.address_line_1,
+          OLD.address_line_2,
+          OLD.address_line_3,
+          OLD.address_line_4,
+          OLD.address_line_5,
+          OLD.address_line_6,
+          OLD.treat_line_2_as_addressee,
+          OLD.treat_line_3_as_addressee,
+          OLD.city,
+          OLD.state,
+          OLD.postal_code,
+          OLD.country_name,
+          OLD.country_code,
+          OLD.created_at,
+          OLD.updated_at,
+          OLD.vbms_distribution_id,
+          OLD.created_by_id,
+          OLD.updated_by_id;
+      elsif (TG_OP = 'UPDATE') then
+        insert into caseflow_audit.vbms_distribution_destinations_audit
+        select
+          nextval('caseflow_audit.vbms_distribution_destinations_audit_id_seq'::regclass),
+          'U',
+          NEW.id,
+          NEW.destination_type,
+          NEW.address_line_1,
+          NEW.address_line_2,
+          NEW.address_line_3,
+          NEW.address_line_4,
+          NEW.address_line_5,
+          NEW.address_line_6,
+          NEW.treat_line_2_as_addressee,
+          NEW.treat_line_3_as_addressee,
+          NEW.city,
+          NEW.state,
+          NEW.postal_code,
+          NEW.country_name,
+          NEW.country_code,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.vbms_distribution_id,
+          NEW.created_by_id,
+          NEW.updated_by_id;
+      elsif (TG_OP = 'INSERT') then
+        insert into caseflow_audit.vbms_distribution_destinations_audit
+        select
+          nextval('caseflow_audit.vbms_distribution_destinations_audit_id_seq'::regclass),
+          'I',
+          NEW.id,
+          NEW.destination_type,
+          NEW.address_line_1,
+          NEW.address_line_2,
+          NEW.address_line_3,
+          NEW.address_line_4,
+          NEW.address_line_5,
+          NEW.address_line_6,
+          NEW.treat_line_2_as_addressee,
+          NEW.treat_line_3_as_addressee,
+          NEW.city,
+          NEW.state,
+          NEW.postal_code,
+          NEW.country_name,
+          NEW.country_code,
+          NEW.created_at,
+          NEW.updated_at,
+          NEW.vbms_distribution_id,
+          NEW.created_by_id,
+          NEW.updated_by_id;
+      end if;
+      return null;
+    end;
+    $add_row$
+    language plpgsql;"
+  )
+
+  # add_row_to_vbms_uploaded_documents_audit_table_function
+  conn.execute(
+    "create or replace function caseflow_audit.add_row_to_vbms_uploaded_documents_audit() returns trigger
+    as
+    $add_row$
+    begin
+      if (TG_OP = 'DELETE') then
+        insert into caseflow_audit.vbms_uploaded_documents_audit
+        select
+          nextval('caseflow_audit.vbms_uploaded_documents_audit_id_seq'::regclass),
+          'D',
+          OLD.id,
+          OLD.appeal_id,
+          OLD.appeal_type,
+          OLD.attempted_at,
+          OLD.canceled_at,
+          OLD.created_at,
+          OLD.document_name,
+          OLD.document_series_reference_id,
+          OLD.document_subject,
+          OLD.document_type,
+          OLD.document_version_reference_id,
+          OLD.error,
+          OLD.last_submitted_at,
+          OLD.processed_at,
+          OLD.submitted_at,
+          OLD.updated_at,
+          OLD.uploaded_to_vbms_at,
+          OLD.veteran_file_number;
+      elsif (TG_OP = 'UPDATE') then
+        insert into caseflow_audit.vbms_uploaded_documents_audit
+        select
+          nextval('caseflow_audit.vbms_uploaded_documents_audit_id_seq'::regclass),
+          'U',
+          NEW.id,
+          NEW.appeal_id,
+          NEW.appeal_type,
+          NEW.attempted_at,
+          NEW.canceled_at,
+          NEW.created_at,
+          NEW.document_name,
+          NEW.document_series_reference_id,
+          NEW.document_subject,
+          NEW.document_type,
+          NEW.document_version_reference_id,
+          NEW.error,
+          NEW.last_submitted_at,
+          NEW.processed_at,
+          NEW.submitted_at,
+          NEW.updated_at,
+          NEW.uploaded_to_vbms_at,
+          NEW.veteran_file_number;
+      elsif (TG_OP = 'INSERT') then
+        insert into caseflow_audit.vbms_uploaded_documents_audit
+        select
+          nextval('caseflow_audit.vbms_uploaded_documents_audit_id_seq'::regclass),
+          'I',
+          NEW.id,
+          NEW.appeal_id,
+          NEW.appeal_type,
+          NEW.attempted_at,
+          NEW.canceled_at,
+          NEW.created_at,
+          NEW.document_name,
+          NEW.document_series_reference_id,
+          NEW.document_subject,
+          NEW.document_type,
+          NEW.document_version_reference_id,
+          NEW.error,
+          NEW.last_submitted_at,
+          NEW.processed_at,
+          NEW.submitted_at,
+          NEW.updated_at,
+          NEW.uploaded_to_vbms_at,
+          NEW.veteran_file_number;
+      end if;
+      return null;
+    end;
+    $add_row$
+    language plpgsql;"
+  )
+
+  # add_row_to_priority_end_product_sync_queue_audit_table_function
+  conn.execute("CREATE OR REPLACE FUNCTION caseflow_audit.add_row_to_priority_end_product_sync_queue_audit()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    begin
+    if (TG_OP = 'DELETE') then
+      insert into caseflow_audit.priority_end_product_sync_queue_audit
+      select
+        nextval('caseflow_audit.priority_end_product_sync_queue_audit_id_seq'::regclass),
+        'D',
+        OLD.id,
+        OLD.end_product_establishment_id,
+        OLD.batch_id,
+        OLD.status,
+        OLD.created_at,
+        OLD.last_batched_at,
+        CURRENT_TIMESTAMP,
+        OLD.error_messages;
+    elsif (TG_OP = 'UPDATE') then
+      insert into caseflow_audit.priority_end_product_sync_queue_audit
+      select
+        nextval('caseflow_audit.priority_end_product_sync_queue_audit_id_seq'::regclass),
+        'U',
+        NEW.id,
+        NEW.end_product_establishment_id,
+        NEW.batch_id,
+        NEW.status,
+        NEW.created_at,
+        NEW.last_batched_at,
+        CURRENT_TIMESTAMP,
+        NEW.error_messages;
+    elsif (TG_OP = 'INSERT') then
+      insert into caseflow_audit.priority_end_product_sync_queue_audit
+      select
+        nextval('caseflow_audit.priority_end_product_sync_queue_audit_id_seq'::regclass),
+        'I',
+        NEW.id,
+        NEW.end_product_establishment_id,
+        NEW.batch_id,
+        NEW.status,
+        NEW.created_at,
+        NEW.last_batched_at,
+        CURRENT_TIMESTAMP,
+        NEW.error_messages;
+    end if;
+    return null;
+    end;
+    $function$
+    ;")
+
+  conn.close
+rescue ActiveRecord::NoDatabaseError => error
+  if error.message.include?('database "caseflow_certification_development" does not exist')
+    STDOUT.puts "Database caseflow_certification_development does not exist; skipping make audit-remove"
+  else
+    raise error
+  end
+end
+
+

--- a/db/scripts/audit/tables/create_bulk_audit_script.rb
+++ b/db/scripts/audit/tables/create_bulk_audit_script.rb
@@ -1,0 +1,213 @@
+# frozen_string_literal: true
+
+# removes caseflow_audit schema, remove vhms_ext table and other triggers and
+# recreate new schemas.
+
+require "pg"
+
+conn = CaseflowRecord.connection
+
+begin
+  # audit-removed
+  conn.execute(
+    "drop schema IF EXISTS caseflow_audit CASCADE;"
+  )
+
+  # remove_vbms_ext_claim_table.rb
+  conn.execute(
+    "drop table IF EXISTS public.vbms_ext_claim;"
+  )
+
+  # drop trigger and function
+  conn.execute("
+    drop trigger if exists update_claim_status_trigger on vbms_ext_claim;
+    drop function if exists public.update_claim_status_trigger_function();
+  ")
+rescue ActiveRecord::NoDatabaseError => error
+  if error.message.include?('database "caseflow_certification_development" does not exist')
+    STDOUT.puts "Database caseflow_certification_development does not exist; Error during dropping table/triggers/function create_bulk_audit_script."
+  else
+    raise error
+  end
+end
+
+conn.execute("create schema caseflow_audit;")
+
+conn.execute("create table caseflow_audit.appeal_states_audit (
+            id BIGSERIAL PRIMARY KEY,
+            type_of_change CHAR(1) not null,
+            appeal_states_id bigint not null,
+            appeal_cancelled boolean not null,
+            appeal_docketed boolean not null,
+            appeal_id BIGINT not null,
+            appeal_type VARCHAR not null,
+            created_at timestamp not null,
+            created_by_id bigint not null,
+            decision_mailed boolean not null,
+            hearing_postponed boolean not null,
+            hearing_scheduled boolean not null,
+            hearing_withdrawn boolean not null,
+            privacy_act_complete boolean not null,
+            privacy_act_pending boolean not null,
+            scheduled_in_error boolean not null,
+            updated_at timestamp,
+            updated_by_id bigint,
+            vso_ihp_complete boolean not null,
+            vso_ihp_pending boolean not null
+          );")
+# create_vbms_communication_packages_audit
+
+conn.execute(
+  "create table caseflow_audit.vbms_communication_packages_audit
+    (
+      id BIGSERIAL PRIMARY KEY,
+      type_of_change CHAR(1) not null,
+      vbms_communication_package_id bigint not null,
+      file_number varchar NULL,
+      copies int8 NULL DEFAULT 1,
+      status varchar NULL,
+      comm_package_name varchar NOT NULL,
+      created_at timestamp NOT NULL,
+      updated_at timestamp NOT NULL,
+      document_mailable_via_pacman_id bigint not NULL,
+      document_mailable_via_pacman_type varchar not NULL,
+      created_by_id int8 NULL,
+      updated_by_id int8 NULL,
+      uuid varchar NULL
+    );"
+)
+
+conn.execute(
+  "create table caseflow_audit.vbms_distributions_audit (
+              id BIGSERIAL PRIMARY KEY,
+              type_of_change CHAR(1) not null,
+              vbms_distributions_id bigint not null,
+              recipient_type varchar NOT NULL,
+              name varchar NULL,
+              first_name varchar NULL,
+              middle_name varchar NULL,
+              last_name varchar NULL,
+              participant_id varchar NULL,
+              poa_code varchar NULL,
+              claimant_station_of_jurisdiction varchar NULL,
+              created_at timestamp NOT NULL,
+              updated_at timestamp NOT NULL,
+              vbms_communication_package_id int8 NULL,
+              created_by_id int8 NULL,
+              updated_by_id int8 NULL,
+              uuid varchar NULL
+            );"
+)
+
+# create_vbms_distribution_destinations_audit
+conn.execute(
+  "create table caseflow_audit.vbms_distribution_destinations_audit (
+              id BIGSERIAL PRIMARY KEY,
+              type_of_change CHAR(1) not null,
+              vbms_distribution_destinations_id bigint not null,
+              destination_type varchar NOT NULL,
+              address_line_1 varchar NULL,
+              address_line_2 varchar NULL,
+              address_line_3 varchar NULL,
+              address_line_4 varchar NULL,
+              address_line_5 varchar NULL,
+              address_line_6 varchar NULL,
+              treat_line_2_as_addressee bool NULL,
+              treat_line_3_as_addressee bool NULL,
+              city varchar NULL,
+              state varchar NULL,
+              postal_code varchar NULL,
+              country_name varchar NULL,
+              country_code varchar NULL,
+              created_at timestamp NOT NULL,
+              updated_at timestamp NOT NULL,
+              vbms_distribution_id int8 NULL,
+              created_by_id int8 NULL,
+              updated_by_id int8 NULL
+            );"
+)
+
+# vbms_uploaded_documents_audit
+conn.execute(
+  "create table caseflow_audit.vbms_uploaded_documents_audit (
+            id BIGSERIAL PRIMARY KEY,
+            type_of_change CHAR(1) not null,
+            vbms_uploaded_documents_id bigint not null,
+            appeal_id int8 NULL,
+            appeal_type varchar NULL,
+            attempted_at timestamp NULL,
+            canceled_at timestamp NULL,
+            created_at timestamp NOT NULL,
+            document_name varchar NULL,
+            document_series_reference_id varchar NULL,
+            document_subject varchar NULL,
+            document_type varchar NOT NULL,
+            document_version_reference_id varchar NULL,
+            error varchar NULL,
+            last_submitted_at timestamp NULL,
+            processed_at timestamp NULL,
+            submitted_at timestamp NULL,
+            updated_at timestamp NOT NULL,
+            uploaded_to_vbms_at timestamp NULL,
+            veteran_file_number varchar NULL
+          );"
+)
+
+# PRIORITY_END_PRODUCT_SYNC_QUEUE_AUDIT
+conn.execute("CREATE TABLE CASEFLOW_AUDIT.PRIORITY_END_PRODUCT_SYNC_QUEUE_AUDIT (
+            ID BIGSERIAL PRIMARY KEY UNIQUE NOT NULL,
+            TYPE_OF_CHANGE CHAR(1) NOT NULL,
+            PRIORITY_END_PRODUCT_SYNC_QUEUE_ID BIGINT NOT NULL,
+            END_PRODUCT_ESTABLISHMENT_ID BIGINT NOT NULL REFERENCES END_PRODUCT_ESTABLISHMENTS(ID),
+            BATCH_ID UUID REFERENCES BATCH_PROCESSES(BATCH_ID),
+            STATUS VARCHAR(50) NOT NULL,
+            CREATED_AT TIMESTAMP WITHOUT TIME ZONE,
+            LAST_BATCHED_AT TIMESTAMP WITHOUT TIME ZONE,
+            AUDIT_CREATED_AT TIMESTAMP WITHOUT TIME ZONE DEFAULT NOW(),
+            ERROR_MESSAGES TEXT[]
+          );")
+
+# Create vbms_ext_claim file -> aka external-db-create
+conn.execute('CREATE TABLE IF NOT EXISTS public.vbms_ext_claim (
+          "CLAIM_ID" numeric(38,0) primary key unique NOT null,
+          "CLAIM_DATE" timestamp without time zone,
+          "EP_CODE" character varying(25),
+          "SUSPENSE_DATE" timestamp without time zone,
+          "SUSPENSE_REASON_CODE" character varying(25),
+          "SUSPENSE_REASON_COMMENTS" character varying(1000),
+          "CLAIMANT_PERSON_ID" numeric(38,0),
+          "CONTENTION_COUNT" integer,
+          "CLAIM_SOJ" character varying(25),
+          "TEMPORARY_CLAIM_SOJ" character varying(25),
+          "PRIORITY" character varying(10),
+          "TYPE_CODE" character varying(25),
+          "LIFECYCLE_STATUS_NAME" character varying(50),
+          "LEVEL_STATUS_CODE" character varying(25),
+          "SUBMITTER_APPLICATION_CODE" character varying(25),
+          "SUBMITTER_ROLE_CODE" character varying(25),
+          "VETERAN_PERSON_ID" numeric(15,0),
+          "ESTABLISHMENT_DATE" timestamp without time zone,
+          "INTAKE_SITE" character varying(25),
+          "PAYEE_CODE" character varying(25),
+          "SYNC_ID" numeric(38,0) NOT null,
+          "CREATEDDT" timestamp without time zone NOT null default NULL,
+          "LASTUPDATEDT" timestamp without time zone NOT null default NULL,
+          "EXPIRATIONDT" timestamp without time zone,
+          "VERSION" numeric(38,0) NOT null default NULL,
+          "LIFECYCLE_STATUS_CHANGE_DATE" timestamp without time zone,
+          "RATING_SOJ" character varying(25),
+          "PROGRAM_TYPE_CODE" character varying(10),
+          "SERVICE_TYPE_CODE" character varying(10),
+          "PREVENT_AUDIT_TRIG" smallint NOT null default 0,
+          "PRE_DISCHARGE_TYPE_CODE" character varying(10),
+          "PRE_DISCHARGE_IND" character varying(5),
+          "ORGANIZATION_NAME" character varying(100),
+          "ORGANIZATION_SOJ" character varying(25),
+          "ALLOW_POA_ACCESS" character varying(5),
+          "POA_CODE" character varying(25)
+);')
+
+conn.execute('CREATE INDEX IF NOT EXISTS claim_id_index ON public.vbms_ext_claim ("CLAIM_ID")')
+conn.execute('CREATE INDEX IF NOT EXISTS level_status_code_index ON public.vbms_ext_claim ("LEVEL_STATUS_CODE")')
+
+conn.close

--- a/db/scripts/audit/triggers/create_bulk_trigger_script.rb
+++ b/db/scripts/audit/triggers/create_bulk_trigger_script.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "pg"
+
+conn = CaseflowRecord.connection
+
+# appeal_states_audit_trigger
+conn.execute(
+  "create trigger appeal_states_audit_trigger
+  after insert or update or delete on public.appeal_states
+  for each row
+  execute procedure caseflow_audit.add_row_to_appeal_states_audit();"
+)
+
+# create_vbms_communication_packages_audit_trigger
+
+conn.execute(
+  "create trigger vbms_communication_packages_audit_trigger
+  after insert or update or delete on public.vbms_communication_packages
+  for each row
+  execute procedure caseflow_audit.add_row_to_vbms_communication_packages_audit();"
+)
+
+# create_vbms_distributions_audit_trigger
+
+conn.execute(
+  "create trigger vbms_distributions_audit_trigger
+  after insert or update or delete on public.vbms_distributions
+  for each row
+  execute procedure caseflow_audit.add_row_to_vbms_distributions_audit();"
+)
+
+# create_vbms_distribution_destinations_audit_trigger
+
+conn.execute(
+  "create trigger vbms_distribution_destinations_audit_trigger
+  after insert or update or delete on public.vbms_distribution_destinations
+  for each row
+  execute procedure caseflow_audit.add_row_to_vbms_distribution_destinations_audit();"
+)
+
+# create_vbms_uploaded_documents_audit_trigger
+
+conn.execute(
+  "create trigger vbms_uploaded_documents_audit_trigger
+  after insert or update or delete on public.vbms_uploaded_documents
+  for each row
+  execute procedure caseflow_audit.add_row_to_vbms_uploaded_documents_audit();"
+)
+
+# create_priority_end_product_sync_queue_audit_trigger
+conn.execute(
+  "create trigger priority_end_product_sync_queue_audit_trigger
+  after insert or update or delete on public.priority_end_product_sync_queue
+  for each row
+  execute procedure caseflow_audit.add_row_to_priority_end_product_sync_queue_audit();"
+)
+
+# add_pepsq_populate_trigger_to_vbms_ext_claim.rb
+conn.execute("
+  drop trigger if exists update_claim_status_trigger on vbms_ext_claim;
+
+  create or replace function public.update_claim_status_trigger_function()
+  returns trigger as $$
+    declare
+      string_claim_id varchar(25);
+      epe_id integer;
+    begin
+      if (NEW.\"EP_CODE\" LIKE '04%'
+          OR NEW.\"EP_CODE\" LIKE '03%'
+          OR NEW.\"EP_CODE\" LIKE '93%'
+          OR NEW.\"EP_CODE\" LIKE '68%')
+          and (NEW.\"LEVEL_STATUS_CODE\" = 'CLR' OR NEW.\"LEVEL_STATUS_CODE\" = 'CAN') then
+
+        string_claim_id := cast(NEW.\"CLAIM_ID\" as varchar);
+
+        select id into epe_id
+        from end_product_establishments
+        where (reference_id = string_claim_id
+        and (synced_status is null or synced_status <> NEW.\"LEVEL_STATUS_CODE\"));
+
+        if epe_id > 0
+        then
+          if not exists (
+            select 1
+            from priority_end_product_sync_queue
+            where end_product_establishment_id = epe_id
+          ) then
+            insert into priority_end_product_sync_queue (created_at, end_product_establishment_id, updated_at)
+            values (now(), epe_id, now());
+          end if;
+        end if;
+      end if;
+      return null;
+    end;
+  $$
+  language plpgsql;
+
+  create trigger update_claim_status_trigger
+  after update or insert on vbms_ext_claim
+  for each row
+  execute procedure public.update_claim_status_trigger_function();
+  ")
+
+conn.close


### PR DESCRIPTION
* adding new bulk scripts

* fixing the order of execution

* reverting one thing

* revert

* adding back audit-remove;

* fixing pr comments

* bring back audit command

* reverting the changes for remove-vbms-ext-claim-seeds

Resolves [APPEALS-33934](https://jira.devops.va.gov/browse/APPEALS-33934)

# Description
Consolidates the 21 scripts that are run during `make reset` into three to greatly speed up the time to reset a local environment

## Acceptance Criteria
- [ ] Code compiles correctly
