### PR TITLE
Fix for VA DOR displaying incorrectly in the table.

### DIFF
--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -235,7 +235,7 @@ export const vaDor = () => {
   return {
     header: 'VA DOR',
     valueFunction: (task) => {
-      return moment(task.vador).format('MM/DD/YYYY');
+      return moment(task.vaDor).format('MM/DD/YYYY');
     }
   };
 };


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Correspondence QueueTable - VA DOR displaying current date](https://jira.devops.va.gov/browse/APPEALS-39904)

# Description
The TaskTableColumns was configured incorrectly, causing the value of VA DOR to be displayed as current date at all times. The value it receives has been fixed with the PR.

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan

1. Navigate to correspondences where you have some data (JOLLY_POSTMAN, Jon Snow)
2. Note the date in the VA DOR column. 
3. Change system time to the next day and refresh the page.
4. Note that the VA DOR time is no longer the current date.

