### PR TITLE
jefftmarks/APPEALS-37292-37293

### DIFF
--- a/app/controllers/hearings/transcription_files_controller.rb
+++ b/app/controllers/hearings/transcription_files_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class TranscriptionFilesController < ApplicationController
+class Hearings::TranscriptionFilesController < ApplicationController
   def index
     nil
   end

--- a/app/controllers/hearings/transcription_files_controller.rb
+++ b/app/controllers/hearings/transcription_files_controller.rb
@@ -3,19 +3,14 @@
 class Hearings::TranscriptionFilesController < ApplicationController
   include HearingsConcerns::VerifyAccess
 
-  rescue_from ActionController::UnknownFormat, with: :render_page_not_found
   rescue_from ActiveRecord::RecordNotFound, with: :render_page_not_found
   before_action :verify_access_to_hearings, only: [:download_transcription_file]
 
   # Downloads file and sends to user's local computer
   def download_transcription_file
-    respond_to do |format|
-      format.any(:vtt, :rtf, :mp3, :mp4, :csv) do |_|
-        tmp_location = file.download_from_s3
-        File.open(tmp_location, "r") { |f| send_data f.read, filename: file.file_name }
-        file.clean_up_tmp_location
-      end
-    end
+    tmp_location = file.download_from_s3
+    File.open(tmp_location, "r") { |f| send_data f.read, filename: file.file_name }
+    file.clean_up_tmp_location
   end
 
   def render_page_not_found

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -102,4 +102,13 @@ module HearingConcern
 
     end_date
   end
+
+  def serialize_transcription_files
+    recordings = transcription_files.group_by(&:base_file_name).values
+    recordings.map do |recording|
+      recording.map do |file|
+        TranscriptionFileSerializer.new(file).serializable_hash[:data][:attributes]
+      end
+    end
+  end
 end

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -103,8 +103,10 @@ module HearingConcern
     end_date
   end
 
+  # One hearing may yield multiple recording segments. Group transcription files by base file name to associate the file
+  # with a recording.
   def serialize_transcription_files
-    recordings = transcription_files.group_by(&:base_file_name).values
+    recordings = transcription_files.order(:created_at).group_by(&:base_file_name).values
     recordings.map do |recording|
       recording.map do |file|
         TranscriptionFileSerializer.new(file).serializable_hash[:data][:attributes]

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -103,7 +103,7 @@ module HearingConcern
     end_date
   end
 
-  # TO-DO: Associate hearing with transcription files across multiple dockets and order accordingly
+  # Associate hearing with transcription files across multiple dockets and order accordingly
   def transcription_files_by_docket_number
     # Remove hyphen in case of counter at end of file name to allow for alphabetical sort
     transcription_files.sort_by { |f| f.file_name.split("-").join }.group_by(&:docket_number).values

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -103,11 +103,14 @@ module HearingConcern
     end_date
   end
 
-  # One hearing may yield multiple recording segments. Group transcription files by base file name to associate the file
-  # with a recording.
+  # One hearing may yield multiple recordings. Group transcription files by base file name to associate with recording
+  def transcription_files_by_recording
+    transcription_files.order(:created_at).group_by(&:base_file_name).values
+  end
+
+  # Group transcription files by associated recording before mapping through nested array and serializing
   def serialized_transcription_files
-    recordings = transcription_files.order(:created_at).group_by(&:base_file_name).values
-    recordings.map do |recording|
+    transcription_files_by_recording.map do |recording|
       recording.map do |file|
         TranscriptionFileSerializer.new(file).serializable_hash[:data][:attributes]
       end

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -103,15 +103,16 @@ module HearingConcern
     end_date
   end
 
-  # One hearing may yield multiple recordings. Group transcription files by base file name to associate with recording
-  def transcription_files_by_recording
-    transcription_files.order(:created_at).group_by(&:base_file_name).values
+  # TO-DO: Associate hearing with transcription files across multiple dockets and order accordingly
+  def transcription_files_by_docket_number
+    # Remove hyphen in case of counter at end of file name to allow for alphabetical sort
+    transcription_files.sort_by { |f| f.file_name.split("-").join }.group_by(&:docket_number).values
   end
 
-  # Group transcription files by associated recording before mapping through nested array and serializing
+  # Group transcription files by docket number before mapping through nested array and serializing
   def serialized_transcription_files
-    transcription_files_by_recording.map do |recording|
-      recording.map do |file|
+    transcription_files_by_docket_number.map do |file_groups|
+      file_groups.map do |file|
         TranscriptionFileSerializer.new(file).serializable_hash[:data][:attributes]
       end
     end

--- a/app/models/concerns/hearing_concern.rb
+++ b/app/models/concerns/hearing_concern.rb
@@ -105,7 +105,7 @@ module HearingConcern
 
   # One hearing may yield multiple recording segments. Group transcription files by base file name to associate the file
   # with a recording.
-  def serialize_transcription_files
+  def serialized_transcription_files
     recordings = transcription_files.order(:created_at).group_by(&:base_file_name).values
     recordings.map do |recording|
       recording.map do |file|

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -48,6 +48,7 @@ class Hearing < CaseflowRecord
   has_many :hearing_issue_notes
   has_many :email_events, class_name: "SentHearingEmailEvent"
   has_many :email_recipients, class_name: "HearingEmailRecipient"
+  has_many :transcription_files
 
   class HearingDayFull < StandardError; end
 

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -73,4 +73,8 @@ class TranscriptionFile < CaseflowRecord
   def clean_up_tmp_location
     File.delete(tmp_location) if File.exist?(tmp_location)
   end
+
+  def base_file_name
+    file_name.split(".").first
+  end
 end

--- a/app/models/hearings/transcription_file.rb
+++ b/app/models/hearings/transcription_file.rb
@@ -80,8 +80,4 @@ class TranscriptionFile < CaseflowRecord
   def clean_up_tmp_location
     File.delete(tmp_location) if File.exist?(tmp_location)
   end
-
-  def base_file_name
-    file_name.split(".").first
-  end
 end

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -74,6 +74,7 @@ class LegacyHearing < CaseflowRecord
   has_one :hearing_location, as: :hearing
   has_many :email_events, class_name: "SentHearingEmailEvent", foreign_key: :hearing_id
   has_many :email_recipients, class_name: "HearingEmailRecipient", foreign_key: :hearing_id
+  has_many :transcription_files
 
   alias_attribute :location, :hearing_location
   accepts_nested_attributes_for :hearing_location, reject_if: proc { |attributes| attributes.blank? }

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -74,7 +74,7 @@ class LegacyHearing < CaseflowRecord
   has_one :hearing_location, as: :hearing
   has_many :email_events, class_name: "SentHearingEmailEvent", foreign_key: :hearing_id
   has_many :email_recipients, class_name: "HearingEmailRecipient", foreign_key: :hearing_id
-  has_many :transcription_files
+  has_many :transcription_files, foreign_key: :hearing_id
 
   alias_attribute :location, :hearing_location
   accepts_nested_attributes_for :hearing_location, reject_if: proc { |attributes| attributes.blank? }

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -103,6 +103,11 @@ class HearingSerializer
   attribute :transcript_requested
   attribute :transcript_sent_date
   attribute :transcription
+  attribute :transcription_files, if: for_worksheet do |hearing|
+    if hearing.conference_provider == "webex"
+      hearing.serialize_transcription_files
+    end
+  end
   attribute :uuid
   attribute :veteran_age, if: for_full
   attribute :veteran_file_number

--- a/app/serializers/hearings/hearing_serializer.rb
+++ b/app/serializers/hearings/hearing_serializer.rb
@@ -105,7 +105,7 @@ class HearingSerializer
   attribute :transcription
   attribute :transcription_files, if: for_worksheet do |hearing|
     if hearing.conference_provider == "webex"
-      hearing.serialize_transcription_files
+      hearing.serialized_transcription_files
     end
   end
   attribute :uuid

--- a/app/serializers/hearings/legacy_hearing_serializer.rb
+++ b/app/serializers/hearings/legacy_hearing_serializer.rb
@@ -95,6 +95,11 @@ class LegacyHearingSerializer
   attribute :submission_window_end, if: for_worksheet, &:calculate_submission_window
   attribute :summary
   attribute :transcript_requested
+  attribute :transcription_files, if: for_worksheet do |hearing|
+    if hearing.conference_provider == "webex"
+      hearing.serialized_transcription_files
+    end
+  end
   attribute :user_id
   attribute :vacols_id, if: for_worksheet
   attribute :vbms_id

--- a/app/serializers/hearings/transcription_file_serializer.rb
+++ b/app/serializers/hearings/transcription_file_serializer.rb
@@ -5,7 +5,6 @@ class TranscriptionFileSerializer
 
   attribute :date_upload_aws
   attribute :file_name
-  attribute :file_type
   attribute :aws_link
   attribute :file_status
 end

--- a/app/serializers/hearings/transcription_file_serializer.rb
+++ b/app/serializers/hearings/transcription_file_serializer.rb
@@ -3,7 +3,6 @@
 class TranscriptionFileSerializer
   include FastJsonapi::ObjectSerializer
 
-  attribute :docket_number
   attribute :date_upload_aws
   attribute :file_name
   attribute :file_type

