### PR TITLE
Fix corner and size font in dropdown

### DIFF
--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -15,6 +15,7 @@ import Modal from 'app/components/Modal';
 import RadioFieldWithChildren from '../../components/RadioFieldWithChildren';
 import ReactSelectDropdown from '../../components/ReactSelectDropdown';
 import TextareaField from '../../components/TextareaField';
+import { css } from 'glamor';
 
 const CorrespondenceCases = (props) => {
   const dispatch = useDispatch();
@@ -90,10 +91,22 @@ const CorrespondenceCases = (props) => {
     return false;
   };
 
+  const styles = {
+    optSelect: css({
+      '.reassign': {
+      },
+      '& .css-yk16xz-control, .css-1pahdxg-control': {
+        borderRadius: '0px',
+        fontSize: '17px'
+      }
+    })
+  };
+
   const approveElement = (
     <div style={{ width: '250%' }}>
       <ReactSelectDropdown
-        className="cf-margin-left-2rem img"
+        // className="cf-margin-left-2rem img"
+        className = {`cf-margin-left-2rem img reassign ${styles.optSelect}`}
         label="Assign to person"
         onChangeMethod={(val) => setSelectedMailTeamUser(val.value)}
         options={buildMailUserData(props.mailTeamUsers)}


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-43142](https://jira.devops.va.gov/browse/APPEALS-43142)

# Description
As a Mail Team user, Superuser, or Supervisor I need to see the UI of the Correspondence queue be cohesive with the rest of Caseflow.

## Acceptance Criteria
- [x] Code compiles correctly

When a Superuser or Supervisor is on the on the Action Required tab for the Correspondence Cases queue the following occurs when a Reassign correspondence is selected:
1. When the "Approve request" radio button is clicked the dropdown box within the Reassign modal aligns with the Caseflow dropdown style of square edges
2. When the dropdown is clicked, the text font size for the items is 17 px

## Testing Plan
Demo - https://voyager.demo.appeals.va.gov/
Supervisor - MAIL_TEAM_SUPERVISOR_ADMIN_USER
Superuser - AMBRISVACO
Mail Team user - JOLLY_POSTMAN

1. Go to the demo environment, and login like `Mail Team user or Supervisor `.
2. Go to Queue, click on `Switch views` and select `Correspondences Cases`
3. Select any `reassign case` under `Action Required tab`

![image](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/89d6c0b3-9e98-407e-9751-a741199280f0)

![image_720](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/a029f1b7-89c6-490d-8f20-fa3d12b26a77)

![image_720](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/fe833cb2-fbde-4fbe-a906-f951cbf0a1ca)


