### PR TITLE
disable the dropdown when failed to upload to the eFolder

### DIFF
--- a/client/app/queue/correspondence/review_package/CorrespondenceReviewPackage.jsx
+++ b/client/app/queue/correspondence/review_package/CorrespondenceReviewPackage.jsx
@@ -40,6 +40,7 @@ export const CorrespondenceReviewPackage = (props) => {
   const [selectedId, setSelectedId] = useState(0);
   const [isReadOnly, setIsReadOnly] = useState(false);
   const [isReassignPackage, setIsReassignPackage] = useState(false);
+  const [isEfolderUploadFailedTask, setIsEfolderUploadFailedTask] = useState(true);
   const [reviewPackageDetails, setReviewPackageDetails] = useState({
     veteranName: '',
     taskId: [],
@@ -81,6 +82,16 @@ export const CorrespondenceReviewPackage = (props) => {
       );
     };
 
+    const hasEfolderUploadTask = (tasks) => {
+      const existEfolderUploadTask = tasks.find((task) => task.status === 'in_progress' &&
+      task.type === 'EfolderUploadFailedTask');
+
+      if (existEfolderUploadTask) {
+        setIsEfolderUploadFailedTask(false);
+      }
+
+    };
+
     try {
       const response = await ApiUtil.get(
         `/queue/correspondence/${correspondence.correspondence_uuid}`
@@ -89,12 +100,15 @@ export const CorrespondenceReviewPackage = (props) => {
       setApiResponse(response.body.general_information);
       const data = response.body.general_information;
 
+      hasEfolderUploadTask(data.correspondence_tasks);
+
       if (response.body.efolder_upload_failed_before.length > 0) {
         setBannerInformation({
           title: CORRESPONDENCE_DOC_UPLOAD_FAILED_HEADER,
           message: CORRESPONDENCE_DOC_UPLOAD_FAILED_MESSAGE,
           bannerType: 'error'
         });
+
       }
       setReviewDetails({
         veteran_name: data.veteran_name || {},
@@ -120,6 +134,7 @@ export const CorrespondenceReviewPackage = (props) => {
         });
         setIsReadOnly(true);
       }
+
       if (hasAssignedReassignPackageTask(data.correspondence_tasks)) {
         setBannerInformation({
           title: CORRESPONDENCE_READONLY_BANNER_HEADER,
@@ -213,6 +228,7 @@ export const CorrespondenceReviewPackage = (props) => {
         <AppSegment filledBackground>
           <ReviewPackageCaseTitle
             reviewDetails={reviewPackageDetails}
+            Efolder={isEfolderUploadFailedTask}
             handlePackageActionModal={handlePackageActionModal}
             correspondence={props.correspondence}
             packageActionModal={packageActionModal}

--- a/client/app/queue/correspondence/review_package/ReviewPackageCaseTitle.jsx
+++ b/client/app/queue/correspondence/review_package/ReviewPackageCaseTitle.jsx
@@ -98,7 +98,7 @@ const CaseSubTitleScaffolding = (props) => (
       {COPY.CORRESPONDENCE_REVIEW_PACKAGE_SUB_TITLE}
     </div>
     <div className="correspondence-drop-down-div">
-      { !props.isReadOnly &&
+      { !props.isReadOnly && props.Efolder &&
       <SearchableDropdown
         options={[
           { value: 'splitPackage', label: 'Split package' },
@@ -133,6 +133,7 @@ CaseSubTitleScaffolding.propTypes = {
   mailTeamUsers: PropTypes.array,
   packageActionModal: PropTypes.string,
   isReadOnly: PropTypes.bool,
+  Efolder: PropTypes.bool,
   userIsCorrespondenceSupervisor: PropTypes.bool,
   userIsCorrespondenceSuperuser: PropTypes.bool
 };

--- a/client/app/queue/correspondence/review_package/utils.js
+++ b/client/app/queue/correspondence/review_package/utils.js
@@ -89,7 +89,7 @@ export const getPackageActionColumns = (dropdownType) => {
                 {`${vaDate}`}
               </p>
             </span>
-          )
+          );
         }
       }
     );


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-43403](https://jira.devops.va.gov/browse/APPEALS-43403)

# Description
disable the dropdown when failed to upload to the eFolder

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
1. In Caseflow, Log in as a Mail Team User (JOLLY_POSTMAN)
2. In Switch Views, click Your Correspondence.
3. Click a Veterans Details link from the Assigned Tab.
4. You are now on the Review Package Page and there is an Efolder Upload Failed Banner (If there is no Efolder Upload Failed Banner, select another link from the previous page until you find one that has the banner.)
5.Repeat steps for Superuser (AMBRISVACO)

![image_720](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/ced031de-60bf-4a3c-9bcf-7440a1517fcb)

![image_720](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/8aeb6825-180e-4ff1-bb55-8b78c4204a3a)


