### PR TITLE
Hotfix/appeals 23420 v2

### DIFF
--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -197,7 +197,7 @@ class AppealsController < ApplicationController
   # :reek:FeatureEnvy
   def render_search_results_as_json(result)
     if result.success?
-      render json: result.extra[:search_results]
+      render json: result.extra[:case_search_results]
     else
       render json: result.to_h, status: result.extra[:status]
     end

--- a/app/controllers/appeals_controller.rb
+++ b/app/controllers/appeals_controller.rb
@@ -24,11 +24,11 @@ class AppealsController < ApplicationController
         result = if docket_number?(case_search)
                    CaseSearchResultsForDocketNumber.new(
                      docket_number: case_search, user: current_user
-                   ).call
+                   ).search_call
                  else
                    CaseSearchResultsForVeteranFileNumber.new(
                      file_number_or_ssn: case_search, user: current_user
-                   ).call
+                   ).search_call
                  end
 
         render_search_results_as_json(result)
@@ -42,7 +42,7 @@ class AppealsController < ApplicationController
       format.json do
         result = CaseSearchResultsForCaseflowVeteranId.new(
           caseflow_veteran_ids: params[:veteran_ids]&.split(","), user: current_user
-        ).call
+        ).search_call
 
         render_search_results_as_json(result)
       end

--- a/app/models/serializers/work_queue/appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_search_serializer.rb
@@ -18,7 +18,7 @@ class WorkQueue::AppealSearchSerializer
         diagnostic_code: issue.contested_rating_issue_diagnostic_code,
         remand_reasons: issue.remand_reasons,
         closed_status: issue.closed_status,
-        decision_date: issue.decision_date,
+        decision_date: issue.decision_date
       }
     end
   end

--- a/app/models/serializers/work_queue/appeal_search_serializer.rb
+++ b/app/models/serializers/work_queue/appeal_search_serializer.rb
@@ -18,7 +18,7 @@ class WorkQueue::AppealSearchSerializer
         diagnostic_code: issue.contested_rating_issue_diagnostic_code,
         remand_reasons: issue.remand_reasons,
         closed_status: issue.closed_status,
-        decision_date: issue.decision_date
+        decision_date: issue.decision_date,
       }
     end
   end
@@ -58,13 +58,19 @@ class WorkQueue::AppealSearchSerializer
 
   attribute :withdrawn, &:withdrawn?
 
-  attribute :removed, &:removed?
-
   attribute :overtime, &:overtime?
 
   attribute :veteran_appellant_deceased, &:veteran_appellant_deceased?
 
-  attribute :assigned_to_location
+  attribute :assigned_to_location do |object, params|
+    if object&.status&.status == :distributed_to_judge
+      if params[:user]&.judge? || params[:user]&.attorney? || User.list_hearing_coordinators.include?(params[:user])
+        object.assigned_to_location
+      end
+    else
+      object.assigned_to_location
+    end
+  end
 
   attribute :distributed_to_a_judge, &:distributed_to_a_judge?
 
@@ -88,22 +94,6 @@ class WorkQueue::AppealSearchSerializer
     object.claimant&.suffix
   end
 
-  attribute :appellant_date_of_birth do |object|
-    object.claimant&.date_of_birth
-  end
-
-  attribute :appellant_address do |object|
-    object.claimant&.address
-  end
-
-  attribute :appellant_phone_number do |object|
-    object.claimant&.unrecognized_claimant? ? object.claimant&.phone_number : nil
-  end
-
-  attribute :appellant_email_address do |object|
-    object.claimant&.email_address
-  end
-
   attribute :veteran_death_date
 
   attribute :veteran_file_number
@@ -112,7 +102,9 @@ class WorkQueue::AppealSearchSerializer
     object.veteran ? object.veteran.name.formatted(:readable_full) : "Cannot locate"
   end
 
-  attribute(:available_hearing_locations) { |object| available_hearing_locations(object) }
+  attribute :closest_regional_office
+
+  attribute :closest_regional_office_label
 
   attribute :external_id, &:uuid
 
@@ -130,13 +122,14 @@ class WorkQueue::AppealSearchSerializer
     false
   end
 
+  attribute :regional_office do
+  end
+
   attribute :caseflow_veteran_id do |object|
     object.veteran ? object.veteran.id : nil
   end
 
