### PR TITLE
Min/APPEALS-39905

### DIFF
--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -150,13 +150,14 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   # Returns: integer value of 1 if tmp file deleted after successful upload
   def convert_to_rtf_and_upload_to_s3!
     log_info("Converting file #{file_name} to rtf...")
-    rtf_file_path = @transcription_file.convert_to_rtf!
-    file_name = rtf_file_path.split("/").last
-    rtf_file = find_or_create_transcription_file(file_name)
-
-    log_info("Successfully converted #{file_name} to rtf. Uploading to S3...")
-    rtf_file.upload_to_s3!
-    rtf_file.clean_up_tmp_location
+    file_paths = @transcription_file.convert_to_rtf!
+    file_paths.each do |file_path|
+      output_file_name = file_path.split("/").last
+      output_file = find_or_create_transcription_file(output_file_name)
+      log_info("Successfully converted #{file_name} to rtf. Uploading #{output_file.file_type} to S3...")
+      output_file.upload_to_s3!
+      output_file.clean_up_tmp_location
+    end
   end
 
   # Purpose: If disposition of associated hearing is not marked as held, sends email to VA Operations Team and

--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -171,7 +171,7 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
         log_info("Errors were found during conversion. Uploading csv to S3...")
       end
       file.upload_to_s3
-      # file.clean_up_tmp_location
+      file.clean_up_tmp_location
     end
   end
 

--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -154,7 +154,6 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   def maybe_convert_vtt_to_rtf_and_upload_to_s3
     return unless @transcription_file.file_type == "vtt"
 
