### PR TITLE
Add tests for nil handling on ama_statistics method supporting APPEALS-43712 and APPEALS-43835

### DIFF
--- a/spec/models/concerns/by_docket_date_distribution_spec.rb
+++ b/spec/models/concerns/by_docket_date_distribution_spec.rb
@@ -211,5 +211,27 @@ describe ByDocketDateDistribution, :all_dbs do
         expect(nonpriority_stats).to include(sym)
       end
     end
+
+    context "handles errors without stopping a distribution" do
+      let(:appeal) { create(:appeal) }
+
+      before do
+        @new_acd.instance_variable_set(:@appeals, [appeal, nil])
+        Rails.cache.fetch("case_distribution_ineligible_judges") { [{ sattyid: "1", id: "1" }] }
+      end
+
+      it "#ama_distributed_cases_tied_to_ineligible_judges raises an error if passed nil in array" do
+        expect { @new_acd.send(:ama_distributed_cases_tied_to_ineligible_judges) }.to raise_error(NoMethodError)
+      end
+
+      it "#distributed_cases_tied_to_ineligible_judges raises an error if passed nil in array" do
+        expect { @new_acd.send(:distributed_cases_tied_to_ineligible_judges) }.to raise_error(NoMethodError)
+      end
+
+      it "ama_statistics handles the errors from #ama_distributed_cases_tied_to_ineligible_judges
+          and #distributed_cases_tied_to_ineligible_judges" do
+        expect { @new_acd.send(:ama_statistics) }.not_to raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-43712](https://jira.devops.va.gov/browse/APPEALS-43712)
Resolves [APPEALS-43835](https://jira.devops.va.gov/browse/APPEALS-43835)

# Description
Adds tests for the `ama_statistics` method called during distributions to verify that it handles errors that occur while generating statistics, and doesn't cause the entire distribution to fail.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] New tests passing
