### PR TITLE
jcroteau/APPEALS-34124- Post-Rails 6.0 configuration updates

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -65,16 +65,6 @@ module CaseflowCertification
     # Default as of 5.2: true
     config.active_record.cache_versioning = false
 
-    # Use AES-256-GCM authenticated encryption for encrypted cookies.
-    # Also, embed cookie expiry in signed or encrypted cookies for increased security.
-    #
-    # This option is not backwards compatible with earlier Rails versions.
-    # It's best enabled when your entire app is migrated and stable on 5.2.
-    #
-    # Existing cookies will be converted on read then written with the new scheme.
-    # Default as of 5.2: true
-    config.action_dispatch.use_authenticated_cookie_encryption = false
-    #
     # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
     # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
     # Default as of 5.2: true

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,7 +12,7 @@ require "vbms"
 module CaseflowCertification
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.0
     config.autoloader = :classic
 
     # Settings in config/environments/* take precedence over those specified here.
@@ -96,27 +96,9 @@ module CaseflowCertification
     # Default as of 6.0: false
     config.action_view.default_enforce_utf8 = true
 
-    # Embed purpose and expiry metadata inside signed and encrypted
-    # cookies for increased security.
-    #
-    # This option is not backwards compatible with earlier Rails versions.
-    # It's best enabled when your entire app is migrated and stable on 6.0.
-    # Default as of 6.0: true
-    config.action_dispatch.use_cookies_with_metadata = false
-
     # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
     # Default as of 6.0: false
     config.action_dispatch.return_only_media_type_on_content_type = true
-
-    # Use ActionMailer::MailDeliveryJob for sending parameterized and normal mail.
-    #
-    # The default delivery jobs (ActionMailer::Parameterized::DeliveryJob, ActionMailer::DeliveryJob),
-    # will be removed in Rails 6.1. This setting is not backwards compatible with earlier Rails versions.
-    # If you send mail in the background, job workers need to have a copy of
-    # MailDeliveryJob to ensure all delivery jobs are processed properly.
-    # Make sure your entire app is migrated and stable on 6.0 before using this setting.
-    # Default as of 6.0: "ActionMailer::MailDeliveryJob"
-    config.action_mailer.delivery_job = nil
 
     # Enable the same cache key to be reused when the object being cached of type
     # `ActiveRecord::Relation` changes by moving the volatile information (max updated at and count)

--- a/config/application.rb
+++ b/config/application.rb
@@ -65,6 +65,16 @@ module CaseflowCertification
     # Default as of 5.2: true
     config.active_record.cache_versioning = false
 
+    # Use AES-256-GCM authenticated encryption for encrypted cookies.
+    # Also, embed cookie expiry in signed or encrypted cookies for increased security.
+    #
+    # This option is not backwards compatible with earlier Rails versions.
+    # It's best enabled when your entire app is migrated and stable on 5.2.
+    #
+    # Existing cookies will be converted on read then written with the new scheme.
+    # Default as of 5.2: true
+    config.action_dispatch.use_authenticated_cookie_encryption = false
+    #
     # Use AES-256-GCM authenticated encryption as default cipher for encrypting messages
     # instead of AES-256-CBC, when use_authenticated_message_encryption is set to true.
     # Default as of 5.2: true
@@ -85,6 +95,14 @@ module CaseflowCertification
     # Don't force requests from old versions of IE to be UTF-8 encoded.
     # Default as of 6.0: false
     config.action_view.default_enforce_utf8 = true
+
+    # Embed purpose and expiry metadata inside signed and encrypted
+    # cookies for increased security.
+    #
+    # This option is not backwards compatible with earlier Rails versions.
+    # It's best enabled when your entire app is migrated and stable on 6.0.
+    # Default as of 6.0: true
+    config.action_dispatch.use_cookies_with_metadata = false
 
     # Change the return value of `ActionDispatch::Response#content_type` to Content-Type header without modification.
     # Default as of 6.0: false

--- a/spec/feature/non_comp/report_page_spec.rb
+++ b/spec/feature/non_comp/report_page_spec.rb
@@ -331,7 +331,7 @@ feature "NonComp Report Page", :postgres do
   end
 
   def change_history_csv_file
-    wait_for(5)
+    sleep 5
     # Copied from Capybara setup
     download_directory = Rails.root.join("tmp/downloads_#{ENV['TEST_SUBCATEGORY'] || 'all'}")
     list_of_files = Dir.glob(File.join(download_directory, "*")).select { |f| File.file?(f) }
@@ -339,12 +339,5 @@ feature "NonComp Report Page", :postgres do
 
     expect(latest_file).to_not eq(nil)
     latest_file
-  end
-
-  def wait_for(seconds)
-    start_time = Time.zone.now
-    while Time.zone.now - start_time < seconds
-      # Do nothing, just wait
-    end
   end
 end


### PR DESCRIPTION
**This PR is part of a 4 PR stack:**
1. [This PR]
2. https://github.com/department-of-veterans-affairs/caseflow/pull/21336
3. https://github.com/department-of-veterans-affairs/caseflow/pull/21453
4. https://github.com/department-of-veterans-affairs/caseflow/pull/22181

---

Resolves: https://jira.devops.va.gov/browse/APPEALS-34124

## Background

After Rails 6.0 is stable in production, there are some updates we need to make to the configuration settings.

### `config.action_mailer.delivery_job`

Prior to Rails 6.1, the default delivery jobs, `ActionMailer::Parameterized::DeliveryJob` and  `ActionMailer::DeliveryJob`, are enqueued when `deliver_later` is called on a Rails mailer.

In Rails 6.1, these jobs will be removed and entirely replaced with a new `ActionMailer::MailDeliveryJob` class moving forward.

In order to ease the transition between these classes, Rails 6.0 introduces an optional config setting, `config.action_mailer.delivery_job = "ActionMailer::MailDeliveryJob"`, which will allow existing jobs to continue processing with the old classes while new jobs are enqueued with `ActionMailer::MailDeliveryJob`.

This setting is not backwards compatible, so it should only be activated once the application is stable on Rails 6.0.

After Rails 6.0 is stable in production, we can assume the default value for this setting.

_**Note:** As of this writing, we are not using `ActionMailer::Base #deliver_later` anywhere in caseflow to deliver emails (we use background jobs executed via Shoryuken instead), so this change should have no effect on any of our email deliveries._

### `config.load_defaults`

Due to the backwards-incompatible config settings mentioned above, we were not able to set `config.load_defaults` to `6.0` during the Rails 6.0 upgrade. Now that we can safely assume 
 the above defaults, we can change `config.load_defaults` from `5.2` to `6.0`.

## Proposed Solution

After Rails 6.0 is stable in production, in the `config/application.rb` file:
- remove the override for `config.action_mailer.delivery_job`
- set `config.load_defaults` to `6.0`

---

## Testing
Jira Test: https://jira.devops.va.gov/browse/APPEALS-43257