### PR TITLE
Fix Misc. Auto Assign Correspondence Regressions

### DIFF
--- a/app/models/organizations/inbound_ops_team.rb
+++ b/app/models/organizations/inbound_ops_team.rb
@@ -1,9 +1,25 @@
 # frozen_string_literal: true
 
 class InboundOpsTeam < Organization
-  def self.singleton
-    InboundOpsTeam.first ||
-      InboundOpsTeam.create(name: "Inbound Ops Team", url: "inbound-ops-team")
+  class << self
+    def singleton
+      InboundOpsTeam.first ||
+        InboundOpsTeam.create(name: "Inbound Ops Team", url: "inbound-ops-team")
+    end
+
+    def super_users
+      super_users = []
+
+      OrganizationsUser.includes(:user).where(organization: InboundOpsTeam.singleton).find_each do |org_user|
+        user = org_user.user
+
+        if user.inbound_ops_team_superuser?
+          super_users.push(user)
+        end
+      end
+
+      super_users
+    end
   end
 
   # :reek:UtilityFunction

--- a/app/services/auto_assignable_user_finder.rb
+++ b/app/services/auto_assignable_user_finder.rb
@@ -105,14 +105,14 @@ class AutoAssignableUserFinder
   def find_users
     # Do NOT use manual caching here!!!
     # Other processes may update data, so always use the DB as the source of truth and let Rails handle any caching
-    InboundOpsTeam.singleton.users.includes(:tasks, :organization_user_permissions)
+    InboundOpsTeam.singleton.users.includes(:tasks, :organizations, :organization_user_permissions)
       .where(
         organization_user_permissions: {
           organization_permission: OrganizationPermission.auto_assign(InboundOpsTeam.singleton),
           permitted: true
         }
       )
-      .references(:tasks, :organization_user_permissions)
+      .references(:tasks, :organizations, :organization_user_permissions)
   end
 
   def sensitivity_checker

--- a/app/services/correspondence_auto_assigner.rb
+++ b/app/services/correspondence_auto_assigner.rb
@@ -65,8 +65,9 @@ class CorrespondenceAutoAssigner
 
     ReviewPackageTask
       .where(status: Constants.TASK_STATUSES.unassigned)
-      .includes(:correspondence)
-      .references(:correspondence)
+      .preload(:appeal, :assigned_by, :assigned_to, :parent)
+      .includes(:correspondence, correspondence: :veteran)
+      .references(:correspondence, correspondence: :veteran)
       .merge(Correspondence.order(va_date_of_receipt: :desc))
   end
 

--- a/spec/services/correspondence_auto_assigner_spec.rb
+++ b/spec/services/correspondence_auto_assigner_spec.rb
@@ -83,7 +83,7 @@ describe CorrespondenceAutoAssigner do
     context "when a run is NOT permitted" do
       before do
         expect(mock_run_verifier).to receive(:can_run_auto_assign?).and_return(false)
-        expect(mock_run_verifier).to receive(:err_msg).and_return("Test error")
+        expect(mock_run_verifier).to receive(:err_msg).twice.and_return("Test error")
       end
 
       it "raises an error" do


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Create Capacity Rule](https://jira.devops.va.gov/browse/APPEALS-38551)

# Description
- Restores code from https://github.com/department-of-veterans-affairs/caseflow/pull/20857 that appears to have accidentally been deleted during a git merge operation.
- Add eager loading to various finder queries.
- Fix spec failures.

## Acceptance Criteria
- [ ] Auto assignable user finder spec passing: `bundle exec rspec spec/services/auto_assignable_user_finder_spec.rb`

## Testing Plan
1. Auto assign smoke test.
2. Run specs as per AC above.