### PR TITLE
update codeclimate rubocop version and reek exclusions

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -83,7 +83,7 @@ plugins:
     - 'app/mailers/dispatch_mailer.rb'
   rubocop:
     enabled: true
-    channel: rubocop-0-79
+    channel: rubocop-0-83
   stylelint:
     enabled: true
   grep:

--- a/.reek.yml
+++ b/.reek.yml
@@ -279,6 +279,11 @@ directories:
   "app/mailers":
     InstanceVariableAssumption:
       enabled: false
+  "db/seeds":
+    InstanceVariableAssumption:
+      enabled: false
+    TooManyInstanceVariables:
+      enabled: false
 
 ### Excluding directories
 # Directories and files below will not be scanned at all

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,17 +4,13 @@ require:
 
 AllCops:
   Exclude:
-    - 'db/migrate/*'
-    - 'db/schema.rb'
-    - 'db/etl/migrate/*'
-    - 'db/etl/schema.rb'
+    - 'db/**/*'
     - 'config/**/*'
     - 'script/**/*'
     - 'vendor/**/*'
     - './.simplecov'
     - 'client/node_modules/**/*'
     - 'app/mappers/zip_code_to_lat_lng_mapper.rb'
-    - 'db/seeds/*'
   TargetRailsVersion: 5.1
   TargetRubyVersion: 2.5
   UseCache: true


### PR DESCRIPTION
Resolves [APPEALS-39031](https://jira.devops.va.gov/browse/APPEALS-39031)

# Description
- Updates the Rubocop version used by Codeclimate to 0.83.0 which matches our installed gem version
- Excluded 'db/seeds' directory from TooManyInstanceVariables and InstanceVariableAssumption checks in Reek

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Rubocop and Reek run in Codeclimate
