### PR TITLE
jefftmarks/APPEALS-40657

### DIFF
--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -90,7 +90,7 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   #          GetRecordingDetailsJob. Update file status of transcription file depending on download success/failure.
   #
   # Params: download_link - string, URI for temporary download link
-  #         file_name - string, to be parsed for appeal/hearing identifiers
+  #         file_name - string, to be parsed for hearing identifiers
   #
   # Returns: Updated @transcription_file
   def download_file_to_tmp!(link)
@@ -128,13 +128,6 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
     raise FileNameError, "Encountered error #{error} when attempting to parse hearing from file name '#{file_name}'"
   end
 
-  # Purpose: Appeal associated with the hearing for which the transcription was created
-  #
-  # Returns: Appeal object
-  def appeal
-    @appeal ||= hearing.appeal
-  end
-
   # Purpose: Docket number associated with the hearing for which the transcription was created
   #
   # Returns: string or error
@@ -152,8 +145,8 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   def find_or_create_transcription_file(file_name_arg = file_name)
     TranscriptionFile.find_or_create_by(
       file_name: file_name_arg,
-      appeal_id: appeal&.id,
-      appeal_type: appeal&.class&.name,
+      hearing_id: hearing.id,
+      hearing_type: hearing.class.name,
       docket_number: docket_number
     ) do |file|
       file.file_type = file_name_arg.split(".").last

--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -11,6 +11,7 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   include Hearings::EnsureCurrentUserIsSet
 
   queue_with_priority :low_priority
+  application_attr :hearing_schedule
 
   attr_reader :file_name, :transcription_file
 
@@ -29,7 +30,7 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   end
 
   retry_on(TranscriptionTransformer::FileConversionError, wait: 10.seconds) do |job, exception|
-    job.build_csv_and_upload_to_s3(exception)
+    job.build_csv_and_upload_to_s3!(exception)
     job.transcription_file.clean_up_tmp_location
     # TO IMPLEMENT: SEND EMAIL TO VA OPS TEAM
     job.log_error(exception)
@@ -49,9 +50,9 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
     @transcription_file = find_or_create_transcription_file
     ensure_hearing_held
 
-    download_file_to_tmp(download_link)
-    @transcription_file.upload_to_s3 if @transcription_file.date_upload_aws.nil?
-    maybe_convert_vtt_to_rtf_and_upload_to_s3
+    download_file_to_tmp!(download_link)
+    @transcription_file.upload_to_s3! if @transcription_file.date_upload_aws.nil?
+    convert_to_rtf_and_upload_to_s3! if @transcription_file.file_type == "vtt"
     @transcription_file.clean_up_tmp_location
   end
 
@@ -76,10 +77,10 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   #          Uploads csv file to S3.
   #
   # Params: exception - Error object
-  def build_csv_and_upload_to_s3(exception)
+  def build_csv_and_upload_to_s3!(exception)
     build_csv_from_error(exception)
     csv_file = find_or_create_transcription_file(file_name.gsub("vtt", "csv"))
-    csv_file.upload_to_s3
+    csv_file.upload_to_s3!
     csv_file.clean_up_tmp_location
   end
 
@@ -92,16 +93,16 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   #         file_name - string, to be parsed for appeal/hearing identifiers
   #
   # Returns: Updated @transcription_file
-  def download_file_to_tmp(link)
+  def download_file_to_tmp!(link)
     return if File.exist?(@transcription_file.tmp_location)
 
     URI(link).open do |download|
       IO.copy_stream(download, @transcription_file.tmp_location)
     end
-    @transcription_file.update_download_status!(:success)
+    @transcription_file.update_status!(process: :retrieval, status: :success)
     log_info("File #{file_name} successfully downloaded from Webex. Uploading to S3...")
   rescue OpenURI::HTTPError => error
-    @transcription_file.update_download_status!(:failure)
+    @transcription_file.update_status!(process: :retrieval, status: :failure)
     @transcription_file.clean_up_tmp_location
     raise FileDownloadError, "Webex temporary download link responded with error: #{error}"
   end
@@ -163,17 +164,18 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
     raise FileNameError, error
   end
 
