### PR TITLE
Hotfix/APPEALS-10993 v2

### DIFF
--- a/app/models/attorney_claimant.rb
+++ b/app/models/attorney_claimant.rb
@@ -9,16 +9,16 @@ class AttorneyClaimant < Claimant
 
   delegate :name, to: :bgs_attorney
 
-  def advanced_on_docket?(_appeal)
-    false
+  def advanced_on_docket?(appeal)
+    advanced_on_docket_motion_granted?(appeal)
   end
 
   def advanced_on_docket_based_on_age?
     false
   end
 
-  def advanced_on_docket_motion_granted?(_appeal)
-    false
+  def advanced_on_docket_motion_granted?(appeal)
+    AdvanceOnDocketMotion.granted.for_appeal(appeal).any?
   end
 
   def relationship

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -288,6 +288,35 @@ FactoryBot.define do
       end
     end
 
+    trait :advanced_on_docket_attorney_claimant do
+      # the appeal has to be established before the motion is created to apply to it.
+      established_at { Time.zone.now - 1 }
+      after(:create) do |appeal|
+        # Create an appeal with two claimants, one with a denied AOD motion
+        # and one with a granted motion. The appeal should still be counted as AOD. Appeals only support one claimant,
+        # so set the aod claimant as the last claimant on the appeal (and create it last)
+        another_claimant = create(:claimant, decision_review: appeal)
+        create(:advance_on_docket_motion, person: another_claimant.person, granted: false, appeal: appeal)
+
+        claimant = create(:claimant, decision_review: appeal)
+        create(:advance_on_docket_motion, person: claimant.person, granted: true, appeal: appeal)
+
+        appeal.claimants = [another_claimant, claimant]
+      end
+    end
+
+    trait :advanced_on_docket_granted_attorney_claimant do
+      # the appeal has to be established before the motion is created to apply to it.
+      established_at { Time.zone.now - 1 }
+      after(:create) do |appeal|
+        # Create an appeal with a granted AOD motion
+        claimant = create(:claimant, :attorney, decision_review: appeal)
+        create(:advance_on_docket_motion, person: claimant.person, granted: true, appeal: appeal)
+
+        appeal.claimants = [claimant]
+      end
+    end
+
     trait :cancelled do
       after(:create) do |appeal, _evaluator|
         # make sure a request issue exists, then mark all removed

--- a/spec/models/appeal_spec.rb
+++ b/spec/models/appeal_spec.rb
@@ -579,6 +579,19 @@ describe Appeal, :all_dbs do
     end
   end
 
+  context "when there is a granted aod, claimant is an AttorneyClaimant and aod_based_on_age is false" do
+    let(:appeal) { create(:appeal, :advanced_on_docket_granted_attorney_claimant) }
+
+    it "returns true" do
+      expect(appeal.advanced_on_docket?).to eq(true)
+      expect(appeal.aod_based_on_age).to eq(false)
+    end
+
+    it "does not return nil" do
+      expect(appeal.advanced_on_docket?).not_to eq(nil)
+    end
+  end
+
   context "#find_appeal_by_uuid_or_find_or_create_legacy_appeal_by_vacols_id" do
     context "with a uuid (AMA appeal id)" do
       let(:veteran_file_number) { "64205050" }

--- a/spec/models/claimant_spec.rb
+++ b/spec/models/claimant_spec.rb
@@ -171,10 +171,13 @@ describe Claimant, :postgres do
         create(:advance_on_docket_motion, person_id: claimant.person.id, granted: true, appeal: appeal)
       end
 
-      it "returns false" do
+      it "returns false when based on age" do
         expect(claimant.advanced_on_docket_based_on_age?).to eq(false)
-        expect(claimant.advanced_on_docket_motion_granted?(appeal)).to eq(false)
-        expect(claimant.advanced_on_docket?(appeal)).to eq(false)
+      end
+
+      it "returns true when motion is granted" do
+        expect(claimant.advanced_on_docket_motion_granted?(appeal)).to eq(true)
+        expect(claimant.advanced_on_docket?(appeal)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-10993 AOD badge for AttorneyClaimant is not displayed regardless of a granted motion for AOD on Appeal](https://jira.devops.va.gov/browse/APPEALS-10993)

# Description
Reverted logic on deciding AOD on Appeal and then added logic for deciding AOD on AttorneyClaimant

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below


Find appeal created by AttorneyClaimant
 ```ruby
attorney_claimant_appeals = []

Appeal.last(2000).each do |a|
    if a.claimant.type == "AttorneyClaimant"
        attorney_claimant_appeals.push(a)
    end
end
```
 
 Check to see if there is a granted AOD associated with the appeal
```ruby
appeals_with_granted_aod = []

attorney_claimant_appeals.each do |a|
    aod = AdvanceOnDocketMotion.find_by(appeal_id: a.id)
    if aod && aod.granted: true
        granted.push(a)
    end
end
``` 


If we find that the appeals_with_granted_aod array has an appeal, we need to check the appeal to see if aod_based_on_age is false
If false, then our defect scenario has been found and we should see the red AOD symbol on the case details page for the appeal
If aod_based_on_age is true, or the array is empty, we will need to create an AdvanceOnDocketMotion (AOD) for one of the appeals
```ruby
a = attorney_claimant_appeals.first
```

 
In order to create an AOD, we will need a user
When choosing a user, I looked at a number of AOD's and selected the most common user_id

 ```ruby
AdvanceOnDocketMotion.last(15)
 
user = User.find([id of most common user_id])
 
```

Create an AOD for the appeal
 ```ruby
AdvanceOnDocketMotion.create_or_update_by_appeal(
    a,
    reason: "financial_distress",
    granted: "true",
    user_id: u.id,
)
```


- [ ] For feature branches merging into master: Was this deployed to UAT?


### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added
