### PR TITLE
Correspondence - Add validation to foreign keys

### DIFF
--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -3,6 +3,12 @@
 # Correspondence is a top level object similar to Appeals.
 # Serves as a collection of all data related to Correspondence workflow
 class Correspondence < CaseflowRecord
+  validates :correspondence_type_id, presence: true
+  validates :package_document_type_id, presence: true
+  validates :assigned_by_id, presence: true
+  validates :updated_by_id, presence: true
+  validates :veteran_id, presence: true
+
   has_paper_trail
   include PrintsTaskTree
   include AppealableCorrespondence

--- a/app/models/correspondence.rb
+++ b/app/models/correspondence.rb
@@ -5,8 +5,7 @@
 class Correspondence < CaseflowRecord
   validates :correspondence_type_id, presence: true
   validates :package_document_type_id, presence: true
-  validates :assigned_by_id, presence: true
-  validates :updated_by_id, presence: true
+  validates :updated_by_id, presence: true, on: :update
   validates :veteran_id, presence: true
 
   has_paper_trail
@@ -22,6 +21,7 @@ class Correspondence < CaseflowRecord
   belongs_to :correspondence_type
   belongs_to :package_document_type
   belongs_to :veteran
+  belongs_to :assigned_by, class_name: "User", foreign_key: :assigned_by_id, optional: false
 
   after_create :initialize_correspondence_tasks
 

--- a/db/migrate/20240110185350_add_foreign_keys_to_correspondence.rb
+++ b/db/migrate/20240110185350_add_foreign_keys_to_correspondence.rb
@@ -1,0 +1,9 @@
+class AddForeignKeysToCorrespondence < Caseflow::Migration
+  def change
+    add_foreign_key :correspondences, :correspondence_types, validate: false
+    add_foreign_key :correspondences, :package_document_types, validate: false
+    add_foreign_key :correspondences, :users, column: :assigned_by_id, validate: false
+    add_foreign_key :correspondences, :users, column: :updated_by_id, validate: false
+    add_foreign_key :correspondences, :veterans, validate: false
+  end
+end

--- a/db/migrate/20240110185623_validate_correspondence_foreign_keys.rb
+++ b/db/migrate/20240110185623_validate_correspondence_foreign_keys.rb
@@ -1,0 +1,8 @@
+class ValidateCorrespondenceForeignKeys < Caseflow::Migration
+  def change
+    validate_foreign_key :correspondences, :correspondence_types
+    validate_foreign_key :correspondences, :package_document_types
+    validate_foreign_key :correspondences, :users
+    validate_foreign_key :correspondences, :veterans
+  end
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -63,9 +63,9 @@ class SeedDB
     call_and_log_seed_step Seeds::VbmsExtClaim
     call_and_log_seed_step Seeds::RemandedAmaAppeals
     call_and_log_seed_step Seeds::RemandedLegacyAppeals
-    call_and_log_seed_step Seeds::Correspondence
     call_and_log_seed_step Seeds::CorrespondenceTypes
     call_and_log_seed_step Seeds::PackageDocumentTypes
+    call_and_log_seed_step Seeds::Correspondence
     call_and_log_seed_step Seeds::MultiCorrespondences
     call_and_log_seed_step Seeds::VbmsDocumentTypes
     # Always run this as last one

