### PR TITLE
jcroteau/APPEALS-29105 - Fix Deprecation Warning: Controller-level `force_ssl` is deprecated and will be removed from Rails 6.1 (dev)

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -5,7 +5,6 @@ class Api::ApplicationController < ActionController::Base
 
   include TrackRequestId
 
-  force_ssl if: :ssl_enabled?
   before_action :strict_transport_security
 
   before_action :setup_fakes,
@@ -49,10 +48,6 @@ class Api::ApplicationController < ActionController::Base
 
   def unauthorized
     render json: { status: "unauthorized" }, status: :unauthorized
-  end
-
-  def ssl_enabled?
-    Rails.env.production?
   end
 
   def strict_transport_security

--- a/app/controllers/application_base_controller.rb
+++ b/app/controllers/application_base_controller.rb
@@ -8,7 +8,6 @@ class ApplicationBaseController < ActionController::Base
 
   include TrackRequestId
 
-  force_ssl if: :ssl_enabled?
   before_action :check_out_of_service
   before_action :strict_transport_security
 
@@ -33,10 +32,6 @@ class ApplicationBaseController < ActionController::Base
 
   def check_out_of_service
     render "out_of_service", layout: "application" if Rails.cache.read("out_of_service")
-  end
-
-  def ssl_enabled?
-    Rails.env.production?
   end
 
   def strict_transport_security

--- a/app/policies/ssl_redirect_exclusion_policy.rb
+++ b/app/policies/ssl_redirect_exclusion_policy.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# @note To be used in the environment configuration settings for excluding exempt request paths from SSL redirects
+#   when `config.force_ssl = true`
+#
+# @example config/environments/production.rb
+#
+#   Rails.application.configure do
+#     config.force_ssl = true
+#     config.ssl_options = { redirect: { exclude: SslRedirectExclusionPolicy } }
+#     # etc.
+class SslRedirectExclusionPolicy
+  EXEMPT_PATH_PATTERNS = [
+    %r{^/api/docs/v3/},
+    %r{^/api/metadata$},
+    %r{^/health-check$},
+    %r{^/idt/api/v1/},
+    %r{^/idt/api/v2/},
+    %r{^/pdfjs/}
+  ].freeze
+
+  # @param [ActionDispatch::Request] request
+  # @return [TrueClass, FalseClass] true if request path is exempt from an SSL redirect
+  def self.call(request)
+    EXEMPT_PATH_PATTERNS.any? { |pattern| pattern =~ request.path }
+  end
+end

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -24,7 +24,8 @@ module DisallowedDeprecations
     /ActionView::Base instances must implement `compiled_method_container`/,
     /render file: should be given the absolute path to a file/,
     /`ActiveRecord::Result#to_hash` has been renamed to `to_a`/,
-    /Class level methods will no longer inherit scoping/
+    /Class level methods will no longer inherit scoping/,
+    /Controller-level `force_ssl` is deprecated and will be removed from Rails 6\.1/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,10 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
+
+  require_relative "../../app/policies/ssl_redirect_exclusion_policy"
+  config.ssl_options = { redirect: { exclude: SslRedirectExclusionPolicy } }
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/spec/requests/ssl_redirects_spec.rb
+++ b/spec/requests/ssl_redirects_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+describe "SSL Redirects" do
+  # `app` is what RSpec tests against in request specs, similar to `controller` in controller specs.
+  # Here, we override it with our modified app.
+  def app
+    # Since `CaseflowCertification::Application` is already loaded at this stage, we can't modify the middleware stack,
+    #   so we subclass the application and adjust the relevant SSL config settings.
+    @app ||= Class.new(Rails.application.class) do
+      config.force_ssl = true
+      config.ssl_options = { redirect: { exclude: SslRedirectExclusionPolicy } }
+    end
+  end
+
+  before { allow(SslRedirectExclusionPolicy).to receive(:call).and_call_original }
+
+  context "when request is not SSL" do
+    context "when path matches '/api/docs/v3/'" do
+      it "is exempt from SSL redirect" do
+        get "/api/docs/v3/decision_reviews"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path is '/api/metadata'" do
+      it "is exempt from SSL redirect" do
+        get "/api/metadata"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path is '/health-check'" do
+      it "is exempt from SSL redirect" do
+        get "/health-check"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path matches '/idt/api/v1/'" do
+      it "is exempt from SSL redirect" do
+        get "/idt/api/v1/appeals"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path matches '/idt/api/v2/'" do
+      it "is exempt from SSL redirect" do
+        get "/idt/api/v2/appeals"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path matches '/pdfjs/'" do
+      it "is exempt from SSL redirect" do
+        get "/pdfjs/full?file=%2Fcertifications%2F2774535%2Fform9_pdf"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+        expect(response).not_to have_http_status(:redirect)
+      end
+    end
+
+    context "when path is not exempt from SSL redirects" do
+      it "is redirected with SSL" do
+        get "/users"
+        expect(SslRedirectExclusionPolicy).to have_received(:call)
+
+        expect(response).to redirect_to("https://#{request.host}/users")
+      end
+    end
+  end
+end