--- a/app/serializers/hearings/transcription_file_serializer.rb
+++ b/app/serializers/hearings/transcription_file_serializer.rb
@@ -4,6 +4,8 @@ class TranscriptionFileSerializer
   include FastJsonapi::ObjectSerializer
 
   attribute :id
+  attribute :docket_number
+  attribute :hearing_type
   attribute :date_upload_aws
   attribute :file_name
   attribute :file_status

--- a/app/serializers/hearings/transcription_file_serializer.rb
+++ b/app/serializers/hearings/transcription_file_serializer.rb
@@ -3,8 +3,9 @@
 class TranscriptionFileSerializer
   include FastJsonapi::ObjectSerializer
 
+  attribute :id
   attribute :date_upload_aws
   attribute :file_name
-  attribute :aws_link
   attribute :file_status
+  attribute :file_type
 end

--- a/client/app/components/Table.jsx
+++ b/client/app/components/Table.jsx
@@ -312,7 +312,7 @@ BodyRows.propTypes = {
   tbodyRef: PropTypes.func,
   id: PropTypes.string,
   getKeyForRow: PropTypes.func,
-  bodyStyling: PropTypes.array
+  bodyStyling: PropTypes.object
 };
 
 FooterRow.propTypes = {
@@ -342,5 +342,5 @@ Table.propTypes = {
     sortAscending: PropTypes.bool
   }),
   bodyClassName: PropTypes.string,
-  bodyStyling: PropTypes.array
+  bodyStyling: PropTypes.object
 };

--- a/client/app/hearings/components/details/DetailsForm.jsx
+++ b/client/app/hearings/components/details/DetailsForm.jsx
@@ -117,14 +117,14 @@ const DetailsForm = (props) => {
         initialRepresentativeTz={initialHearing?.representativeTz}
       />
 
-      {!isLegacy && (
-        <TranscriptionFormSection
-          hearing={hearing}
-          readOnly={readOnly}
-          transcription={hearing.transcription}
-          update={update}
-        />
-      )}
+      <TranscriptionFormSection
+        hearing={hearing}
+        readOnly={readOnly}
+        transcription={hearing.transcription}
+        update={update}
+        isLegacy={isLegacy}
+      />
+
     </React.Fragment>
   );
 };

--- a/client/app/hearings/components/details/DetailsForm.jsx
+++ b/client/app/hearings/components/details/DetailsForm.jsx
@@ -117,14 +117,16 @@ const DetailsForm = (props) => {
         initialRepresentativeTz={initialHearing?.representativeTz}
       />
 
-      <TranscriptionFormSection
-        hearing={hearing}
-        readOnly={readOnly}
-        transcription={hearing.transcription}
-        update={update}
-        isLegacy={isLegacy}
-      />
-
+      {/* Don't render Transcription Details section if Legacy Hearing AND Pexip conference provider*/}
+      {!(isLegacy && hearing.conferenceProvider === 'pexip') && (
+        <TranscriptionFormSection
+          hearing={hearing}
+          readOnly={readOnly}
+          transcription={hearing.transcription}
+          update={update}
+          isLegacy={isLegacy}
+        />
+      )}
     </React.Fragment>
   );
 };