--- a/db/seeds/correspondence.rb
+++ b/db/seeds/correspondence.rb
@@ -55,6 +55,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "This is a note from CMP.",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         create_multiple_docs(corres, veteran)
@@ -74,6 +75,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "This is a note from CMP.",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(
@@ -100,6 +102,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "This is a note from CMP.",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(
@@ -126,6 +129,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "This is a note from CMP.",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(

--- a/db/seeds/multi_correspondences.rb
+++ b/db/seeds/multi_correspondences.rb
@@ -61,6 +61,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "Notes from CMP - Multi Correspondence Seed",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(
@@ -102,6 +103,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "Notes from CMP - Multi Correspondence Seed",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(
@@ -144,6 +146,7 @@ module Seeds
           va_date_of_receipt: Time.zone.yesterday,
           notes: "Notes from CMP - Multi Correspondence Seed",
           assigned_by_id: 81,
+          updated_by_id: 81,
           veteran_id: veteran.id,
         )
         CorrespondenceDocument.find_or_create_by(

--- a/lib/tasks/correspondence.rake
+++ b/lib/tasks/correspondence.rake
@@ -126,6 +126,7 @@ namespace :correspondence do
         va_date_of_receipt: Time.zone.yesterday,
         notes: "Notes from CMP - Multi Correspondence Seed",
         assigned_by_id: 81,
+        updated_by_id: 81,
         veteran_id: veteran.id
       )
       CorrespondenceDocument.find_or_create_by(
@@ -241,6 +242,7 @@ def create_correspondences_with_documents
       va_date_of_receipt: Time.zone.yesterday,
       notes: "This is a note from CMP.",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     create_multiple_docs(corres, veteran)
@@ -260,6 +262,7 @@ def create_correspondences_with_documents
       va_date_of_receipt: Time.zone.yesterday,
       notes: "This is a note from CMP.",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(
@@ -286,6 +289,7 @@ def create_correspondences_with_documents
       va_date_of_receipt: Time.zone.yesterday,
       notes: "This is a note from CMP.",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(
@@ -312,6 +316,7 @@ def create_correspondences_with_documents
       va_date_of_receipt: Time.zone.yesterday,
       notes: "This is a note from CMP.",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(
@@ -484,6 +489,7 @@ def create_multi_correspondences
       va_date_of_receipt: Time.zone.yesterday,
       notes: "Notes from CMP - Multi Correspondence Seed",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(
@@ -528,6 +534,7 @@ def create_multi_correspondences
       va_date_of_receipt: Time.zone.yesterday,
       notes: "Notes from CMP - Multi Correspondence Seed",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(
@@ -572,6 +579,7 @@ def create_multi_correspondences
       va_date_of_receipt: Time.zone.yesterday,
       notes: "Notes from CMP - Multi Correspondence Seed",
       assigned_by_id: 81,
+      updated_by_id: 81,
       veteran_id: veteran.id
     )
     CorrespondenceDocument.find_or_create_by(

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -2,7 +2,9 @@
 
 RSpec.describe CorrespondenceController, :all_dbs, type: :controller do
   let(:veteran) { create(:veteran) }
+  let(:correspondence_type) { create(:correspondence_type) }
   let(:correspondence) { create(:correspondence, veteran: veteran) }
+
   let(:related_correspondence_uuids) do
     (1..3).map { create(:correspondence) }.pluck(:uuid)
   end
@@ -17,7 +19,7 @@ RSpec.describe CorrespondenceController, :all_dbs, type: :controller do
     end
   end
   let(:veteran) { create(:veteran) }
-  let(:valid_params) { { notes: "Updated notes", correspondence_type_id: 12 } }
+  let(:valid_params) { { notes: "Updated notes", correspondence_type_id: correspondence_type.id } }
   let(:new_file_number) { "50000005" }
   let(:current_user) { create(:user) }
   let!(:parent_task) { create(:correspondence_intake_task, appeal: correspondence, assigned_to: current_user) }
@@ -149,7 +151,7 @@ RSpec.describe CorrespondenceController, :all_dbs, type: :controller do
       expect(response).to have_http_status(:ok)
       expect(veteran.reload.file_number).to eq(new_file_number)
       expect(correspondence.reload.notes).to eq("Updated notes")
-      expect(correspondence.reload.correspondence_type_id).to eq(12)
+      expect(correspondence.reload.correspondence_type_id).to eq(1)
       expect(correspondence.reload.updated_by_id).to eq(current_user.id)
     end
   end

--- a/spec/controllers/correspondence_controller_spec.rb
+++ b/spec/controllers/correspondence_controller_spec.rb
@@ -151,7 +151,7 @@ RSpec.describe CorrespondenceController, :all_dbs, type: :controller do
       expect(response).to have_http_status(:ok)
       expect(veteran.reload.file_number).to eq(new_file_number)
       expect(correspondence.reload.notes).to eq("Updated notes")
-      expect(correspondence.reload.correspondence_type_id).to eq(1)
+      expect(correspondence.reload.correspondence_type_id).to eq(correspondence_type.id)
       expect(correspondence.reload.updated_by_id).to eq(current_user.id)
     end
   end

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -1,19 +1,30 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
+
+  User.find_or_create_by(
+    css_id: "TEST_USER",
+    station_id: 101
+  )
+
   factory :correspondence do
     uuid { SecureRandom.uuid }
     portal_entry_date { Time.zone.now }
     source_type { "Mail" }
     package_document_type_id { 15 }
-    correspondence_type_id { 9 }
+    correspondence_type { CorrespondenceType.find_or_create_by(name: "a correspondence type.") }
+    # correspondence_type_id { correspondence_type.id }
     cmp_queue_id { 1 }
     cmp_packet_number { rand(1_000_000_000..9_999_999_999) }
     va_date_of_receipt { Time.zone.yesterday }
     notes { "This is a note from CMP." }
-    assigned_by_id { 81 }
-    updated_by_id { 81 }
-    veteran_id { 1 }
+    # binding.pry
+    assigned_by_id { User.first.id }
+    updated_by_id { User.first.id }
+    veteran_id {   Veteran.find_or_create_by(
+      last_name: "Smith", file_number: "12345678"
+    ).id }
+    package_document_type { PackageDocumentType.create! }
 
     trait :with_single_doc do
       after(:create) do |correspondence|
@@ -23,7 +34,7 @@ FactoryBot.define do
 
     trait :with_correspondence_intake_task do
       transient do
-        assigned_to { nil }
+        assigned_to { User.first }
       end
 
       after(:create) do |correspondence, evaluator|

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -12,6 +12,7 @@ FactoryBot.define do
     va_date_of_receipt { Time.zone.yesterday }
     notes { "This is a note from CMP." }
     assigned_by_id { 81 }
+    updated_by_id { 81 }
     veteran_id { 1 }
 
     trait :with_single_doc do

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -7,18 +7,20 @@ FactoryBot.define do
   )
 
   factory :correspondence do
+    correspondence_type
+    veteran
+    user
     uuid { SecureRandom.uuid }
     portal_entry_date { Time.zone.now }
     source_type { "Mail" }
     package_document_type_id { 15 }
-    correspondence_type { CorrespondenceType.find_or_create_by(name: "a correspondence type.") }
     cmp_queue_id { 1 }
     cmp_packet_number { rand(1_000_000_000..9_999_999_999) }
     va_date_of_receipt { Time.zone.yesterday }
     notes { "This is a note from CMP." }
-    assigned_by_id { User.first.id }
-    updated_by_id { User.first.id }
-    veteran_id { Veteran.find_or_create_by(last_name: "Smith", file_number: "12345678").id }
+    assigned_by_id { user.id }
+    updated_by_id { user.id }
+    veteran_id { veteran.id }
     package_document_type { PackageDocumentType.create! }
 
     trait :with_single_doc do

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -1,27 +1,19 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  User.find_or_create_by(
-    css_id: "TEST_USER",
-    station_id: 101
-  )
-
   factory :correspondence do
-    correspondence_type
-    veteran
-    user
-    package_document_type
     uuid { SecureRandom.uuid }
     portal_entry_date { Time.zone.now }
     source_type { "Mail" }
-    package_document_type_id { 15 }
     cmp_queue_id { 1 }
     cmp_packet_number { rand(1_000_000_000..9_999_999_999) }
     va_date_of_receipt { Time.zone.yesterday }
     notes { "This is a note from CMP." }
-    assigned_by_id { user.id }
-    updated_by_id { user.id }
-    veteran_id { veteran.id }
+    assigned_by factory: :user
+
+    correspondence_type
+    veteran
+    package_document_type
 
     trait :with_single_doc do
       after(:create) do |correspondence|

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-
   User.find_or_create_by(
     css_id: "TEST_USER",
     station_id: 101
@@ -13,17 +12,13 @@ FactoryBot.define do
     source_type { "Mail" }
     package_document_type_id { 15 }
     correspondence_type { CorrespondenceType.find_or_create_by(name: "a correspondence type.") }
-    # correspondence_type_id { correspondence_type.id }
     cmp_queue_id { 1 }
     cmp_packet_number { rand(1_000_000_000..9_999_999_999) }
     va_date_of_receipt { Time.zone.yesterday }
     notes { "This is a note from CMP." }
-    # binding.pry
     assigned_by_id { User.first.id }
     updated_by_id { User.first.id }
-    veteran_id {   Veteran.find_or_create_by(
-      last_name: "Smith", file_number: "12345678"
-    ).id }
+    veteran_id { Veteran.find_or_create_by(last_name: "Smith", file_number: "12345678").id }
     package_document_type { PackageDocumentType.create! }
 
     trait :with_single_doc do

--- a/spec/factories/correspondence.rb
+++ b/spec/factories/correspondence.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     correspondence_type
     veteran
     user
+    package_document_type
     uuid { SecureRandom.uuid }
     portal_entry_date { Time.zone.now }
     source_type { "Mail" }
@@ -21,7 +22,6 @@ FactoryBot.define do
     assigned_by_id { user.id }
     updated_by_id { user.id }
     veteran_id { veteran.id }
-    package_document_type { PackageDocumentType.create! }
 
     trait :with_single_doc do
       after(:create) do |correspondence|

--- a/spec/factories/correspondence_type.rb
+++ b/spec/factories/correspondence_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :correspondence_type do
+    name { "a correspondence type." }
+  end
+end

--- a/spec/factories/package_document_type.rb
+++ b/spec/factories/package_document_type.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :package_document_type do
+  end
+end

--- a/spec/feature/queue/correspondence/edit_cmp_information_spec.rb
+++ b/spec/feature/queue/correspondence/edit_cmp_information_spec.rb
@@ -17,8 +17,6 @@ RSpec.feature("The Correspondence Review Package page") do
       uuid: SecureRandom.uuid,
       assigned_by_id: mail_team_user.id,
       updated_by_id: mail_team_user.id,
-      correspondence_type: correspondence_type,
-      package_document_type: package_document_type
     )
   end
 

--- a/spec/feature/queue/correspondence/edit_cmp_information_spec.rb
+++ b/spec/feature/queue/correspondence/edit_cmp_information_spec.rb
@@ -4,11 +4,23 @@
 RSpec.feature("The Correspondence Review Package page") do
   let(:veteran) { create(:veteran) }
   let(:package_document_type) { PackageDocumentType.create(id: 15, active: true, created_at: Time.zone.now, name: 10_182, updated_at: Time.zone.now) }
-  let(:correspondence) { create(:correspondence, veteran_id: veteran.id, package_document_type_id: package_document_type.id) }
   let(:correspondence_documents) { create(:correspondence_document, correspondence: correspondence, document_file_number: veteran.file_number) }
   let(:mail_team_user) { create(:user) }
   let(:mail_team_org) { MailTeam.singleton }
   let(:current_user) { User.create!(station_id: 101, css_id: "MAIL_TEAM_SUPERVISOR_ADMIN_USER", full_name: "Jon MailTeam Snow Admin") }
+  let!(:correspondence_type) { CorrespondenceType.create!(name: "a correspondence type.") }
+  let!(:package_document_type) { PackageDocumentType.create! }
+  let(:correspondence) do
+    create(
+      :correspondence,
+      veteran_id: veteran.id,
+      uuid: SecureRandom.uuid,
+      assigned_by_id: mail_team_user.id,
+      updated_by_id: mail_team_user.id,
+      correspondence_type: correspondence_type,
+      package_document_type: package_document_type
+    )
+  end
 
   context "Review package feature toggle" do
     before :each do

--- a/spec/feature/queue/correspondence/intake_spec.rb
+++ b/spec/feature/queue/correspondence/intake_spec.rb
@@ -32,10 +32,12 @@ RSpec.feature("The Correspondence Intake page") do
 
   context "intake form feature toggle" do
     before :each do
-      veteran = create(:veteran, last_name: "Smith", file_number: "12345678")
+      CorrespondenceType.create!(
+        name: "a correspondence type"
+      )
+      PackageDocumentType.create!
       create(
         :correspondence,
-        veteran_id: veteran.id,
         uuid: SecureRandom.uuid,
         va_date_of_receipt: Time.zone.local(2023, 1, 1)
       )
@@ -121,12 +123,13 @@ RSpec.feature("The Correspondence Intake page") do
   context "The mail team user is able to add unrelated tasks" do
     before :each do
       FeatureToggle.enable!(:correspondence_queue)
-      veteran = create(:veteran, last_name: "Smith", file_number: "12345678")
+      CorrespondenceType.create!(
+        name: "a correspondence type"
+      )
       create(
         :correspondence,
-        veteran_id: veteran.id,
         uuid: SecureRandom.uuid,
-        va_date_of_receipt: Time.zone.local(2023, 1, 1)
+        va_date_of_receipt: Time.zone.local(2023, 1, 1),
       )
 
       @correspondence_uuid = Correspondence.first.uuid
@@ -233,12 +236,10 @@ RSpec.feature("The Correspondence Intake page") do
 
     before :each do
       FeatureToggle.enable!(:correspondence_queue)
-      veteran = create(:veteran, last_name: "Smith", file_number: "12345678")
       create(
         :correspondence,
-        veteran_id: veteran.id,
         uuid: SecureRandom.uuid,
-        va_date_of_receipt: Time.zone.local(2023, 1, 1)
+        va_date_of_receipt: Time.zone.local(2023, 1, 1),
       )
       @correspondence_uuid = Correspondence.first.uuid
       visit "/queue/correspondence/#{@correspondence_uuid}/intake"

--- a/spec/models/correspondence_intake_spec.rb
+++ b/spec/models/correspondence_intake_spec.rb
@@ -7,15 +7,23 @@ RSpec.describe CorrespondenceIntake, type: :model do
   end
 
   describe "Record entry" do
-    it "can be created" do
-      correspondence = Correspondence.create!(
-        updated_by_id: 1,
-        correspondence_type_id: 1,
-        assigned_by_id: 1,
-        veteran_id: 1,
-        package_document_type_id: 1
+    before do
+      CorrespondenceType.create!(
+        name: "a correspondence type"
       )
+      PackageDocumentType.create!
+
+      FactoryBot.create(:veteran)
+    end
+    it "can be created" do
       user = User.create!(css_id: "User", station_id: "1")
+      correspondence = Correspondence.create!(
+        updated_by_id: User.first.id,
+        correspondence_type: CorrespondenceType.first,
+        assigned_by_id: User.first.id,
+        veteran_id: Veteran.first.id,
+        package_document_type: PackageDocumentType.first
+      )
       subject = CorrespondenceIntake.create!(
         correspondence_id: correspondence.id,
         user_id: user.id,
@@ -27,14 +35,14 @@ RSpec.describe CorrespondenceIntake, type: :model do
     end
 
     it "validates :correspondence_id and :user_id" do
-      correspondence = Correspondence.create!(
-        correspondence_type_id: 1,
-        assigned_by_id: 1,
-        updated_by_id: 1,
-        veteran_id: 1,
-        package_document_type_id: 1
-      )
       user = User.create!(css_id: "User", station_id: "1")
+      correspondence = Correspondence.create!(
+        updated_by_id: User.first.id,
+        correspondence_type: CorrespondenceType.first,
+        assigned_by_id: User.first.id,
+        veteran_id: Veteran.first.id,
+        package_document_type: PackageDocumentType.first
+      )
 
       expect { CorrespondenceIntake.create! }.to raise_error(ActiveRecord::RecordInvalid)
       expect { CorrespondenceIntake.create!(correspondence_id: correspondence.id) }

--- a/spec/models/correspondence_intake_spec.rb
+++ b/spec/models/correspondence_intake_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe CorrespondenceIntake, type: :model do
 
   describe "Record entry" do
     it "can be created" do
-      correspondence = Correspondence.create!
+      correspondence = Correspondence.create!(
+        updated_by_id: 1,
+        correspondence_type_id: 1,
+        assigned_by_id: 1,
+        veteran_id: 1,
+        package_document_type_id: 1
+      )
       user = User.create!(css_id: "User", station_id: "1")
       subject = CorrespondenceIntake.create!(
         correspondence_id: correspondence.id,
@@ -21,7 +27,13 @@ RSpec.describe CorrespondenceIntake, type: :model do
     end
 
     it "validates :correspondence_id and :user_id" do
-      correspondence = Correspondence.create!
+      correspondence = Correspondence.create!(
+        correspondence_type_id: 1,
+        assigned_by_id: 1,
+        updated_by_id: 1,
+        veteran_id: 1,
+        package_document_type_id: 1
+      )
       user = User.create!(css_id: "User", station_id: "1")
 
       expect { CorrespondenceIntake.create! }.to raise_error(ActiveRecord::RecordInvalid)

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -6,13 +6,25 @@ RSpec.describe Correspondence, type: :model do
   end
 
   it "exists" do
-    c = Correspondence.create!
+    c = Correspondence.new
     expect(c).to be_a(Correspondence)
   end
 
   it "can be bi-directionally related to other correspondences" do
-    c_1 = Correspondence.create!
-    c_2 = Correspondence.create!
+    c_1 = Correspondence.create!(
+      updated_by_id: -1,
+      correspondence_type_id: -1,
+      assigned_by_id: -1,
+      veteran_id: -1,
+      package_document_type_id: -1
+    )
+    c_2 = Correspondence.create!(
+      updated_by_id: -2,
+      correspondence_type_id: -2,
+      assigned_by_id: -2,
+      veteran_id: -2,
+      package_document_type_id: -2
+    )
 
     expect(c_1.related_correspondences).to eq([])
     expect(c_2.related_correspondences).to eq([])
@@ -41,6 +53,7 @@ RSpec.describe Correspondence, type: :model do
         va_date_of_receipt: Time.zone.yesterday,
         notes: "This is a note from CMP.",
         assigned_by_id: 81,
+        updated_by_id: 81,
         veteran_id: 1
       )
 

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -11,20 +11,8 @@ RSpec.describe Correspondence, type: :model do
   end
 
   it "can be bi-directionally related to other correspondences" do
-    c_1 = Correspondence.create!(
-      updated_by_id: 1,
-      correspondence_type_id: 1,
-      assigned_by_id: 1,
-      veteran_id: 1,
-      package_document_type_id: 1
-    )
-    c_2 = Correspondence.create!(
-      updated_by_id: 2,
-      correspondence_type_id: 2,
-      assigned_by_id: 2,
-      veteran_id: 2,
-      package_document_type_id: 2
-    )
+    c_1 = create(:correspondence)
+    c_2 = create(:correspondence)
 
     expect(c_1.related_correspondences).to eq([])
     expect(c_2.related_correspondences).to eq([])
@@ -42,20 +30,8 @@ RSpec.describe Correspondence, type: :model do
 
   describe "Create Correspondence Root Task and Review Package task as child" do
     it "Create Root Task and Review Package task for correspondence" do
-      correspondence = Correspondence.create!(
-        uuid: SecureRandom.uuid,
-        portal_entry_date: Time.zone.now,
-        source_type: "Mail",
-        package_document_type_id: 15,
-        correspondence_type_id: 8,
-        cmp_queue_id: 1,
-        cmp_packet_number: 9_999_999_999,
-        va_date_of_receipt: Time.zone.yesterday,
-        notes: "This is a note from CMP.",
-        assigned_by_id: 81,
-        updated_by_id: 81,
-        veteran_id: 1
-      )
+      correspondence = create(:correspondence)
+
 
       ct = CorrespondenceTask.find_by(appeal_id: correspondence.id, type: "CorrespondenceTask")
       expect(ct.appeal_id).to eq(correspondence.id)

--- a/spec/models/correspondence_spec.rb
+++ b/spec/models/correspondence_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe Correspondence, type: :model do
 
   it "can be bi-directionally related to other correspondences" do
     c_1 = Correspondence.create!(
-      updated_by_id: -1,
-      correspondence_type_id: -1,
-      assigned_by_id: -1,
-      veteran_id: -1,
-      package_document_type_id: -1
+      updated_by_id: 1,
+      correspondence_type_id: 1,
+      assigned_by_id: 1,
+      veteran_id: 1,
+      package_document_type_id: 1
     )
     c_2 = Correspondence.create!(
-      updated_by_id: -2,
-      correspondence_type_id: -2,
-      assigned_by_id: -2,
-      veteran_id: -2,
-      package_document_type_id: -2
+      updated_by_id: 2,
+      correspondence_type_id: 2,
+      assigned_by_id: 2,
+      veteran_id: 2,
+      package_document_type_id: 2
     )
 
     expect(c_1.related_correspondences).to eq([])

--- a/spec/requests/correspondence_controller_spec.rb
+++ b/spec/requests/correspondence_controller_spec.rb
@@ -18,8 +18,6 @@ RSpec.describe "Correspondence Requests", :all_dbs, type: :request do
     )
   end
 
-
-
   let(:mock_doc_uploader) { instance_double(CorrespondenceDocumentsEfolderUploader) }
 
   before do

--- a/spec/requests/correspondence_controller_spec.rb
+++ b/spec/requests/correspondence_controller_spec.rb
@@ -1,20 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe "Correspondence Requests", :all_dbs, type: :request do
-  let(:veteran) { create(:veteran, last_name: "Smith", file_number: "12345678") }
   let(:current_user) { create(:intake_user) }
   let!(:parent_task) { create(:correspondence_intake_task, appeal: correspondence, assigned_to: current_user) }
-  let!(:correspondence_type) { CorrespondenceType.create!(name: "a correspondence type.") }
-  let!(:package_document_type) { PackageDocumentType.create! }
   let(:correspondence) do
     create(
-      :correspondence,
-      veteran_id: veteran.id,
-      uuid: SecureRandom.uuid,
-      assigned_by_id: current_user.id,
-      updated_by_id: current_user.id,
-      correspondence_type: correspondence_type,
-      package_document_type: package_document_type
+      :correspondence
     )
   end
 
@@ -54,13 +45,7 @@ RSpec.describe "Correspondence Requests", :all_dbs, type: :request do
     it "saves the user's current step in the intake form" do
       current_step = 1
       correspondence = create(
-        :correspondence,
-        veteran_id: veteran.id,
-        uuid: SecureRandom.uuid,
-        assigned_by_id: current_user.id,
-        updated_by_id: current_user.id,
-        correspondence_type: correspondence_type,
-        package_document_type: package_document_type
+        :correspondence
       )
 
       post queue_correspondence_intake_current_step_path(correspondence_uuid: correspondence.uuid), params: {

--- a/spec/requests/correspondence_controller_spec.rb
+++ b/spec/requests/correspondence_controller_spec.rb
@@ -2,9 +2,23 @@
 
 RSpec.describe "Correspondence Requests", :all_dbs, type: :request do
   let(:veteran) { create(:veteran, last_name: "Smith", file_number: "12345678") }
-  let(:correspondence) { create(:correspondence, veteran_id: veteran.id, uuid: SecureRandom.uuid) }
   let(:current_user) { create(:intake_user) }
   let!(:parent_task) { create(:correspondence_intake_task, appeal: correspondence, assigned_to: current_user) }
+  let!(:correspondence_type) { CorrespondenceType.create!(name: "a correspondence type.") }
+  let!(:package_document_type) { PackageDocumentType.create! }
+  let(:correspondence) do
+    create(
+      :correspondence,
+      veteran_id: veteran.id,
+      uuid: SecureRandom.uuid,
+      assigned_by_id: current_user.id,
+      updated_by_id: current_user.id,
+      correspondence_type: correspondence_type,
+      package_document_type: package_document_type
+    )
+  end
+
+
 
   let(:mock_doc_uploader) { instance_double(CorrespondenceDocumentsEfolderUploader) }
 
@@ -41,7 +55,15 @@ RSpec.describe "Correspondence Requests", :all_dbs, type: :request do
 
     it "saves the user's current step in the intake form" do
       current_step = 1
-      correspondence = create(:correspondence, veteran_id: veteran.id, uuid: SecureRandom.uuid)
+      correspondence = create(
+        :correspondence,
+        veteran_id: veteran.id,
+        uuid: SecureRandom.uuid,
+        assigned_by_id: current_user.id,
+        updated_by_id: current_user.id,
+        correspondence_type: correspondence_type,
+        package_document_type: package_document_type
+      )
 
       post queue_correspondence_intake_current_step_path(correspondence_uuid: correspondence.uuid), params: {
         correspondence_uuid: correspondence.uuid,

--- a/spec/support/correspondence_helpers.rb
+++ b/spec/support/correspondence_helpers.rb
@@ -98,7 +98,7 @@ module CorrespondenceHelpers
       :correspondence,
       :with_correspondence_intake_task,
       uuid: SecureRandom.uuid,
-      va_date_of_receipt: Time.zone.local(2023, 1, 1),
+      va_date_of_receipt: Time.zone.local(2023, 1, 1)
     )
     visit "/queue/correspondence/#{Correspondence.first.uuid}/intake"
 

--- a/spec/support/correspondence_helpers.rb
+++ b/spec/support/correspondence_helpers.rb
@@ -94,14 +94,11 @@ module CorrespondenceHelpers
 
   def visit_intake_form_step_3_with_tasks_unrelated
     setup_access
-    veteran = create(:veteran, last_name: "Smith", file_number: "12345678")
     create(
       :correspondence,
       :with_correspondence_intake_task,
-      assigned_to: current_user,
-      veteran_id: veteran.id,
       uuid: SecureRandom.uuid,
-      va_date_of_receipt: Time.zone.local(2023, 1, 1)
+      va_date_of_receipt: Time.zone.local(2023, 1, 1),
     )
     visit "/queue/correspondence/#{Correspondence.first.uuid}/intake"
 
@@ -144,12 +141,9 @@ module CorrespondenceHelpers
 
   def setup_and_visit_intake
     FeatureToggle.enable!(:correspondence_queue)
-    veteran = create(:veteran, last_name: "Smith", file_number: "12345678")
     create(
       :correspondence,
       :with_correspondence_intake_task,
-      assigned_to: current_user,
-      veteran_id: veteran.id,
       uuid: SecureRandom.uuid,
       va_date_of_receipt: Time.zone.local(2023, 1, 1)
     )


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Add validation to foreign keys](https://jira.devops.va.gov/browse/APPEALS-37706)

# Description
These changes modify the Correspondence Model to have validation for the following foreign keys, and will reject the data if saved without having them present.

- correspondence_type_id
- package_document_type_id
- assigned_by_id
- updated_by_id
- veteran_id

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan

1. Open a rails console within the caseflow directory
2. Attempt to create a new correspondence with `Correspondence.create!`
3. The creation will fail. Instead, pass it data for each of the required foreign keys like so:
`Correspondence.create!(
      updated_by_id: 1,
      correspondence_type_id: 1,
      assigned_by_id: 1,
      veteran_id: 1,
      package_document_type_id: 1
    `)
4. This will pass because the validations are met.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added

