### PR TITLE
Move Correspondence ART CSS Styling Into a Single Stylesheet - 43605

### DIFF
--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -15,7 +15,6 @@ import Modal from 'app/components/Modal';
 import RadioFieldWithChildren from '../../components/RadioFieldWithChildren';
 import ReactSelectDropdown from '../../components/ReactSelectDropdown';
 import TextareaField from '../../components/TextareaField';
-import 'app/styles/queue/_correspondence.scss';
 
 const CorrespondenceCases = (props) => {
   const dispatch = useDispatch();

--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -15,6 +15,7 @@ import Modal from 'app/components/Modal';
 import RadioFieldWithChildren from '../../components/RadioFieldWithChildren';
 import ReactSelectDropdown from '../../components/ReactSelectDropdown';
 import TextareaField from '../../components/TextareaField';
+import 'app/styles/queue/_correspondence.scss';
 
 const CorrespondenceCases = (props) => {
   const dispatch = useDispatch();

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { COLORS } from '../../../../../constants/AppConstants';
 import { css } from 'glamor';
+import 'app/styles/queue/_correspondence.scss';
 
 const styling = { backgroundColor: COLORS.GREY_BACKGROUND, paddingTop: '0px' };
 

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { COLORS } from '../../../../../constants/AppConstants';
 import { css } from 'glamor';
-import 'app/styles/queue/_correspondence.scss';
 
 const styling = { backgroundColor: COLORS.GREY_BACKGROUND, paddingTop: '0px' };
 
@@ -13,7 +12,7 @@ const ConfirmTasksNotRelatedToAnAppeal = () => {
     return (
       <tr key={task.id}>
         <td
-          style={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6', width: '20%' }}>
+          className={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6', width: '20%' }}>
           {task.label}
         </td>
         <td style={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6' }}>

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
@@ -1,21 +1,18 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { COLORS } from '../../../../../constants/AppConstants';
 import { css } from 'glamor';
-
-const styling = { backgroundColor: COLORS.GREY_BACKGROUND, paddingTop: '0px' };
 
 const ConfirmTasksNotRelatedToAnAppeal = () => {
   const tasks = useSelector((state) => state.intakeCorrespondence.unrelatedTasks);
 
   const rowObjects = tasks.map((task) => {
     return (
-      <tr key={task.id}>
+      <tr key={task.id} className="corr">
         <td
-          className={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6', width: '20%' }}>
+          className="td1">
           {task.label}
         </td>
-        <td style={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6' }}>
+        <td className="td2" >
           {task.content}
         </td>
       </tr>
@@ -40,19 +37,14 @@ const ConfirmTasksNotRelatedToAnAppeal = () => {
 
   return (
     <div>
-      <div style={{ position: 'relative', display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+      <div className="unknown-div">
       </div>
-      <div
-        style={{ background: COLORS.GREY_BACKGROUND,
-          padding: '2rem',
-          paddingTop: '.1rem',
-          paddingLeft: '20px',
-          paddingRight: '20px' }}>
+      <div className="div1">
         <table className="usa-table-borderless">
           <thead>
             <tr>
-              <th style={styling}>Tasks</th>
-              <th style={styling}>Task Instructions or Context</th>
+              <th className="style-for-tasks-and-content">Tasks</th>
+              <th className="style-for-tasks-and-content">Task Instructions or Context</th>
             </tr>
           </thead>
           <tbody>

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
@@ -5,6 +5,7 @@ import DocketTypeBadge from '../../../../../components/DocketTypeBadge';
 import { ExternalLinkIcon } from '../../../../../components/icons/ExternalLinkIcon';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
+import 'app/styles/queue/_correspondence.scss';
 
 const borderlessTd = {
   borderTop: 'none',

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
@@ -5,7 +5,7 @@ import DocketTypeBadge from '../../../../../components/DocketTypeBadge';
 import { ExternalLinkIcon } from '../../../../../components/icons/ExternalLinkIcon';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
-import 'app/styles/queue/_correspondence.scss';
+
 
 const borderlessTd = {
   borderTop: 'none',

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksRelatedToAnAppeal.jsx
@@ -3,9 +3,7 @@ import { useSelector } from 'react-redux';
 import { COLORS } from 'app/constants/AppConstants';
 import DocketTypeBadge from '../../../../../components/DocketTypeBadge';
 import { ExternalLinkIcon } from '../../../../../components/icons/ExternalLinkIcon';
-import { css } from 'glamor';
 import PropTypes from 'prop-types';
-
 
 const borderlessTd = {
   borderTop: 'none',
@@ -58,37 +56,32 @@ const ConfirmTasksRelatedToAnAppeal = () => {
     };
 
     // Gives less space to the first appeal, and more to all after.
-    const paddingAmount = index === 0 ? '5px' : '35px';
+    const paddingAmount = index === 0 ? 'first-style-for-appeals-number-tasks' : 'style-for-appeals-number-tasks';
 
     return (
       <>
-        <tr>
-          <td style={{ ...borderlessTd, ...{ paddingBottom: '0px', paddingTop: paddingAmount } }}>
-            <h3 style={{ lineHeight: '10%' }}>Appeal {index + 1} Tasks</h3>
+        <tr >
+          <td className={paddingAmount} >
+            <h3 className="style-for-appeals-number-title">Appeal {index + 1} Tasks</h3>
           </td>
         </tr>
         <tr rowSpan="4">
-          <td style={{ ...borderlessTd, ...{ paddingBottom: '10px' } }}>
-            <b style={{ marginTop: '40px' }}>Linked Appeal</b>
+          <td className="style-for-appeals-first-row">
+            <b className="style-for-appeals-first-row-title">Linked Appeal</b>
           </td>
-          <td style={borderlessTd}>
+          <td className="style-for-appeals-second-row">
             <b>{evidenceSubmission && 'Currently Active Task'}</b>
           </td>
-          <td style={borderlessTd}>
+          <td className="style-for-appeals-third-row">
             <b>{evidenceSubmission && 'Evidence Window Waived?'}</b>
           </td>
-          <td style={borderlessTd}>
+          <td className="style-for-appeals-fourth-row">
             <b>{evidenceSubmission && 'Assigned To'}</b>
           </td>
         </tr>
         <tr>
           <td style={borderlessTd}>
-            <div style={{ width: 'fit-content',
-              padding: '3px',
-              backgroundColor: 'white',
-              border: `1px solid ${COLORS.COLOR_COOL_BLUE_LIGHTER}`,
-              whiteSpace: 'nowrap'
-            }}>
+            <div className="linked-appeal-link-button">
               <a
                 href={`/queue/appeals/${fetchedAppeals.find((appeal) => appeal.id === task).externalId}`}
                 target="_blank"
@@ -99,32 +92,24 @@ const ConfirmTasksRelatedToAnAppeal = () => {
               </a>
             </div>
           </td>
-          <td style={borderlessTd}>{formatDocketName()}</td>
-          <td style={borderlessTd}>{getYesOrNo()}</td>
-          <td style={borderlessTd}>{evidenceSubmission ? evidenceSubmission.assigned_to_type : ''}</td>
+          <td className="currently-active-task-answer">{formatDocketName()}</td>
+          <td className="evidence-window-waived-answer">{getYesOrNo()}</td>
+          <td className="assigned-to-answer">{evidenceSubmission ? evidenceSubmission.assigned_to_type : ''}</td>
         </tr>
         <tr>
-          <td
-            style={{ backgroundColor: COLORS.GREY_BACKGROUND,
-              borderTop: 'none',
-              borderSpacing: '0px' }}>
+          <td className="additional-tasks-row">
             <b>Additional Tasks</b>
           </td>
-          <td
-            colSpan="3"
-            style={{ backgroundColor: COLORS.GREY_BACKGROUND,
-              borderTop: 'none',
-              borderSpacing: '0px' }}>
+          <td className="tasks-instructions-or-context" colSpan="3">
             <b>Task Instructions or Context</b>
           </td>
         </tr>
         {tasks.filter((taskById) => taskById.appealId === task).map((taskById) =>
           <tr>
-            <td
-              style={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6', width: '20%' }}>
+            <td className="additional-tasks-row-content">
               {taskById.label}
             </td>
-            <td colSpan={3} style={{ backgroundColor: COLORS.GREY_BACKGROUND, borderTop: '1px solid #dee2e6' }}>
+            <td className="tasks-instructions-or-context" colSpan={3}>
               {taskById.content}
             </td>
           </tr>)}
@@ -136,11 +121,7 @@ const ConfirmTasksRelatedToAnAppeal = () => {
   const renderingTask = () => {
 
     if (taskIds.length === 0) {
-      const taskRenderer = <div {...css({
-        paddingTop: '20px',
-        marginBottom: '150px',
-        fontWeight: 'bold'
-      })}> Correspondence is not related to an existing appeal</div>;
+      const taskRenderer = <div className="correspondence-not-related-to-appeal"> Correspondence is not related to an existing appeal</div>;
 
       return taskRenderer;
     }
@@ -156,11 +137,9 @@ const ConfirmTasksRelatedToAnAppeal = () => {
 
   return (
     <>
-      <div style={{ marginLeft: 'auto' }}>
-        <div
-          style={{ background: COLORS.GREY_BACKGROUND, padding: '2rem', paddingTop: '0.5rem', marginBottom: '2rem' }}>
+      <div className="linked-appeals-and-new-tasks-margin">
+        <div className="linked-appeal-and-new-tasks-box">
           {renderingTask()}
-
         </div>
       </div></>
   );

--- a/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
+++ b/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
@@ -120,8 +120,7 @@ export const CorrespondenceIntake = (props) => {
     }
     <ProgressBar
       sections={sections}
-      classNames={['cf-progress-bar', 'cf-']}
-      styling={{ style: { marginBottom: '5rem', float: 'right' } }} />
+      classNames={['cf-progress-bar', 'cf-', 'progress-bar-styling']} />
     {currentStep === 1 &&
       <AddCorrespondenceView
         correspondenceUuid={props.correspondence_uuid}

--- a/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
+++ b/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
@@ -20,6 +20,7 @@ import {
   CORRESPONDENCE_INTAKE_FORM_ERROR_BANNER_TITLE,
   CORRESPONDENCE_INTAKE_FORM_ERROR_BANNER_TEXT
 } from '../../../../../COPY';
+import 'app/styles/queue/_correspondence.scss';
 
 const progressBarSections = [
   {

--- a/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
+++ b/client/app/queue/correspondence/intake/components/CorrespondenceIntake.jsx
@@ -20,7 +20,6 @@ import {
   CORRESPONDENCE_INTAKE_FORM_ERROR_BANNER_TITLE,
   CORRESPONDENCE_INTAKE_FORM_ERROR_BANNER_TEXT
 } from '../../../../../COPY';
-import 'app/styles/queue/_correspondence.scss';
 
 const progressBarSections = [
   {

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
@@ -14,7 +14,7 @@ import {
   setTaskRelatedAppealIds,
   setWaivedEvidenceTasks
 } from '../../../correspondenceReducer/correspondenceActions';
-import 'app/styles/queue/_correspondence.scss';
+
 
 const RELATED_NO = '0';
 const RELATED_YES = '1';

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
@@ -148,27 +148,17 @@ export const AddAppealRelatedTaskView = (props) => {
         </LoadingContainer>
       }
       {existingAppealRadio === RELATED_YES && !loading &&
-        <div className="gray-border"
+        <div className="gray-border corr entire-tasks-related-to-existing-appeals"
           style={{ padding: '0rem 0rem', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }}>
-          <div style={{ width: '100%', height: 'auto', backgroundColor: 'white', paddingBottom: '3rem' }}>
-            <div style={{ backgroundColor: COLORS.GREY_BACKGROUND,
-              width: '100%',
-              height: '50px',
-              paddingTop: '1.5rem' }}>
-              <b style={{
-                verticalAlign: 'center',
-                paddingLeft: '2.5rem',
-                paddingTop: '1.5rem',
-                border: '0',
-                paddingBottom: '1.5rem',
-                paddingRigfht: '5.5rem'
-              }}>Existing Appeals</b>
+          <div className="existing-appeals-box">
+            <div className="bottom-of-existing-appeals-title">
+              <b className="existing-appeals-title">Existing Appeals</b>
             </div>
-            <ul style={{ paddingLeft: '2.5rem' }}>
+            <ul className="selection-for-prior-appeals-linked-to-corr">
               Please select prior appeal(s) to link to this correspondence
             </ul>
-            <ul style={{ paddingLeft: '2.5rem' }}>
-              <div style={{ paddingRight: '1rem' }}>
+            <ul className="left-side-of-docket">
+              <div className="right-side-of-assigned-to" >
                 <CaseListTable
                   // Need to use this as key to force React to re-render checkboxes
                   key={tableUpdateTrigger}

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddAppealRelatedTaskView.jsx
@@ -14,6 +14,7 @@ import {
   setTaskRelatedAppealIds,
   setWaivedEvidenceTasks
 } from '../../../correspondenceReducer/correspondenceActions';
+import 'app/styles/queue/_correspondence.scss';
 
 const RELATED_NO = '0';
 const RELATED_YES = '1';

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
@@ -28,21 +28,8 @@ const AddEvidenceSubmissionTaskView = (props) => {
 
   return (
     <div key={task.id} style={{ display: 'block', marginRight: '2rem' }}>
-      <div
-        className="gray-border"
-        style={{
-          display: 'block',
-          padding: '2rem 2rem',
-          marginLeft: '3rem',
-          marginBottom: '3rem',
-          width: '50rem'
-        }}
-      >
-        <div
-          style={{
-            width: '45rem',
-          }}
-        >
+      <div className="gray-border evidence-window-submission-box ">
+        <div className="evidence-window-submission-task-dropdown">
           <div id="reactSelectContainer">
             <ReactSelectDropdown
               options={dropdownOptions}
@@ -51,7 +38,7 @@ const AddEvidenceSubmissionTaskView = (props) => {
               disabled
             />
           </div>
-          <div style={{ padding: '1.5rem' }} />
+          <div className="area-below-evidence-window-submission-task-dropdown"/>
           <TextareaField
             name="content"
             label="Provide context and instruction on this task"

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
@@ -5,7 +5,6 @@ import Checkbox from '../../../../../components/Checkbox';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { COLORS } from '../../../../../constants/AppConstants';
-import 'app/styles/queue/_correspondence.scss';
 
 const AddEvidenceSubmissionTaskView = (props) => {
   const task = props.task;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
@@ -5,6 +5,7 @@ import Checkbox from '../../../../../components/Checkbox';
 import PropTypes from 'prop-types';
 import { css } from 'glamor';
 import { COLORS } from '../../../../../constants/AppConstants';
+import 'app/styles/queue/_correspondence.scss';
 
 const AddEvidenceSubmissionTaskView = (props) => {
   const task = props.task;

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -5,7 +5,6 @@ import Button from '../../../../../components/Button';
 import Select from 'react-select';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
-import 'app/styles/queue/_correspondence.scss';
 
 const customSelectStyless = {
   dropdownIndicator: () => ({

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -112,7 +112,7 @@ const AddTaskView = (props) => {
   };
 
   return (
-    <div key={task.id} style={{ display: 'block', marginRight: '2rem' }}>
+    <div className="new-tasks-gray-border-styling" key={task.id} style={{ display: 'block', marginRight: '2rem' }}>
       {modalVisible &&
         <CheckboxModal
           checkboxData={props.autoTexts}
@@ -122,11 +122,11 @@ const AddTaskView = (props) => {
           handleClear={props.handleClear}
         />
       }
-      <div className="gray-border"
+      <div className="gray-border task-selection-box-for-new-tasks"
         style={
           { display: 'block', padding: '2rem 2rem', marginLeft: '3rem', marginBottom: '3rem', width: '50rem' }
         }>
-        <div
+        <div className="task-selection-dropdown-box"
           style={
             { width: '45rem' }
           }
@@ -135,7 +135,7 @@ const AddTaskView = (props) => {
           <div id="reactSelectContainer"
             {...selectContainerStyless}>
 
-            <label style={{ marginTop: '5px', marginBottom: '5px', marginLeft: '1px' }}>Task</label>
+            <label className="task-selection-title" style={{ marginTop: '5px', marginBottom: '5px', marginLeft: '1px' }}>Task</label>
             <Select
               placeholder="Select..."
               options={props.availableTaskTypeOptions}
@@ -146,7 +146,7 @@ const AddTaskView = (props) => {
               aria-label="dropdown"
             />
           </div>
-          <div style={{ padding: '1.5rem' }} />
+          <div className="provide-context-text-styling" style={{ padding: '1.5rem' }} />
           <TextareaField
             name="content"
             label="Provide context and instruction on this task"

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -5,6 +5,7 @@ import Button from '../../../../../components/Button';
 import Select from 'react-select';
 import { css } from 'glamor';
 import PropTypes from 'prop-types';
+import 'app/styles/queue/_correspondence.scss';
 
 const customSelectStyless = {
   dropdownIndicator: () => ({

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -135,7 +135,7 @@ const AddTaskView = (props) => {
           <div id="reactSelectContainer"
             {...selectContainerStyless}>
 
-            <label className="task-selection-title" style={{ marginTop: '5px', marginBottom: '5px', marginLeft: '1px' }}>Task</label>
+            <label className="task-selection-title">Task</label>
             <Select
               placeholder="Select..."
               options={props.availableTaskTypeOptions}
@@ -146,7 +146,7 @@ const AddTaskView = (props) => {
               aria-label="dropdown"
             />
           </div>
-          <div className="provide-context-text-styling" style={{ padding: '1.5rem' }} />
+          <div className="provide-context-text-styling" />
           <TextareaField
             name="content"
             label="Provide context and instruction on this task"
@@ -156,8 +156,7 @@ const AddTaskView = (props) => {
           <Button
             id="addAutotext"
             name="Add"
-            styling={{ style: { paddingLeft: '0rem', paddingRight: '0rem' } }}
-            classNames={['cf-btn-link', 'cf-left-side']}
+            classNames={['cf-btn-link', 'cf-left-side', 'add-autotext-button']}
             onClick={handleModalToggle}
           >
             Add autotext
@@ -165,9 +164,8 @@ const AddTaskView = (props) => {
           {props.displayRemoveCheck &&
             <Button
               name="Remove"
-              styling={{ style: { paddingLeft: '0rem', paddingRight: '0rem' } }}
               onClick={() => props.removeTask(task.id)}
-              classNames={['cf-btn-link', 'cf-right-side']}
+              classNames={['cf-btn-link', 'cf-right-side', 'remove-task-button']}
             >
               <i className="fa fa-trash-o" aria-hidden="true"></i>&nbsp;Remove task
             </Button>

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -7,7 +7,6 @@ import AddUnrelatedTaskView from './AddUnrelatedTaskView';
 import { saveMailTaskState } from '../../../correspondenceReducer/correspondenceActions';
 import { INTAKE_FORM_TASK_TYPES } from '../../../../constants';
 
-
 const mailTasksLeft = [
   'Change of address',
   'Evidence or argument',

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -6,6 +6,7 @@ import AddAppealRelatedTaskView from './AddAppealRelatedTaskView';
 import AddUnrelatedTaskView from './AddUnrelatedTaskView';
 import { saveMailTaskState } from '../../../correspondenceReducer/correspondenceActions';
 import { INTAKE_FORM_TASK_TYPES } from '../../../../constants';
+import 'app/styles/queue/_correspondence.scss';
 
 const mailTasksLeft = [
   'Change of address',

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -72,7 +72,7 @@ export const AddTasksAppealsView = (props) => {
   }, [relatedTasksCanContinue, unrelatedTasksCanContinue]);
 
   return (
-    <div className="gray-border" style={{ marginBottom: '2rem', padding: '3rem 4rem' }}>
+    <div className="gray-border " style={{ marginBottom: '2rem', padding: '3rem 4rem' }}>
       <h1 style={{ marginBottom: '10px' }}>Review Tasks & Appeals</h1>
       <p>Review any previously completed tasks by the mail team and add new tasks for
       either the mail package or for linked appeals, if any.</p>

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -6,7 +6,7 @@ import AddAppealRelatedTaskView from './AddAppealRelatedTaskView';
 import AddUnrelatedTaskView from './AddUnrelatedTaskView';
 import { saveMailTaskState } from '../../../correspondenceReducer/correspondenceActions';
 import { INTAKE_FORM_TASK_TYPES } from '../../../../constants';
-import 'app/styles/queue/_correspondence.scss';
+
 
 const mailTasksLeft = [
   'Change of address',

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTasksAppealsView.jsx
@@ -72,72 +72,75 @@ export const AddTasksAppealsView = (props) => {
   }, [relatedTasksCanContinue, unrelatedTasksCanContinue]);
 
   return (
-    <div className="gray-border " style={{ marginBottom: '2rem', padding: '3rem 4rem' }}>
-      <h1 style={{ marginBottom: '10px' }}>Review Tasks & Appeals</h1>
-      <p>Review any previously completed tasks by the mail team and add new tasks for
+    <div className="gray-border" >
+      <div className="review-tasks-and-appeal-box">
+        <h1 className="review-tasks-and-appeals-title">Review Tasks & Appeals</h1>
+        <p>Review any previously completed tasks by the mail team and add new tasks for
       either the mail package or for linked appeals, if any.</p>
-      <div>
-        <h2 style={{ margin: '30px auto 20px auto' }}>Mail Tasks</h2>
-        <div className="gray-border" style={{ padding: '0rem 2rem' }}>
-          <p style={{ marginBottom: '0.5rem' }}>Select any tasks completed by the Mail team for this correspondence.</p>
-          <div id="mail-tasks-left" style={{ display: 'inline-block', marginRight: '14rem' }}>
-            {mailTasksLeft.map((name, index) => {
-              return (
-                <Checkbox
-                  key={index}
-                  name={name}
-                  label={name}
-                  defaultValue={mailTasks.includes(name)}
-                  onChange={(checked) => mailTaskCheckboxOnChange(name, checked)}
-                />
-              );
-            })}
+        <div>
+          <h2 className="mail-tasks-title">Mail Tasks</h2>
+          <div className="gray-border">
+            <div className="area-above-select-completed-tasks">
+              <p className="select-completed-mail-tasks-for-correspondence">Select any tasks completed by the Mail team for this correspondence.</p>
+              <div className="mail-tasks-option-left-styling" id="mail-tasks-left">
+                {mailTasksLeft.map((name, index) => {
+                  return (
+                    <Checkbox
+                      key={index}
+                      name={name}
+                      label={name}
+                      defaultValue={mailTasks.includes(name)}
+                      onChange={(checked) => mailTaskCheckboxOnChange(name, checked)}
+                    />
+                  );
+                })}
+              </div>
+              <div className="mail-tasks-option-right-styling" id="mail-tasks-right">
+                {mailTasksRight.map((name, index) => {
+                  return (
+                    <Checkbox
+                      key={index}
+                      name={name}
+                      label={name}
+                      defaultValue={mailTasks.includes(name)}
+                      onChange={(checked) => mailTaskCheckboxOnChange(name, checked)}
+                    />
+                  );
+                })}
+              </div>
+            </div>
           </div>
-          <div id="mail-tasks-right" style={{ display: 'inline-block' }}>
-            {mailTasksRight.map((name, index) => {
-              return (
-                <Checkbox
-                  key={index}
-                  name={name}
-                  label={name}
-                  defaultValue={mailTasks.includes(name)}
-                  onChange={(checked) => mailTaskCheckboxOnChange(name, checked)}
-                />
-              );
-            })}
-          </div>
-        </div>
 
-        <div id="task-related-to-an-appeal">
-          <h2 style={{ margin: '30px auto 20px auto' }}>Tasks related to an existing Appeal</h2>
-          <p style={{ marginBottom: '-7px' }}>Is this correspondence related to an existing appeal?</p>
-          <AddAppealRelatedTaskView
-            correspondenceUuid={props.correspondenceUuid}
-            setRelatedTasksCanContinue={setRelatedTasksCanContinue}
-            filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
-            allTaskTypeOptions={relatedTaskTypes}
-            autoTexts={props.autoTexts}
-            veteranInformation={props.veteranInformation}
-          />
-        </div>
-
-        <hr />
-
-        <div id="task-not-related-to-an-appeal">
-          <h2 style={{ margin: '30px auto 20px auto' }}>Tasks not related to an Appeal</h2>
-          <p style={{ marginTop: '0rem', marginBottom: '2rem' }}>
-            Add new tasks related to this correspondence or to an appeal not yet created in Caseflow.
-          </p>
-          <div>
-            <AddUnrelatedTaskView
-              setUnrelatedTasksCanContinue={setUnrelatedTasksCanContinue}
+          <div id="task-related-to-an-appeal">
+            <h2 className="tasks-related-to-an-appeal-title">Tasks related to an existing Appeal</h2>
+            <p className="is-correspondence-related-to-existing-appeals">Is this correspondence related to an existing appeal?</p>
+            <AddAppealRelatedTaskView
+              correspondenceUuid={props.correspondenceUuid}
+              setRelatedTasksCanContinue={setRelatedTasksCanContinue}
               filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
-              allTaskTypeOptions={unrelatedTaskTypes}
+              allTaskTypeOptions={relatedTaskTypes}
               autoTexts={props.autoTexts}
+              veteranInformation={props.veteranInformation}
             />
           </div>
-        </div>
 
+          <hr />
+
+          <div id="task-not-related-to-an-appeal">
+            <h2 className="tasks-not-related-to-an-appeal-title">Tasks not related to an Appeal</h2>
+            <p className="add-new-tasks-related-to-correspondence">
+            Add new tasks related to this correspondence or to an appeal not yet created in Caseflow.
+            </p>
+            <div>
+              <AddUnrelatedTaskView
+                setUnrelatedTasksCanContinue={setUnrelatedTasksCanContinue}
+                filterUnavailableTaskTypeOptions={filterUnavailableTaskTypeOptions}
+                allTaskTypeOptions={unrelatedTaskTypes}
+                autoTexts={props.autoTexts}
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -93,15 +93,15 @@ export const AddUnrelatedTaskView = (props) => {
         className="gray-border"
         style={{ padding: '0rem 0rem', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }}
       >
-        <div style={{ width: '100%', height: 'auto', backgroundColor: 'white', paddingBottom: '3rem' }}>
-          <div style={{ backgroundColor: COLORS.GREY_BACKGROUND, width: '100%', height: '50px', paddingTop: '1.5rem' }}>
-            <b style={{
+        <div className="area-under-add-tasks-button-not-related-to-appeal">
+          <div className="new-tasks-not-related-to-an-appeal-title" style={{ backgroundColor: COLORS.GREY_BACKGROUND, width: '100%', height: '50px', paddingTop: '1.5rem' }}>
+            <b className="new-tasks-title-not-related-to-appeal" style={{
               verticalAlign: 'center',
               paddingLeft: '2.5rem',
               paddingTop: '1.5rem',
               border: '0',
               paddingBottom: '1.5rem',
-              paddingRigfht: '5.5rem'
+              paddingRight: '5.5rem'
             }}>New Tasks</b>
           </div>
           <div style={{ width: '100%', height: '3rem' }} />

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -5,7 +5,6 @@ import AddTaskView from './AddTaskView';
 import { setUnrelatedTasks } from '../../../correspondenceReducer/correspondenceActions';
 import PropTypes from 'prop-types';
 import { COLORS } from '../../../../../constants/AppConstants';
-import 'app/styles/queue/_correspondence.scss';
 
 const MAX_NUM_TASKS = 4;
 

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -5,6 +5,7 @@ import AddTaskView from './AddTaskView';
 import { setUnrelatedTasks } from '../../../correspondenceReducer/correspondenceActions';
 import PropTypes from 'prop-types';
 import { COLORS } from '../../../../../constants/AppConstants';
+import 'app/styles/queue/_correspondence.scss';
 
 const MAX_NUM_TASKS = 4;
 

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddUnrelatedTaskView.jsx
@@ -4,7 +4,6 @@ import Button from '../../../../../components/Button';
 import AddTaskView from './AddTaskView';
 import { setUnrelatedTasks } from '../../../correspondenceReducer/correspondenceActions';
 import PropTypes from 'prop-types';
-import { COLORS } from '../../../../../constants/AppConstants';
 
 const MAX_NUM_TASKS = 4;
 
@@ -90,44 +89,37 @@ export const AddUnrelatedTaskView = (props) => {
           + Add tasks
       </Button>}
       {addTasksVisible && <div
-        className="gray-border"
-        style={{ padding: '0rem 0rem', display: 'flex', flexWrap: 'wrap', flexDirection: 'column' }}
-      >
-        <div className="area-under-add-tasks-button-not-related-to-appeal">
-          <div className="new-tasks-not-related-to-an-appeal-title" style={{ backgroundColor: COLORS.GREY_BACKGROUND, width: '100%', height: '50px', paddingTop: '1.5rem' }}>
-            <b className="new-tasks-title-not-related-to-appeal" style={{
-              verticalAlign: 'center',
-              paddingLeft: '2.5rem',
-              paddingTop: '1.5rem',
-              border: '0',
-              paddingBottom: '1.5rem',
-              paddingRight: '5.5rem'
-            }}>New Tasks</b>
-          </div>
-          <div style={{ width: '100%', height: '3rem' }} />
-          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-            {getTasks().map((task) => (
-              <AddTaskView
-                key={task.id}
-                task={task}
-                removeTask={removeTask}
-                taskUpdatedCallback={taskUpdatedCallback}
-                displayRemoveCheck
-                allTaskTypeOptions={props.allTaskTypeOptions}
-                availableTaskTypeOptions={availableTaskTypeOptions}
-                autoTexts={props.autoTexts}
-              />
-            ))}
-          </div>
-          <div style={{ padding: '2.5rem 2.5rem' }} >
-            <Button
-              type="button"
-              onClick={clickAddTask}
-              disabled={newTasks.length === MAX_NUM_TASKS}
-              name="addTasks"
-              classNames={['cf-left-side']}>
+        className="gray-border ">
+        <div className="area-above-add-tasks-button-not-related">
+          <div className="area-under-add-tasks-button-not-related-to-appeal">
+            <div className="new-tasks-not-related-to-an-appeal-title">
+              <b className="new-tasks-title-not-related-to-appeal">New Tasks</b>
+            </div>
+            <div className="area-under-new-tasks-title" />
+            <div className="area-above-add-task-view">
+              {getTasks().map((task) => (
+                <AddTaskView
+                  key={task.id}
+                  task={task}
+                  removeTask={removeTask}
+                  taskUpdatedCallback={taskUpdatedCallback}
+                  displayRemoveCheck
+                  allTaskTypeOptions={props.allTaskTypeOptions}
+                  availableTaskTypeOptions={availableTaskTypeOptions}
+                  autoTexts={props.autoTexts}
+                />
+              ))}
+            </div>
+            <div className="add-tasks-button-for-unrelated-appeals">
+              <Button
+                type="button"
+                onClick={clickAddTask}
+                disabled={newTasks.length === MAX_NUM_TASKS}
+                name="addTasks"
+                classNames={['cf-left-side']}>
                 + Add tasks
-            </Button>
+              </Button>
+            </div>
           </div>
         </div>
       </div>}

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
@@ -5,6 +5,7 @@ import AddEvidenceSubmissionTaskView from './AddEvidenceSubmissionTaskView';
 import Button from '../../../../../components/Button';
 import CaseDetailsLink from '../../../../CaseDetailsLink';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
+import 'app/styles/queue/_correspondence.scss';
 
 const MAX_NUM_TASKS = 4;
 

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
@@ -5,7 +5,6 @@ import AddEvidenceSubmissionTaskView from './AddEvidenceSubmissionTaskView';
 import Button from '../../../../../components/Button';
 import CaseDetailsLink from '../../../../CaseDetailsLink';
 import Link from '@department-of-veterans-affairs/caseflow-frontend-toolkit/components/Link';
-import 'app/styles/queue/_correspondence.scss';
 
 const MAX_NUM_TASKS = 4;
 

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/ExistingAppealTasksView.jsx
@@ -72,7 +72,7 @@ export const ExistingAppealTasksView = (props) => {
 
   return (
     <div>
-      <div style={{ marginLeft: '2%', marginBottom: '2%' }}>
+      <div className="tasks-appeal-title">
         <strong>Tasks: Appeal </strong>
         <CaseDetailsLink appeal={props.appeal}
           getLinkText={() => {
@@ -82,7 +82,7 @@ export const ExistingAppealTasksView = (props) => {
         />
       </div>
 
-      <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      <div className="evidence-window-submission-task">
         {props.appeal.hasEvidenceSubmissionTask &&
           <AddEvidenceSubmissionTaskView
             key={props.appeal.evidenceSubmissionTask.id}
@@ -106,8 +106,8 @@ export const ExistingAppealTasksView = (props) => {
         })}
       </div>
 
-      <div style={{ padding: '2.5rem 2.5rem', display: 'flex', justifyContent: 'space-between' }}>
-        <div style={{ width: '80%' }}>
+      <div className="area-around-add-tasks-button">
+        <div className="width-of-add-tasks-button">
           <Button
             type="button"
             onClick={addTask}
@@ -118,7 +118,7 @@ export const ExistingAppealTasksView = (props) => {
           </Button>
         </div>
 
-        <div style={{ cursor: 'pointer' }}>
+        <div className="cursor-style-for-unlink-appeal-button" >
           <Link
             name={`unlink-${props.appeal.id}`}
             onClick={() => props.unlinkAppeal(props.appeal.id, false)}

--- a/client/app/styles/_main.scss
+++ b/client/app/styles/_main.scss
@@ -409,3 +409,5 @@ select {
 .gray-border {
   border: 2px solid $color-gray-lighter;
 }
+
+

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -165,3 +165,8 @@
 .correspondence-doctype-edit-dropdown .cf-select .cf-select__control {
   max-width: 43rem;
 }
+
+.styling {
+  background-color: $color-GREY-BACKGROUND;
+  padding-top: '0px'
+}

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -166,10 +166,241 @@
   max-width: 43rem;
 }
 
-.corr-confirm-tasks {
-  .td {
-    background-color: $color-grey-background;
+.corr {
+  .td1 {
+    background-color: #f9f9f9;
     border-top: 1px solid #dee2e6;
-    width: 20%;
+    width: 20%
+  }
+
+  .td2 {
+    background-color: #f9f9f9;
+    border-top: 1px solid #dee2e6
+  }
+
+  .div1 {
+    background: #f9f9f9;
+    padding: 2rem;
+    padding-top: .1rem;
+    padding-left: 20px;
+    padding-right: 20px;
+  }
+
+  .style-for-tasks-and-content {
+    background-color: #f9f9f9;
+    padding-top: 10px;
+  }
+
+  .unknown-div {
+    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-right
+  }
+
+  .style-for-appeals-number-tasks {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+    padding-bottom: 0px;
+    padding-top: 35px;
+
+  }
+
+  .first-style-for-appeals-number-tasks {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+    padding-bottom: 0px;
+    padding-top: 5px;
+
+  }
+
+  .style-for-appeals-number-title {
+    line-height: 10%
+  }
+
+  .style-for-appeals-first-row {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+    padding-bottom: 10px
+  }
+
+  .style-for-appeals-first-row-title {
+    margin-top: 40px
+  }
+
+  .style-for-appeals-second-row {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .style-for-appeals-third-row {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .style-for-appeals-fourth-row{
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .linked-appeal-link-button {
+    width: fit-content;
+    padding: 3px;
+    background-color: white;
+    border: 1px solid #8ba6ca;
+    white-space: nowrap
+  }
+
+  .currently-active-task-answer {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .evidence-window-waived-answer {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .assigned-to-answer {
+    border-top: none;
+    border-bottom: none;
+    background-color: #f9f9f9;
+  }
+
+  .additional-tasks-row {
+    background-color: #f9f9f9;
+    border-top: none;
+    border-spacing: 0px
+  }
+
+  .tasks-instructions-or-context {
+    background-color: #f9f9f9;
+    border-top: none;
+    border-spacing: 0px
+  }
+
+  .additional-tasks-row-content {
+    background-color: #f9f9f9;
+    border-top: 1px solid #dee2e6;
+    width: 20%
+  }
+
+  .tasks-instructions-or-context {
+    background-color: #f9f9f9;
+    border-top: 1px solid #dee2e6
+  }
+
+  .correspondence-not-related-to-appeal {
+    padding-top: 20px;
+    margin-bottom: 150px;
+    font-weight: bold
+  }
+
+  .linked-appeal-and-new-tasks-box {
+    background: #f9f9f9;
+    padding: 2rem;
+    padding-top: 0.5rem;
+    margin-bottom: 2rem
+  }
+
+  .linked-appeals-and-new-tasks-margin {
+    margin-left: auto
+  }
+
+  .existing-appeals-box {
+    width: 100%;
+    height: auto;
+    background-color: white;
+    padding-bottom: 3rem
+  }
+
+  .bottom-of-existing-appeals-title {
+    background-color:#f9f9f9;
+    width: 100%;
+    height: 50px;
+    padding-top: 1.5rem
+  }
+
+  .existing-appeals-title {
+    vertical-align: center;
+    padding-left: 2.5rem;
+    padding-top: 1.5rem;
+    border: 0;
+    padding-bottom: 1.5rem;
+    padding-right: 50rem
+  }
+
+  .selection-for-prior-appeals-linked-to-corr {
+    padding-left: 2.5rem
+  }
+
+  .left-side-of-docket {
+    padding-left: 2.5rem
+  }
+
+  .right-side-of-assigned-to {
+    padding-right: 1rem
+  }
+
+  .entire-tasks-related-to-existing-appeals {
+    padding: 0rem 0rem;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column
+  }
+
+  .tasks-appeal-title {
+    margin-left: 2%;
+    margin-bottom: 2%
+  }
+
+  .evidence-window-submission-task{
+    display: flex;
+    flex-wrap: wrap
+  }
+
+  .area-around-add-tasks-button {
+    padding: 2.5rem 2.5rem;
+    display: flex;
+    justify-content: space-between
+  }
+
+  .width-of-add-tasks-button {
+    width: 80%
+  }
+
+  .cursor-style-for-unlink-appeal-button {
+    cursor: pointer
+  }
+
+  .area-under-add-tasks-button-not-related-to-appeal {
+    width: 100%;
+    height: auto;
+    background-color: white;
+    padding-bottom: 3rem
+  }
+
+  .new-tasks-not-related-to-an-appeal-title{
+    background-color: #f9f9f9;
+    width: 100%;
+    height: 50px;
+    padding-top: 1.5rem
+  }
+
+  .new-tasks-title-not-related-to-appeal {
+    vertical-align: center;
+    padding-left: 2.5rem;
+    padding-top: 1.5rem;
+    border: 0;
+    padding-bottom: 1.5rem;
+    padding-right: 5.5rem
   }
 }

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -403,4 +403,52 @@
     padding-bottom: 1.5rem;
     padding-right: 5.5rem
   }
+
+  .evidence-window-submission-box {
+    display: block;
+    padding: 2rem 2rem;
+    margin-left: 3rem;
+    margin-bottom: 3rem;
+    width: 50rem
+  }
+
+  .evidence-window-submission-task-dropdown {
+    width: 45rem
+  }
+
+  .area-below-evidence-window-submission-task-dropdown {
+    padding: 1.5rem
+  }
+
+  .review-tasks-and-appeals-box {
+    margin-bottom: 2rem;
+    padding: 3rem 4rem
+  }
+
+  .new-tasks-gray-border-styling {
+    display: block;
+    margin-right: 2rem
+  }
+
+  .task-selection-box-for-new-tasks {
+    display: block;
+    padding: 2rem 2rem;
+    margin-left: 3rem;
+    margin-bottom: 3rem;
+    width: 50rem
+  }
+
+  .task-selection-dropdown-box {
+    width: 45rem
+  }
+
+  .task-selection-title {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    margin-left: 1px
+  }
+
+  .provide-context-text-styling {
+    padding: 1.5rem
+  }
 }

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -166,7 +166,10 @@
   max-width: 43rem;
 }
 
-.styling {
-  background-color: $color-GREY-BACKGROUND;
-  padding-top: '0px'
+.corr-confirm-tasks {
+  .td {
+    background-color: $color-grey-background;
+    border-top: 1px solid #dee2e6;
+    width: 20%;
+  }
 }

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -381,6 +381,13 @@
     cursor: pointer
   }
 
+  .area-above-add-tasks-button-not-related{
+    padding: 0rem 0rem;
+    display: flex;
+    flex-wrap: wrap;
+    flex-direction: column
+  }
+
   .area-under-add-tasks-button-not-related-to-appeal {
     width: 100%;
     height: auto;
@@ -404,12 +411,26 @@
     padding-right: 5.5rem
   }
 
+  .area-under-new-tasks-title {
+    width: 100%;
+    height: 3rem
+  }
+
   .evidence-window-submission-box {
     display: block;
     padding: 2rem 2rem;
     margin-left: 3rem;
     margin-bottom: 3rem;
     width: 50rem
+  }
+
+  .add-tasks-button-for-unrelated-appeals {
+    padding: 2.5rem 2.5rem
+  }
+
+  .area-above-add-task-view {
+    display: flex;
+    flex-wrap: wrap
   }
 
   .evidence-window-submission-task-dropdown {
@@ -451,4 +472,66 @@
   .provide-context-text-styling {
     padding: 1.5rem
   }
+}
+
+.add-autotext-button {
+  padding-left: 0rem;
+  padding-right: 0rem
+}
+
+.remove-task-button {
+  padding-left: 0rem;
+  padding-right: 0rem
+}
+
+.review-tasks-and-appeals-title {
+    margin-bottom: 10px
+}
+
+.review-tasks-and-appeal-box {
+  margin-bottom: 2rem;
+  padding: 3rem 4rem
+}
+
+.mail-tasks-title {
+  margin: 30px auto 20px auto
+}
+
+.area-above-select-completed-tasks {
+  padding: 0rem 2rem
+}
+
+.select-completed-mail-tasks-for-correspondence {
+  margin-bottom: 0.5rem
+}
+
+.mail-tasks-option-left-styling {
+  display: inline-block;
+  margin-right: 14rem
+}
+
+.mail-tasks-option-right-styling {
+  display: inline-block
+}
+
+.tasks-related-to-an-appeal-title {
+  margin: 30px auto 20px auto
+}
+
+.is-correspondence-related-to-existing-appeals {
+  margin-bottom: -7px
+}
+
+.tasks-not-related-to-an-appeal-title {
+  margin: 30px auto 20px auto
+}
+
+.add-new-tasks-related-to-correspondence {
+  margin-top: 0rem;
+  margin-bottom: 2rem
+}
+
+.progress-bar-styling {
+  margin-bottom: 5rem;
+  float: right
 }


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Move Correspondence ART CSS Styling Into a Single Stylesheet](https://jira.devops.va.gov/browse/APPEALS-43605)

# Description
Moved inline styling to a single stylesheet

## Acceptance Criteria
- [ ] Code compiles correctly