### PR TITLE
fix final rubocop warnings and add to lint.rake

### DIFF
--- a/app/models/prepend/va_notify/appeal_docketed.rb
+++ b/app/models/prepend/va_notify/appeal_docketed.rb
@@ -30,7 +30,7 @@ module AppealDocketed
   # Params: NONE
   #
   # Response: Send Appeal Docketed notification to appellant
-  # rubocop:disable Sytle/RedundantSelf
+  # rubocop:disable Style/RedundantSelf
   def create_tasks_on_intake_success!
     super_return_value = super
     distribution_task = tasks.of_type(:DistributionTask).first
@@ -44,7 +44,7 @@ module AppealDocketed
     end
     super_return_value
   end
-  # rubocop:enable Sytle/RedundantSelf
+  # rubocop:enable Style/RedundantSelf
 
   # original method defined in app/models/pre_docket_task.rb
 

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -468,8 +468,8 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     distribute_appeals(fmtd_query, judge, dry_run)
   end
+  # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ParameterLists, Metrics/MethodLength
   def self.distribute_priority_appeals(judge, genpop, limit, dry_run = false)
     query = if use_by_docket_date?
               <<-SQL
@@ -496,8 +496,7 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     distribute_appeals(fmtd_query, judge, dry_run)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ParameterLists, Metrics/MethodLength
-
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # :nocov:
 
   def self.distribute_appeals(query, judge, dry_run)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -12,6 +12,9 @@ task :lint do # rubocop:disable Rails/RakeEnvironment
   puts "running fasterer..."
   fasterer_result = ShellCommand.run("bundle exec fasterer")
 
+  puts "running rubocop..."
+  rubocop_result = ShellCommand.run("bundle exec rubocop")
+
   puts "\nrunning eslint..."
   eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
   eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
@@ -21,7 +24,7 @@ task :lint do # rubocop:disable Rails/RakeEnvironment
   prettier_result = ShellCommand.run("cd ./client && yarn run #{prettier_cmd}")
 
   puts "\n"
-  if scss_result && eslint_result && fasterer_result && prettier_result
+  if scss_result && eslint_result && fasterer_result && prettier_result && rubocop_result
     puts Rainbow("Passed. Everything looks stylish! " \
       "But there may have been auto-corrections that you now need to check in.").green
   else


### PR DESCRIPTION
Resolves [APPEALS-35669](https://jira.devops.va.gov/browse/APPEALS-35669)

# Description
- Fix final rubocop warnings
- Add rubocop run to lint.rake

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Lint.rake includes rubocop when running