-  attribute :docket_switch do |object|
-    if object.docket_switch
-      WorkQueue::DocketSwitchSerializer.new(object.docket_switch).serializable_hash[:data][:attributes]
-    end
-  end
+  attribute :readable_hearing_request_type, &:readable_current_hearing_request_type
+
+  attribute :readable_original_hearing_request_type, &:readable_original_hearing_request_type
 end

--- a/app/workflows/case_search_results_base.rb
+++ b/app/workflows/case_search_results_base.rb
@@ -21,6 +21,18 @@ class CaseSearchResultsBase
     )
   end
 
+  def search_call
+    @success = valid?
+
+    case_search_results if success
+
+    FormResponse.new(
+      success: success,
+      errors: errors.messages[:workflow],
+      extra: error_status_or_search_results
+    )
+  end
+
   protected
 
   attr_reader :status, :user
@@ -71,6 +83,20 @@ class CaseSearchResultsBase
     ama_hash[:data].concat(legacy_hash[:data])
   end
 
+  def search_page_json_appeals(appeals)
+    ama_appeals, legacy_appeals = appeals.partition { |appeal| appeal.is_a?(Appeal) }
+
+    ama_hash = WorkQueue::AppealSearchSerializer.new(
+      ama_appeals, is_collection: true, params: { user: user }
+    ).serializable_hash
+
+    legacy_hash = WorkQueue::LegacyAppealSerializer.new(
+      legacy_appeals, is_collection: true, params: { user: user }
+    ).serializable_hash
+
+    ama_hash[:data].concat(legacy_hash[:data])
+  end
+
   private
 
   attr_reader :success
@@ -100,6 +126,15 @@ class CaseSearchResultsBase
     @search_results ||= {
       search_results: {
         appeals: json_appeals(appeals),
+        claim_reviews: claim_reviews.map(&:search_table_ui_hash)
+      }
+    }
+  end
+
+  def case_search_results
+    @case_search_results ||= {
+      case_search_results: {
+        appeals: search_page_json_appeals(appeals),
         claim_reviews: claim_reviews.map(&:search_table_ui_hash)
       }
     }

--- a/app/workflows/case_search_results_base.rb
+++ b/app/workflows/case_search_results_base.rb
@@ -29,7 +29,7 @@ class CaseSearchResultsBase
     FormResponse.new(
       success: success,
       errors: errors.messages[:workflow],
-      extra: error_status_or_search_results
+      extra: error_status_or_case_search_results
     )
   end
 
@@ -120,6 +120,12 @@ class CaseSearchResultsBase
     return { status: status } unless success
 
     search_results
+  end
+
+  def error_status_or_case_search_results
+    return { status: status } unless success
+
+    case_search_results
   end
 
   def search_results

--- a/client/app/queue/CaseList/CaseListActions.js
+++ b/client/app/queue/CaseList/CaseListActions.js
@@ -4,7 +4,7 @@ import * as Constants from './actionTypes';
 
 import { get, size } from 'lodash';
 import { onReceiveAppealDetails, onReceiveClaimReviewDetails } from '../QueueActions';
-import { prepareAppealForStore, prepareClaimReviewForStore } from '../utils';
+import { prepareAppealForSearchStore, prepareClaimReviewForStore } from '../utils';
 import ValidatorsUtil from '../../util/ValidatorsUtil';
 
 const { validSSN, validFileNum, validDocketNum } = ValidatorsUtil;
