### PR TITLE
Correspondence Cases - Assigned Tab: Batch Assignment - hotfix

### DIFF
--- a/app/controllers/correspondence_controller.rb
+++ b/app/controllers/correspondence_controller.rb
@@ -202,6 +202,8 @@ class CorrespondenceController < ApplicationController
 
   def handle_mail_superuser_or_supervisor
     @mail_team_users = User.mail_team_users.pluck(:css_id)
+    @is_superuser = current_user.mail_superuser?
+    @is_supervisor = current_user.mail_supervisor?
     mail_team_user = User.find_by(css_id: params[:user]) if params[:user].present?
     task_ids = params[:taskIds]&.split(",") if params[:taskIds].present?
     tab = params[:tab] if params[:tab].present?

--- a/app/views/correspondence/correspondence_team.html.erb
+++ b/app/views/correspondence/correspondence_team.html.erb
@@ -11,6 +11,8 @@
     feedbackUrl: feedback_url,
     configUrl: '/queue/correspondence/team?json',
     flash: flash,
+    isSuperuser: @is_superuser,
+    isSupervisor: @is_supervisor,
     mailTeamUsers: @mail_team_users,
     responseType: @response_type,
     responseHeader: @response_header,

--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -70,7 +70,10 @@ const CorrespondenceCases = (props) => {
           />
         )}
         {config &&
-        <CorrespondenceTableBuilder mailTeamUsers={props.mailTeamUsers} />}
+        <CorrespondenceTableBuilder
+          mailTeamUsers={props.mailTeamUsers}
+          isSuperuser={props.isSuperuser}
+          isSupervisor={props.isSupervisor} />}
         {showReassignPackageModal &&
         <Modal
           title={COPY.CORRESPONDENCE_CASES_REASSIGN_PACKAGE_MODAL_TITLE}
@@ -99,7 +102,9 @@ CorrespondenceCases.propTypes = {
   responseType: PropTypes.string,
   responseHeader: PropTypes.string,
   responseMessage: PropTypes.string,
-  taskIds: PropTypes.array
+  taskIds: PropTypes.array,
+  isSuperuser: PropTypes.bool,
+  isSupervisor: PropTypes.bool
 
 };
 

--- a/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
+++ b/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
@@ -62,8 +62,6 @@ const CorrespondenceTableBuilder = (props) => {
     querystring.parse(window.location.search.slice(1))
   );
 
-  const isInboundOpsTeam = props.organizations.find((org) => org.name === 'Inbound Ops Team');
-
   // Causes one additional rerender of the QueueTables/tabs but prevents saved pagination behavior
   // e.g. clearing filter in a tab, then swapping tabs, then swapping back and the filter will still be applied
   useEffect(() => {
@@ -167,6 +165,46 @@ const CorrespondenceTableBuilder = (props) => {
     // Setup default sorting.
     const defaultSort = {};
 
+    const getBulkAssignArea = () => {
+      return (<>
+        <p className="cf-margin-bottom-0rem">Assign to mail team user</p>
+        <div style={{ display: 'flex', flexDirection: 'row' }}>
+          <SearchableDropdown
+            className="cf-dropdown"
+            name="Assign to mail team user"
+            hideLabel
+            styling={{ width: '200px', marginRight: '2rem' }}
+            dropdownStyling={{ width: '200px' }}
+            options={buildMailUserData(props.mailTeamUsers)}
+            onChange={handleMailTeamUserChange}
+          />
+          {tabConfig.name === 'correspondence_unassigned' &&
+              <>
+                <Button
+                  name="Assign"
+                  onClick={handleAssignButtonClick}
+                  disabled={!isDropdownItemSelected || !isAnyCheckboxSelected}
+                />
+                <span style={{ marginLeft: 'auto' }}>
+                  <Button
+                    name="Auto assign correspondence"
+                  />
+                </span>
+              </>
+          }
+          {tabConfig.name === 'correspondence_team_assigned' &&
+            <Button
+              name="Reassign"
+              onClick={handleAssignButtonClick}
+              disabled={!isDropdownItemSelected || !isAnyCheckboxSelected}
+            />
+          }
+        </div>
+        <hr></hr>
+      </>);
+
+    };
+
     // If there is no sort by column in the pagination options, then use the tab config default sort
     // eslint-disable-next-line camelcase
     if (!savedPaginationOptions?.sort_by) {
@@ -177,44 +215,20 @@ const CorrespondenceTableBuilder = (props) => {
       label: sprintf(tabConfig.label, totalTaskCount),
       page: (
         <>
-          {isInboundOpsTeam &&
+          {/* this setup should prevent a double render of the bulk assign area if a
+          user is a superuser and also a supervisor */}
+          {(props.isSupervisor || (props.isSupervisor && props.isSuperuser)) &&
             (tabConfig.name === 'correspondence_unassigned' || tabConfig.name === 'correspondence_team_assigned') &&
             <>
-              <p className="cf-margin-bottom-0rem">Assign to mail team user</p>
-              <div style={{ display: 'flex', flexDirection: 'row' }}>
-                <SearchableDropdown
-                  className="cf-dropdown"
-                  name="Assign to mail team user"
-                  hideLabel
-                  styling={{ width: '200px', marginRight: '2rem' }}
-                  dropdownStyling={{ width: '200px' }}
-                  options={buildMailUserData(props.mailTeamUsers)}
-                  onChange={handleMailTeamUserChange}
-                />
-                {tabConfig.name === 'correspondence_unassigned' &&
-              <>
-                <Button
-                  name="Assign"
-                  onClick={handleAssignButtonClick}
-                  disabled={!isDropdownItemSelected || !isAnyCheckboxSelected}
-                />
-                <span style={{ marginLeft: 'auto' }}>
-                  <Button
-                    name="Auto assign correspondence"
-                    />
-                  </span>
-                </>
-                }
-                {tabConfig.name === 'correspondence_team_assigned' &&
-            <Button
-              name="Reassign"
-              onClick={handleAssignButtonClick}
-              disabled={!isDropdownItemSelected || !isAnyCheckboxSelected}
-            />
-                }
-              </div>
-              <hr></hr>
+              {getBulkAssignArea()}
             </>
+          }
+          {
+            (props.isSuperuser && !props.isSupervisor && tabConfig.name === 'correspondence_team_assigned') &&
+          <>
+            {getBulkAssignArea()}
+          </>
+
           }
           <p className="cf-margin-top-0">
             {noCasesMessage || tabConfig.description}
@@ -284,6 +298,9 @@ CorrespondenceTableBuilder.propTypes = {
   featureToggles: PropTypes.object,
   mailTeamUsers: PropTypes.array,
   selectedTasks: PropTypes.array,
+  isSuperuser: PropTypes.bool,
+  isSupervisor: PropTypes.bool
+
 };
 
 export default connect(mapStateToProps)(CorrespondenceTableBuilder);


### PR DESCRIPTION
Resolves [Correspondence Cases - Assigned Tab: Batch Assignment](https://jira.devops.va.gov/browse/APPEALS-36209)

# Description
This update changes the requirements for rendering the batch assignment area. Superusers will now only see this dropdown in the assigned tab, and supervisors will continue to see it in both locations.


## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan

1. Login as AMRISVACO and navigate to the assigned tab for team correspondence.
2. Note that the batch assignment area is populated.
3. Navigate to the unassigned tab.
4. Note that there is no bulk assignment area.
5. Swap to MAIL_TEAM_SUPERVISOR_ADMIN_USER
6. note that the bulk assignment area is available on both assigned and unassigned tabs.