-  # Purpose: If file is vtt, converts to rtf and uploads the rtf file to S3. If any errors, builds xls/csv file to
-  #          record error and uploads error file to S3.
-  def maybe_convert_vtt_to_rtf_and_upload_to_s3
-    return unless @transcription_file.file_type == "vtt"
-
+  # Purpose: Converts vtt to rtf, creates new record for converted transcription file, and uploads
+  #          converted file to S3
+  #
+  # Returns: integer value of 1 if tmp file deleted after successful upload
+  def convert_to_rtf_and_upload_to_s3!
     log_info("Converting file #{file_name} to rtf...")
-    rtf_file_path = @transcription_file.convert_to_rtf
+    rtf_file_path = @transcription_file.convert_to_rtf!
     file_name = rtf_file_path.split("/").last
     rtf_file = find_or_create_transcription_file(file_name)
+
     log_info("Successfully converted #{file_name} to rtf. Uploading to S3...")
-    rtf_file.upload_to_s3
+    rtf_file.upload_to_s3!
     rtf_file.clean_up_tmp_location
   end
 

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -11,59 +11,47 @@ class TranscriptionFile < CaseflowRecord
   validates :file_type, inclusion: { in: VALID_FILE_TYPES, message: "'%<value>s' is not valid" }
 
   # Purpose: Uploads transcription file to its corresponding location in S3
-  def upload_to_s3
+  def upload_to_s3!
     UploadTranscriptionFileToS3.new(self).call
   end
 
   # Purpose: Converts transcription file from vtt to rtf
   #
   # Returns: string, tmp location of rtf (or xls/csv file if error)
-  def convert_to_rtf
+  def convert_to_rtf!
     return unless file_type == "vtt"
 
-    rtf_file_path = TranscriptionTransformer.new(self.tmp_location).call
-    update_conversion_status!(:success)
+    rtf_file_path = TranscriptionTransformer.new(tmp_location).call
+    update_status!(process: :conversion, status: :success)
     rtf_file_path
   rescue TranscriptionTransformer::FileConversionError => error
-    update_conversion_status!(:failure)
+    update_status!(process: :conversion, status: :failure)
     raise error, error.message
   end
 
-  # Purpose: Updates with success or failure status after download completes. If download
-  #          successful, updates date_receipt_webex.
-  #
-  # Returns: TranscriptionFile object
-  def update_download_status!(status)
-    update!(
-      file_status: Constants.TRANSCRIPTION_FILE_STATUSES.retrieval.send(status),
-      date_receipt_webex: (status == :success) ? Time.zone.now : nil,
-      updated_by_id: RequestStore[:current_user].id
-    )
-  end
+  # Purpose: Maps file handling process with associated field to update
+  DATE_FIELDS = {
+    retrieval: :date_receipt_webex,
+    upload: :date_upload_aws,
+    conversion: :date_converted
+  }.freeze
 
-  # Purpose: Updates with success or failure status after upload to s3 completes. If upload
-  #          successful, updates date_upload_aws and aws_link.
+  # Purpose: Updates statue of transcription file after completion of process. If process was success, updates
+  #          associated date field on record.
   #
-  # Returns: TranscriptionFile object
-  def update_upload_status!(status:, aws_link: nil)
-    update!(
-      file_status: Constants.TRANSCRIPTION_FILE_STATUSES.upload.send(status),
-      aws_link: aws_link,
-      date_upload_aws: (status == :success) ? Time.zone.now : nil,
-      updated_by_id: RequestStore[:current_user].id
-    )
-  end
-
-  # Purpose: Updates with success or failure status after conversion from vtt to rtf completes. If download
-  #          successful, updates date_converted.
+  # Params: process - symbol, used to map process with associated file status and date field
+  #         status - symbol, either :success or :failure
+  #         aws_link - string, optional argument of AWS S3 location
   #
-  # Returns: TranscriptionFile object
-  def update_conversion_status!(status)
-    update!(
-      file_status: Constants.TRANSCRIPTION_FILE_STATUSES.conversion.send(status),
-      date_converted: (status == :success) ? Time.zone.now : nil,
+  # Returns: Updated transcription file record
+  def update_status!(process:, status:, upload_link: nil)
+    params = {
+      file_status: Constants.TRANSCRIPTION_FILE_STATUSES.send(process).send(status),
       updated_by_id: RequestStore[:current_user].id
-    )
+    }
+    params[:aws_link] = upload_link if upload_link
+    params[DATE_FIELDS[process]] = Time.zone.now if status == :success
+    update!(params)
   end
 
   # Purpose: Location of temporary file in tmp/transcription_files/<file_type> folder

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 class TranscriptionFile < CaseflowRecord
-  include BelongsToPolymorphicAppealConcern
-  belongs_to_polymorphic_appeal :appeal
+  include BelongsToPolymorphicHearingConcern
+  belongs_to_polymorphic_hearing :hearing
+
   belongs_to :transcription
   belongs_to :docket
 

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -281,9 +281,7 @@ class VirtualHearing < CaseflowRecord
 
   # :reek:FeatureEnvy
   def subject_for_conference
