### PR TITLE
jcroteau/APPEALS-44282 - Fix Deprecation Warning: NOT conditions will no longer behave as NOR in Rails 6.1. (dev)

### DIFF
--- a/app/jobs/quarterly_notifications_job.rb
+++ b/app/jobs/quarterly_notifications_job.rb
@@ -16,9 +16,8 @@ class QuarterlyNotificationsJob < CaseflowJob
   def perform # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/PerceivedComplexity
     ensure_current_user_is_set
 
-    AppealState.where.not(
-      decision_mailed: true, appeal_cancelled: true
-    ).find_in_batches(batch_size: QUERY_LIMIT.to_i) do |batched_appeal_states|
+    AppealState.where.not(decision_mailed: true).where.not(appeal_cancelled: true)
+      .find_in_batches(batch_size: QUERY_LIMIT.to_i) do |batched_appeal_states|
       batched_appeal_states.each do |appeal_state|
         # add_record_to_appeal_states_table(appeal_state.appeal)
         if appeal_state.appeal_type == "Appeal"

--- a/app/models/vbms_uploaded_document.rb
+++ b/app/models/vbms_uploaded_document.rb
@@ -10,7 +10,10 @@ class VbmsUploadedDocument < CaseflowRecord
   attribute :file, :string
 
   scope :successfully_uploaded, lambda {
-    where(error: nil).where.not(uploaded_to_vbms_at: nil, attempted_at: nil, processed_at: nil)
+    where(error: nil)
+      .where.not(uploaded_to_vbms_at: nil)
+      .where.not(attempted_at: nil)
+      .where.not(processed_at: nil)
   }
 
   def cache_file

--- a/app/queries/etl/unknown_status_with_completed_root_task_query.rb
+++ b/app/queries/etl/unknown_status_with_completed_root_task_query.rb
@@ -21,6 +21,7 @@ class ETL::UnknownStatusWithCompletedRootTaskQuery
   def appeal_ids_for_open_child_tasks
     ETL::Task.select(:appeal_id).distinct
       .where(appeal_type: "Appeal")
-      .where.not(task_type: "RootTask", task_status: Task.closed_statuses)
+      .where.not(task_type: "RootTask")
+      .where.not(task_status: Task.closed_statuses)
   end
 end

--- a/app/queries/etl/unknown_status_with_open_root_task_query.rb
+++ b/app/queries/etl/unknown_status_with_open_root_task_query.rb
@@ -21,6 +21,7 @@ class ETL::UnknownStatusWithOpenRootTaskQuery
   def appeal_ids_for_open_child_tasks
     ETL::Task.select(:appeal_id).distinct
       .where(appeal_type: "Appeal")
-      .where.not(task_type: "RootTask", task_status: Task.closed_statuses)
+      .where.not(task_type: "RootTask")
+      .where.not(task_status: Task.closed_statuses)
   end
 end


### PR DESCRIPTION
Resolves: https://jira.devops.va.gov/browse/APPEALS-44282

> # Background
> 
> ### DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1
> 
> **General Warning**
> ```
> DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1.
> ```
> 
> **Specific Example**
> ```
> DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually (`.where.not(:decision_mailed => ...).where.not(:appeal_cancelled => ...)`). (called from perform at /opt/caseflow-certification/src/app/jobs/quarterly_notifications_job.rb:19)
> ```
> 
> **Deprecation Horizon:** Rails 6.1
> 
> #### Example
> 
> ##### Rails 6.0
> 
> `where.not` with multiple conditions behaves like **logical NOR**
> 
> ```ruby
> AppealState.where.not(decision_mailed: true, appeal_cancelled: true).to_sql
> ```
> ```
> DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually (`.where.not(:decision_mailed => ...).where.not(:appeal_cancelled => ...)`). (called from <main> at (pry):1)
> ```
> ```sql
> SELECT "appeal_states".*
> FROM "appeal_states"
> WHERE "appeal_states"."decision_mailed" != TRUE AND "appeal_states"."appeal_cancelled" != TRUE
> ```
> 
> ##### Rails 6.1
> 
> `where.not` with multiple conditions behaves like **logical NAND**
> 
> ```ruby
> AppealState.where.not(decision_mailed: true, appeal_cancelled: true).to_sql
> ```
> ```sql
> SELECT "appeal_states".*
> FROM "appeal_states"
> WHERE NOT ("appeal_states"."decision_mailed" = TRUE AND "appeal_states"."appeal_cancelled" = TRUE)
> ```
> ## Affected Locations
> 
> RegEx Search: `/\.not\b/`
> 
> ### app/queries/etl/unknown_status_with_open_root_task_query.rb:24
> 
> ```ruby
> # app/queries/etl/unknown_status_with_open_root_task_query.rb
> 
> def appeal_ids_for_open_child_tasks  
>   ETL::Task.select(:appeal_id).distinct  
>     .where(appeal_type: "Appeal")  
>     .where.not(task_type: "RootTask", task_status: Task.closed_statuses)  
> end
> ```
> 
> ### app/queries/etl/unknown_status_with_completed_root_task_query.rb:24
> 
> ```ruby
> # app/queries/etl/unknown_status_with_completed_root_task_query.rb
> 
> def appeal_ids_for_open_child_tasks  
>   ETL::Task.select(:appeal_id).distinct  
>     .where(appeal_type: "Appeal")  
>     .where.not(task_type: "RootTask", task_status: Task.closed_statuses)  
> end
> ```
> 
> ### app/models/vbms_uploaded_document.rb:13
> 
> ```ruby
> # app/models/vbms_uploaded_document.rb
> 
> scope :successfully_uploaded, lambda {  
>   where(error: nil).where.not(uploaded_to_vbms_at: nil, attempted_at: nil, processed_at: nil)  
> }
> ```
> 
> ### app/jobs/quarterly_notifications_job.rb:19
> 
> ```ruby
> # app/jobs/quarterly_notifications_job.rb
> 
> AppealState.where.not(  
>   decision_mailed: true, appeal_cancelled: true  
> )
> ```
> 
> 
> ## Proposed Solution
> 
> Rewrite each of the affected ActiveRecord queries above to preserve existing NOR behavior:
> 
> ### Example
> 
> #### BEFORE fix
> 
> Query with `where.not` having multiple conditions behaves like **logical NOR** but triggers deprecation warning.
> 
> ```ruby
> AppealState.where.not(decision_mailed: true, appeal_cancelled: true).to_sql
> ```
> ```
> DEPRECATION WARNING: NOT conditions will no longer behave as NOR in Rails 6.1. To continue using NOR conditions, NOT each condition individually (`.where.not(:decision_mailed => ...).where.not(:appeal_cancelled => ...)`). (called from <main> at (pry):1)
> ```
> ```sql
> SELECT "appeal_states".*
> FROM "appeal_states"
> WHERE "appeal_states"."decision_mailed" != TRUE AND "appeal_states"."appeal_cancelled" != TRUE
> ```
> 
> #### AFTER fix
> 
> Query with multiple, chained`where.not` relations, each on a single condition, preserves  **logical NOR** and no longer triggers deprecation warning.
> 
> ```ruby
> AppealState.where.not(decision_mailed: true).where.not(appeal_cancelled: true).to_sql
> ```
> ```sql
> SELECT "appeal_states".*
> FROM "appeal_states"
> WHERE "appeal_states"."decision_mailed" != TRUE AND "appeal_states"."appeal_cancelled" != TRUE 
> ```

---

Jira Test Plan: https://jira.devops.va.gov/browse/APPEALS-45156