### PR TITLE
jcroteau/APPEALS-43428 - Replace `Caseflow::Migration` for concurrent index migrations on ActiveRecord 6.0+

### DIFF
--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -6,6 +6,11 @@
 module DisallowedDeprecations
   class ::DisallowedDeprecationError < StandardError; end
 
+  # Regular expressions for custom deprecation warnings that we have addressed in the codebase
+  CUSTOM_DEPRECATION_WARNING_REGEXES = [
+    /Caseflow::Migration is deprecated/
+  ].freeze
+
   # Regular expressions for Rails 6.0 deprecation warnings that we have addressed in the codebase
   RAILS_6_0_FIXED_DEPRECATION_WARNING_REGEXES = [
     /Dangerous query method \(method whose arguments are used as raw SQL\) called with non\-attribute argument\(s\)/,
@@ -24,6 +29,7 @@ module DisallowedDeprecations
 
   # Regular expressions for deprecation warnings that should raise an exception on detection
   DISALLOWED_DEPRECATION_WARNING_REGEXES = [
+    *CUSTOM_DEPRECATION_WARNING_REGEXES,
     *RAILS_6_0_FIXED_DEPRECATION_WARNING_REGEXES,
     *RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES
   ].freeze

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,2 +1,20 @@
 StrongMigrations.start_after = 20190111000717
 StrongMigrations.auto_analyze = true
+
+# Customized error message when a new migration uses `add_index` non-concurrently
+StrongMigrations.error_messages[:add_index] = <<~TEXT
+  Adding a non-concurrent index locks the table for writes.
+  Instead, prefer using `Caseflow::Migrations::AddIndexConcurrently #add_safe_index`:
+   
+      class YourMigrationName < ActiveRecord::Migration%{migration_suffix}
+        include Caseflow::Migrations::AddIndexConcurrently
+        
+        def change
+          add_safe_index # add args here...
+        end
+      end
+
+  Nota Bene: Since adding indexes concurrently must occur outside of a transaction, 
+  one should avoid mixing in other DB changes when doing so. It is strongly recommended 
+  to segregate index additions from other DB changes in a separate migration.
+  TEXT

--- a/lib/caseflow/migration.rb
+++ b/lib/caseflow/migration.rb
@@ -1,8 +1,25 @@
 # frozen_string_literal: true
 
-# Migration with built-in timeout extensions for adding indexes
-
+# @deprecated Use {Caseflow::Migrations::AddIndexConcurrently} instead, because descendants of this class are forever
+#   coupled to Active Record 5.1.
+#   This class should be preserved until all descendant migrations <= LAST_DESCENDANT_MIGRATION_VERSION are pruned.
+#
+# @note Migration with built-in timeout extensions for adding indexes
 class Caseflow::Migration < ActiveRecord::Migration[5.1]
+  # version of last migration that inherits from this class (across 'primary' and 'etl' databases)
+  LAST_DESCENDANT_MIGRATION_VERSION = 20_240_617_205_006
+
+  def initialize(*)
+    super
+    # Trigger deprecation warning to prevent re-introduction in migrations after LAST_DESCENDANT_MIGRATION_VERSION
+    if version > LAST_DESCENDANT_MIGRATION_VERSION
+      ActiveSupport::Deprecation.warn(
+        "Caseflow::Migration is deprecated and should no longer be used.\n" \
+        "If adding an index, see Caseflow::Migrations::AddIndexConcurrently."
+      )
+    end
+  end
+
   # hardcode this because setting via class method does not work in subclass
   def disable_ddl_transaction
     say "disable_ddl_transaction is true"

--- a/lib/caseflow/migrations/add_index_concurrently.rb
+++ b/lib/caseflow/migrations/add_index_concurrently.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+# @note Usage: Include this module only in migrations where you need to add an index concurrently.
+#   Invoke `#add_safe_index` in place of `#add index`.
+#
+# @note Since this module necessarily disables transactions, you should avoid mixing in other DB changes when
+#   adding indexes concurrently. Prefer isolating index additions in their own migration.
+#
+# @see [PostgreSQL: Building Indexes Concurrently](https://www.postgresql.org/docs/14/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY)
+# @see [thoughtbot: How to Create Postgres Indexes Concurrently in ActiveRecord Migrations](https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in)
+#
+# @example
+#   class YourMigrationName < ActiveRecord::Migration[6.0]
+#     include Caseflow::Migrations::AddIndexConcurrently
+#
+#     change
+#       add_safe_index :some_table, :some_column
+#     end
+#   end
+#
+# @example
+#   # Alternatively, you can add in the requisite incantations yourself, without this module
+#
+#   class YourMigrationName < ActiveRecord::Migration[6.0]
+#     disable_ddl_transaction!
+#
+#     change
+#       add_index :some_table, :some_column, algorithm: :concurrently
+#     rescue StandardError => error
+#       remove_index :some_table, :some_column
+#     end
+#   end
+module Caseflow
+  module Migrations
+    module AddIndexConcurrently
+      extend ActiveSupport::Concern
+
+      EXTENDED_STATEMENT_TIMEOUT_DURATION = 30.minutes
+
+      included do
+        # Disables the automatic transaction wrapping this migration.
+        # https://github.com/rails/rails/blob/28bb76d3efc39b2ef663dfe2346f7c2621343cd6/activerecord/lib/active_record/migration.rb#L508-L524
+        disable_ddl_transaction!
+
+        # @note Use this method in place of `#add_index` to add an index concurrently (i.e. without blocking DB writes).
+        # - Accommodates long-running index builds by extending the statement_timeout duration
+        # - Performs a rollback should an error occur during the migration, since transactions are disabled
+        #
+        # @note Inspired by {Caseflow::Migration} https://github.com/department-of-veterans-affairs/caseflow/blob/6fc9d26a5ae9417b69d7d1f30cc70bea57a0700d/lib/caseflow/migration.rb#L12-L29
+        def add_safe_index(*args)
+          original_statement_timeout_duration = get_current_statement_timeout_duration
+          extend_statement_timeout
+          add_index_concurrently(args)
+        rescue StandardError => error
+          rollback_index(error, args)
+          raise error # re-raise to abort migration
+        ensure
+          restore_original_statement_timeout(original_statement_timeout_duration)
+        end
+
+        private
+
+        def get_current_statement_timeout_duration
+          ActiveSupport::Duration.build(
+            ActiveRecord::Base.connection.execute("SHOW statement_timeout").first["statement_timeout"].to_i
+          )
+        end
+
+        def extend_statement_timeout
+          say "Extending statement_timeout to #{EXTENDED_STATEMENT_TIMEOUT_DURATION.inspect}"
+          ActiveRecord::Base.connection.execute(
+            "SET statement_timeout = #{EXTENDED_STATEMENT_TIMEOUT_DURATION.in_milliseconds}"
+          )
+        end
+
+        def add_index_concurrently(args)
+          table, columns, options = *args
+          options ||= {}
+          options[:algorithm] ||= :concurrently
+          add_index(table, columns, options)
+        end
+
+        def rollback_index(error, args)
+          say "Caught #{error}, rolling back index"
+          table, columns, options = *args
+          options[:column] = columns unless options[:name]
+          remove_index(table, options)
+        end
+
+        def restore_original_statement_timeout(duration)
+          say "Restoring statement_timeout to #{duration.inspect}"
+          ActiveRecord::Base.connection.execute("SET statement_timeout = #{duration.in_milliseconds}")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- [ ] 🔴 **Pre-release Note:** Update `Caseflow::Migration` [deprecation cut-off version](https://github.com/department-of-veterans-affairs/caseflow/pull/21336/files#diff-e395522a7cdcd30c994b9965bdd5509dd517c28018678a915047e356055b11d4R10) to latest migration version before testing and release.

---

**This PR is part of a 4 PR stack:**
1. https://github.com/department-of-veterans-affairs/caseflow/pull/21286
2. [This PR]
3. https://github.com/department-of-veterans-affairs/caseflow/pull/21453
4. https://github.com/department-of-veterans-affairs/caseflow/pull/22181

---

Resolves https://jira.devops.va.gov/browse/APPEALS-43428

# Description

> ## Background
> 
> By default, Postgres locks writes (but not reads) to a table while creating an index on it. That can result in unacceptable downtime during a production deploy. On a large table, indexing can take hours.
> 
> _(For further details on this problem and its workaround in Rails projects, you can refer to [this article](https://thoughtbot.com/blog/how-to-create-postgres-indexes-concurrently-in "Follow link").)_
> 
> In caseflow, we have a `Caseflow::Migration` utility class, whose intended purpose is to make it more convenient to add DB indexes concurrently (i.e. without locking write operations). This is often needed because we have some rather large tables, so building new indexes on them can take a long time.  
>    
> It does this in two ways:
> 1. It disables transactions during the migration (by overriding `ActiveRecord::Migration #disable_ddl_transaction` to always be true). This is necessary to prevent table locking.
> 2. It defines a utility method to be used in place of `add_index` for adding the index concurrently (`Caseflow::Migration #add_safe_index`). This method prevents timeouts under 30 minutes and also performs a rollback should an error occur while adding the index (since transactions are disabled).
> 
> Since it turns off transactions, we **_should NOT_** be using this class for migrations in general, but only for those migrations that **_only_** add indexes.
> - There are many examples where we use it for making changes other than adding indexes, and these were likely misguided.
> - We should not be adding indexes and mixing in other database changes within the same migration.
> - We should be adding indexes concurrently in their own, isolated migrations.
> 
> ## Problems
> 1. Our `Caseflow::Migration` class inherits from `ActiveRecord::Migration[5.1]`. Now that we are Rails 6.0 / ActiveRecord 6.0, all new migrations should inherit from `ActiveRecord::Migration[6.0]`.
> 2. There are numerous examples of past migrations that have used `Caseflow::Migration` inappropriately, either accidentally or due to developer negligence. This is potentially problematic, as this opens the door to failing migrations without transaction rollbacks.
> 
> ## Proposed Solution
> 
> 1. Introduce a module to supersede `Caseflow::Migration`, to be included in new migrations that add indexes concurrently.
>     - `Caseflow::Migration` and past migrations that inherit from it will be left unchanged for posterity.
> 2. Deprecate `Caseflow::Migration` for migrations AFTER version `20240617205006`.
>   - Running `Caseflow::Migration` for migrations BEFORE version `20240617205006` should still be successful.
>   - Attempting to run a migration using `Caseflow::Migration` AFTER version `20240617205006` results in an instructive deprecation error. 
> 3. Update the configuration for the `StrongMigrations` gem such that attempting to run a migration that adds an index non-concurrently (via `add_index`) fails with an instructive error message.

## Acceptance Criteria
- A new module exists to aid in migrations for adding indexes concurrently and which supersedes `Caseflow::Migration`. 
- Attempting to run a migration using `Caseflow::Migration` BEFORE cut-off version is still successful.
- Attempting to run a migration using `Caseflow::Migration` ON the cut-off version is still successful.
- Attempting to run a migration using `Caseflow::Migration` AFTER cut-off version results in an instructive deprecation error.
- Attempting to run a migration that adds an index non-concurrently fails with an instructive error message.

## Testing Plan
- See Jira Test https://jira.devops.va.gov/browse/APPEALS-43648