-    appeal = hearing.appeal
-
-    "#{appeal.docket_number}_#{appeal.id}_#{appeal.class}"
+    "#{hearing.docket_number}_#{hearing.id}_#{hearing.class}"
   end
 
   def nbf

--- a/app/workflows/transcription_transformer.rb
+++ b/app/workflows/transcription_transformer.rb
@@ -6,6 +6,7 @@ require "rtf"
 # Workflow for converting VTT transcription files to RTF
 class TranscriptionTransformer
   class FileConversionError < StandardError; end
+
   def initialize(vtt_path)
     @vtt_path = vtt_path
     @rtf_path = vtt_path.gsub("vtt", "rtf")

--- a/app/workflows/upload_transcription_file_to_s3.rb
+++ b/app/workflows/upload_transcription_file_to_s3.rb
@@ -27,10 +27,10 @@ class UploadTranscriptionFileToS3
   # Purpose: Uploads transcription file to its corresponding location in S3
   def call
     S3Service.store_file(s3_location, @transcription_file.tmp_location, :filepath)
-    @transcription_file.update_upload_status!(status: :success, aws_link: s3_location)
+    @transcription_file.update_status!(process: :upload, status: :success, upload_link: s3_location)
     Rails.logger.info("File #{file_name} successfully uploaded to S3 location: #{s3_location}")
   rescue StandardError => error
-    @transcription_file.update_upload_status!(status: :failure)
+    @transcription_file.update_status!(process: :upload, status: :failure)
     raise FileUploadError, "Amazon S3 service responded with error: #{error}"
   end
 

--- a/client/constants/TRANSCRIPTION_FILE_STATUSES.json
+++ b/client/constants/TRANSCRIPTION_FILE_STATUSES.json
@@ -3,12 +3,12 @@
     "success": "Successful retrieval (Webex)",
     "failure": "Failed retrieval (Webex)"
   },
-  "conversion": {
-    "success": "Successful conversion",
-    "failure": "Failed conversion"
-  },
   "upload": {
     "success": "Successful upload (AWS)",
     "failure": "Failed upload (AWS)"
+  },
+  "conversion": {
+    "success": "Successful conversion",
+    "failure": "Failed conversion"
   }
 }

--- a/db/migrate/20240118165914_create_transcription_files.rb
+++ b/db/migrate/20240118165914_create_transcription_files.rb
@@ -3,8 +3,8 @@ class CreateTranscriptionFiles < Caseflow::Migration
     create_table :transcription_files do |t|
       t.string :file_name, null: false, comment: "File name, with extension, of the transcription file migrated by caseflow"
       t.string :file_type, null: false, comment: "One of mp4, vtt, mp3, rtf, pdf, xls"
-      t.bigint :hearing_id, comment: "ID of the hearing associated with this record"
-      t.string :hearing_type, comment: "Type of hearing associated with this record"
+      t.bigint :hearing_id, null: false, comment: "ID of the hearing associated with this record"
+      t.string :hearing_type, null: false, comment: "Type of hearing associated with this record"
       t.string :docket_number, null: false, comment: "Docket number of associated hearing"
       t.string :file_status, comment: "Status of the file, could be one of nil, 'Successful retrieval (Webex), Failed retrieval (Webex), Sucessful conversion, Failed conversion, Successful upload (AWS), Failed upload (AWS)'"
       t.string :aws_link, comment: "Link to be used by HMB to download original or transformed file"

--- a/db/migrate/20240118165914_create_transcription_files.rb
+++ b/db/migrate/20240118165914_create_transcription_files.rb
@@ -10,7 +10,7 @@ class CreateTranscriptionFiles < Caseflow::Migration
       t.string :aws_link, comment: "Link to be used by HMB to download original or transformed file"
 
       t.datetime :date_receipt_webex, comment: "Timestamp when file was added to webex"
