### PR TITLE
jcroteau/APPEALS-29632 Fix Deprecation Warning: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller. [pre Rails 6.1] (dev)

### DIFF
--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -14,7 +14,10 @@ module DisallowedDeprecations
 
   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
-    /update_attributes is deprecated and will be removed from Rails 6\.1/
+    /update_attributes is deprecated and will be removed from Rails 6\.1/,
+    /ActionView::Base instances should be constructed with a lookup context, assignments, and a controller./,
+    /ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache`/,
+    /render file: should be given the absolute path to a file/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -16,7 +16,7 @@ module DisallowedDeprecations
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
     /update_attributes is deprecated and will be removed from Rails 6\.1/,
     /ActionView::Base instances should be constructed with a lookup context, assignments, and a controller./,
-    /ActionView::Base instances must implement `compiled_method_container` or use the class method `with_empty_template_cache`/,
+    /ActionView::Base instances must implement `compiled_method_container`/,
     /render file: should be given the absolute path to a file/
   ].freeze
 

--- a/app/services/hearings/calendar_service.rb
+++ b/app/services/hearings/calendar_service.rb
@@ -8,6 +8,11 @@ require "icalendar/tzinfo"
 # emails.
 
 class Hearings::CalendarService
+  class CalendarEventView < ActionView::Base
+    include Hearings::CalendarTemplateHelper
+    include Hearings::AppellantNameHelper
+  end
+
   class << self
     # Sent when first switching a video hearing to a virtual hearing,
     # and also when the scheduled time for an existing virtual hearing
@@ -95,11 +100,8 @@ class Hearings::CalendarService
     end
 
     def render_virtual_hearing_calendar_event_template(email_recipient_info, event_type, locals)
-      template = ActionView::Base.new(ActionMailer::Base.view_paths, {})
-      template.class_eval do
-        include Hearings::CalendarTemplateHelper
-        include Hearings::AppellantNameHelper
-      end
+      lookup_context = ActionView::Base.build_lookup_context(ActionController::Base.view_paths)
+      context = CalendarEventView.new(lookup_context)
 
       # Some *~ magic ~* here. The recipient title is used to determine which template to load:
       #
@@ -112,8 +114,8 @@ class Hearings::CalendarService
 
       template_name = "#{email_recipient_info.title.downcase}_#{event_type}_event_description"
 
-      template.render(
-        file: "hearing_mailer/calendar_events/#{template_name}",
+      context.render(
+        template: "hearing_mailer/calendar_events/#{template_name}",
         locals: locals
       )
     end

--- a/spec/services/hearings/calendar_service_spec.rb
+++ b/spec/services/hearings/calendar_service_spec.rb
@@ -53,8 +53,12 @@ describe Hearings::CalendarService do
 
         ical_event = Icalendar::Calendar.parse(confirmation_calendar_invite).first.events.first
 
-        expect(ical_event.url.to_s).to eq("https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest")
-        expect(ical_event.location).to eq("https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest")
+        expect(ical_event.url.to_s).to eq(
+          "https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest"
+        )
+        expect(ical_event.location).to eq(
+          "https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest"
+        )
         expect(ical_event.status).to eq("CONFIRMED")
         expect(ical_event.summary).to be_nil
         expect(ical_event.description).to eq(expected_description)

--- a/spec/services/hearings/calendar_service_spec.rb
+++ b/spec/services/hearings/calendar_service_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+describe Hearings::CalendarService do
+  describe ".confirmation_calendar_invite" do
+    subject(:confirmation_calendar_invite) do
+      described_class.confirmation_calendar_invite(virtual_hearing, email_recipient_info, link)
+    end
+
+    let(:regional_office) { "RO06" } # nyc_ro_eastern
+    let(:appeal) { create(:appeal, :hearing_docket) }
+    let(:hearing_day) do
+      create(:hearing_day, scheduled_for: Date.parse("January 1, 1970"),
+                           request_type: HearingDay::REQUEST_TYPES[:video],
+                           regional_office: regional_office)
+    end
+    let(:hearing) do
+      create(:hearing, appeal: appeal,
+                       scheduled_time: "8:30AM",
+                       hearing_day: hearing_day,
+                       regional_office: regional_office)
+    end
+    let(:virtual_hearing) do
+      create(:virtual_hearing, hearing: hearing, appellant_tz: nil, representative_tz: nil)
+    end
+    let(:email_recipient_info) do
+      EmailRecipientInfo.new(name: "LastName",
+                             title: "appellant",
+                             hearing_email_recipient: hearing_email_recipient)
+    end
+    let(:hearing_email_recipient) { virtual_hearing.hearing.appellant_recipient }
+    let(:link) { virtual_hearing.guest_link }
+
+    it "returns appropriate iCalendar event" do
+      expected_description = <<~TEXT
+        You're scheduled for a virtual hearing with a Veterans Law Judge of the Board of Veterans' Appeals.
+
+        Date and Time
+        Thursday, 1 January 1970 at 8:30am EST
+
+        How to Join
+        We recommend joining 15 minutes before your hearing start time. Click on the link below, or copy and paste the link into the address field of your web browser:
+        https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest
+
+        Help Desk
+        If you are experiencing technical difficulties, call the VA Video Connect Helpdesk at 855-519-7116 and press 4 for Board of Veterans' Appeals support.
+
+        Rescheduling or Canceling Your Hearing
+        If you need to reschedule or cancel your virtual hearing, contact us by email at bvahearingteamhotline@va.gov
+      TEXT
+
+      aggregate_failures do
+        expect(confirmation_calendar_invite).to be_a(String)
+
+        ical_event = Icalendar::Calendar.parse(confirmation_calendar_invite).first.events.first
+
+        expect(ical_event.url.to_s).to eq("https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest")
+        expect(ical_event.location).to eq("https://care.evn.va.gov/bva-app/?join=1&media=&escalate=1&conference=BVA@care.evn.va.gov&pin=&role=guest")
+        expect(ical_event.status).to eq("CONFIRMED")
+        expect(ical_event.summary).to be_nil
+        expect(ical_event.description).to eq(expected_description)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-29632

> ## Background
> 
> ### Deprecation Warning
> 
> > DEPRECATION WARNING: ActionView::Base instances should be constructed with a lookup context, assignments, and a controller.
> 
> **Deprecation Horizon:** Rails 6.1
> 
> ### References
> 
> - Source: [https://stackoverflow.com/a/63865988](https://stackoverflow.com/a/63865988 "Follow link")
> 
> > This deprecation warning appears because you passed `ActionController::Base.view_paths` to `ActionView::Base.new` as the first argument. This used to be okay but now an instance of `ActionView::LookupContext` is expected. If you look at the [most recent version of `ActionView::Base#initialize`](https://github.com/rails/rails/blob/v6.0.3.3/actionview/lib/action_view/base.rb#L258 "Follow link") you'll see that where the message appears it calls [`ActionView::Base.build_lookup_context`](https://github.com/rails/rails/blob/v6.0.3.3/actionview/lib/action_view/base.rb#L210 "Follow link") using your first argument to `ActionView::Base.new`. You can easily silence this warning by passing `ActionView::LookupContext.new(ActionController::Base.view_paths)` or `ActionView::Base.build_lookup_context(ActionController::Base.view_paths)` since that's what it ends up using anyways.
> 
> ### Affected locations
> 
> #### Found In Test / CI Build
> 
> **app/services/hearings/calendar_service.rb:98**
> ```ruby
> def render_virtual_hearing_calendar_event_template(email_recipient_info, event_type, locals)  
>   template = ActionView::Base.new(ActionMailer::Base.view_paths, {})
> ```
> 
> ## Proposed Solution
> 
> **app/services/hearings/calendar_service.rb**
> ```ruby
> def render_virtual_hearing_calendar_event_template(email_recipient_info, event_type, locals)
>   lookup_context = ActionView::Base.build_lookup_context(ActionController::Base.view_paths)
>   template = ActionView::Base.new(lookup_context, {})
>   # ...
> ```
> 
> After making the change above, a new deprecation warning will manifest when running `spec/mailers/hearing_mailer_spec.rb`:
> 
> ```
> DEPRECATION WARNING: render file: should be given the absolute path to a file 
> ```
> 
> - called from `render_virtual_hearing_calendar_event_template` at `/Users/jeremycroteau/dev/appeals/caseflow/app/services/hearings/calendar_service.rb:115
> 
> **app/services/hearings/calendar_service.rb**
> ```ruby
> def render_virtual_hearing_calendar_event_template(email_recipient_info, event_type, locals)
>   # ...
>   template_name = "#{email_recipient_info.title.downcase}_#{event_type}_event_description"
>     
>   template.render(  
>     file: "app/views/hearing_mailer/calendar_events/#{template_name}",
>     locals: locals
>   )
> end
> ```
> 
> needs to be _effectively_ changed to something like this:
> 
> ```ruby
> def render_virtual_hearing_calendar_event_template(email_recipient_info, event_type, locals)
>   # ...
>   template_filepaths = Dir.glob(Rails.root.join("app/views/hearing_mailer/calendar_events/*"))
>   template_name = "#{email_recipient_info.title.downcase}_#{event_type}_event_description"
>   absolute_filepath = template_filepaths.find { |path| path.match?(template_name) }
>   
>   template.render(file: absolute_filepath, locals: locals)
> end
> ```

---

Jira Test Plans:
- development: [APPEALS-31296](https://jira.devops.va.gov/browse/APPEALS-31296)
- uat: [APPEALS-44459](https://jira.devops.va.gov/browse/APPEALS-44459)
- prodtest: [APPEALS-44460](https://jira.devops.va.gov/browse/APPEALS-44460)
