### PR TITLE
fix final rubocop warnings and add to lint.rake

### DIFF
--- a/app/models/prepend/va_notify/appeal_docketed.rb
+++ b/app/models/prepend/va_notify/appeal_docketed.rb
@@ -30,7 +30,7 @@ module AppealDocketed
   # Params: NONE
   #
   # Response: Send Appeal Docketed notification to appellant
-  # rubocop:disable Sytle/RedundantSelf
+  # rubocop:disable Style/RedundantSelf
   def create_tasks_on_intake_success!
     super_return_value = super
     distribution_task = tasks.of_type(:DistributionTask).first
@@ -44,7 +44,7 @@ module AppealDocketed
     end
     super_return_value
   end
-  # rubocop:enable Sytle/RedundantSelf
+  # rubocop:enable Style/RedundantSelf
 
   # original method defined in app/models/pre_docket_task.rb
 

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -468,8 +468,8 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     distribute_appeals(fmtd_query, judge, dry_run)
   end
+  # rubocop:enable Metrics/ParameterLists, Metrics/MethodLength
 
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ParameterLists, Metrics/MethodLength
   def self.distribute_priority_appeals(judge, genpop, limit, dry_run = false)
     query = if use_by_docket_date?
               <<-SQL
@@ -496,8 +496,7 @@ class VACOLS::CaseDocket < VACOLS::Record
 
     distribute_appeals(fmtd_query, judge, dry_run)
   end
-  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/ParameterLists, Metrics/MethodLength
-
+  # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
   # :nocov:
 
   def self.distribute_appeals(query, judge, dry_run)

--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -12,6 +12,9 @@ task :lint do # rubocop:disable Rails/RakeEnvironment
   puts "running fasterer..."
   fasterer_result = ShellCommand.run("bundle exec fasterer")
 
+  puts "running rubocop..."
+  rubocop_result = ShellCommand.run("bundle exec rubocop")
+
   puts "\nrunning eslint..."
   eslint_cmd = ENV["CI"] ? "lint" : "lint:fix"
   eslint_result = ShellCommand.run("cd ./client && yarn run #{eslint_cmd}")
@@ -21,7 +24,7 @@ task :lint do # rubocop:disable Rails/RakeEnvironment
   prettier_result = ShellCommand.run("cd ./client && yarn run #{prettier_cmd}")
 
   puts "\n"
-  if scss_result && eslint_result && fasterer_result && prettier_result
+  if scss_result && eslint_result && fasterer_result && prettier_result && rubocop_result
     puts Rainbow("Passed. Everything looks stylish! " \
       "But there may have been auto-corrections that you now need to check in.").green
   else

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -635,7 +635,7 @@ feature "Higher-Level Review", :all_dbs do
 
     let!(:untimely_rating) { generate_untimely_rating_from_ramp(veteran, receipt_date, old_reference_id) }
     let!(:before_ama_rating_from_ramp) { generate_rating_before_ama_from_ramp(veteran) }
-    let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran, receipt_date) }
+    let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran) }
     let(:old_rating_decision_text) { "Bone (Right arm broken) is denied." }
 
     let!(:request_issue_in_progress) do

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -26,7 +26,7 @@ feature "Supplemental Claim Edit issues", :all_dbs do
   let!(:ratings_with_legacy_issues) do
     generate_rating_with_legacy_issues(veteran, receipt_date - 4.days, receipt_date - 4.days)
   end
-  let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran, receipt_date) }
+  let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran) }
   let(:request_issue_decision_mdY) { request_issue.decision_or_promulgation_date.mdY }
   let(:old_rating_decision_text) { "Bone (Right arm broken) is denied." }
 

--- a/spec/feature/intake/supplemental_claim_spec.rb
+++ b/spec/feature/intake/supplemental_claim_spec.rb
@@ -443,7 +443,7 @@ feature "Supplemental Claim Intake", :all_dbs do
     let(:active_epe) { create(:end_product_establishment, :active) }
 
     let!(:timely_ratings) { generate_timely_rating(veteran, receipt_date, duplicate_reference_id) }
-    let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran, receipt_date) }
+    let!(:rating_with_old_decisions) { generate_rating_with_old_decisions(veteran) }
     let(:old_rating_decision_text) { "Bone (Right arm broken) is denied." }
     let!(:untimely_rating_from_ramp) do
       generate_untimely_rating_from_ramp(veteran, receipt_date, old_reference_id, with_associated_claims: true)

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -842,19 +842,19 @@ module IntakeHelpers
   def generate_rating_with_old_decisions(veteran, receipt_date)
     Generators::PromulgatedRating.build(
       participant_id: veteran.participant_id,
-      promulgation_date: receipt_date - 5.years,
-      profile_date: receipt_date - 5.years,
+      promulgation_date: Constants::DATES["AMA_ACTIVATION"].to_date - 5.days,
+      profile_date: Constants::DATES["AMA_ACTIVATION"].to_date - 5.days,
       issues: [
         { reference_id: "9876", decision_text: "Left hand broken" }
       ],
       decisions: [
         {
           rating_issue_reference_id: nil,
-          original_denial_date: receipt_date - 5.years - 3.days,
+          original_denial_date: Constants::DATES["AMA_ACTIVATION"].to_date - 3.days,
           diagnostic_text: "Right arm broken",
           diagnostic_type: "Bone",
           disability_id: "123",
-          disability_date: receipt_date - 5.years - 2.days,
+          disability_date: Constants::DATES["AMA_ACTIVATION"].to_date - 2.days,
           type_name: "Not Service Connected"
         }
       ]

--- a/spec/support/intake_helpers.rb
+++ b/spec/support/intake_helpers.rb
@@ -839,7 +839,7 @@ module IntakeHelpers
     )
   end
 
-  def generate_rating_with_old_decisions(veteran, receipt_date)
+  def generate_rating_with_old_decisions(veteran)
     Generators::PromulgatedRating.build(
       participant_id: veteran.participant_id,
       promulgation_date: Constants::DATES["AMA_ACTIVATION"].to_date - 5.days,


### PR DESCRIPTION
Resolves [APPEALS-35669](https://jira.devops.va.gov/browse/APPEALS-35669)

# Description
- Fix final rubocop warnings
- Add rubocop run to lint.rake

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Lint.rake includes rubocop when running
