### PR TITLE
Use New BGS Gem Sensitivity Check Methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "acts_as_tree"
 gem "amoeba"
 # BGS
 
-gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "5f47e7b2656ef347d314ef43c93d38a9f20816ec"
+gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", branch: "caseflow/add-new-security-endpoint"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "browser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,10 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby-bgs.git
-  revision: 5f47e7b2656ef347d314ef43c93d38a9f20816ec
-  ref: 5f47e7b2656ef347d314ef43c93d38a9f20816ec
+  revision: ebb9d8add944ce2125d1fb226494edabbc8adf1c
+  branch: caseflow/add-new-security-endpoint
   specs:
-    bgs (0.3)
+    bgs (0.3.1)
       httpclient
       nokogiri (>= 1.11.0.rc4)
       savon (~> 2.12)

--- a/app/services/correspondence_auto_assigner.rb
+++ b/app/services/correspondence_auto_assigner.rb
@@ -95,7 +95,7 @@ class CorrespondenceAutoAssigner
   end
 
   def assignable_user_finder
-    @assignable_user_finder ||= AutoAssignableUserFinder.new
+    @assignable_user_finder ||= AutoAssignableUserFinder.new(current_user)
   end
 
   def run_verifier

--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -10,41 +10,7 @@ class ExternalApi::BGSService
 
   attr_reader :client
 
-  class << self
-    def init_client_for_user(user:)
-      fail "User required" if user.blank?
-
-      BGS::Services.new(**BGSService.init_client_params(user: user))
-    end
-
-    # These are the params for initializing a BGS client;
-    # this method sets the passed user's data in the request header,
-    # and as a result the passed users permissions are what get
-    # checked by the BGS service when determining permissions for BGS
-    # resource access.
-    #
-    # If no user param is passed, the current user is used
-    def init_client_params(user:)
-      forward_proxy_url = FeatureToggle.enabled?(:bgs_forward_proxy) ? ENV["RUBY_BGS_PROXY_BASE_URL"] : nil
-
-      {
-        env: Rails.application.config.bgs_environment,
-        application: "CASEFLOW",
-        client_ip: ENV.fetch("USER_IP_ADDRESS", Rails.application.secrets.user_ip_address),
-        client_station_id: user.station_id,
-        client_username: user.css_id,
-        ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],
-        ssl_cert_file: ENV["BGS_CERT_LOCATION"],
-        ssl_ca_cert: ENV["BGS_CA_CERT_LOCATION"],
-        forward_proxy_url: forward_proxy_url,
-        jumpbox_url: ENV["RUBY_BGS_JUMPBOX_URL"],
-        log: true,
-        logger: Rails.logger
-      }
-    end
-  end
-
-  def initialize(client: init_default_client)
+  def initialize(client: init_client)
     @client = client
 
     # These instance variables are used for caching their
@@ -312,8 +278,8 @@ class ExternalApi::BGSService
   #
   # We cache at 2 levels: the boolean check per user, and the veteran record itself.
   # The veteran record is so that subsequent calls to fetch_veteran_info can read from cache.
