### PR TITLE
Move Auto Assign Button to Correspondence Queue

### DIFF
--- a/client/app/queue/OrganizationQueue.jsx
+++ b/client/app/queue/OrganizationQueue.jsx
@@ -8,7 +8,6 @@ import QueueTableBuilder from './QueueTableBuilder';
 import Alert from '../components/Alert';
 import AppSegment from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/AppSegment';
 import { clearCaseSelectSearch } from '../reader/CaseSelect/CaseSelectActions';
-import AutoAssignAlertBanner from './correspondence/component/AutoAssignAlertBanner';
 
 const containerStyles = css({
   position: 'relative'
@@ -28,7 +27,6 @@ class OrganizationQueue extends React.PureComponent {
 
     return <React.Fragment>
       {success && <Alert styling={alertPaddingStyles} type="success" title={success.title} message={success.detail} />}
-      {featureToggles.correspondence_queue && <AutoAssignAlertBanner />}
       <AppSegment filledBackground styling={containerStyles}>
         <QueueTableBuilder featureToggles={featureToggles} />
       </AppSegment>

--- a/client/app/queue/QueueTableBuilder.jsx
+++ b/client/app/queue/QueueTableBuilder.jsx
@@ -42,7 +42,6 @@ import COPY from '../../COPY';
 import QUEUE_CONFIG from '../../constants/QUEUE_CONFIG';
 import { css } from 'glamor';
 import { isActiveOrganizationVHA } from '../queue/selectors';
-import BatchAutoAssignButton from './correspondence/component/BatchAutoAssignButton';
 
 const rootStyles = css({
   '.usa-alert + &': {
@@ -211,11 +210,6 @@ const QueueTableBuilder = (props) => {
       label: sprintf(tabConfig.label, totalTaskCount),
       page: (
         <React.Fragment>
-          {props.userCanBulkAssign &&
-          tabConfig.allow_bulk_assign &&
-          props.activeOrganization.type === 'InboundOpsTeam' && (
-            <BatchAutoAssignButton />
-          )}
           <p className="cf-margin-top-0">
             {noCasesMessage || tabConfig.description}
           </p>

--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -11,6 +11,8 @@ import { css } from 'glamor';
 import CorrespondenceTable from './CorrespondenceTable';
 import QueueOrganizationDropdown from '../components/QueueOrganizationDropdown';
 import Alert from '../../components/Alert';
+import AutoAssignAlertBanner from '../correspondence/component/AutoAssignAlertBanner';
+import BatchAutoAssignButton from '../correspondence/component/BatchAutoAssignButton';
 
 export const CorrespondenceCases = (props) => {
   const {
@@ -46,6 +48,7 @@ export const CorrespondenceCases = (props) => {
 
   return (
     <AppSegment filledBackground>
+      {props.featureToggles.correspondence_queue && <AutoAssignAlertBanner />}
       {(Object.keys(veteranInformation).length > 0) &&
         currentAction.action_type === 'DeleteReviewPackage' &&
         <Alert
@@ -56,6 +59,7 @@ export const CorrespondenceCases = (props) => {
       }
       <h1 {...css({ display: 'inline-block' })}>{COPY.CASE_LIST_TABLE_QUEUE_DROPDOWN_CORRESPONDENCE_CASES}</h1>
       <QueueOrganizationDropdown organizations={organizations} />
+      {props.featureToggles.correspondence_queue && <BatchAutoAssignButton />}
       {vetCorrespondences &&
         <CorrespondenceTable
           vetCorrespondences={vetCorrespondences}
@@ -70,7 +74,8 @@ CorrespondenceCases.propTypes = {
   loadVetCorrespondence: PropTypes.func,
   vetCorrespondences: PropTypes.array,
   currentAction: PropTypes.object,
-  veteranInformation: PropTypes.object
+  veteranInformation: PropTypes.object,
+  featureToggles: PropTypes.object
 };
 
 const mapStateToProps = (state) => ({

--- a/client/app/queue/correspondence/component/AutoAssignAlertBanner.jsx
+++ b/client/app/queue/correspondence/component/AutoAssignAlertBanner.jsx
@@ -99,7 +99,7 @@ const AutoAssignAlertBanner = (props) => {
           title={bannerAlert.title}
           message={bannerAlert.message}
           scrollOnAlert={false}
-	  lowerMargin={true}
+          lowerMargin
         />
       }
     </>

--- a/client/app/queue/correspondence/component/AutoAssignAlertBanner.jsx
+++ b/client/app/queue/correspondence/component/AutoAssignAlertBanner.jsx
@@ -93,12 +93,13 @@ const AutoAssignAlertBanner = (props) => {
 
   return (
     <>
-      { batchId && bannerAlert.message &&
+      {batchId && bannerAlert.message &&
         <Alert
           type={bannerAlert.type}
           title={bannerAlert.title}
           message={bannerAlert.message}
           scrollOnAlert={false}
+	  lowerMargin={true}
         />
       }
     </>

--- a/client/app/queue/correspondence/component/BatchAutoAssignButton.jsx
+++ b/client/app/queue/correspondence/component/BatchAutoAssignButton.jsx
@@ -5,8 +5,10 @@ import COPY from '../../../../COPY';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { setBatchAutoAssignmentAttemptId,
-  setAutoAssignButtonDisabled } from '../correspondenceReducer/reviewPackageActions';
+import {
+  setBatchAutoAssignmentAttemptId,
+  setAutoAssignButtonDisabled
+} from '../correspondenceReducer/reviewPackageActions';
 
 const BatchAutoAssignButton = (props) => {
   const handleAutoAssign = async () => {
@@ -22,7 +24,7 @@ const BatchAutoAssignButton = (props) => {
   };
 
   return (
-    <div>
+    <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
       <Button
         onClick={handleAutoAssign}
         ariaLabel="Auto assign correspondences"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves ['Auto Assign Correspondence' button not running job](https://jira.devops.va.gov/browse/APPEALS-43476)

# Description
- Moved "Auto Assign Correspondences" button to the "Correspondence Cases" queue page.
- Fix misc. styling issues

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Go to "Correspondence Cases" queue page and verify they match the wireframes.

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="1487" alt="before" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/cbcea00f-aaf4-4c10-85d5-28e5688b6feb">|<img width="1487" alt="after" src="https://github.com/department-of-veterans-affairs/caseflow/assets/2421172/ce04ec08-006e-402f-a091-92412dcc299c">