### PR TITLE
fixed inbound ops team being listed in queuetable dropdown

### DIFF
--- a/app/models/organizations/inbound_ops_team.rb
+++ b/app/models/organizations/inbound_ops_team.rb
@@ -8,6 +8,6 @@ class InboundOpsTeam < Organization
 
   # :reek:UtilityFunction
   def selectable_in_queue?
-    FeatureToggle.enabled?(:correspondence_queue, user: RequestStore.store[:current_user])
+    false
   end
 end

--- a/client/app/queue/components/QueueOrganizationDropdown.jsx
+++ b/client/app/queue/components/QueueOrganizationDropdown.jsx
@@ -18,13 +18,7 @@ export default class QueueOrganizationDropdown extends React.Component {
     let correspondenceItems = {};
 
     const isMailTeamAffiliated = () => {
-      if (isMailSuperUser) {
-        return true;
-      }
-      if (isMailSupervisor) {
-        return true;
-      }
-      if (isMailTeamUser) {
+      if (isMailSuperUser || isMailSupervisor || isMailTeamUser) {
         return true;
       }
 

--- a/client/app/queue/components/QueueOrganizationDropdown.jsx
+++ b/client/app/queue/components/QueueOrganizationDropdown.jsx
@@ -17,7 +17,21 @@ export default class QueueOrganizationDropdown extends React.Component {
     const queueHref = (location === 'queue') ? '#' : '/queue';
     let correspondenceItems = {};
 
-    if (organizations.length < 1) {
+    const isMailTeamAffiliated = () => {
+      if (isMailSuperUser) {
+        return true;
+      }
+      if (isMailSupervisor) {
+        return true;
+      }
+      if (isMailTeamUser) {
+        return true;
+      }
+
+      return false;
+    };
+
+    if (organizations.length < 1 && !isMailTeamAffiliated()) {
       return null;
     }
 

--- a/client/app/queue/components/QueueOrganizationDropdown.jsx
+++ b/client/app/queue/components/QueueOrganizationDropdown.jsx
@@ -72,13 +72,6 @@ export default class QueueOrganizationDropdown extends React.Component {
       const items2 = items.slice(1);
 
       items = [...items1, correspondenceItems, ...items2];
-
-      // const browserLocation = useLocation();
-
-      // console.log(browserLocation);
-      // if (browserLocation === '/queue/correspondence/team') {
-      //   return <Redirect to= "/queue/correspondence" />;
-      // }
     }
 
     return <QueueSelectorDropdown items={items} />;


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Remove Inbound Ops Team team cases from Switch Views](https://jira.devops.va.gov/browse/APPEALS-43918)

# Description
These changes cause the Inbound Ops Team cases to no longer be listed inside of the QueueTable component.
## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Navigate to queue as mail team admin
2. Click the switch view dropdown
3. Notice that inbound ops team is no longer listed.
# Frontend

## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
<img width="1328" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/3ec9c6f6-c951-464a-a931-edb0a66a2e95">
|
<img width="1330" alt="image" src="https://github.com/department-of-veterans-affairs/caseflow/assets/110805785/75bd330b-e961-44f2-a3c0-bf1b4fc6af36">

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [X] No new code climate issues added