### PR TITLE
hotfix/APPEALS-23420

### DIFF
--- a/app/models/serializers/work_queue/appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_search_serializer.rb
@@ -150,4 +150,12 @@ class WorkQueue::AppealSearchSerializer
       WorkQueue::DocketSwitchSerializer.new(object.docket_switch).serializable_hash[:data][:attributes]
     end
   end
+
+  attribute :has_notifications do |object|
+    @all_notifications = Notification.where(appeals_id: object.uuid.to_s, appeals_type: "Appeal")
+    @allowed_notifications = @all_notifications.where(email_notification_status: nil)
+      .or(@all_notifications.where.not(email_notification_status: EXCLUDE_STATUS))
+      .merge(@all_notifications.where(sms_notification_status: nil)
+      .or(@all_notifications.where.not(sms_notification_status: EXCLUDE_STATUS))).any?
+  end
 end

--- a/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
@@ -61,6 +61,26 @@ class WorkQueue::LegacyAppealSearchSerializer
 
   attribute(:available_hearing_locations) { |object| available_hearing_locations(object) }
 
+  attribute :readable_hearing_request_type, &:readable_current_hearing_request_type
+
+  attribute :readable_original_hearing_request_type, &:readable_original_hearing_request_type
+
+  attribute :closest_regional_office
+
+  attribute :closest_regional_office_label
+
+  attribute :mst, &:mst?
+
+  attribute :pact, &:pact?
+
+  attribute :regional_office do |object|
+    {
+      key: object.regional_office&.key,
+      city: object.regional_office&.city,
+      state: object.regional_office&.state
+    }
+  end
+
   attribute :docket_name do
     "legacy"
   end

--- a/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/legacy_appeal_search_serializer.rb
@@ -117,4 +117,12 @@ class WorkQueue::LegacyAppealSearchSerializer
   def self.latest_vacols_attorney_case_review(object)
     VACOLS::CaseAssignment.latest_task_for_appeal(object.vacols_id)
   end
+
+  attribute :has_notifications do |object|
+    @all_notifications = Notification.where(appeals_id: object.vacols_id.to_s, appeals_type: "LegacyAppeal")
+    @allowed_notifications = @all_notifications.where(email_notification_status: nil)
+      .or(@all_notifications.where.not(email_notification_status: EXCLUDE_STATUS))
+      .merge(@all_notifications.where(sms_notification_status: nil)
+      .or(@all_notifications.where.not(sms_notification_status: EXCLUDE_STATUS))).any?
+  end
 end

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -602,6 +602,7 @@ export const prepareAppealForSearchStore = (appeals) => {
       availableHearingLocations: prepareAppealAvailableHearingLocationsForStore(
         appeal
       ),
+      hasNotifications: appeal.attributes.has_notifications,
       locationHistory: prepareLocationHistoryForStore(appeal),
       mst: appeal.attributes.mst,
       pact: appeal.attributes.pact

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -564,6 +564,8 @@ export const prepareAppealForSearchStore = (appeals) => {
       readableOriginalHearingRequestType:
         appeal.attributes.readable_original_hearing_request_type,
       vacateType: appeal.attributes.vacate_type,
+      mst: appeal.attributes.mst,
+      pact: appeal.attributes.pact
     };
 
     return accumulator;
@@ -601,6 +603,8 @@ export const prepareAppealForSearchStore = (appeals) => {
         appeal
       ),
       locationHistory: prepareLocationHistoryForStore(appeal),
+      mst: appeal.attributes.mst,
+      pact: appeal.attributes.pact
     };
 
     return accumulator;


### PR DESCRIPTION
This branch should resolve and localize [APPEALS-23420](https://jira.devops.va.gov/browse/APPEALS-23420)

# Description
This search defect timeout is reached prior to returned results. There is no reportable issue/error coming from the logs. Only client side error as show in the screenshot below. This is due to the high amount of code execution time in VACOLS, and the unoptimized serializers being used that cause the 60 second timeout to expire and the client code throws an error stating that a server error has occurred. After an initial fix to the serializer globally, too many downstream errors in the system were experienced by users limited by the new serializer elsewhere wihin Caseflow. This new code should localize this defect code to the case search page.


## Before/Error message
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/22192993/aa60d103-7e87-47d9-a3ea-f9beabde6964)


## Expected results
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/22192993/806075d4-c100-441a-a052-e255ad8cc8c0)


## Acceptance Criteria
- [x] Code compiles correctly
- [ ] Previously failing veteran cases now return within 10 seconds
- [ ] No downstream errors are found elsewhere within Caseflow (Hearings Org, and Case Details error)

## Testing Plan
- [x] Successful testing in Demo
- [x] Successful testing in UAT
- [ ] Successful testing in Prodtest