-      t.datetime :date_converted, comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
+      t.datetime :date_converted, comment: "Timestamp when file was converted from vtt to rtf"
       t.datetime :date_upload_box, comment: "Timestamp when file was added to box"
       t.datetime :date_upload_aws, comment: "Timestamp when file was loaded to AWS"
 

--- a/db/migrate/20240118165914_create_transcription_files.rb
+++ b/db/migrate/20240118165914_create_transcription_files.rb
@@ -3,14 +3,14 @@ class CreateTranscriptionFiles < Caseflow::Migration
     create_table :transcription_files do |t|
       t.string :file_name, null: false, comment: "File name, with extension, of the transcription file migrated by caseflow"
       t.string :file_type, null: false, comment: "One of mp4, vtt, mp3, rtf, pdf, xls"
-      t.bigint :appeal_id, comment: "ID of the appeal associated with this record"
-      t.string :appeal_type, comment: "Type of appeal associated with this record"
-      t.string :docket_number, null: false, comment: "Docket number of associated appeal"
+      t.bigint :hearing_id, comment: "ID of the hearing associated with this record"
+      t.string :hearing_type, comment: "Type of hearing associated with this record"
+      t.string :docket_number, null: false, comment: "Docket number of associated hearing"
       t.string :file_status, comment: "Status of the file, could be one of nil, 'Successful retrieval (Webex), Failed retrieval (Webex), Sucessful conversion, Failed conversion, Successful upload (AWS), Failed upload (AWS)'"
       t.string :aws_link, comment: "Link to be used by HMB to download original or transformed file"
 
       t.datetime :date_receipt_webex, comment: "Timestamp when file was added to webex"
-      t.date :date_converted, comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
+      t.datetime :date_converted, comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
       t.datetime :date_upload_box, comment: "Timestamp when file was added to box"
       t.datetime :date_upload_aws, comment: "Timestamp when file was loaded to AWS"
 
@@ -20,15 +20,15 @@ class CreateTranscriptionFiles < Caseflow::Migration
     end
 
     add_index :transcription_files,
-              [:file_name, :docket_number, :appeal_id, :appeal_type],
+              [:file_name, :docket_number, :hearing_id, :hearing_type],
               unique: true,
-              name: "idx_transcription_files_on_file_name_and_docket_num_and_appeal"
+              name: "idx_transcription_files_on_file_name_and_docket_num_and_hearing"
     add_index :transcription_files,
-              [:appeal_id, :appeal_type, :docket_number],
-              name: "index_transcription_files_on_docket_number_and_appeal"
-    add_index :transcription_files, [:appeal_id, :appeal_type]
+              [:hearing_id, :hearing_type, :docket_number],
+              name: "index_transcription_files_on_docket_number_and_hearing"
+    add_index :transcription_files, [:hearing_id, :hearing_type]
     add_index :transcription_files, [:docket_number]
     add_index :transcription_files, [:file_type]
-    add_index :transcription_files, [:aws_link], unique: true
+    add_index :transcription_files, [:aws_link]
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1798,7 +1798,7 @@ ActiveRecord::Schema.define(version: 2024_01_18_165914) do
     t.string "aws_link", comment: "Link to be used by HMB to download original or transformed file"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", comment: "The user who created the transcription record"
-    t.datetime "date_converted", comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
+    t.datetime "date_converted", comment: "Timestamp when file was converted from vtt to rtf"
     t.datetime "date_receipt_webex", comment: "Timestamp when file was added to webex"
     t.datetime "date_upload_aws", comment: "Timestamp when file was loaded to AWS"
     t.datetime "date_upload_box", comment: "Timestamp when file was added to box"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1795,27 +1795,27 @@ ActiveRecord::Schema.define(version: 2024_01_18_165914) do
   end
 
   create_table "transcription_files", force: :cascade do |t|
-    t.bigint "appeal_id", comment: "ID of the appeal associated with this record"
-    t.string "appeal_type", comment: "Type of appeal associated with this record"
     t.string "aws_link", comment: "Link to be used by HMB to download original or transformed file"
     t.datetime "created_at", null: false
     t.bigint "created_by_id", comment: "The user who created the transcription record"
-    t.date "date_converted", comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
+    t.datetime "date_converted", comment: "Timestamp when file was converted from vtt to rtf or mp4 to mp3"
     t.datetime "date_receipt_webex", comment: "Timestamp when file was added to webex"
     t.datetime "date_upload_aws", comment: "Timestamp when file was loaded to AWS"
     t.datetime "date_upload_box", comment: "Timestamp when file was added to box"