@@ -54,7 +54,7 @@ export const fetchedNoAppeals = (searchQuery) => ({
 });
 
 export const onReceiveAppeals = (appeals) => (dispatch) => {
-  dispatch(onReceiveAppealDetails(prepareAppealForStore(appeals)));
+  dispatch(onReceiveAppealDetails(prepareAppealForSearchStore(appeals)));
   dispatch({
     type: Constants.RECEIVED_APPEALS_USING_VETERAN_ID_SUCCESS
   });

--- a/client/app/queue/VeteranCasesView.jsx
+++ b/client/app/queue/VeteranCasesView.jsx
@@ -12,7 +12,7 @@ import { setFetchedAllCasesFor } from './CaseList/CaseListActions';
 import { hideVeteranCaseList } from './uiReducer/uiActions';
 import { onReceiveAppealDetails } from './QueueActions';
 import { appealsByCaseflowVeteranId } from './selectors';
-import { prepareAppealForStore } from './utils';
+import { prepareAppealForSearchStore } from './utils';
 
 import COPY from '../../COPY';
 import WindowUtil from '../util/WindowUtil';
@@ -50,7 +50,7 @@ class VeteranCasesView extends React.PureComponent {
           return Promise.reject(response);
         }
 
-        this.props.onReceiveAppealDetails(prepareAppealForStore(returnedObject.appeals));
+        this.props.onReceiveAppealDetails(prepareAppealForSearchStore(returnedObject.appeals));
         this.props.setFetchedAllCasesFor(caseflowVeteranId);
 
         return Promise.resolve();

--- a/client/app/queue/utils.js
+++ b/client/app/queue/utils.js
@@ -551,7 +551,11 @@ export const prepareAppealForSearchStore = (appeals) => {
       veteranFullName: appeal.attributes.veteran_full_name,
       veteranFileNumber: appeal.attributes.veteran_file_number,
       isPaperCase: appeal.attributes.paper_case,
-      vacateType: appeal.attributes.vacate_type,
+      readableHearingRequestType:
+        appeal.attributes.readable_hearing_request_type,
+      readableOriginalHearingRequestType:
+        appeal.attributes.readable_original_hearing_request_type,
+      vacateType: appeal.attributes.vacate_type
     };
 
     return accumulator;
@@ -568,22 +572,19 @@ export const prepareAppealForSearchStore = (appeals) => {
       appellantMiddleName: appeal.attributes.appellant_middle_name,
       appellantLastName: appeal.attributes.appellant_last_name,
       appellantSuffix: appeal.attributes.appellant_suffix,
-      appellantDateOfBirth: appeal.attributes.appellant_date_of_birth,
-      appellantAddress: appeal.attributes.appellant_address,
-      appellantEmailAddress: appeal.attributes.appellant_email_address,
-      appellantPhoneNumber: appeal.attributes.appellant_phone_number,
       contestedClaim: appeal.attributes.contested_claim,
       assignedToLocation: appeal.attributes.assigned_to_location,
       veteranGender: appeal.attributes.veteran_gender,
       veteranAddress: appeal.attributes.veteran_address,
       veteranParticipantId: appeal.attributes.veteran_participant_id,
+      closestRegionalOffice: appeal.attributes.closest_regional_office,
+      closestRegionalOfficeLabel:
+        appeal.attributes.closest_regional_office_label,
       externalId: appeal.attributes.external_id,
       status: appeal.attributes.status,
       decisionDate: appeal.attributes.decision_date,
+      regionalOffice: appeal.attributes.regional_office,
       caseflowVeteranId: appeal.attributes.caseflow_veteran_id,
-      availableHearingLocations: prepareAppealAvailableHearingLocationsForStore(
-        appeal
-      ),
       locationHistory: prepareLocationHistoryForStore(appeal),
     };
 


### PR DESCRIPTION
This branch should resolve and localize [APPEALS-23420](https://jira.devops.va.gov/browse/APPEALS-23420)

# Description
This search defect timeout is reached prior to returned results. There is no reportable issue/error coming from the logs. Only client side error as show in the screenshot below. This is due to the high amount of code execution time in VACOLS, and the unoptimized serializers being used that cause the 60 second timeout to expire and the client code throws an error stating that a server error has occurred. After an initial fix to the serializer globally, too many downstream errors in the system were experienced by users limited by the new serializer elsewhere wihin Caseflow. This new code should localize this defect code to the case search page.


## Before/Error message
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/22192993/aa60d103-7e87-47d9-a3ea-f9beabde6964)


## Expected results
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/22192993/806075d4-c100-441a-a052-e255ad8cc8c0)


## Acceptance Criteria
- [x] Code compiles correctly
- [x] Previously failing veteran case searches now beat the timeout by 30 seconds
- [ ] No downstream errors are found elsewhere within Caseflow (Hearings Org, IDT, and Case Details error)

## Testing Plan
- [x] Successful testing in Demo
- [x] Successful testing in UAT
- [ ] Successful testing in Prodtest