### PR DESCRIPTION
**This PR is part of a 4 PR stack:**
1. https://github.com/department-of-veterans-affairs/caseflow/pull/21286
2. https://github.com/department-of-veterans-affairs/caseflow/pull/21336
3. [This PR]
4. https://github.com/department-of-veterans-affairs/caseflow/pull/22181

---

Resolves https://jira.devops.va.gov/browse/APPEALS-29105

> ## Background
> 
> ### Deprecation Warning
> 
> > DEPRECATION WARNING: Controller-level `force_ssl` is deprecated and will be removed from Rails 6.1. Please enable `config.force_ssl` in your environment configuration to enable the ActionDispatch::SSL middleware to more fully enforce that your application communicate over HTTPS. If needed, you can use `config.ssl_options` to exempt matching endpoints from being redirected to HTTPS.
> 
> **Deprecation Horizon:** Rails 6.1
> 
> ### Affected locations
> 
> Currently, the only controllers enforcing SSL via `force_ssl` (in `production` environments only) are the following:
> 
> - `ApplicationBaseController < ActionController::Base`
> - `Api::ApplicationController < ActionController::Base`
> 
> These inherit from `ActionController::Base`, and so will be covered when we flip on `config.force_ssl = true` in `config/environments/production.rb`.
> 
> ## Proposed Solution
> ### Identify all routes to be exempt from SSL redirects
> Controllers that are **not** descendants of the above controllers (`ApplicationBaseController` or ``Api::ApplicationController``) need to have their associated routes explicitly exempted from SSL redirects to preserve the status quo. 
>
> Also, routes that get mounted under `/pdfjs` (for the `pdfjs_viewer-rails` engine) may need to be exempted as well, since the engine's internal controllers do not currently enforce SSL redirects.
>
>  **Note:** It appears that [HSTS is probably being enforced at the `va.gov ` domain level](https://github.com/department-of-veterans-affairs/veteran-facing-services-tools/blob/164ab4e79bc09dae66babfbb0a18d8e89ab79019/packages/documentation/src/pages/platform/front-end-standards/security.mdx?plain=1#L13-L14), so all requests to Caseflow will have already been upgraded to SSL before even reaching the Rails application, including any routes that are explicitly allow-listed.
> 
> ### Fix Deprecated Code
> 1. Under the `policies` directory, create a policy class `SslRedirectExclusionPolicy` that responds to `.call(request)`, which returns `true` when `request.path` matches any of the following path patterns and otherwise returns `false`:
>    - `%r(^/api/docs/v3/)`
>    - `%r(^/api/metadata$)`
>    - `%r(^/health-check$)`
>    - `%r(^/idt/api/v1/)`
>    - `%r(^/idt/api/v2/)`
>    - `%r(^/pdfjs/)`
> 2. In the `config/environments/production.rb` file,
>    1. Uncomment `config.force_ssl = true`
>    2. Add `config.ssl_options` underneath (see example below)
>
>```
># Force all access to the app over SSL, use Strict-Transport-Security, and use secure >cookies.
>config.force_ssl = true
>config.ssl_options = { redirect: { exclude: SslRedirectExclusionPolicy } }
>```
>
>3. Remove `force_ssl` and associated method `ssl_enabled?` from affected controllers `ApplicationBaseController` and `Api::ApplicationController`
>
>SSL redirects will now be enforced on all routes except for those explicitly excluded via `config.ssl_options` above.

---

Jira Test Plans:
- dev: [APPEALS-31223](https://jira.devops.va.gov/browse/APPEALS-31223) 
- uat: [APPEALS-44913](https://jira.devops.va.gov/browse/APPEALS-44913)
- prodtest: [APPEALS-44914](https://jira.devops.va.gov/browse/APPEALS-44914) 