-    t.string "docket_number", null: false, comment: "Docket number of associated appeal"
+    t.string "docket_number", null: false, comment: "Docket number of associated hearing"
     t.string "file_name", null: false, comment: "File name, with extension, of the transcription file migrated by caseflow"
     t.string "file_status", comment: "Status of the file, could be one of nil, 'Successful retrieval (Webex), Failed retrieval (Webex), Sucessful conversion, Failed conversion, Successful upload (AWS), Failed upload (AWS)'"
     t.string "file_type", null: false, comment: "One of mp4, vtt, mp3, rtf, pdf, xls"
+    t.bigint "hearing_id", null: false, comment: "ID of the hearing associated with this record"
+    t.string "hearing_type", null: false, comment: "Type of hearing associated with this record"
     t.datetime "updated_at", null: false
     t.bigint "updated_by_id", comment: "The user who most recently updated the transcription file"
-    t.index ["appeal_id", "appeal_type", "docket_number"], name: "index_transcription_files_on_docket_number_and_appeal"
-    t.index ["appeal_id", "appeal_type"], name: "index_transcription_files_on_appeal_id_and_appeal_type"
-    t.index ["aws_link"], name: "index_transcription_files_on_aws_link", unique: true
+    t.index ["aws_link"], name: "index_transcription_files_on_aws_link"
     t.index ["docket_number"], name: "index_transcription_files_on_docket_number"
-    t.index ["file_name", "docket_number", "appeal_id", "appeal_type"], name: "idx_transcription_files_on_file_name_and_docket_num_and_appeal", unique: true
+    t.index ["file_name", "docket_number", "hearing_id", "hearing_type"], name: "idx_transcription_files_on_file_name_and_docket_num_and_hearing", unique: true
     t.index ["file_type"], name: "index_transcription_files_on_file_type"
+    t.index ["hearing_id", "hearing_type", "docket_number"], name: "index_transcription_files_on_docket_number_and_hearing"
+    t.index ["hearing_id", "hearing_type"], name: "index_transcription_files_on_hearing_id_and_hearing_type"
   end
 
   create_table "transcriptions", force: :cascade do |t|
@@ -1960,6 +1960,46 @@ ActiveRecord::Schema.define(version: 2024_01_18_165914) do
     t.index ["created_by_id"], name: "index_vbms_distributions_on_created_by_id"
     t.index ["updated_by_id"], name: "index_vbms_distributions_on_updated_by_id"
     t.index ["vbms_communication_package_id"], name: "index_vbms_distributions_on_vbms_communication_package_id"
+  end
+
+  create_table "vbms_ext_claim", primary_key: "CLAIM_ID", id: :decimal, precision: 38, force: :cascade do |t|
+    t.string "ALLOW_POA_ACCESS", limit: 5
+    t.decimal "CLAIMANT_PERSON_ID", precision: 38
+    t.datetime "CLAIM_DATE"
+    t.string "CLAIM_SOJ", limit: 25
+    t.integer "CONTENTION_COUNT"
+    t.datetime "CREATEDDT", null: false
+    t.string "EP_CODE", limit: 25
+    t.datetime "ESTABLISHMENT_DATE"
+    t.datetime "EXPIRATIONDT"
+    t.string "INTAKE_SITE", limit: 25
+    t.datetime "LASTUPDATEDT", null: false
+    t.string "LEVEL_STATUS_CODE", limit: 25
+    t.datetime "LIFECYCLE_STATUS_CHANGE_DATE"
+    t.string "LIFECYCLE_STATUS_NAME", limit: 50
+    t.string "ORGANIZATION_NAME", limit: 100
+    t.string "ORGANIZATION_SOJ", limit: 25
+    t.string "PAYEE_CODE", limit: 25
+    t.string "POA_CODE", limit: 25
+    t.integer "PREVENT_AUDIT_TRIG", limit: 2, default: 0, null: false
+    t.string "PRE_DISCHARGE_IND", limit: 5
+    t.string "PRE_DISCHARGE_TYPE_CODE", limit: 10
+    t.string "PRIORITY", limit: 10
+    t.string "PROGRAM_TYPE_CODE", limit: 10
+    t.string "RATING_SOJ", limit: 25
+    t.string "SERVICE_TYPE_CODE", limit: 10
+    t.string "SUBMITTER_APPLICATION_CODE", limit: 25
+    t.string "SUBMITTER_ROLE_CODE", limit: 25
+    t.datetime "SUSPENSE_DATE"
+    t.string "SUSPENSE_REASON_CODE", limit: 25
+    t.string "SUSPENSE_REASON_COMMENTS", limit: 1000
+    t.decimal "SYNC_ID", precision: 38, null: false
+    t.string "TEMPORARY_CLAIM_SOJ", limit: 25
+    t.string "TYPE_CODE", limit: 25
+    t.decimal "VERSION", precision: 38, null: false
+    t.decimal "VETERAN_PERSON_ID", precision: 15
+    t.index ["CLAIM_ID"], name: "claim_id_index"
+    t.index ["LEVEL_STATUS_CODE"], name: "level_status_code_index"
   end
 
   create_table "vbms_uploaded_documents", force: :cascade do |t|

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -22,11 +22,34 @@ describe Hearings::DownloadTranscriptionFileJob do
         csv: "transcript_text"
       }
     end
