### PR TITLE
Allow Feature Flags to Work in Prod Env

### DIFF
--- a/app/services/auto_assignable_user_finder.rb
+++ b/app/services/auto_assignable_user_finder.rb
@@ -5,7 +5,7 @@ class AutoAssignableUserFinder
   AssignableUser = Struct.new(:user_obj, :last_assigned_date, :num_assigned, :nod?, keyword_init: true)
 
   def assignable_users_exist?
-    return false if FeatureToggle.enabled?(:auto_assign_banner_max_queue) && !Rails.env.production?
+    return false if FeatureToggle.enabled?(:auto_assign_banner_max_queue)
 
     assignable_users.count.positive?
   end

--- a/app/services/correspondence_auto_assign_run_verifier.rb
+++ b/app/services/correspondence_auto_assign_run_verifier.rb
@@ -20,7 +20,7 @@ class CorrespondenceAutoAssignRunVerifier
   private
 
   def verify_feature_toggles
-    if !Rails.env.production? && FeatureToggle.enabled?(:auto_assign_banner_failure)
+    if FeatureToggle.enabled?(:auto_assign_banner_failure)
       self.err_msg = "#{COPY::BAAA_ERROR_MESSAGE} (failure triggered via feature toggle)"
       return false
     end

--- a/app/services/correspondence_auto_assigner.rb
+++ b/app/services/correspondence_auto_assigner.rb
@@ -61,7 +61,7 @@ class CorrespondenceAutoAssigner
   end
 
   def unassigned_review_package_tasks
-    return [] if !Rails.env.production? && FeatureToggle.enabled?(:auto_assign_banner_no_rpt)
+    return [] if FeatureToggle.enabled?(:auto_assign_banner_no_rpt)
 
     ReviewPackageTask
       .where(status: Constants.TASK_STATUSES.unassigned)


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Feature Flag Updates](https://jira.devops.va.gov/browse/APPEALS-38955)

# Description
Updates the auto assign feature flags to allow them to work in the production environment.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Auto assign correspondence smoke test.