### PR TITLE
APPEALS-41972 Simplify Error Message

### DIFF
--- a/client/app/caseDistribution/utils.js
+++ b/client/app/caseDistribution/utils.js
@@ -126,11 +126,11 @@ export const validateLeverInput = (lever, value) => {
   const { min_value: minValue, max_value: maxValue } = lever;
 
   if (value === null || value === '') {
-    errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.minimum_not_met });
+    errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
   }
   if (parseFloat(value)) {
     if (value < minValue) {
-      errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.minimum_not_met });
+      errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
     }
     if (maxValue && value > maxValue) {
       const message = ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue);

--- a/client/app/caseDistribution/utils.js
+++ b/client/app/caseDistribution/utils.js
@@ -126,11 +126,13 @@ export const validateLeverInput = (lever, value) => {
   const { min_value: minValue, max_value: maxValue } = lever;
 
   if (value === null || value === '') {
-    errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
+    errors.push({ leverItem: lever.item,
+      message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
   }
   if (parseFloat(value)) {
     if (value < minValue) {
-      errors.push({ leverItem: lever.item, message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
+      errors.push({ leverItem: lever.item,
+        message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
     }
     if (maxValue && value > maxValue) {
       const message = ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue);

--- a/client/app/caseDistribution/utils.js
+++ b/client/app/caseDistribution/utils.js
@@ -123,22 +123,22 @@ export const formatLeverHistory = (leverHistoryList) => {
 
 export const validateLeverInput = (lever, value) => {
   const errors = [];
-  const { min_value: minValue, max_value: maxValue } = lever;
+  const { item, min_value: minValue, max_value: maxValue } = lever;
+  let valueErrorMessage = null;
 
-  if (value === null || value === '') {
-    errors.push({ leverItem: lever.item,
-      message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
+  const numericValue = value === '' || value === null ? NaN : parseFloat(value);
+
+  if (maxValue !== null && (isNaN(numericValue) || numericValue < minValue || numericValue > maxValue)) {
+    valueErrorMessage = ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue);
+  } else if (maxValue === null && (value === '' || value === null)) {
+    valueErrorMessage = ACD_LEVERS.validation_error_message.minimum_not_met;
   }
-  if (parseFloat(value)) {
-    if (value < minValue) {
-      errors.push({ leverItem: lever.item,
-        message: ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue) });
-    }
-    if (maxValue && value > maxValue) {
-      const message = ACD_LEVERS.validation_error_message.out_of_bounds.replace('%s', maxValue);
 
-      errors.push({ leverItem: lever.item, message });
-    }
+  if (valueErrorMessage !== null) {
+    errors.push({
+      leverItem: item,
+      message: valueErrorMessage
+    });
   }
 
   return errors;

--- a/client/test/app/caseDistribution/reducers/levers/leversActions.test.js
+++ b/client/test/app/caseDistribution/reducers/levers/leversActions.test.js
@@ -218,7 +218,8 @@ describe('levers actions', () => {
     const lever = alternativeBatchSize;
     const dispatch = jest.fn();
 
-    actions.validateLever(lever, lever.item, -1, [])(dispatch);
+    actions.validateLever(lever, lever.item, '', [])(dispatch);
+    actions.validateLever(lever, lever.item, null, [])(dispatch);
 
     expect(dispatch).toHaveBeenLastCalledWith(expect.any(Function));
   });


### PR DESCRIPTION
Resolves [Two different validation error messages are being displayed for AMA Hearing Affinity Days levers on the admin UI](https://jira.devops.va.gov/browse/APPEALS-41972)

# Description
Fixes bug in DocketTimeGoals where two error messages displayed instead of just one "Please enter a value from 0 to 999"
## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Two different validation error messages are being displayed for AMA Hearing Affinity Days levers on the admin UI](https://jira.devops.va.gov/browse/APPEALS-41972)
