### PR TITLE
Add Task Creation to Correspondence Factory

### DIFF
--- a/db/seeds/correspondence.rb
+++ b/db/seeds/correspondence.rb
@@ -34,7 +34,8 @@ module Seeds
       }
       veteran = create(:veteran, params.merge(options))
       5.times do
-        create(:appeal, veteran_file_number: veteran.file_number)
+        appeal = create(:appeal, veteran_file_number: veteran.file_number)
+        InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
       end
       veteran
     end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/APPEALS-27311)

# Description
- Fix seed file so that it creates root and default sub-tasks for correspondences.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Reseed your local DB.
1. Enable the `ce_api_demo_toggle` feature flag.
1. Do an intake correspondence for one of the "Bob" users.
1. Verify the intake succeeds and you get the success banner.