### PR TITLE
APPEALS-43927: Create Correspondence Admin Page CMP Seed Data Logic

### DIFF
--- a/lib/tasks/correspondence.rake
+++ b/lib/tasks/correspondence.rake
@@ -194,27 +194,6 @@ def create_package_document_types
   end
 end
 
-# randomly generates notes for the correspondence
-def generate_notes(params)
-  note_type = params.sample
-
-  note = ""
-  # generate note from value pulled
-  case note_type
-  when PackageDocumentType
-    note = "Package Document Type is #{note_type&.name}"
-  when CorrespondenceType
-    note = "Correspondence Type is #{note_type&.name}"
-  when ActiveSupport::TimeWithZone
-    note = "Correspondence added to Caseflow on #{note_type&.strftime("%m/%d/%y")}"
-
-  when User
-    note = "This correspondence was originally assigned to and updated by #{note_type&.css_id}."
-  end
-
-  note
-end
-
 # default packet number to 1_000_000 or increment the list of current correspondences
 def create_cmp_packet_number
   packet_number = Correspondence.last.blank? ? 1_000_000_000 : (Correspondence.last.cmp_packet_number + 1)


### PR DESCRIPTION
Resolves [APPEALS-43927](https://jira.devops.va.gov/browse/APPEALS-43927)

# Description
Create rake task that generates "CMP" seed data for use in demo/UAT.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Log into the Rails Console
2. Run the following commands:
3.  `RequestStore[:current_user] = User.find_by(css_id: 'OFFERBVAJ')`
4. `vet = Veteran.first`
5. `Rake::Task['correspondence:seed_cmp_correspondences'].invoke(vet.file_number, 20)`
6. When the rake task has completed, sign into local/Demo with OFFERBVAJ
7. Navigate to Queue
8. Navigate to Correspondence Cases
9. In the **Unassigned** tab, search for **Bob Smithklein (225630002)** and find the 20 records that were created. Validation can also be done in rails console `with Correspondence.where(veteran_id: vet.id).count`
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/e5c697a1-1186-4b85-bc61-9528e3e2ed9a)
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/ee6ba6fe-d3aa-42a0-8e6d-376d68db96bc)
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/bd558c53-ce25-4a40-9e96-eb039463a007)

![image](https://github.com/department-of-veterans-affairs/caseflow/assets/99915461/7913560c-a541-4177-9eea-0817392e9a0a)


