### PR TITLE
Fix Auto Assign VA DOR Bug

### DIFF
--- a/app/services/correspondence_auto_assigner.rb
+++ b/app/services/correspondence_auto_assigner.rb
@@ -71,7 +71,7 @@ class CorrespondenceAutoAssigner
       .preload(:appeal, :assigned_by, :assigned_to, :parent)
       .includes(:correspondence, correspondence: :veteran)
       .references(:correspondence, correspondence: :veteran)
-      .merge(Correspondence.order(va_date_of_receipt: :desc))
+      .order(va_date_of_receipt: :asc)
   end
 
   def validate_run!(current_user_id, batch_auto_assignment_attempt_id)


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Correspondence Auto Assign VA DOR Bug](https://jira.devops.va.gov/browse/APPEALS-44184)

# Description
- Fix bug causing correspondences not be sorted by VA DOR in ascending (oldest -> newest) order.

- Update specs to test this scenario.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Run specs for changed files:
  - `bundle exec rspec spec/services/correspondence_auto_assigner_spec.rb`