-  def can_access?(vbms_id, user_to_check: current_user)
-    Rails.cache.fetch(can_access_cache_key(user_to_check, vbms_id), expires_in: 2.hours) do
+  def can_access?(vbms_id)
+    Rails.cache.fetch(can_access_cache_key(current_user, vbms_id), expires_in: 2.hours) do
       DBService.release_db_connections
 
       MetricsService.record("BGS: can_access? (find_by_file_number): #{vbms_id}",
@@ -550,8 +516,23 @@ class ExternalApi::BGSService
     "bgs_veteran_info_#{vbms_id}"
   end
 
-  def init_default_client
-    BGS::Services.new(**BGSService.init_client_params(user: current_user))
+  def init_client
+    forward_proxy_url = FeatureToggle.enabled?(:bgs_forward_proxy) ? ENV["RUBY_BGS_PROXY_BASE_URL"] : nil
+
+    BGS::Services.new(
+      env: Rails.application.config.bgs_environment,
+      application: "CASEFLOW",
+      client_ip: ENV.fetch("USER_IP_ADDRESS", Rails.application.secrets.user_ip_address),
+      client_station_id: current_user.station_id,
+      client_username: current_user.css_id,
+      ssl_cert_key_file: ENV["BGS_KEY_LOCATION"],
+      ssl_cert_file: ENV["BGS_CERT_LOCATION"],
+      ssl_ca_cert: ENV["BGS_CA_CERT_LOCATION"],
+      forward_proxy_url: forward_proxy_url,
+      jumpbox_url: ENV["RUBY_BGS_JUMPBOX_URL"],
+      log: true,
+      logger: Rails.logger
+    )
   end
 
   def formatted_start_and_end_dates(start_date, end_date)

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -118,18 +118,6 @@ class Fakes::BGSService
       vet_record[attr] = new_value
       store_veteran_record(file_number, vet_record)
     end
-
-    def init_client_for_user(user:)
-      BGSService.init_client_params(user: user)
-    end
-
-    def init_client_params(user:)
-      { user: user } if user.is_a?(User)
-    end
-  end
-
-  def initialize(client: nil)
-    client
   end
 
   def get_end_products(file_number)
@@ -609,11 +597,11 @@ class Fakes::BGSService
     (self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
   end
 
-  def can_access?(vbms_id, user_to_check: current_user)
+  def can_access?(vbms_id)
     is_accessible = !(self.class.inaccessible_appeal_vbms_ids || []).include?(vbms_id)
 
-    if user_to_check
-      Rails.cache.fetch(can_access_cache_key(user_to_check, vbms_id), expires_in: 1.minute) do
+    if current_user
+      Rails.cache.fetch(can_access_cache_key(current_user, vbms_id), expires_in: 1.minute) do
         is_accessible
       end
     else

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -120,6 +120,22 @@ class Fakes::BGSService
     end
   end
 
+  def sensitivity_level_for_user(user)
+    fail "Invalid user" if !user.instance_of?(User)
+
+    Random.new.rand(5..9)
+  end
+
+  def sensitivity_level_for_veteran(veteran)
+    fail "Invalid veteran" if !veteran.instance_of?(Veteran)
+
+    Random.new.rand(1..4)
+  end
+
+  def sensitivity_level_for_participant_id(participant_id)
+    Random.new.rand(1..9)
+  end
+
   def get_end_products(file_number)
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -123,17 +123,13 @@ class Fakes::BGSService
   def sensitivity_level_for_user(user)
     fail "Invalid user" if !user.instance_of?(User)
 
-    Random.new.rand(5..9)
+    Random.new.rand(4..9)
   end
 
   def sensitivity_level_for_veteran(veteran)
     fail "Invalid veteran" if !veteran.instance_of?(Veteran)
 
     Random.new.rand(1..4)
-  end
-
-  def sensitivity_level_for_participant_id(participant_id)
-    Random.new.rand(1..9)
   end
 
   def get_end_products(file_number)

--- a/spec/services/auto_assignable_user_finder_spec.rb
+++ b/spec/services/auto_assignable_user_finder_spec.rb
@@ -12,6 +12,18 @@ describe AutoAssignableUserFinder do
   before do
     allow(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
 
+    allow(mock_sensitivity_checker).to receive(:sensitivity_level_for_user) do |user|
+      bgs.sensitivity_level_for_user(user)
+    end
+
+    allow(mock_sensitivity_checker).to receive(:sensitivity_level_for_veteran) do |vet|
+      bgs.sensitivity_level_for_veteran(vet)
+    end
+
+    allow(mock_sensitivity_checker).to receive(:sensitivity_level_for_participant_id) do |participant_id|
+      bgs.sensitivity_level_for_participant_id(participant_id)
+    end
+
     allow(mock_sensitivity_checker).to receive(:fetch_person_info) do |vbms_id|
       bgs.fetch_person_info(vbms_id)
     end
@@ -188,13 +200,21 @@ describe AutoAssignableUserFinder do
     end
 
     context "with sensitivity level check" do
+      let(:high_sensitivity_level) { 9 }
+      let(:low_sensitivity_level) { 1 }
+
       let!(:correspondence) { create(:correspondence, veteran_id: veteran.id) }
       let!(:user_1) { create(:correspondence_auto_assignable_user) }
       let!(:user_2) { create(:correspondence_auto_assignable_user) }
 
       context "with no BGSService errors" do
         before do
-          expect(mock_sensitivity_checker).to receive(:can_access?).twice.and_return(false)
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+            .with(user_1).and_return(low_sensitivity_level)
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+            .with(user_2).and_return(low_sensitivity_level)
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_veteran)
+            .with(correspondence.veteran).twice.and_return(high_sensitivity_level)
           expect(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
         end
 
@@ -205,8 +225,12 @@ describe AutoAssignableUserFinder do
 
       context "when the BGSService raises an error" do
         before do
-          expect(mock_sensitivity_checker).to receive(:can_access?).once.and_raise("Test BGS error")
-          expect(mock_sensitivity_checker).to receive(:can_access?).once.and_return(true)
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+            .with(user_1).and_raise("Test BGS error")
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+            .with(user_2).and_return(high_sensitivity_level)
+          expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_veteran)
+            .with(correspondence.veteran).and_return(high_sensitivity_level)
           expect(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
         end
 

--- a/spec/services/auto_assignable_user_finder_spec.rb
+++ b/spec/services/auto_assignable_user_finder_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 describe AutoAssignableUserFinder do
-  subject(:described) { described_class.new }
+  let!(:current_user) { create(:user) }
+  subject(:described) { described_class.new(current_user) }
 
   let(:veteran) { create(:veteran) }
 
@@ -194,7 +195,7 @@ describe AutoAssignableUserFinder do
       context "with no BGSService errors" do
         before do
           expect(mock_sensitivity_checker).to receive(:can_access?).twice.and_return(false)
-          expect(BGSService).to receive(:new).twice.and_return(mock_sensitivity_checker)
+          expect(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
         end
 
         it "does not allow access for users without the correct sensitivity level" do
@@ -206,7 +207,7 @@ describe AutoAssignableUserFinder do
         before do
           expect(mock_sensitivity_checker).to receive(:can_access?).once.and_raise("Test BGS error")
           expect(mock_sensitivity_checker).to receive(:can_access?).once.and_return(true)
-          expect(BGSService).to receive(:new).twice.and_return(mock_sensitivity_checker)
+          expect(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
         end
 
         it "continues iterating through all assignable users" do

--- a/spec/services/auto_assignable_user_finder_spec.rb
+++ b/spec/services/auto_assignable_user_finder_spec.rb
@@ -20,10 +20,6 @@ describe AutoAssignableUserFinder do
       bgs.sensitivity_level_for_veteran(vet)
     end
 
-    allow(mock_sensitivity_checker).to receive(:sensitivity_level_for_participant_id) do |participant_id|
-      bgs.sensitivity_level_for_participant_id(participant_id)
-    end
-
     allow(mock_sensitivity_checker).to receive(:fetch_person_info) do |vbms_id|
       bgs.fetch_person_info(vbms_id)
     end

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -30,11 +30,18 @@ describe ExternalApi::BGSService do
       expect { bgs.sensitivity_level_for_user(nil) }.to raise_error(RuntimeError, "Invalid user")
     end
 
-    it "wraps sensitivity_level_for_participant_id" do
-      expect(bgs).to receive(:get_participant_id_for_user).with(user).and_return("1234")
-      expect(bgs).to receive(:sensitivity_level_for_participant_id).with("1234")
+    it "calls the security service and caches the result" do
+      participant_id = "1234"
+      sensitivity_level = Random.new.rand(1..9)
 
-      bgs.sensitivity_level_for_user(user)
+      expect(bgs).to receive(:get_participant_id_for_user).with(user).and_return(participant_id)
+      expect(bgs_client).to receive(:security).and_return(bgs_security_service)
+      expect(bgs_security_service).to receive(:find_person_scrty_log_by_ptcpnt_id)
+        .with(participant_id).and_return({ scrty_level_type_cd: "#{sensitivity_level}" })
+
+      expect(bgs.sensitivity_level_for_user(user)).to eq(sensitivity_level)
+
+      expect(Rails.cache.exist?("sensitivity_level_for_user_id_#{user.id}")).to be true
     end
   end
 
@@ -45,28 +52,16 @@ describe ExternalApi::BGSService do
       expect { bgs.sensitivity_level_for_veteran(nil) }.to raise_error(RuntimeError, "Invalid veteran")
     end
 
-    it "wraps sensitivity_level_for_participant_id" do
-      expect(bgs).to receive(:sensitivity_level_for_participant_id).with(veteran.participant_id)
-
-      bgs.sensitivity_level_for_veteran(veteran)
-    end
-  end
-
-  describe "#sensitivity_level_for_participant_id" do
-    it "validates the participant_id param" do
-      expect { bgs.sensitivity_level_for_participant_id(nil) }.to raise_error(RuntimeError, "Invalid participant_id")
-    end
-
     it "calls the security service and caches the result" do
       sensitivity_level = Random.new.rand(1..9)
 
       expect(bgs_client).to receive(:security).and_return(bgs_security_service)
       expect(bgs_security_service).to receive(:find_sensitivity_level_by_participant_id)
-        .with("1234").and_return({ scrty_level_type_cd: sensitivity_level })
+        .with(veteran.participant_id).and_return({ scrty_level_type_cd: "#{sensitivity_level}" })
 
-      expect(bgs.sensitivity_level_for_participant_id("1234")).to eq(sensitivity_level)
+      expect(bgs.sensitivity_level_for_veteran(veteran)).to eq(sensitivity_level)
 
-      expect(Rails.cache.exist?("sensitivity_level_for_participant_id_1234")).to be true
+      expect(Rails.cache.exist?("sensitivity_level_for_veteran_id_#{veteran.id}")).to be true
     end
   end
 

--- a/spec/services/external_api/bgs_service_spec.rb
+++ b/spec/services/external_api/bgs_service_spec.rb
@@ -62,7 +62,7 @@ describe ExternalApi::BGSService do
 
       expect(bgs_client).to receive(:security).and_return(bgs_security_service)
       expect(bgs_security_service).to receive(:find_sensitivity_level_by_participant_id)
-        .with("1234").and_return({scrty_level_type_cd: sensitivity_level})
+        .with("1234").and_return({ scrty_level_type_cd: sensitivity_level })
 
       expect(bgs.sensitivity_level_for_participant_id("1234")).to eq(sensitivity_level)
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [BGSService Sensitivity Level Method for Auto Assign Correspondence](https://jira.devops.va.gov/browse/APPEALS-43005)

# Description
- Create new method in BGSService for checking participant sensitivity using the BGS gem.

- Update auto assign logic to use new method for checking sensitivity for user/veteran pairs.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Run specs for changes files:
    - `bundle exec rspec ./spec/services/auto_assignable_user_finder_spec.rb`
    - `bundle exec rspec ./spec/services/correspondence_auto_assigner_spec.rb`
    - `bundle exec rspec spec/services/external_api/bgs_service_spec.rb`