-    let(:s3_location) { folder_name + "/" + s3_sub_folders[file_type.to_sym] + "/" + file_name }
+    let(:s3_location) { "#{folder_name}/#{s3_sub_folders[file_type.to_sym]}/#{file_name}" }
 
     subject { described_class.new.perform(download_link: link, file_name: file_name) }
 
     after { File.delete(tmp_location) if File.exist?(tmp_location) }
+
+    shared_examples "all file types" do
+      it "saves downloaded file to correct tmp sub-directory" do
+        allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return("hi")
+        subject
+        expect(File.exist?(tmp_location)).to be true
+      end
+
+      it "updates date_upload_aws of TranscriptionFile record" do
+        subject
+        expect(transcription_file.date_upload_aws).to_not be_nil
+      end
+
+      it "uploads file to correct S3 location" do
+        subject
+        expect(transcription_file.aws_link).to eq(s3_location)
+      end
+
+      it "updates file_status of TranscriptionFile record" do
+        subject
+        expect(transcription_file.file_status).to eq(file_status)
+      end
+    end
 
     shared_examples "failed download from Webex" do
       it "raises error and creates TranscriptionFileRecord" do
@@ -42,26 +65,15 @@ describe Hearings::DownloadTranscriptionFileJob do
 
       it "doesn't queue upload to AWS" do
         expect { subject }.to raise_error(Hearings::DownloadTranscriptionFileJob::FileDownloadError)
-        expect(transcription_file).to_not receive(:upload_to_s3)
+        expect(transcription_file).to_not receive(:upload_to_s3!)
         expect(transcription_file.date_upload_aws).to be_nil
       end
     end
 
-    shared_examples "whether mp3, mp4, or vtt" do
-      it "updates date_receipt_webex of TranscriptionFile record" do
-        subject
-        expect(transcription_file.date_receipt_webex).to_not be_nil
-      end
-
-      it "uploads file to correct S3 location" do
-        subject
-        expect(transcription_file.aws_link).to eq(s3_location)
-      end
-    end
-
-    %w[mp3 mp4].each do |file_type|
+    %w[mp4 mp3].each do |file_type|
       context "#{file_type} file" do
         let(:file_type) { file_type }
+        let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.upload.success }
 
         context "successful download from Webex and upload to S3" do
           it "creates new TranscriptionFile record" do
@@ -69,13 +81,12 @@ describe Hearings::DownloadTranscriptionFileJob do
             expect(transcription_file.file_type).to eq(file_type)
           end
 
-          it "updates date_upload_aws and file_status of TranscriptionFile record" do
+          it "updates date_receipt_webex of TranscriptionFile record" do
             subject
-            expect(transcription_file.date_upload_aws).to_not be_nil
-            expect(transcription_file.file_status).to eq(Constants.TRANSCRIPTION_FILE_STATUSES.upload.success)
+            expect(transcription_file.date_receipt_webex).to_not be_nil
           end
 
-          include_examples "whether mp3, mp4, or vtt"
+          include_examples "all file types"
         end
 
         context "failed download from Webex" do
@@ -86,50 +97,51 @@ describe Hearings::DownloadTranscriptionFileJob do
       end
     end
 
