### PR TITLE
jcroteau/APPEALS-43158 - Bypass DNS rebinding protection for all `demo` domains (dev)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -70,6 +70,9 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  # Bypass DNS rebinding protection for all `demo` sub-domains
+  config.hosts << ".demo.appeals.va.gov"
+
   #=====================================================================================================================
   # Please keep custom config settings below this comment.
   #   This will ensure cleaner diffs when generating config file changes during Rails upgrades.


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-43158

## Background

[Rails 6.0 introduced protection against DNS Rebinding Attacks](https://blog.saeloun.com/2019/10/31/rails-6-adds-guard-against-dns-rebinding-attacks/ "Follow link") by default in `development` environments.

See relevant documentation from the [Rails Guides](https://guides.rubyonrails.org/v6.0/configuring.html#configuring-middleware "Follow link"):
> 
> `ActionDispatch::HostAuthorization` prevents against DNS rebinding and other Host header attacks. It is included in the development environment by default with the following configuration:
> 
> ```ruby
> Rails.application.config.hosts = [
>   IPAddr.new("0.0.0.0/0"), # All IPv4 addresses.
>   IPAddr.new("::/0"),      # All IPv6 addresses.
>   "localhost"              # The localhost reserved domain.
> ]
> ```
> 
> In other environments Rails.application.config.hosts is empty and no Host header checks will be done. If you want to guard against header attacks on production, you have to manually permit the allowed hosts with:
> 
> ```
> Rails.application.config.hosts << "product.com"
> ```
> 
> The host of a request is checked against the hosts entries with the case operator (`#===`), which lets hosts support entries of type `Regexp`, `Proc` and `IPAddr` to name a few. Here is an example with a regexp.
> 
> ```ruby
> # Allow requests from subdomains like `www.product.com` and `beta1.product.com`.
> 
> Rails.application.config.hosts << /.*\.product\.com/
> ```
> 
> The provided regexp will be wrapped with both anchors (\A and \z) so it must match the entire hostname. `/product.com/`, for example, once anchored, would fail to match www.product.com.
> 
> A special case is supported that allows you to permit all sub-domains:
> 
> ```ruby
> # Allow requests from subdomains like `www.product.com` and `beta1.product.com`.
> 
> Rails.application.config.hosts << ".product.com"
> ```
> 
## Problem

This is causing issues for us in our `demo` environments, since these use the `development` configuration. In `demo` , we leverage custom domain names, which are running afoul of the aforementioned DNS Rebinding Attack protection and prevent pages from loading.

## Proposed Solution

In the `config/development.rb` file, we need to add something like the following to bypass protection for our custom `demo` domains:

```ruby
# Bypass DNS rebinding protection for all `demo` sub-domains  
config.hosts << ".demo.appeals.va.gov"
```