-
     hearing_info = {
       judge: hearing.judge&.full_name,
       appeal_id: hearing.appeal&.veteran_file_number,

--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -154,10 +154,11 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   def maybe_convert_vtt_to_rtf_and_upload_to_s3
     return unless @transcription_file.file_type == "vtt"
 
+
     hearing_info = {
       judge: hearing.judge&.full_name,
       appeal_id: hearing.appeal&.veteran_file_number,
-      date: hearing.scheduled_for
+      date: hearing.scheduled_time
     }
 
     log_info("Converting file #{file_name} to rtf...")

--- a/app/jobs/hearings/download_transcription_file_job.rb
+++ b/app/jobs/hearings/download_transcription_file_job.rb
@@ -130,7 +130,7 @@ class Hearings::DownloadTranscriptionFileJob < CaseflowJob
   #
   # Returns: TranscriptionFile object
   def find_or_create_transcription_file(file_name_arg = file_name)
-    TranscriptionFile.find_or_create_by(
+    Hearings::TranscriptionFile.find_or_create_by(
       file_name: file_name_arg,
       hearing_id: hearing.id,
       hearing_type: hearing.class.name,

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -27,9 +27,9 @@ class TranscriptionFile < CaseflowRecord
       appeal_id: hearing.appeal&.veteran_file_number,
       date: hearing.scheduled_time
     }
-    rtf_file_path = TranscriptionTransformer.new(tmp_location, hearing_info).call
+    file_paths = TranscriptionTransformer.new(tmp_location, hearing_info).call
     update_status!(process: :conversion, status: :success)
-    rtf_file_path
+    file_paths
   rescue TranscriptionTransformer::FileConversionError => error
     update_status!(process: :conversion, status: :failure)
     raise error, error.message

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -18,10 +18,10 @@ class TranscriptionFile < CaseflowRecord
   # Purpose: Converts transcription file from vtt to rtf
   #
   # Returns: string, tmp location of rtf (or xls/csv file if error)
-  def convert_to_rtf
+  def convert_to_rtf(hearing_info)
     return unless file_type == "vtt"
 
-    rtf_file_path = TranscriptionTransformer.new(self.tmp_location).call
+    rtf_file_path = TranscriptionTransformer.new(tmp_location, hearing_info).call
     update_conversion_status!(:success)
     rtf_file_path
   rescue TranscriptionTransformer::FileConversionError => error

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TranscriptionFile < CaseflowRecord
+class Hearings::TranscriptionFile < CaseflowRecord
   include BelongsToPolymorphicHearingConcern
   belongs_to_polymorphic_hearing :hearing
 

--- a/app/workflows/transcription_transformer.rb
+++ b/app/workflows/transcription_transformer.rb
@@ -153,8 +153,8 @@ class TranscriptionTransformer
     length_string = "#{(length / 3600).floor}:#{(length / 60 % 60).floor}:#{(length % 60).floor}"
     CSV.open(path, "w") do |writer|
       writer << header
-      writer << [length_string, hearing_info[:appeal_id], hearing_info[:date].strftime("%m/%d/%Y"),
-                 hearing_info[:judge].upcase, "#{count} inaudible", filename]
+      writer << [length_string, hearing_info[:appeal_id], hearing_info[:date]&.strftime("%m/%d/%Y"),
+                 hearing_info[:judge]&.upcase, "#{count} inaudible", filename]
     end
     path
   end

--- a/app/workflows/transcription_transformer.rb
+++ b/app/workflows/transcription_transformer.rb
@@ -103,7 +103,7 @@ class TranscriptionTransformer
       name = (identifier == "") ? "Unknown" : identifier
       if cue.text == ""
         @error_count += 1
-        text = "[INAUDIBLE]"
+        text = "[...]"
       else text = cue.text
       end
       if name.match?(/#{prev_id}/)

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -167,7 +167,6 @@ describe Hearings::DownloadTranscriptionFileJob do
 
         it "updates date_upload_aws of vtt TranscriptionFile record" do
           subject
-          byebug
           expect(transcription_file.date_upload_aws).to_not be_nil
         end
 

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -4,7 +4,7 @@ describe Hearings::DownloadTranscriptionFileJob do
   include ActiveJob::TestHelper
 
   describe "#perform" do
-    let(:link) { "https://picsum.photos/200" }
+    let(:link) { "https://random.imagecdn.app/500/150" }
     let(:hearing) { create(:hearing) }
     let(:docket_number) { hearing.docket_number }
     let(:file_name) { "#{docket_number}_#{hearing.id}_#{hearing.class}.#{file_type}" }
@@ -30,7 +30,7 @@ describe Hearings::DownloadTranscriptionFileJob do
 
     shared_examples "all file types" do
       it "saves downloaded file to correct tmp sub-directory" do
-        allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return("hi")
+        allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
         subject
         expect(File.exist?(tmp_location)).to be true
       end
@@ -103,14 +103,6 @@ describe Hearings::DownloadTranscriptionFileJob do
       let(:converted_transcription_file) { TranscriptionFile.find_by(file_name: converted_file_name) }
       let(:converted_s3_location) { "#{folder_name}/#{s3_sub_folders[conversion_type.to_sym]}/#{converted_file_name}" }
 
-      after { File.delete(converted_tmp_location) if File.exist?(converted_tmp_location) }
-
-      it "creates two new TranscriptionFile records" do
-        expect { subject }.to change(TranscriptionFile, :count).by(2)
-        expect(transcription_file.file_type).to eq(file_type)
-        expect(converted_transcription_file.file_type).to eq(conversion_type)
-      end
-
       it "updates date_receipt_webex of TranscriptionFile record" do
         subject
         expect(transcription_file.date_receipt_webex).to_not be_nil
@@ -135,7 +127,15 @@ describe Hearings::DownloadTranscriptionFileJob do
       context "successful download from Webex, upload to S3, and conversion to rtf" do
         before do
           File.open(converted_tmp_location, "w")
-          allow_any_instance_of(TranscriptionTransformer).to receive(:call).and_return(converted_tmp_location)
+          allow_any_instance_of(TranscriptionTransformer).to receive(:call).and_return([converted_tmp_location])
+        end
+
+        after { File.delete(converted_tmp_location) if File.exist?(converted_tmp_location) }
+
+        it "creates two new TranscriptionFile records" do
+          expect { subject }.to change(TranscriptionFile, :count).by(2)
+          expect(transcription_file.file_type).to eq(file_type)
+          expect(converted_transcription_file.file_type).to eq(conversion_type)
         end
 
         include_context "convertible file"
@@ -151,13 +151,10 @@ describe Hearings::DownloadTranscriptionFileJob do
         include_examples "failed download from Webex"
       end
 
-      context "failed conversion to rtf" do
-        let(:conversion_type) { "csv" }
-        let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.conversion.failure }
-
-        subject do
-          perform_enqueued_jobs { described_class.perform_later(download_link: link, file_name: file_name) }
-        end
+      context "inaudibles present in vtt" do
+        let(:rtf_tmp_location) { tmp_location.gsub(file_type, "rtf") }
+        let(:csv_tmp_location) { tmp_location.gsub(file_type, "csv") }
+        let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.conversion.success }
 
         before do
           File.open(rtf_tmp_location, "w")
@@ -166,17 +163,63 @@ describe Hearings::DownloadTranscriptionFileJob do
             .and_return([rtf_tmp_location, csv_tmp_location])
         end
 
+        after do
+          File.delete(rtf_tmp_location) if File.exist?(rtf_tmp_location)
+          File.delete(csv_tmp_location) if File.exist?(csv_tmp_location)
+        end
+
         include_context "convertible file"
 
-        it "does not update date_converted of TranscriptionFile record" do
-          subject
-          expect(transcription_file.date_converted).to be_nil
+        it "creates three new TranscriptionFile records" do
+          expect { subject }.to change(TranscriptionFile, :count).by(3)
+          expect(transcription_file.file_type).to eq(file_type)
+          expect(converted_transcription_file.file_type).to eq(conversion_type)
         end
 
         include_examples "all file types"
 
-        context "csv file" do
-          include_context "converted file"
+        %w[rtf csv].each do |conversion_type|
+          context "#{conversion_type} file" do
+            let(:conversion_type) { conversion_type }
+
+            include_context "converted file"
+          end
+        end
+      end
+
+      context "failed conversion" do
+        let(:file_status) { Constants.TRANSCRIPTION_FILE_STATUSES.conversion.failure }
+
+        before do
+          allow_any_instance_of(TranscriptionTransformer).to receive(:call)
+            .and_raise(TranscriptionTransformer::FileConversionError)
+        end
+
+        it "raises error and creates TranscriptionFileRecord" do
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
+            .and change(TranscriptionFile, :count).by(1)
+          expect(transcription_file.file_type).to eq(file_type)
+        end
+
+        it "saves downloaded file to correct tmp sub-directory" do
+          allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect(File.exist?(tmp_location)).to be true
+        end
+
+        it "updates date_upload_aws of TranscriptionFile record" do
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect(transcription_file.date_upload_aws).to_not be_nil
+        end
+
+        it "uploads file to correct S3 location" do
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect(transcription_file.aws_link).to eq(s3_location)
+        end
+
+        it "updates file_status of TranscriptionFile record" do
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect(transcription_file.file_status).to eq(file_status)
         end
       end
     end

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -167,6 +167,7 @@ describe Hearings::DownloadTranscriptionFileJob do
 
         it "updates date_upload_aws of vtt TranscriptionFile record" do
           subject
+          byebug
           expect(transcription_file.date_upload_aws).to_not be_nil
         end
 

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -9,7 +9,7 @@ describe Hearings::DownloadTranscriptionFileJob do
     let(:docket_number) { hearing.docket_number }
     let(:file_name) { "#{docket_number}_#{hearing.id}_#{hearing.class}.#{file_type}" }
     let(:tmp_location) { File.join(Rails.root, "tmp", "transcription_files", file_type, file_name) }
-    let(:transcription_file) { TranscriptionFile.find_by(file_name: file_name) }
+    let(:transcription_file) { Hearings::TranscriptionFile.find_by(file_name: file_name) }
     let(:s3_sub_bucket) { "vaec-appeals-caseflow" }
     let(:folder_name) { (Rails.deploy_env == :prod) ? s3_sub_bucket : "#{s3_sub_bucket}-#{Rails.deploy_env}" }
     let(:s3_sub_folders) do
@@ -30,7 +30,7 @@ describe Hearings::DownloadTranscriptionFileJob do
 
     shared_examples "all file types" do
       it "saves downloaded file to correct tmp sub-directory" do
-        allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
+        allow_any_instance_of(Hearings::TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
         subject
         expect(File.exist?(tmp_location)).to be true
       end
@@ -54,7 +54,7 @@ describe Hearings::DownloadTranscriptionFileJob do
     shared_examples "failed download from Webex" do
       it "raises error and creates TranscriptionFileRecord" do
         expect { subject }.to raise_error(Hearings::DownloadTranscriptionFileJob::FileDownloadError)
-          .and change(TranscriptionFile, :count).by(1)
+          .and change(Hearings::TranscriptionFile, :count).by(1)
       end
 
       it "updates file_status of TranscriptionFile record, leaves date_receipt_webex nil" do
@@ -77,7 +77,7 @@ describe Hearings::DownloadTranscriptionFileJob do
 
         context "successful download from Webex and upload to S3" do
           it "creates new TranscriptionFile record" do
-            expect { subject }.to change(TranscriptionFile, :count).by(1)
+            expect { subject }.to change(Hearings::TranscriptionFile, :count).by(1)
             expect(transcription_file.file_type).to eq(file_type)
           end
 
@@ -100,7 +100,7 @@ describe Hearings::DownloadTranscriptionFileJob do
     shared_context "convertible file" do
       let(:converted_file_name) { file_name.gsub(file_type, conversion_type) }
       let(:converted_tmp_location) { tmp_location.gsub(file_type, conversion_type) }
-      let(:converted_transcription_file) { TranscriptionFile.find_by(file_name: converted_file_name) }
+      let(:converted_transcription_file) { Hearings::TranscriptionFile.find_by(file_name: converted_file_name) }
       let(:converted_s3_location) { "#{folder_name}/#{s3_sub_folders[conversion_type.to_sym]}/#{converted_file_name}" }
 
       it "updates date_receipt_webex of TranscriptionFile record" do
@@ -133,7 +133,7 @@ describe Hearings::DownloadTranscriptionFileJob do
         after { File.delete(converted_tmp_location) if File.exist?(converted_tmp_location) }
 
         it "creates two new TranscriptionFile records" do
-          expect { subject }.to change(TranscriptionFile, :count).by(2)
+          expect { subject }.to change(Hearings::TranscriptionFile, :count).by(2)
           expect(transcription_file.file_type).to eq(file_type)
           expect(converted_transcription_file.file_type).to eq(conversion_type)
         end
@@ -171,7 +171,7 @@ describe Hearings::DownloadTranscriptionFileJob do
         include_context "convertible file"
 
         it "creates three new TranscriptionFile records" do
-          expect { subject }.to change(TranscriptionFile, :count).by(3)
+          expect { subject }.to change(Hearings::TranscriptionFile, :count).by(3)
           expect(transcription_file.file_type).to eq(file_type)
           expect(converted_transcription_file.file_type).to eq(conversion_type)
         end
@@ -197,12 +197,12 @@ describe Hearings::DownloadTranscriptionFileJob do
 
         it "raises error and creates TranscriptionFileRecord" do
           expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
-            .and change(TranscriptionFile, :count).by(1)
+            .and change(Hearings::TranscriptionFile, :count).by(1)
           expect(transcription_file.file_type).to eq(file_type)
         end
 
         it "saves downloaded file to correct tmp sub-directory" do
-          allow_any_instance_of(TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
+          allow_any_instance_of(Hearings::TranscriptionFile).to receive(:clean_up_tmp_location).and_return(nil)
           expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
           expect(File.exist?(tmp_location)).to be true
         end

--- a/spec/jobs/hearings/download_transcription_file_job_spec.rb
+++ b/spec/jobs/hearings/download_transcription_file_job_spec.rb
@@ -4,7 +4,7 @@ describe Hearings::DownloadTranscriptionFileJob do
   include ActiveJob::TestHelper
 
   describe "#perform" do
-    let(:link) { "https://random.imagecdn.app/500/150" }
+    let(:link) { "https://picsum.photos/200" }
     let(:hearing) { create(:hearing) }
     let(:docket_number) { hearing.docket_number }
     let(:file_name) { "#{docket_number}_#{hearing.id}_#{hearing.class}.#{file_type}" }

--- a/spec/workflows/transcription_transformer_spec.rb
+++ b/spec/workflows/transcription_transformer_spec.rb
@@ -3,44 +3,61 @@
 require "rails_helper"
 
 describe TranscriptionTransformer do
-  let(:hearing) { create(:hearing) }
+  let(:hearing_info) { { date: Time.zone.today, judge: "John Smith", appeal_id: "100000001" } }
+  let(:subject) { transformer.call }
 
   describe "#call" do
     context "errors" do
       context "vtt doesn't exist" do
         let(:path) { "/this/does/not/exist" }
-        let(:transformer) { TranscriptionTransformer.new(path, hearing) }
+        let(:transformer) { TranscriptionTransformer.new(path, hearing_info) }
 
         it "raises a HearingConversionError" do
-          expect { transformer.call }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
         end
       end
 
       context "file is malformed or unreadable" do
         let(:file_name) { ["foo", ".vtt"] }
         let(:file) { Tempfile.new(file_name) }
-        let(:transformer) { TranscriptionTransformer.new(file.path, hearing) }
+        let(:transformer) { TranscriptionTransformer.new(file.path, hearing_info) }
         it "raises a HearingConversionError" do
-          expect { transformer.call }.to raise_error(TranscriptionTransformer::FileConversionError)
+          expect { subject }.to raise_error(TranscriptionTransformer::FileConversionError)
         end
       end
     end
   end
+
   describe "successful conversion" do
     let(:file_name) { ["foo", ".vtt"] }
     let(:file) { Tempfile.new(file_name) }
-    let(:transformer) { TranscriptionTransformer.new(file.path, hearing) }
+    let(:transformer) { TranscriptionTransformer.new(file.path, hearing_info) }
     let(:doc) { RTF::Document.new(RTF::Font.new(RTF::Font::ROMAN, "Times New Roman")) }
     let(:rtf_path) { file.path.gsub("vtt", "rtf") }
 
     before do
-      allow_any_instance_of(TranscriptionTransformer).to receive(:convert_to_rtf).and_return([rtf_path])
+      allow_any_instance_of(TranscriptionTransformer).to receive(:convert_to_rtf).and_return(rtf_path)
     end
 
     it "returns the file path of rtf" do
       allow(WebVTT).to receive(:read).and_return(file)
       allow(transformer).to receive(:create_transcription_pages).and_return(doc)
-      transformer.call
+      subject
+    end
+
+    describe "csv creation" do
+      let(:csv_path) { file.path.gsub("vtt", "csv") }
+
+      it "will not create csv if no errors detected" do
+        expect(transformer).to_not receive(:build_csv)
+        expect(subject).to eq([rtf_path])
+      end
+
+      it "will create csv if errors are detected" do
+        transformer.instance_variable_set(:@length, 1000)
+        transformer.instance_variable_set(:@error_count, 2)
+        expect(subject).to eq([rtf_path, csv_path])
+      end
     end
   end
 end


### PR DESCRIPTION
Resolves [APPEALS-39905](https://jira.devops.va.gov/browse/APPEALS-39905)

# Description
Add error handling and CSV creation to TranscriptionTransformer

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Creates an xls/csv file when there are issues annotated within the vtt file
- [ ] Each error (inaudible) found will contain the following headers
       Length (of recording) 
       Appeal ID (vbms_id for legacy appeals, tbd for ama) 
       Hearing Date 
       Judge
       Issues (ex. 4 inaudible) 
      Filename (without extension)
- [ ] Each of the above headers has the correct information populated for that VTT file
- [ ] The TranscriptionTransformer workflow returns an array of filepaths
- [ ] Update the DownloadTranscriptionFileJob to iterate through the returned array and upload all files to S3
- [ ] If a fatal error is encountered, raise it to the DownloadTranscriptionFileJob

## Testing Plan
1. Go to [APPEALS-40678](https://jira.devops.va.gov/browse/APPEALS-40678)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other