@@ -140,7 +142,8 @@ DetailsForm.propTypes = {
     wasVirtual: PropTypes.bool,
     isVirtual: PropTypes.bool,
     scheduledTimeString: PropTypes.string,
-    readableRequestType: PropTypes.string
+    readableRequestType: PropTypes.string,
+    conferenceProvider: PropTypes.string
   }),
   initialHearing: PropTypes.shape({
     virtualHearing: PropTypes.object

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -117,7 +117,7 @@ const TranscriptionFilesTable = ({ hearing }) => {
   return (
     <div {...genericRow}>
       <Table
-        id="transcripton-files-table"
+        id="transcription-files-table"
         columns={transcriptionFileColumns}
         getKeyForRow={(index) => index}
         rowObjects={rows}

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { css } from 'glamor';
+import _ from 'lodash';
 
 import Table from '../../../components/Table';
 import { genericRow } from './style';
@@ -60,7 +61,7 @@ const transcriptionFileColumns = [
   },
   {
     align: 'left',
-    valueName: 'dateUploaded',
+    valueName: 'dateUploadAws',
     header: 'Uploaded',
   },
   {
@@ -75,26 +76,30 @@ const transcriptionFileColumns = [
   },
   {
     align: 'left',
-    valueName: 'status',
+    valueName: 'fileStatus',
     header: 'Status'
   }
 ];
 
 const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-row-group`;
 
-const TranscriptionFilesTable = ({ recordings, hearing }) => {
+const TranscriptionFilesTable = ({ hearing }) => {
   const [rows, setRows] = useState([]);
 
   const buildRowsFromRecordings = () => {
+    const recordings = _.flatMap(hearing.transcriptionFiles);
+
     return recordings.map((recording, recordingIndex) => {
-      return recording.files.map((file, fileIndex) => {
+      const files = _.flatMap(recording);
+
+      return files.map((file, fileIndex) => {
         const fileObj = {
           ...file,
           isEvenGroup: recordingIndex % 2 === 0
         };
 
         if (fileIndex === 0) {
-          fileObj.docketNumber = recording.docketNumber;
+          fileObj.docketNumber = hearing.docketNumber;
           fileObj.docketName = hearing.docketName;
         }
 

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import { css } from 'glamor';
 import _ from 'lodash';
 import moment from 'moment-timezone';
 
@@ -11,48 +10,10 @@ import DocketTypeBadge from '../../../components/DocketTypeBadge';
 import { COLORS } from '../../../constants/AppConstants';
 import { DownloadIcon } from '../../../components/icons/DownloadIcon';
 
-const tableStyling = css({
-  marginTop: 0,
-  '& *:focus': {
-    outline: 'none'
-  },
-  '& tr > *:first-child': {
-    paddingLeft: '2.5rem'
-  }
-});
-
-const bodyStyling = css({
-  '& tr:first-child td': {
-    paddingTop: '3rem'
-  },
-  '& tr.even-row-group td': {
-    backgroundColor: '#F9F9F9'
-  },
-  '& tr.even-row-group + tr.odd-row-group td, tr.odd-row-group + tr.even-row-group td': {
-    borderTop: '1px solid #D6D7D9',
-    paddingTop: '3rem'
-  },
-  '& tr td': {
-    border: '0',
-    paddingTop: '0',
-    paddingBottom: '3rem',
-    '&:last-child': {
-      fontStyle: 'italic'
-    },
-    '& a': {
-      display: 'inline-flex',
-      alignItems: 'center'
-    },
-    '& svg': {
-      marginLeft: '1rem'
-    }
-  }
-});
-
 const transcriptionFileColumns = [
   {
     align: 'left',
-    valueFunction: (rowObject) => (
+    valueFunction: (rowObject) => rowObject.docketName && (
       <span>
         <DocketTypeBadge name={rowObject.docketName} number={rowObject.docketNumber} />
         {rowObject.docketNumber}
@@ -69,7 +30,7 @@ const transcriptionFileColumns = [
   {
     align: 'left',
     valueFunction: (rowObject) => (
-      <Link href={`/hearings/transcription_file/${rowObject.id}/download.${rowObject.fileType}`}>
+      <Link href={`/hearings/transcription_file/${rowObject.id}/download`}>
         {rowObject.fileName}
         <DownloadIcon color={COLORS.PRIMARY} />
       </Link>
@@ -97,9 +58,9 @@ const TranscriptionFilesTable = ({ hearing }) => {
       return fileGroup.map((file, fileIndex) => {
         return {
           ...file,
-          docketNumber: fileIndex === 0 && file.docketNumber,
-          docketName: fileIndex === 0 && file.hearingType,
-          isEvenGroup: groupIndex % 2 === 0
+          isEvenGroup: groupIndex % 2 === 0,
+          docketName: fileIndex === 0 ? file.hearingType : null,
+          docketNumber: fileIndex === 0 ? file.docketNumber : null
         };
       });
     }).flat();
@@ -112,13 +73,11 @@ const TranscriptionFilesTable = ({ hearing }) => {
   return (
     <div {...genericRow}>
       <Table
-        id="transcription-files-table"
+        className="transcription-files-table"
         columns={transcriptionFileColumns}
         getKeyForRow={(index) => index}
         rowObjects={rows}
         rowClassNames={rowClassNames}
-        styling={tableStyling}
-        bodyStyling={bodyStyling}
       />
     </div>
   );

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -1,10 +1,10 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import Link from '../../../components/Link';
 import { css } from 'glamor';
 import _ from 'lodash';
 import moment from 'moment-timezone';
 
+import Link from '../../../components/Link';
 import Table from '../../../components/Table';
 import { genericRow } from './style';
 import DocketTypeBadge from '../../../components/DocketTypeBadge';
@@ -88,9 +88,10 @@ const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-
 const TranscriptionFilesTable = ({ hearing }) => {
   const [rows, setRows] = useState([]);
 
-  // One hearing may have multiple recordings. Format table to associate files by recording
+  // One hearing may yield multiple recordings. Format table to group associated files by recording
   const buildRowsFromRecordings = () => {
-    const recordings = _.flatMap(hearing.transcriptionFiles, (rec) => [_.flatMap(rec)]);
+    // Flatten nested objects into nested arrays
+    const recordings = _.values(hearing.transcriptionFiles).map((rec) => _.values(rec));
 
     return recordings.map((recording, recordingIndex) => {
       return recording.map((file, fileIndex) => {
@@ -130,14 +131,9 @@ const TranscriptionFilesTable = ({ hearing }) => {
 
 TranscriptionFilesTable.propTypes = {
   hearing: PropTypes.shape({
-    docketNumber: PropTypes.string,
+    transcriptionFiles: PropTypes.object,
     docketName: PropTypes.string,
-    transcriptionFiles: PropTypes.shape({
-      awsLink: PropTypes.string,
-      dateUploadAws: PropTypes.string,
-      fileName: PropTypes.string,
-      fileStatus: PropTypes.string
-    })
+    docketNumber: PropTypes.string
   })
 };
 

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -9,139 +9,41 @@ import DocketTypeBadge from '../../../components/DocketTypeBadge';
 import { COLORS } from '../../../constants/AppConstants';
 import { DownloadIcon } from '../../../components/icons/DownloadIcon';
 
-const RECORDINGS = [
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  }
-];
-
 const tableStyling = css({
   marginTop: 0,
   '& tr > *:first-child': {
     paddingLeft: '2.5rem'
+  },
+  '& *:focus': {
+    outline: 'none'
   }
 });
 
 const bodyStyling = css({
+  '& tr:first-child td': {
+    paddingTop: '3rem'
+  },
   '& tr.even-row-group td': {
     backgroundColor: '#F9F9F9'
   },
-  '& tr td': {
-    border: '0'
-  },
   '& tr.even-row-group + tr.odd-row-group td, tr.odd-row-group + tr.even-row-group td': {
-    borderTop: '1px solid #D6D7D9'
+    borderTop: '1px solid #D6D7D9',
+    paddingTop: '3rem'
   },
-  '& tr td a': {
-    display: 'inline-flex',
-    alignItems: 'center'
-  },
-  '& tr td svg': {
-    marginLeft: '1rem'
-  },
-  '& tr td:last-child': {
-    fontStyle: 'italic'
+  '& tr td': {
+    border: '0',
+    paddingTop: '0',
+    paddingBottom: '3rem',
+    '&:last-child': {
+      fontStyle: 'italic'
+    },
+    '& a': {
+      display: 'inline-flex',
+      alignItems: 'center'
+    },
+    '& svg': {
+      marginLeft: '1rem'
+    }
   }
 });
 
@@ -178,9 +80,8 @@ const transcriptionFileColumns = [
   }
 ];
 
-const buildRowObjectsFromRecordings = (hearing) => {
-  // TO-DO: Replace hard-coded recordings with props
-  return RECORDINGS.map((recording, recordingIndex) => {
+const buildRowObjectsFromRecordings = (recordings, hearing) => {
+  return recordings.map((recording, recordingIndex) => {
     return recording.files.map((file, fileIndex) => {
       const fileObj = {
         ...file,
@@ -199,17 +100,19 @@ const buildRowObjectsFromRecordings = (hearing) => {
 
 const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-row-group`;
 
-const TranscriptionFilesTable = ({ hearing }) => (
+const TranscriptionFilesTable = ({ recordings, hearing }) => (
   <div {...genericRow}>
-    <Table
-      id="transcripton-files-table"
-      columns={transcriptionFileColumns}
-      getKeyForRow={(index) => index}
-      rowObjects={buildRowObjectsFromRecordings(hearing)}
-      rowClassNames={rowClassNames}
-      styling={tableStyling}
-      bodyStyling={bodyStyling}
-    />
+    {recordings.length > 0 && (
+      <Table
+        id="transcripton-files-table"
+        columns={transcriptionFileColumns}
+        getKeyForRow={(index) => index}
+        rowObjects={buildRowObjectsFromRecordings(recordings, hearing)}
+        rowClassNames={rowClassNames}
+        styling={tableStyling}
+        bodyStyling={bodyStyling}
+      />
+    )}
   </div>
 );
 

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -88,30 +88,25 @@ const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-
 const TranscriptionFilesTable = ({ hearing }) => {
   const [rows, setRows] = useState([]);
 
-  // One hearing may yield multiple recordings. Format table to group associated files by recording
-  const buildRowsFromRecordings = () => {
+  // Format table to group files by docket number and style accordingly
+  const buildRowsFromFileGroups = () => {
     // Flatten nested objects into nested arrays
-    const recordings = _.values(hearing.transcriptionFiles).map((rec) => _.values(rec));
+    const fileGroups = _.values(hearing.transcriptionFiles).map((rec) => _.values(rec));
 
-    return recordings.map((recording, recordingIndex) => {
-      return recording.map((file, fileIndex) => {
-        const fileObj = {
+    return fileGroups.map((fileGroup, groupIndex) => {
+      return fileGroup.map((file, fileIndex) => {
+        return {
           ...file,
-          isEvenGroup: recordingIndex % 2 === 0
+          docketNumber: fileIndex === 0 && file.docketNumber,
+          docketName: fileIndex === 0 && file.hearingType,
+          isEvenGroup: groupIndex % 2 === 0
         };
-
-        if (fileIndex === 0) {
-          fileObj.docketNumber = hearing.docketNumber;
-          fileObj.docketName = hearing.docketName;
-        }
-
-        return fileObj;
       });
     }).flat();
   };
 
   useEffect(() => {
-    setRows(buildRowsFromRecordings());
+    setRows(buildRowsFromFileGroups());
   }, []);
 
   return (

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { css } from 'glamor';
 import _ from 'lodash';
+import moment from 'moment-timezone';
 
 import Table from '../../../components/Table';
 import { genericRow } from './style';
@@ -62,12 +63,13 @@ const transcriptionFileColumns = [
   {
     align: 'left',
     valueName: 'dateUploadAws',
+    valueFunction: (rowObject) => moment(rowObject.dateUploadAws).format('MM/DD/YYYY'),
     header: 'Uploaded',
   },
   {
     align: 'left',
     valueFunction: (rowObject) => (
-      <Link to="/">
+      <Link to={rowObject.awsLink}>
         {rowObject.fileName}
         <DownloadIcon color={COLORS.PRIMARY} />
       </Link>

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -1,0 +1,221 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { css } from 'glamor';
+
+import Table from '../../../components/Table';
+import { genericRow } from './style';
+import DocketTypeBadge from '../../../components/DocketTypeBadge';
+import { COLORS } from '../../../constants/AppConstants';
+import { DownloadIcon } from '../../../components/icons/DownloadIcon';
+
+const RECORDINGS = [
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  }
+];
+
+const tableStyling = css({
+  marginTop: 0,
+  '& tr > *:first-child': {
+    paddingLeft: '2.5rem'
+  }
+});
+
+const bodyStyling = css({
+  '& tr.even-row-group td': {
+    backgroundColor: '#F9F9F9'
+  },
+  '& tr td': {
+    border: '0'
+  },
+  '& tr.even-row-group + tr.odd-row-group td, tr.odd-row-group + tr.even-row-group td': {
+    borderTop: '1px solid #D6D7D9'
+  },
+  '& tr td a': {
+    display: 'inline-flex',
+    alignItems: 'center'
+  },
+  '& tr td svg': {
+    marginLeft: '1rem'
+  },
+  '& tr td:last-child': {
+    fontStyle: 'italic'
+  }
+});
+
+const transcriptionFileColumns = [
+  {
+    align: 'left',
+    valueFunction: (rowObject) => (
+      <span>
+        <DocketTypeBadge name={rowObject.docketName} number={rowObject.docketNumber} />
+        {rowObject.docketNumber}
+      </span>
+    ),
+    header: 'Docket(s)'
+  },
+  {
+    align: 'left',
+    valueName: 'dateUploaded',
+    header: 'Uploaded',
+  },
+  {
+    align: 'left',
+    valueFunction: (rowObject) => (
+      <Link to="/">
+        {rowObject.fileName}
+        <DownloadIcon color={COLORS.PRIMARY} />
+      </Link>
+    ),
+    header: 'File Link'
+  },
+  {
+    align: 'left',
+    valueName: 'status',
+    header: 'Status'
+  }
+];
+
+const buildRowObjectsFromRecordings = (hearing) => {
+  // TO-DO: Replace hard-coded recordings with props
+  return RECORDINGS.map((recording, recordingIndex) => {
+    return recording.files.map((file, fileIndex) => {
+      const fileObj = {
+        ...file,
+        isEvenGroup: recordingIndex % 2 === 0
+      };
+
+      if (fileIndex === 0) {
+        fileObj.docketNumber = recording.docketNumber;
+        fileObj.docketName = hearing.docketName;
+      }
+
+      return fileObj;
+    });
+  }).flat();
+};
+
+const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-row-group`;
+
+const TranscriptionFilesTable = ({ hearing }) => (
+  <div {...genericRow}>
+    <Table
+      id="transcripton-files-table"
+      columns={transcriptionFileColumns}
+      getKeyForRow={(index) => index}
+      rowObjects={buildRowObjectsFromRecordings(hearing)}
+      rowClassNames={rowClassNames}
+      styling={tableStyling}
+      bodyStyling={bodyStyling}
+    />
+  </div>
+);
+
+TranscriptionFilesTable.propTypes = {
+  recordings: PropTypes.arrayOf(PropTypes.object),
+  hearing: PropTypes.object
+};
+
+export default TranscriptionFilesTable;

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -107,7 +107,6 @@ const TranscriptionFilesTable = ({ recordings, hearing }) => {
     setRows(buildRowsFromRecordings());
   }, []);
 
-
   return (
     <div {...genericRow}>
       <Table

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { css } from 'glamor';
 
@@ -11,11 +11,11 @@ import { DownloadIcon } from '../../../components/icons/DownloadIcon';
 
 const tableStyling = css({
   marginTop: 0,
-  '& tr > *:first-child': {
-    paddingLeft: '2.5rem'
-  },
   '& *:focus': {
     outline: 'none'
+  },
+  '& tr > *:first-child': {
+    paddingLeft: '2.5rem'
   }
 });
 
@@ -80,41 +80,48 @@ const transcriptionFileColumns = [
   }
 ];
 
-const buildRowObjectsFromRecordings = (recordings, hearing) => {
-  return recordings.map((recording, recordingIndex) => {
-    return recording.files.map((file, fileIndex) => {
-      const fileObj = {
-        ...file,
-        isEvenGroup: recordingIndex % 2 === 0
-      };
-
-      if (fileIndex === 0) {
-        fileObj.docketNumber = recording.docketNumber;
-        fileObj.docketName = hearing.docketName;
-      }
-
-      return fileObj;
-    });
-  }).flat();
-};
-
 const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-row-group`;
 
-const TranscriptionFilesTable = ({ recordings, hearing }) => (
-  <div {...genericRow}>
-    {recordings.length > 0 && (
+const TranscriptionFilesTable = ({ recordings, hearing }) => {
+  const [rows, setRows] = useState([]);
+
+  const buildRowsFromRecordings = () => {
+    return recordings.map((recording, recordingIndex) => {
+      return recording.files.map((file, fileIndex) => {
+        const fileObj = {
+          ...file,
+          isEvenGroup: recordingIndex % 2 === 0
+        };
+
+        if (fileIndex === 0) {
+          fileObj.docketNumber = recording.docketNumber;
+          fileObj.docketName = hearing.docketName;
+        }
+
+        return fileObj;
+      });
+    }).flat();
+  };
+
+  useEffect(() => {
+    setRows(buildRowsFromRecordings());
+  }, []);
+
+
+  return (
+    <div {...genericRow}>
       <Table
         id="transcripton-files-table"
         columns={transcriptionFileColumns}
         getKeyForRow={(index) => index}
-        rowObjects={buildRowObjectsFromRecordings(recordings, hearing)}
+        rowObjects={rows}
         rowClassNames={rowClassNames}
         styling={tableStyling}
         bodyStyling={bodyStyling}
       />
-    )}
-  </div>
-);
+    </div>
+  );
+};
 
 TranscriptionFilesTable.propTypes = {
   recordings: PropTypes.arrayOf(PropTypes.object),

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import Link from '../../../components/Link';
 import { css } from 'glamor';
 import _ from 'lodash';
 import moment from 'moment-timezone';
@@ -69,7 +69,7 @@ const transcriptionFileColumns = [
   {
     align: 'left',
     valueFunction: (rowObject) => (
-      <Link to={rowObject.awsLink}>
+      <Link href={rowObject.awsLink} target="_blank">
         {rowObject.fileName}
         <DownloadIcon color={COLORS.PRIMARY} />
       </Link>
@@ -88,13 +88,12 @@ const rowClassNames = (rowObject) => `${rowObject.isEvenGroup ? 'even' : 'odd'}-
 const TranscriptionFilesTable = ({ hearing }) => {
   const [rows, setRows] = useState([]);
 
+  // One hearing may have multiple recordings. Format table to associate files by recording
   const buildRowsFromRecordings = () => {
-    const recordings = _.flatMap(hearing.transcriptionFiles);
+    const recordings = _.flatMap(hearing.transcriptionFiles, (rec) => [_.flatMap(rec)]);
 
     return recordings.map((recording, recordingIndex) => {
-      const files = _.flatMap(recording);
-
-      return files.map((file, fileIndex) => {
+      return recording.map((file, fileIndex) => {
         const fileObj = {
           ...file,
           isEvenGroup: recordingIndex % 2 === 0
@@ -130,8 +129,16 @@ const TranscriptionFilesTable = ({ hearing }) => {
 };
 
 TranscriptionFilesTable.propTypes = {
-  recordings: PropTypes.arrayOf(PropTypes.object),
-  hearing: PropTypes.object
+  hearing: PropTypes.shape({
+    docketNumber: PropTypes.string,
+    docketName: PropTypes.string,
+    transcriptionFiles: PropTypes.shape({
+      awsLink: PropTypes.string,
+      dateUploadAws: PropTypes.string,
+      fileName: PropTypes.string,
+      fileStatus: PropTypes.string
+    })
+  })
 };
 
 export default TranscriptionFilesTable;

--- a/client/app/hearings/components/details/TranscriptionFilesTable.jsx
+++ b/client/app/hearings/components/details/TranscriptionFilesTable.jsx
@@ -69,7 +69,7 @@ const transcriptionFileColumns = [
   {
     align: 'left',
     valueFunction: (rowObject) => (
-      <Link href={rowObject.awsLink} target="_blank">
+      <Link href={`/hearings/transcription_file/${rowObject.id}/download.${rowObject.fileType}`}>
         {rowObject.fileName}
         <DownloadIcon color={COLORS.PRIMARY} />
       </Link>

--- a/client/app/hearings/components/details/TranscriptionFormSection.jsx
+++ b/client/app/hearings/components/details/TranscriptionFormSection.jsx
@@ -7,6 +7,114 @@ import TranscriptionProblemInputs from './TranscriptionProblemInputs';
 import TranscriptionRequestInputs from './TranscriptionRequestInputs';
 import TranscriptionFilesTable from './TranscriptionFilesTable';
 
+// TO-DO: Replace hard-coded recordings
+const RECORDINGS = [
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  },
+  {
+    hearingType: 'Hearing',
+    docketNumber: '230808-800',
+    files: [
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP4',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.vtt',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.MP3',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      },
+      {
+        fileName: 'ROSELIA_TURNER0510-2.rtf',
+        status: 'Successful upload (AWS)',
+        dateUploaded: '08/11/22'
+      }
+    ]
+  }
+];
+
 export const TranscriptionFormSection = (
   { hearing, transcription, readOnly, update }
 ) => (
@@ -37,6 +145,7 @@ export const TranscriptionFormSection = (
 
     <h3>Transcription Files</h3>
     <TranscriptionFilesTable
+      recordings={RECORDINGS}
       hearing={hearing}
     />
   </ContentSection>

--- a/client/app/hearings/components/details/TranscriptionFormSection.jsx
+++ b/client/app/hearings/components/details/TranscriptionFormSection.jsx
@@ -120,6 +120,7 @@ export const TranscriptionFormSection = (
   { hearing, transcription, readOnly, update, isLegacy }
 ) => (
   <ContentSection header="Transcription Details">
+    {/* If Legacy Hearing and conference provider Webex, only render Transcription Files table */}
     {!isLegacy && (
       <>
         <TranscriptionDetailsInputs
@@ -144,15 +145,21 @@ export const TranscriptionFormSection = (
           update={(values) => update('hearing', values)}
           readOnly={readOnly}
         />
-        <div className="cf-help-divider" />
+        {hearing.conferenceProvider === 'webex' && <div className="cf-help-divider" />}
       </>
     )}
 
-    <h3 {...(isLegacy && { ...genericRow })}>Transcription Files</h3>
-    <TranscriptionFilesTable
-      recordings={RECORDINGS}
-      hearing={hearing}
-    />
+    {/* If conference provider not Webex, do not render Transcriptoin Files table */}
+    {hearing.conferenceProvider === 'webex' && (
+      <>
+        <h3 {...(isLegacy && { ...genericRow })}>Transcription Files</h3>
+        <TranscriptionFilesTable
+          // TO-DO: Update when hard-coded recordings removed
+          recordings={RECORDINGS}
+          hearing={hearing}
+        />
+      </>
+    )}
   </ContentSection>
 );
 

--- a/client/app/hearings/components/details/TranscriptionFormSection.jsx
+++ b/client/app/hearings/components/details/TranscriptionFormSection.jsx
@@ -6,6 +6,7 @@ import TranscriptionDetailsInputs from './TranscriptionDetailsInputs';
 import TranscriptionProblemInputs from './TranscriptionProblemInputs';
 import TranscriptionRequestInputs from './TranscriptionRequestInputs';
 import TranscriptionFilesTable from './TranscriptionFilesTable';
+import { genericRow } from './style';
 
 // TO-DO: Replace hard-coded recordings
 const RECORDINGS = [
@@ -116,34 +117,38 @@ const RECORDINGS = [
 ];
 
 export const TranscriptionFormSection = (
-  { hearing, transcription, readOnly, update }
+  { hearing, transcription, readOnly, update, isLegacy }
 ) => (
   <ContentSection header="Transcription Details">
-    <TranscriptionDetailsInputs
-      title="Transcription Details"
-      transcription={transcription}
-      update={(values) => update('transcription', values)}
-      readOnly={readOnly}
-    />
-    <div className="cf-help-divider" />
+    {!isLegacy && (
+      <>
+        <TranscriptionDetailsInputs
+          title="Transcription Details"
+          transcription={transcription}
+          update={(values) => update('transcription', values)}
+          readOnly={readOnly}
+        />
+        <div className="cf-help-divider" />
 
-    <h3>Transcription Problem</h3>
-    <TranscriptionProblemInputs
-      transcription={transcription}
-      update={(values) => update('transcription', values)}
-      readOnly={readOnly}
-    />
-    <div className="cf-help-divider" />
+        <h3>Transcription Problem</h3>
+        <TranscriptionProblemInputs
+          transcription={transcription}
+          update={(values) => update('transcription', values)}
+          readOnly={readOnly}
+        />
+        <div className="cf-help-divider" />
 
-    <h3>Transcription Request</h3>
-    <TranscriptionRequestInputs
-      hearing={hearing}
-      update={(values) => update('hearing', values)}
-      readOnly={readOnly}
-    />
-    <div className="cf-help-divider" />
+        <h3>Transcription Request</h3>
+        <TranscriptionRequestInputs
+          hearing={hearing}
+          update={(values) => update('hearing', values)}
+          readOnly={readOnly}
+        />
+        <div className="cf-help-divider" />
+      </>
+    )}
 
-    <h3>Transcription Files</h3>
+    <h3 {...(isLegacy && { ...genericRow })}>Transcription Files</h3>
     <TranscriptionFilesTable
       recordings={RECORDINGS}
       hearing={hearing}
@@ -155,5 +160,6 @@ TranscriptionFormSection.propTypes = {
   update: PropTypes.func,
   hearing: PropTypes.object,
   readOnly: PropTypes.bool,
-  transcription: PropTypes.object
+  transcription: PropTypes.object,
+  isLegacy: PropTypes.bool
 };

--- a/client/app/hearings/components/details/TranscriptionFormSection.jsx
+++ b/client/app/hearings/components/details/TranscriptionFormSection.jsx
@@ -5,6 +5,7 @@ import { ContentSection } from '../../../components/ContentSection';
 import TranscriptionDetailsInputs from './TranscriptionDetailsInputs';
 import TranscriptionProblemInputs from './TranscriptionProblemInputs';
 import TranscriptionRequestInputs from './TranscriptionRequestInputs';
+import TranscriptionFilesTable from './TranscriptionFilesTable';
 
 export const TranscriptionFormSection = (
   { hearing, transcription, readOnly, update }
@@ -31,6 +32,12 @@ export const TranscriptionFormSection = (
       hearing={hearing}
       update={(values) => update('hearing', values)}
       readOnly={readOnly}
+    />
+    <div className="cf-help-divider" />
+
+    <h3>Transcription Files</h3>
+    <TranscriptionFilesTable
+      hearing={hearing}
     />
   </ContentSection>
 );

--- a/client/app/hearings/components/details/TranscriptionFormSection.jsx
+++ b/client/app/hearings/components/details/TranscriptionFormSection.jsx
@@ -8,114 +8,6 @@ import TranscriptionRequestInputs from './TranscriptionRequestInputs';
 import TranscriptionFilesTable from './TranscriptionFilesTable';
 import { genericRow } from './style';
 
-// TO-DO: Replace hard-coded recordings
-const RECORDINGS = [
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  },
-  {
-    hearingType: 'Hearing',
-    docketNumber: '230808-800',
-    files: [
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP4',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.vtt',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.MP3',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      },
-      {
-        fileName: 'ROSELIA_TURNER0510-2.rtf',
-        status: 'Successful upload (AWS)',
-        dateUploaded: '08/11/22'
-      }
-    ]
-  }
-];
-
 export const TranscriptionFormSection = (
   { hearing, transcription, readOnly, update, isLegacy }
 ) => (
@@ -154,8 +46,6 @@ export const TranscriptionFormSection = (
       <>
         <h3 {...(isLegacy && { ...genericRow })}>Transcription Files</h3>
         <TranscriptionFilesTable
-          // TO-DO: Update when hard-coded recordings removed
-          recordings={RECORDINGS}
           hearing={hearing}
         />
       </>

--- a/client/app/styles/hearings/_hearings.scss
+++ b/client/app/styles/hearings/_hearings.scss
@@ -705,3 +705,53 @@ $form-width: 575px;
     margin-right: 1rem;
   }
 }
+
+// Transcription Files Table
+.transcription-files-table {
+  margin-top: 0;
+
+  *:focus {
+    outline: none;
+  }
+
+  tr > *:first-child {
+    padding-left: 2.5rem !important;
+  }
+
+  tbody {
+
+    tr {
+      &:first-child td {
+        padding-top: 3rem;
+      }
+
+      &.even-row-group td {
+        background-color: #F9F9F9;
+      }
+
+      td {
+        border: 0;
+        padding-top: 0;
+        padding-bottom: 3rem;
+
+        &:last-child {
+          font-style: italic;
+        }
+
+        a {
+          display: inline-flex;
+          align-items: center;
+        }
+
+        svg {
+          margin-left: 1rem;
+        }
+      }
+    }
+
+    tr.even-row-group + tr.odd-row-group td, tr.odd-row-group + tr.even-row-group td {
+      border-top: 1px solid #D6D7D9;
+      padding-top: 3rem;
+    }
+  }
+}

--- a/client/app/styles/hearings/_hearings.scss
+++ b/client/app/styles/hearings/_hearings.scss
@@ -714,8 +714,8 @@ $form-width: 575px;
     outline: none;
   }
 
-  tr > *:first-child {
-    padding-left: 2.5rem !important;
+  th:first-child {
+    padding-left: 2.5rem;
   }
 
   tbody {
@@ -726,13 +726,17 @@ $form-width: 575px;
       }
 
       &.even-row-group td {
-        background-color: #F9F9F9;
+        background-color: $cf-background;
       }
 
       td {
         border: 0;
         padding-top: 0;
         padding-bottom: 3rem;
+
+        &:first-child {
+          padding-left: 2.5rem;
+        }
 
         &:last-child {
           font-style: italic;
@@ -749,8 +753,8 @@ $form-width: 575px;
       }
     }
 
-    tr.even-row-group + tr.odd-row-group td, tr.odd-row-group + tr.even-row-group td {
-      border-top: 1px solid #D6D7D9;
+    .even-row-group + .odd-row-group td, .odd-row-group + .even-row-group td {
+      border-top: 1px solid $color-gray-lighter;
       padding-top: 3rem;
     }
   }

--- a/client/app/styles/hearings/_hearings.scss
+++ b/client/app/styles/hearings/_hearings.scss
@@ -753,7 +753,8 @@ $form-width: 575px;
       }
     }
 
-    .even-row-group + .odd-row-group td, .odd-row-group + .even-row-group td {
+    .even-row-group + .odd-row-group td,
+    .odd-row-group + .even-row-group td {
       border-top: 1px solid $color-gray-lighter;
       padding-top: 3rem;
     }

--- a/client/test/app/hearings/components/Details.test.js
+++ b/client/test/app/hearings/components/Details.test.js
@@ -12,6 +12,9 @@ import {
   amaHearing,
   defaultHearing,
   virtualHearing,
+  nonVirtualWebexHearing,
+  amaWebexHearing,
+  legacyWebexHearing,
   vsoUser
 } from 'test/data';
 import Button from 'app/components/Button';
@@ -20,8 +23,10 @@ import Details from 'app/hearings/components/Details';
 import DetailsForm from 'app/hearings/components/details/DetailsForm';
 import HearingTypeDropdown from 'app/hearings/components/details/HearingTypeDropdown';
 import SearchableDropdown from 'app/components/SearchableDropdown';
-import TranscriptionRequestInputs from
-  'app/hearings/components/details/TranscriptionRequestInputs';
+import TranscriptionDetailsInputs from 'app/hearings/components/details/TranscriptionDetailsInputs';
+import TranscriptionProblemInputs from 'app/hearings/components/details/TranscriptionProblemInputs';
+import TranscriptionRequestInputs from 'app/hearings/components/details/TranscriptionRequestInputs';
+import TranscriptionFilesTable from 'app/hearings/components/details/TranscriptionFilesTable';
 import EmailConfirmationModal from 'app/hearings/components/EmailConfirmationModal';
 import toJson from 'enzyme-to-json';
 import { node } from 'prop-types';
@@ -230,43 +235,131 @@ describe('Details', () => {
     expect(toJson(details, { noKey: true })).toMatchSnapshot();
   });
 
-  test('Does not display transcription section for legacy hearings', () => {
-    const details = mount(
-      <Details
-        hearing={legacyHearing}
-        saveHearing={saveHearingSpy}
-        setHearing={setHearingSpy}
-        goBack={goBackSpy}
-        onReceiveAlerts={onReceiveAlertsSpy}
-        onReceiveTransitioningAlert={onReceiveTransitioningAlertSpy}
-        transitionAlert={transitionAlertSpy}
-      />,
-      {
-        wrappingComponent: hearingDetailsWrapper(
-          anyUser,
-          legacyHearing
-        ),
-        wrappingComponentProps: { store: detailsStore },
-      }
-    );
+  describe('TranscriptiomFormSection', () => {
+    describe('pexip hearing', () => {
+      test('Displays transcription section but not transcription files table for AMA hearings', () => {
+        const details = mount(
+          <Details
+            hearing={amaHearing}
+            saveHearing={saveHearingSpy}
+            setHearing={setHearingSpy}
+            goBack={goBackSpy}
+            onReceiveAlerts={onReceiveAlertsSpy}
+            onReceiveTransitioningAlert={onReceiveTransitioningAlertSpy}
+            transitionAlert={transitionAlertSpy}
+          />,
+          {
+            wrappingComponent: hearingDetailsWrapper(
+              anyUser,
+              amaHearing
+            ),
+            wrappingComponentProps: { store: detailsStore },
+          }
+        );
 
-    // Assertions
-    expect(details.find(DetailsHeader)).toHaveLength(1);
-    expect(details.find(DetailsForm)).toHaveLength(1);
+        expect(details.find(TranscriptionFormSection)).toHaveLength(1);
+        expect(details.find(TranscriptionDetailsInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionProblemInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionRequestInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionFilesTable)).toHaveLength(0);
+      });
 
-    // Ensure that the virtualHearing form is not displayed by default
-    expect(details.find(VirtualHearingFields).prop('virtualHearing')).toEqual(
-      null
-    );
-    expect(details.find(VirtualHearingFields).children()).toHaveLength(0);
+      test('Does not display transcription section for legacy hearings', () => {
+        const details = mount(
+          <Details
+            hearing={legacyHearing}
+            saveHearing={saveHearingSpy}
+            setHearing={setHearingSpy}
+            goBack={goBackSpy}
+            onReceiveAlerts={onReceiveAlertsSpy}
+            onReceiveTransitioningAlert={onReceiveTransitioningAlertSpy}
+            transitionAlert={transitionAlertSpy}
+          />,
+          {
+            wrappingComponent: hearingDetailsWrapper(
+              anyUser,
+              legacyHearing
+            ),
+            wrappingComponentProps: { store: detailsStore },
+          }
+        );
 
-    // Ensure the transcription form is not displayed for legacy hearings
-    expect(details.find(TranscriptionFormSection)).toHaveLength(0);
+        // Assertions
+        expect(details.find(DetailsHeader)).toHaveLength(1);
+        expect(details.find(DetailsForm)).toHaveLength(1);
 
-    // Ensure the save and cancel buttons are present
-    detailButtonsTest(details);
+        // Ensure that the virtualHearing form is not displayed by default
+        expect(details.find(VirtualHearingFields).prop('virtualHearing')).toEqual(
+          null
+        );
+        expect(details.find(VirtualHearingFields).children()).toHaveLength(0);
 
-    expect(toJson(details, { noKey: true })).toMatchSnapshot();
+        // Ensure the transcription form is not displayed for legacy hearings
+        expect(details.find(TranscriptionFormSection)).toHaveLength(0);
+        // expect(details.find(TranscriptionFilesTable)).toHaveLength(0);
+
+        // Ensure the save and cancel buttons are present
+        detailButtonsTest(details);
+
+        expect(toJson(details, { noKey: true })).toMatchSnapshot();
+      });
+    });
+
+    describe('webex hearing', () => {
+      test('Displays transcription section, including transcription files table, for AMA hearings', () => {
+        const details = mount(
+          <Details
+            hearing={amaWebexHearing}
+            saveHearing={saveHearingSpy}
+            setHearing={setHearingSpy}
+            goBack={goBackSpy}
+            onReceiveAlerts={onReceiveAlertsSpy}
+            onReceiveTransitioningAlert={onReceiveTransitioningAlertSpy}
+            transitionAlert={transitionAlertSpy}
+          />,
+          {
+            wrappingComponent: hearingDetailsWrapper(
+              anyUser,
+              amaWebexHearing
+            ),
+            wrappingComponentProps: { store: detailsStore },
+          }
+        );
+
+        expect(details.find(TranscriptionFormSection)).toHaveLength(1);
+        expect(details.find(TranscriptionDetailsInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionProblemInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionRequestInputs)).toHaveLength(1);
+        expect(details.find(TranscriptionFilesTable)).toHaveLength(1);
+      });
+
+      test('Only displays transcription files table, and not other transcription form inputs, for legacy hearings', () => {
+        const details = mount(
+          <Details
+            hearing={legacyWebexHearing}
+            saveHearing={saveHearingSpy}
+            setHearing={setHearingSpy}
+            goBack={goBackSpy}
+            onReceiveAlerts={onReceiveAlertsSpy}
+            onReceiveTransitioningAlert={onReceiveTransitioningAlertSpy}
+            transitionAlert={transitionAlertSpy}
+          />,
+          {
+            wrappingComponent: hearingDetailsWrapper(
+              anyUser,
+              legacyWebexHearing
+            ),
+            wrappingComponentProps: { store: detailsStore },
+          }
+        );
+
+        expect(details.find(TranscriptionFormSection)).toHaveLength(1);
+        expect(details.find(TranscriptionDetailsInputs)).toHaveLength(0);
+        expect(details.find(TranscriptionProblemInputs)).toHaveLength(0);
+        expect(details.find(TranscriptionRequestInputs)).toHaveLength(0);
+        expect(details.find(TranscriptionFilesTable)).toHaveLength(1);
+      });
+    });
   });
 
   test('Displays VirtualHearing details when there is a virtual hearing', () => {

--- a/client/test/app/hearings/components/Details.test.js
+++ b/client/test/app/hearings/components/Details.test.js
@@ -12,10 +12,8 @@ import {
   amaHearing,
   defaultHearing,
   virtualHearing,
-  nonVirtualWebexHearing,
   amaWebexHearing,
-  legacyWebexHearing,
-  vsoUser
+  legacyWebexHearing
 } from 'test/data';
 import Button from 'app/components/Button';
 import DateSelector from 'app/components/DateSelector';

--- a/client/test/app/hearings/components/details/__snapshots__/HearingLinks.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/HearingLinks.test.js.snap
@@ -137,7 +137,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
         }
       }
       label="Hearing Coordinator Link"
-      link="https://instant-usgov.webex.com/visit/wz17ys8"
+      link={null}
       linkText="Start Hearing"
       role="HC"
       user={
@@ -172,7 +172,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
             }
           }
           label="Start Hearing"
-          link="https://instant-usgov.webex.com/visit/wz17ys8"
+          link={null}
           role="HC"
           user={
             Object {
@@ -199,7 +199,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
             }
             isVirtual={false}
             label="Start Hearing"
-            link="https://instant-usgov.webex.com/visit/wz17ys8"
+            link={null}
             newWindow={true}
             showFullLink={false}
             user={
@@ -213,11 +213,11 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
             }
           >
             <Link
-              href="https://instant-usgov.webex.com/visit/wz17ys8"
+              href={null}
               target="_blank"
             >
               <a
-                href="https://instant-usgov.webex.com/visit/wz17ys8"
+                href={null}
                 target="_blank"
                 type={null}
               >
@@ -273,15 +273,13 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
           <div
             className="helper-text"
             data-css-1abghdv=""
-          >
-            https://instant-usgov.webex.com/visit/wz17ys8
-          </div>
+          />
           <CopyTextButton
             ariaLabel="Copy HC Link"
             label=""
             styling={Object {}}
             text="Copy HC Link"
-            textToCopy="https://instant-usgov.webex.com/visit/wz17ys8"
+            textToCopy={null}
           >
             <Tooltip
               id="tooltip-Copy HC Link"
@@ -296,7 +294,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                 data-for="tooltip-Copy HC Link"
                 data-tip={true}
                 tabIndex={0}
-                text="https://instant-usgov.webex.com/visit/wz17ys8"
+                text="Copy HC Link"
               >
                 <button
                   aria-describedby="tooltip-Copy HC Link"
@@ -307,7 +305,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                   data-event-off="mouseleave keydown"
                   data-for="tooltip-Copy HC Link"
                   data-tip={true}
-                  disabled={false}
+                  disabled={true}
                   onClick={[Function]}
                   tabIndex={0}
                   type="submit"

--- a/client/test/data/hearings.js
+++ b/client/test/data/hearings.js
@@ -147,6 +147,66 @@ export const nonVirtualWebexHearing = {
   summary: null,
   transcriptRequested: null,
   transcription: {},
+  transcriptionFiles: {
+    0: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    },
+    1: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      4: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.csv',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    }
+  },
   veteranAge: 30,
   veteranFileNumber: '100000100',
   veteranFirstName: 'Dennis',
@@ -156,7 +216,148 @@ export const nonVirtualWebexHearing = {
   isVirtual: false,
   wasVirtual: false,
   witness: null,
-}
+};
+
+export const legacyWebexHearing = {
+  poaName: 'AMERICAN LEGION',
+  currentIssueCount: 1,
+  caseType: 'Original',
+  aod: false,
+  advanceOnDocketMotion: null,
+  appealExternalId: '0bf0263c-d863-4405-9b2e-f55cff77c6c3',
+  appealId: 613,
+  appellantAddressLine1: '9999 MISSION ST',
+  appellantCity: 'SAN FRANCISCO',
+  appellantEmailAddress: 'tom.brady@caseflow.gov',
+  appellantFirstName: 'Tom',
+  appellantIsNotVeteran: true,
+  appellantLastName: 'Brady',
+  appellantState: 'CA',
+  appellantZip: '94103',
+  availableHearingLocations: {},
+  bvaPoc: null,
+  centralOfficeTimeString: '04:00',
+  claimantId: 604,
+  closestRegionalOffice: null,
+  conferenceProvider: 'pexip',
+  disposition: null,
+  dispositionEditable: true,
+  docketName: 'legacy',
+  docketNumber: '200624-613',
+  evidenceWindowWaived: false,
+  externalId: '61e7af7a-586c-446d-b8ee-a65be467e9e0',
+  hearingDayId: 11,
+  id: 10,
+  judge: {
+    id: 3,
+    createdAt: '2020-06-25T11:00:43.257-04:00',
+    cssId: 'BVAAABSHIRE',
+    efolderDocumentsFetchedAt: null,
+    email: null,
+    fullName: 'Aaron Judge_HearingsAndCases Abshire',
+    lastLoginAt: null,
+    roles: {},
+    selectedRegionalOffice: null,
+    stationId: '101',
+    status: 'active',
+    statusUpdatedAt: null,
+    updatedAt: '2020-06-25T11:00:43.257-04:00',
+    displayName: 'BVAAABSHIRE (VACO)',
+  },
+  judgeId: '3',
+  location: null,
+  militaryService: '',
+  notes: null,
+  paperCase: false,
+  prepped: null,
+  readableLocation: null,
+  readableRequestType: 'Video',
+  regionalOfficeKey: 'RO17',
+  regionalOfficeName: 'St. Petersburg regional office',
+  regionalOfficeTimezone: 'America/New_York',
+  representative: 'PARALYZED VETERANS OF AMERICA, INC.',
+  representativeName: null,
+  representativeEmailAddress: 'tom.brady@caseflow.gov',
+  room: '1',
+  scheduledFor: '2020-07-06T04:00:00.000-04:00',
+  scheduledForIsPast: false,
+  scheduledTime: '2000-01-01T04:00:00.000-05:00',
+  scheduledTimeString: '04:00',
+  summary: null,
+  transcriptionFiles: {
+    0: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    },
+    1: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      4: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.csv',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    }
+  },
+  uuid: '61e7af7a-586c-446d-b8ee-a65be467e9e0',
+  veteranAge: 85,
+  veteranFileNumber: '100000005',
+  veteranFirstName: 'Brian',
+  veteranGender: 'M',
+  veteranLastName: 'Hodkiewicz',
+  veteranEmailAddress: 'Brian.Hodkiewicz@test.com',
+  isVirtual: false,
+  virtualHearing: null,
+  emailEvents: [],
+  wasVirtual: false,
+  witness: null,
+  worksheetIssues: {},
+};
 
 export const amaHearingPast = {
   poaName: 'AMERICAN LEGION',

--- a/client/test/data/hearings.js
+++ b/client/test/data/hearings.js
@@ -544,25 +544,25 @@ export const amaWebexHearing = {
   transcriptionFiles: {
     0: {
       0: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name.mp4',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       1: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name.mp3',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       2: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name.vtt',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       3: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name.rtf',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
@@ -570,31 +570,31 @@ export const amaWebexHearing = {
     },
     1: {
       0: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name-2.mp4',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       1: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name-2.mp3',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       2: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name-2.vtt',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       3: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name-2.rtf',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'
       },
       4: {
-        dateUploadAws: '',
+        dateUploadAws: '2024-03-14 00:00:00 UTC',
         fileName: 'test_file_name-2.csv',
         awsLink: 'test_aws_location',
         fileStatus: 'Successful Upload (AWS)'

--- a/client/test/data/hearings.js
+++ b/client/test/data/hearings.js
@@ -147,66 +147,6 @@ export const nonVirtualWebexHearing = {
   summary: null,
   transcriptRequested: null,
   transcription: {},
-  transcriptionFiles: {
-    0: {
-      0: {
-        dateUploadAws: '',
-        fileName: 'test_file_name.mp4',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      1: {
-        dateUploadAws: '',
-        fileName: 'test_file_name.mp3',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      2: {
-        dateUploadAws: '',
-        fileName: 'test_file_name.vtt',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      3: {
-        dateUploadAws: '',
-        fileName: 'test_file_name.rtf',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      }
-    },
-    1: {
-      0: {
-        dateUploadAws: '',
-        fileName: 'test_file_name-2.mp4',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      1: {
-        dateUploadAws: '',
-        fileName: 'test_file_name-2.mp3',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      2: {
-        dateUploadAws: '',
-        fileName: 'test_file_name-2.vtt',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      3: {
-        dateUploadAws: '',
-        fileName: 'test_file_name-2.rtf',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      },
-      4: {
-        dateUploadAws: '',
-        fileName: 'test_file_name-2.csv',
-        awsLink: 'test_aws_location',
-        fileStatus: 'Successful Upload (AWS)'
-      }
-    }
-  },
   veteranAge: 30,
   veteranFileNumber: '100000100',
   veteranFirstName: 'Dennis',
@@ -239,7 +179,7 @@ export const legacyWebexHearing = {
   centralOfficeTimeString: '04:00',
   claimantId: 604,
   closestRegionalOffice: null,
-  conferenceProvider: 'pexip',
+  conferenceProvider: 'webex',
   disposition: null,
   dispositionEditable: true,
   docketName: 'legacy',
@@ -515,6 +455,152 @@ export const amaHearing = {
   summary: null,
   transcriptRequested: null,
   transcription: {},
+  uuid: '9bb8e27e-9b89-48cd-8b0b-2e75cfa5627a',
+  veteranAge: 85,
+  veteranFileNumber: '500000003',
+  veteranFirstName: 'Bob',
+  veteranGender: 'M',
+  veteranLastName: 'Smith',
+  veteranEmailAddress: 'Bob.Smith@test.com',
+  isVirtual: true,
+  wasVirtual: false,
+  witness: null,
+  worksheetIssues: {},
+  ...virtualHearing,
+  ...virtualHearingEmails,
+};
+
+export const amaWebexHearing = {
+  poaName: 'AMERICAN LEGION',
+  currentIssueCount: 1,
+  caseType: 'Original',
+  aod: false,
+  advanceOnDocketMotion: null,
+  appealExternalId: '005334f7-b5c6-490c-a310-7dc5db22c8c3',
+  appealId: 4,
+  appellantAddressLine1: '9999 MISSION ST',
+  appellantCity: 'SAN FRANCISCO',
+  appellantEmailAddress: 'tom.brady@caseflow.gov',
+  appellantFirstName: 'Bob',
+  appellantIsNotVeteran: false,
+  appellantLastName: 'Smith',
+  appellantState: 'CA',
+  appellantTz: 'America/Los_Angeles',
+  appellantZip: '94103',
+  availableHearingLocations: {},
+  bvaPoc: null,
+  centralOfficeTimeString: '03:30',
+  claimantId: 4,
+  closestRegionalOffice: null,
+  conferenceProvider: 'webex',
+  disposition: null,
+  dispositionEditable: true,
+  docketName: 'hearing',
+  docketNumber: '200628-4',
+  evidenceWindowWaived: false,
+  externalId: '9bb8e27e-9b89-48cd-8b0b-2e75cfa5627a',
+  hearingDayId: 4,
+  id: 4,
+  judgeId: 3,
+  judge: {
+    id: 3,
+    createdAt: '2020-06-25T11:00:43.257-04:00',
+    cssId: 'BVAAABSHIRE',
+    efolderDocumentsFetchedAt: null,
+    email: null,
+    fullName: 'Aaron Judge_HearingsAndCases Abshire',
+    lastLoginAt: null,
+    roles: {},
+    selectedRegionalOffice: null,
+    stationId: '101',
+    status: 'active',
+    statusUpdatedAt: null,
+    updatedAt: '2020-06-25T11:00:43.257-04:00',
+    displayName: 'BVAAABSHIRE (VACO)',
+    meetingType: 'pexip'
+  },
+  location: null,
+  militaryService: '',
+  notes: null,
+  paperCase: false,
+  prepped: null,
+  readableLocation: 'Washington, DC',
+  readableRequestType: 'Central',
+  regionalOfficeKey: 'C',
+  regionalOfficeName: 'Central',
+  regionalOfficeTimezone: 'America/New_York',
+  representative: 'Clarence Darrow',
+  representativeName: 'PARALYZED VETERANS OF AMERICA, INC.',
+  representativeEmailAddress: 'tom.brady@caseflow.gov',
+  representativeTz: 'America/Denver',
+  room: '2',
+  scheduledFor: '2020-07-06T06:00:00.000-04:00',
+  scheduledForIsPast: false,
+  scheduledTime: '2000-01-01T03:30:00.000-05:00',
+  scheduledTimeString: '03:30',
+  summary: null,
+  transcriptRequested: null,
+  transcription: {},
+  transcriptionFiles: {
+    0: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    },
+    1: {
+      0: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp4',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      1: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.mp3',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      2: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.vtt',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      3: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.rtf',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      },
+      4: {
+        dateUploadAws: '',
+        fileName: 'test_file_name-2.csv',
+        awsLink: 'test_aws_location',
+        fileStatus: 'Successful Upload (AWS)'
+      }
+    }
+  },
   uuid: '9bb8e27e-9b89-48cd-8b0b-2e75cfa5627a',
   veteranAge: 85,
   veteranFileNumber: '500000003',

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,4 +1,8 @@
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "text/richtext", :rtf
+Mime::Type.register "audio/mpeg", :mp3
+Mime::Type.register "video/mp4", :mp4
+Mime::Type.register "text/csv", :csv
+Mime::Type.register "text/vtt", :vtt

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,8 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:
-Mime::Type.register "text/richtext", :rtf
-Mime::Type.register "audio/mpeg", :mp3
-Mime::Type.register "video/mp4", :mp4
-Mime::Type.register "text/csv", :csv
-Mime::Type.register "text/vtt", :vtt
+# Mime::Type.register "text/richtext", :rtf

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -236,7 +236,7 @@ Rails.application.routes.draw do
   get 'hearings/schedule/assign/hearing_days', to: "hearings/hearing_day#index_with_hearings"
   get 'hearings/queue/appeals/:vacols_id', to: 'queue#index'
   get 'hearings/find_closest_hearing_locations', to: 'hearings#find_closest_hearing_locations'
-  get 'hearings/:hearing_id/transcript_file', to: 'hearings/transcription_files#download_transcription_file'
+  get 'hearings/transcription_file/:file_id/download', to: 'hearings/transcription_files#download_transcription_file'
 
   post 'hearings/hearing_view/:id', to: 'hearings/hearing_view#create'
 

--- a/spec/controllers/hearings/transcription_files_controller_spec.rb
+++ b/spec/controllers/hearings/transcription_files_controller_spec.rb
@@ -4,8 +4,9 @@ describe Hearings::TranscriptionFilesController, :all_dbs, type: :controller do
   let(:hearings_user) { create(:hearings_coordinator) }
   before { User.authenticate!(user: hearings_user) }
   describe "routes" do
-    let!(:hearing) { create(:hearing, :held) }
-    let(:options) { { format: :vtt, hearing_id: hearing.id } }
+    let!(:hearing) { create(:hearing, :with_transcription_files) }
+    let(:transcription_file) { hearing.transcription_files.first }
+    let(:options) { { format: :vtt, file_id: transcription_file.id } }
     subject { get :download_transcription_file, params: options }
 
     it "downloading file" do

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -135,7 +135,8 @@ FactoryBot.define do
               file_type: file_type,
               docket_number: hearing.docket_number,
               file_status: "Successful upload (AWS)",
-              date_upload_aws: Time.zone.today
+              date_upload_aws: Time.zone.today,
+              aws_link: "www.test.com"
             )
           end
         end

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -121,5 +121,25 @@ FactoryBot.define do
                appeal: hearing.appeal)
       end
     end
+
+    trait :with_transcription_files do
+      after(:create) do |hearing, _evaluator|
+        hearing.meeting_type.update(service_name: "webex")
+
+        2.times do |count|
+          %w[mp4 mp3 vtt rtf].each do |file_type|
+            TranscriptionFile.create!(
+              hearing_id: hearing.id,
+              hearing_type: "LegacyHearing",
+              file_name: "#{hearing.docket_number}_#{hearing.id}_LegacyHearing#{count == 1 ? '-2' : ''}.#{file_type}",
+              file_type: file_type,
+              docket_number: hearing.docket_number,
+              file_status: "Successful upload (AWS)",
+              date_upload_aws: Time.zone.today
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -130,8 +130,8 @@ FactoryBot.define do
           %w[mp4 mp3 vtt rtf].each do |file_type|
             TranscriptionFile.create!(
               hearing_id: hearing.id,
-              hearing_type: "LegacyHearing",
-              file_name: "#{hearing.docket_number}_#{hearing.id}_LegacyHearing#{count == 1 ? '-2' : ''}.#{file_type}",
+              hearing_type: "Hearing",
+              file_name: "#{hearing.docket_number}_#{hearing.id}_Hearing#{count == 1 ? '-2' : ''}.#{file_type}",
               file_type: file_type,
               docket_number: hearing.docket_number,
               file_status: "Successful upload (AWS)",

--- a/spec/factories/legacy_hearing.rb
+++ b/spec/factories/legacy_hearing.rb
@@ -91,5 +91,25 @@ FactoryBot.define do
         )
       end
     end
+
+    trait :with_transcription_files do
+      after(:create) do |hearing, _evaluator|
+        hearing.meeting_type.update(service_name: "webex")
+
+        2.times do |count|
+          %w[mp4 mp3 vtt rtf].each do |file_type|
+            TranscriptionFile.create!(
+              hearing_id: hearing.id,
+              hearing_type: "LegacyHearing",
+              file_name: "#{hearing.docket_number}_#{hearing.id}_LegacyHearing#{count == 1 ? '-2' : ''}.#{file_type}",
+              file_type: file_type,
+              docket_number: hearing.docket_number,
+              file_status: "Successful upload (AWS)",
+              date_upload_aws: Time.zone.today
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/factories/legacy_hearing.rb
+++ b/spec/factories/legacy_hearing.rb
@@ -105,7 +105,8 @@ FactoryBot.define do
               file_type: file_type,
               docket_number: hearing.docket_number,
               file_status: "Successful upload (AWS)",
-              date_upload_aws: Time.zone.today
+              date_upload_aws: Time.zone.today,
+              aws_link: "www.test.com"
             )
           end
         end

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -108,7 +108,7 @@ RSpec.feature "Hearing Details", :all_dbs do
   def check_transcription_files_table(hearing)
     check_transcription_files_table_headers
 
-    within "table#transcription-files-table > tbody" do
+    within "table.transcription-files-table > tbody" do
       expect(find_all("tr").length).to eq(hearing.transcription_files.size)
 
       # Group transcription files by docket number to ensure table styled accordingly
@@ -127,7 +127,7 @@ RSpec.feature "Hearing Details", :all_dbs do
   end
 
   def check_transcription_files_table_headers
-    within "table#transcription-files-table > thead > tr" do
+    within "table.transcription-files-table > thead > tr" do
       expect(find("th:first-child")).to have_content("Docket(s)")
       expect(find("th:nth-child(2)")).to have_content("Uploaded")
       expect(find("th:nth-child(3)")).to have_content("File Link")
@@ -140,7 +140,7 @@ RSpec.feature "Hearing Details", :all_dbs do
     formatted_date = file.date_upload_aws.strftime("%m/%d/%Y")
 
     within "#table-row-#{row_number}" do
-      download_url = "/hearings/transcription_file/#{file.id}/download.#{file.file_type}"
+      download_url = "/hearings/transcription_file/#{file.id}/download"
 
       expect(find("td:first-child")).to have_content(docket_number)
       expect(find("td:nth-child(2)")).to have_content(formatted_date)

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -140,7 +140,7 @@ RSpec.feature "Hearing Details", :all_dbs do
     within "#table-row-#{row_number}" do
       expect(find("td:first-child")).to have_content(docket_number)
       expect(find("td:nth-child(2)")).to have_content(formatted_date)
-      expect(find("td:nth-child(3)")).to have_content(file.file_name)
+      expect(find("td:nth-child(3)")).to have_link(file.file_name, href: file.aws_link)
       expect(find("td:last-child")).to have_content(file.file_status)
     end
   end

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -111,8 +111,8 @@ RSpec.feature "Hearing Details", :all_dbs do
     within "table#transcription-files-table > tbody" do
       expect(find_all("tr").length).to eq(hearing.transcription_files.size)
 
-      # Group transcription files by associated recording to ensure table styled accordingly
-      hearing.transcription_files_by_recording.each_with_index do |recording, group_index|
+      # Group transcription files by docket number to ensure table styled accordingly
+      hearing.transcription_files_by_docket_number.each_with_index do |recording, group_index|
         group_class = "#{group_index.even? ? 'even' : 'odd'}-row-group"
 
         recording.each_with_index do |file, file_index|


### PR DESCRIPTION
Resolves:
- [APPEALS-37292: Add Transcription Files subsection to Hearing Details](https://jira.devops.va.gov/browse/APPEALS-37292)
- [APPEALS-37293: Populate table within Transcript Files section on Hearing Details](https://jira.devops.va.gov/browse/APPEALS-37293)

# Description
As a Caseflow Developer I need to create a new table in TranscriptionFormSection.jsx and have information dynamically populated per hearing

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] A new section is added
  - [ ] as a subsection of Transcription Details section
  - [ ] contains title of Transcription Files
  - [ ] contains a table (to be populated later) with the following header
    - [ ] Docket(s)
    - [ ] Uploaded
    - [ ] File Link
    - [ ] Status
  - [ ] This section is visible for both Legacy and AMA Appeals
    - [ ] This does not expose the rest of the Transcription Details section for Legacy Appeals
- [ ] The following headers have information dynamically populated per hearing
  - [ ] Docket(s)
  - [ ] Uploaded
  - [ ] File Link
  - [ ] Status

## Testing Plan
1. Go to [APPEALS-42501](https://jira.devops.va.gov/browse/APPEALS-42501)

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---
**Hearing Details**![Screenshot 2024-03-19 at 10 53 23 AM](https://github.com/department-of-veterans-affairs/caseflow/assets/106996298/639a9b5e-13d1-4b65-b819-e12303415aa0)|**Hearing Details**![Screenshot 2024-03-19 at 10 51 33 AM](https://github.com/department-of-veterans-affairs/caseflow/assets/106996298/14d65ac1-0dd9-47ef-91a5-c268e5afd6a3)
N/A|**with transcription files**<img width="1405" alt="Screenshot 2024-03-22 at 11 17 18 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/106996298/76f6a244-fc79-4d98-9dad-a45ca6797471">


