### PR TITLE
Update in_progress_tab query to prevent EfolderUploadFailedTasks from populating.

### DIFF
--- a/app/models/queue_tabs/correspondence_in_progress_tasks_tab.rb
+++ b/app/models/queue_tabs/correspondence_in_progress_tasks_tab.rb
@@ -18,7 +18,8 @@ class CorrespondenceInProgressTasksTab < CorrespondenceQueueTab
   end
 
   def tasks
-    CorrespondenceTask.where(assigned_to: assignee).in_progress
+    CorrespondenceTask.where(assigned_to: assignee).where.not(type: "EfolderUploadFailedTask")
+      .where("status = ? OR status = ?", "in_progress", "on_hold").in_progress
   end
 
   # :reek:UtilityFunction

--- a/app/models/queue_tabs/correspondence_in_progress_tasks_tab.rb
+++ b/app/models/queue_tabs/correspondence_in_progress_tasks_tab.rb
@@ -18,8 +18,9 @@ class CorrespondenceInProgressTasksTab < CorrespondenceQueueTab
   end
 
   def tasks
-    CorrespondenceTask.where(assigned_to: assignee).where.not(type: "EfolderUploadFailedTask")
-      .where("status = ? OR status = ?", "in_progress", "on_hold").in_progress
+    CorrespondenceTask.where(assigned_to: assignee)
+      .where.not(type: "EfolderUploadFailedTask")
+      .where(status: ["in_progress", "on_hold"]).in_progress
   end
 
   # :reek:UtilityFunction

--- a/app/models/task_sorter.rb
+++ b/app/models/task_sorter.rb
@@ -34,6 +34,8 @@ class TaskSorter
       tasks.joins(:appeal).order(notes: sort_order.to_sym)
     when Constants.QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.name
       tasks.joins(:appeal).order(va_date_of_receipt: sort_order.to_sym)
+    when Constants.QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name
+      tasks.joins(:appeal).order(assigned_at: sort_order.to_sym)
     else
       tasks.with_assignees.with_assigners.with_cached_appeals.order(order_clause)
     end

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -362,7 +362,8 @@ export const actionType = () => {
 export const daysWaitingCorrespondence = () => {
   return {
     header: 'Days Waiting',
-    name: QUEUE_CONFIG.COLUMNS.DAYS_WAITING_CORRESPONDENCE.name,
+    name: QUEUE_CONFIG.COLUMNS.DAYS_WAITING.name,
+    enableFilter: true,
     backendCanSort: true,
     getSortValue: (task) => task.daysWaiting,
     valueFunction: (task) => task.daysWaiting


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Your Correspondence - In Progress Tab](https://jira.devops.va.gov/browse/APPEALS-35479)

# Description
The tasks method in correspondence_in_progress_task_tab.rb has been refactored so that EfolderUploadFailedTasks no longer populate. Additional query criteria for tasks being in a "in_progress" or "on_hold" state are also required.

## Testing Plan
1. Login as jolly_postman
2. Navigate to the in progress tab
3. Note that EfolderUploadFailedTask tasks are no longer listed.
