### PR TITLE
Merge pull request #20509 from department-of-veterans-affairs/jcohen/APPEALS-37561

### DIFF
--- a/app/serializers/api/v2/hearing_serializer.rb
+++ b/app/serializers/api/v2/hearing_serializer.rb
@@ -42,4 +42,5 @@ class Api::V2::HearingSerializer
   attribute :zip_code do |hearing|
     hearing.hearing_location_or_regional_office.zip_code
   end
+  attribute :scheduled_in_timezone
 end

--- a/app/serializers/hearings/appeal_hearing_serializer.rb
+++ b/app/serializers/hearings/appeal_hearing_serializer.rb
@@ -22,4 +22,5 @@ class AppealHearingSerializer
     !hearing.hearing_views.empty?
   end
   attribute :created_at
+  attribute :scheduled_in_timezone
 end

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -117,4 +117,5 @@ class HearingSerializer
   attribute :current_user_timezone do |_, params|
     params[:user]&.timezone
   end
+  attribute :scheduled_in_timezone
 end

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -122,4 +122,5 @@ class LegacyHearingSerializer
   attribute :current_user_timezone do |_, params|
     params[:user]&.timezone
   end
+  attribute :scheduled_in_timezone
 end

--- a/spec/serializers/api/v2/hearing_serializer_spec.rb
+++ b/spec/serializers/api/v2/hearing_serializer_spec.rb
@@ -18,7 +18,8 @@ describe Api::V2::HearingSerializer do
       build(
         :hearing,
         hearing_day: hearing_day,
-        hearing_location: nil
+        hearing_location: nil,
+        scheduled_in_timezone: "America/New_York"
       )
     end
 
@@ -29,6 +30,7 @@ describe Api::V2::HearingSerializer do
       expect(subject[:timezone]).to eq "America/New_York"
       expect(subject[:zip_code]).to eq "02203"
       expect(subject[:address]).to eq "15 New Sudbury Street"
+      expect(subject[:scheduled_in_timezone]).to eq "America/New_York"
     end
   end
 


### PR DESCRIPTION
jcohen/APPEALS-37039 : Add "scheduled_in_timezone" Column to "hearings" and "legacy_hearings" Tables

<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-37561](https://jira.devops.va.gov/browse/APPEALS-37561)

# Description
This story involves updating the appropriate serializers with the new attribute of `scheduled_in_timezone`.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The [HearingSerializer](https://github.com/department-of-veterans-affairs/caseflow/blob/30af47a537c1c266246287ab7b6418e4606f0f74/app/serializers/hearings/hearing_serializer.rb) is updated to return the following attribute
&nbsp;&nbsp;&nbsp;&nbsp;1.)scheduled_in_timezone
- [ ] The [LegacyHearingSerializer](https://github.com/department-of-veterans-affairs/caseflow/blob/30af47a537c1c266246287ab7b6418e4606f0f74/app/serializers/hearings/legacy_hearing_serializer.rb) is updated to return the following attribute
&nbsp;&nbsp;&nbsp;&nbsp;1.)scheduled_in_timezone
- [ ] The [AppealHearingSerializer](https://github.com/department-of-veterans-affairs/caseflow/blob/66f0184abf872fa5e5c5973b14a6969e70f1fc40/app/serializers/hearings/appeal_hearing_serializer.rb) is updated to return the following attribute
&nbsp;&nbsp;&nbsp;&nbsp;1.)scheduled_in_timezone
- [ ] The [Api::V2::HearingSerializer](https://github.com/department-of-veterans-affairs/caseflow/blob/79e992e16b9296c0def4ab4be59e7819bf72f805/app/serializers/api/v2/hearing_serializer.rb) is updated to return the following attribute
&nbsp;&nbsp;&nbsp;&nbsp;1.)scheduled_in_timezone
- [ ] Any relevant tests (serializer unit tests, and perhaps some more) are updated to reflect these additional values.
&nbsp;&nbsp;&nbsp;&nbsp;1.)AppealHearingSerializer does not test hearing time
&nbsp;&nbsp;&nbsp;&nbsp;2.)Api::V2::HearingSerializer tests timezones after creating a hearing, but not hearing time.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added