+    shared_context "convertible file" do
+      let(:converted_file_name) { file_name.gsub(file_type, conversion_type) }
+      let(:converted_tmp_location) { tmp_location.gsub(file_type, conversion_type) }
+      let(:converted_transcription_file) { TranscriptionFile.find_by(file_name: converted_file_name) }
+      let(:converted_s3_location) { "#{folder_name}/#{s3_sub_folders[conversion_type.to_sym]}/#{converted_file_name}" }
+
+      after { File.delete(converted_tmp_location) if File.exist?(converted_tmp_location) }
+
+      it "creates two new TranscriptionFile records" do
+        expect { subject }.to change(TranscriptionFile, :count).by(2)
+        expect(transcription_file.file_type).to eq(file_type)
+        expect(converted_transcription_file.file_type).to eq(conversion_type)
+      end
+
+      it "updates date_receipt_webex of TranscriptionFile record" do
+        subject
+        expect(transcription_file.date_receipt_webex).to_not be_nil
+      end
+
+      include_examples "all file types"
+    end
+
+    shared_context "converted file" do
+      let(:transcription_file) { converted_transcription_file }
+      let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.upload.success }
+      let(:s3_location) { converted_s3_location }
+
+      include_examples "all file types"
+    end
+
     context "vtt file" do
       let(:file_type) { "vtt" }
+      let(:conversion_type) { "rtf" }
+      let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.conversion.success }
 
       context "successful download from Webex, upload to S3, and conversion to rtf" do
-        let(:rtf_file_name) { file_name.gsub("vtt", "rtf") }
-        let(:rtf_tmp_location) { tmp_location.gsub("vtt", "rtf") }
-        let(:rtf_transcription_file) { TranscriptionFile.find_by(file_name: rtf_file_name) }
-        let(:rtf_s3_location) { folder_name + "/transcript_text/" + rtf_file_name }
-
         before do
-          File.open(rtf_tmp_location, "w")
-          allow_any_instance_of(TranscriptionTransformer).to receive(:call).and_return(rtf_tmp_location)
+          File.open(converted_tmp_location, "w")
+          allow_any_instance_of(TranscriptionTransformer).to receive(:call).and_return(converted_tmp_location)
         end
 
-        after { File.delete(rtf_tmp_location) if File.exist?(rtf_tmp_location) }
+        include_context "convertible file"
 
-        it "creates two new TranscriptionFile records, one for vtt and one for rtf" do
-          expect { subject }.to change(TranscriptionFile, :count).by(2)
-          expect(transcription_file.file_type).to eq("vtt")
-          expect(rtf_transcription_file.file_type).to eq("rtf")
-        end
-
-        it "updates date_upload_aws of vtt TranscriptionFile record" do
-          subject
-          expect(transcription_file.date_upload_aws).to_not be_nil
-        end
-
-        include_examples "whether mp3, mp4, or vtt"
-
-        it "updates date_converted and file_status of vtt TranscriptionFile record" do
-          subject
-          expect(transcription_file.date_converted).to_not be_nil
-          expect(transcription_file.file_status).to eq(Constants.TRANSCRIPTION_FILE_STATUSES.conversion.success)
-        end
-
-        it "updates date_upload_aws and file_status of rtf TranscriptionFile record" do
-          subject
-          expect(rtf_transcription_file.date_upload_aws).to_not be_nil
-          expect(rtf_transcription_file.file_status).to eq(Constants.TRANSCRIPTION_FILE_STATUSES.upload.success)
-        end
-
-        it "uploads rtf file to correct S3 location" do
-          subject
-          expect(rtf_transcription_file.aws_link).to eq(rtf_s3_location)
+        context "rtf file" do
+          include_context "converted file"
         end
       end
 
@@ -139,11 +151,9 @@ describe Hearings::DownloadTranscriptionFileJob do
         include_examples "failed download from Webex"
       end
 
-      context "failed conversion of vtt to rtf" do
-        let(:csv_file_name) { file_name.gsub("vtt", "csv") }
-        let(:csv_tmp_location) { tmp_location.gsub("vtt", "csv") }
-        let(:csv_transcription_file) { TranscriptionFile.find_by(file_name: csv_file_name) }
-        let(:csv_s3_location) { folder_name + "/transcript_text/" + csv_file_name }
+      context "failed conversion to rtf" do
+        let(:conversion_type) { "csv" }
+        let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.conversion.failure }
 
         subject do
           perform_enqueued_jobs { described_class.perform_later(download_link: link, file_name: file_name) }
