### PR TITLE
jcroteau/APPEALS-44188 - Fix Deprecation Warning - Class level methods will no longer inherit scoping from {deprecated_scope_source} in Rails 6.1 (dev)

### DIFF
--- a/app/models/bgs_power_of_attorney.rb
+++ b/app/models/bgs_power_of_attorney.rb
@@ -49,7 +49,7 @@ class BgsPowerOfAttorney < CaseflowRecord
     end
 
     def find_or_create_by_claimant_participant_id(claimant_participant_id)
-      poa = find_or_create_by!(claimant_participant_id: claimant_participant_id)
+      poa = default_scoped.find_or_create_by!(claimant_participant_id: claimant_participant_id)
       if FeatureToggle.enabled?(:poa_auto_refresh, user: RequestStore.store[:current_user])
         poa.save_with_updated_bgs_record! if poa&.expired?
       end

--- a/app/models/dispatch/task.rb
+++ b/app/models/dispatch/task.rb
@@ -273,7 +273,7 @@ class Dispatch::Task < CaseflowRecord
   end
 
   def no_open_tasks_for_appeal
-    if self.class.to_complete_task_for_appeal(appeal).any?
+    if self.class.default_scoped.to_complete_task_for_appeal(appeal).any?
       errors.add(:appeal, "Uncompleted task already exists for this appeal")
     end
   end

--- a/app/models/team_quota.rb
+++ b/app/models/team_quota.rb
@@ -94,6 +94,6 @@ class TeamQuota < CaseflowRecord
 
   # Cap the search to the last month to avoid an infinite loop
   def most_recent_user_counts
-    self.class.where(task_type: task_type).order(:date).limit(31).lazy.map(&:user_count)
+    self.class.default_scoped.where(task_type: task_type).order(:date).limit(31).lazy.map(&:user_count)
   end
 end

--- a/app/services/deprecation_warnings/disallowed_deprecations.rb
+++ b/app/services/deprecation_warnings/disallowed_deprecations.rb
@@ -14,7 +14,8 @@ module DisallowedDeprecations
 
   # Regular expressions for Rails 6.1 deprecation warnings that we have addressed in the codebase
   RAILS_6_1_FIXED_DEPRECATION_WARNING_REGEXES = [
-    /update_attributes is deprecated and will be removed from Rails 6\.1/
+    /update_attributes is deprecated and will be removed from Rails 6\.1/,
+    /Class level methods will no longer inherit scoping/
   ].freeze
 
   # Regular expressions for deprecation warnings that should raise an exception on detection


### PR DESCRIPTION
Resolves https://jira.devops.va.gov/browse/APPEALS-44188

> ## Background
> 
> ### DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1.
> 
> **Generic Warning**
> ```
> DEPRECATION WARNING: Class level methods will no longer inherit scoping from `{deprecated_scope_source}` in Rails 6.1.
> ```
> 
> **Specific Example**
> ```
> DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create!` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `BgsPowerOfAttorney.default_scoped`.
> ```
> 
> 
> **Deprecation Horizon:** Rails 6.1
> 
> ### Affected locations
> 
> #### Found In Sentry
> 
> ##### app/models/bgs_power_of_attorney.rb:52
> 
> ```
> /opt/caseflow-certification/src/vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.6.1/lib/active_record/querying.rb:21:in `find_or_create_by!',   
> /opt/caseflow-certification/src/app/models/bgs_power_of_attorney.rb:52:in `find_or_create_by_claimant_participant_id',   
> /opt/caseflow-certification/src/app/models/bgs_power_of_attorney.rb:77:in `find_or_fetch_by',   
> /opt/caseflow-certification/src/app/models/veteran_claimant.rb:9:in `find_power_of_attorney',   
> /opt/caseflow-certification/src/app/models/claimant.rb:72:in `power_of_attorney',
> ```
> 
> ##### app/models/team_quota.rb:97
> 
> ```
> /opt/caseflow-certification/src/vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.6.1/lib/active_record/querying.rb:21:in `where',   
> /opt/caseflow-certification/src/app/models/team_quota.rb:97:in `most_recent_user_counts',   
> /opt/caseflow-certification/src/app/models/team_quota.rb:92:in `most_recent_user_count',   
> /opt/caseflow-certification/src/app/models/team_quota.rb:88:in `carry_over_user_count',   
> /opt/caseflow-certification/src/app/models/team_quota.rb:82:in `adjust_user_count',
> ```
> 
> - Exercised via test: `https://github.com/department-of-veterans-affairs/caseflow/blob/1a5bb08a9db81e84a939fd7f5c1bcc413d39f34b/spec/feature/dispatch/establish_claim_spec.rb#L297`
> 
> ##### app/models/dispatch/task.rb:80
> 
> ```
> /opt/caseflow-certification/src/vendor/bundle/ruby/2.7.0/gems/activerecord-6.0.6.1/lib/active_record/querying.rb:21:in `where',   
> /opt/caseflow-certification/src/app/models/dispatch/task.rb:80:in `to_complete',   
> /opt/caseflow-certification/src/app/models/dispatch/task.rb:88:in `to_complete_task_for_appeal',   
> /opt/caseflow-certification/src/app/models/dispatch/task.rb:276:in `no_open_tasks_for_appeal'
> ```
> 
> - Exercised via test: `https://github.com/department-of-veterans-affairs/caseflow/blob/d924e2e167ccdc93eb7a26ba1e02d9ec02ee8a76/spec/jobs/create_establish_claim_tasks_job_spec.rb#L20`
> 
> ## Proposed Solution(s)
> 
> ### Prefix affected calls with `default_scoped
> 
> Prefix affected calls with the `default_scoped` relation (e.g. `BgsPowerOfAttorney.default_scoped.find_or_create_by!(...))`).'
> 
> We are not setting `default_scope`s in the affected models, however, this will leave the door open to such implementations if necessary (though `default_scope` s should be avoided in general).
> 
> #### app/models/bgs_power_of_attorney.rb:52
> 
> ```
> # app/models/bgs_power_of_attorney.rb
> 
> def find_or_create_by_claimant_participant_id(claimant_participant_id)  
>   poa = default_scoped.find_or_create_by!(claimant_participant_id: claimant_participant_id)
>   # ...
> end
> ```
> 
> #### app/models/team_quota.rb:97
> 
> ```
> # app/models/team_quota.rb
> 
> def most_recent_user_counts  
>   self.class.default_scoped.where(task_type: task_type).order(:date).limit(31).lazy.map(&:user_count)  
> end
> ```
> 
> #### app/models/dispatch/task.rb:80
> 
> ```
> # app/models/dispatch/task.rb
> 
>   def no_open_tasks_for_appeal
>     if self.class.default_scoped.to_complete_task_for_appeal(appeal).any?
>       errors.add(:appeal, "Uncompleted task already exists for this appeal")
>     end
>   end
> ```
---

Jira Test Plan: https://jira.devops.va.gov/browse/APPEALS-44936