@@ -154,34 +164,17 @@ describe Hearings::DownloadTranscriptionFileJob do
             .and_raise(TranscriptionTransformer::FileConversionError)
         end
 
-        it "creates two new TranscriptionFile records, one for vtt and one for csv" do
-          expect { subject }.to change(TranscriptionFile, :count).by(2)
-          expect(transcription_file.file_type).to eq("vtt")
-          expect(csv_transcription_file.file_type).to eq("csv")
-        end
+        include_context "convertible file"
 
-        it "updates date_upload_aws of vtt TranscriptionFile record" do
-          subject
-          expect(transcription_file.date_upload_aws).to_not be_nil
-        end
-
-        include_examples "whether mp3, mp4, or vtt"
-
-        it "updates file_status of vtt TranscriptionFile record, leaves date_converted nil" do
+        it "does not update date_converted of TranscriptionFile record" do
           subject
           expect(transcription_file.date_converted).to be_nil
-          expect(transcription_file.file_status).to eq(Constants.TRANSCRIPTION_FILE_STATUSES.conversion.failure)
         end
 
-        it "updates date_upload_aws and file_status of csv TranscriptionFile record" do
-          subject
-          expect(csv_transcription_file.date_upload_aws).to_not be_nil
-          expect(csv_transcription_file.file_status).to eq(Constants.TRANSCRIPTION_FILE_STATUSES.upload.success)
-        end
+        include_examples "all file types"
 
-        it "uploads csv file to correct S3 location" do
-          subject
-          expect(csv_transcription_file.aws_link).to eq(csv_s3_location)
+        context "csv file" do
+          include_context "converted file"
         end
       end
     end

--- a/spec/models/hearings/virtual_hearing_spec.rb
+++ b/spec/models/hearings/virtual_hearing_spec.rb
@@ -442,26 +442,24 @@ describe VirtualHearing do
     end
     let(:virtual_hearing) { create(:virtual_hearing, hearing: hearing) }
 
+    shared_examples "subject for conference" do
+      it "returns the expected meeting conference details" do
+        is_expected.to eq("#{hearing.docket_number}_#{hearing.id}_#{hearing.class.name}")
+      end
+    end
+
     context "For an AMA Hearing" do
       let(:hearing) { create(:hearing, hearing_day: hearing_day) }
       subject { virtual_hearing.subject_for_conference }
 
-      it "returns the expected meeting conference details" do
-        is_expected.to eq(
-          "#{hearing.appeal.docket_number}_#{hearing.appeal.id}_#{hearing.appeal.class.name}"
-        )
-      end
+      include_examples "subject for conference"
     end
 
     context "For a Legacy Hearing" do
       let(:hearing) { create(:legacy_hearing, hearing_day: hearing_day) }
       subject { virtual_hearing.subject_for_conference }
 
-      it "returns the expected meeting conference details" do
-        is_expected.to eq(
-          "#{hearing.appeal.docket_number}_#{hearing.appeal.id}_LegacyAppeal"
-        )
-      end
+      include_examples "subject for conference"
     end
 
     context "nbf and exp" do


### PR DESCRIPTION
Resolves [APPEALS-40657: Refactor File Movement and use Hearing attributes](https://jira.devops.va.gov/browse/APPEALS-40657)

# Description
As a Caseflow developer, I need the hearing objects to be directly associated with the webex meetings so that Caseflow is set up for future automation.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Database/Model
  - [ ] Change appeal_id and appeal_type to hearing_id and hearing_type in create_transcription_file migration
  - [ ] Updates model to use PolymorphicHearingConcern instead of PolymorphicAppealConcern
  - [ ] Remove aws_link unique constraint in index
- [ ] Refactors
  - [ ] DownloadTranscipriptionFileJob
  - [ ] Update spec to account for file deletion
- [ ] Naming conventions
  - [ ] Update #subject_for_conference in virtual_hearing.rb
  - [ ]   uses hearing specific attributes instead of appeal specific
  - [ ] Fix any failing spec tests as a result of this change

## Testing Plan
1. [APPEALS-39783: Test Create DownloadTranscriptionFileJob](https://jira.devops.va.gov/browse/APPEALS-39783)
2. [APPEALS-38416: Test Create new table transcription_files](https://jira.devops.va.gov/browse/APPEALS-38416)
