### PR TITLE
Revert ce api gem from release/FY24Q3.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,6 @@ gem "tzinfo", "1.2.10"
 gem "uglifier", ">= 1.3.0"
 gem "validates_email_format_of"
 gem "ziptz"
-gem "ruby_claim_evidence_api", git: "https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git"
 
 group :production, :staging, :ssh_forwarding, :development, :test do
   # Oracle DB

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,19 +66,6 @@ GIT
       savon (~> 2.12)
 
 GIT
-  remote: https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git
-  revision: fed623802afe7303f4b8b5fe27cff0e903699873
-  specs:
-    ruby_claim_evidence_api (0.0.1)
-      activesupport
-      base64
-      faraday
-      faraday-multipart
-      httpi
-      railties
-      webmock (~> 3.6.2)
-
-GIT
   remote: https://github.com/department-of-veterans-affairs/sniffybara.git
   revision: 351560b5789ca638ba7c9b093c2bb1a9a6fda4b3
   specs:
@@ -179,7 +166,6 @@ GEM
       aws-sdk-core (= 2.10.112)
     aws-sigv4 (1.0.2)
     backport (1.2.0)
-    base64 (0.2.0)
     benchmark-ips (2.7.2)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -317,8 +303,6 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.4.1)
       faraday (>= 0.8)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fast_jsonapi (1.5)
@@ -848,7 +832,6 @@ DEPENDENCIES
   ruby-debug-ide
   ruby-oci8 (~> 2.2)
   ruby-prof (~> 1.4)
-  ruby_claim_evidence_api!
   sass-rails (~> 5.0)
   scss_lint
   sentry-raven


### PR DESCRIPTION
Reverts commit [c78afe30620716d59d2ac31ad6eed71585d78a98](https://github.com/department-of-veterans-affairs/caseflow/commit/c78afe30620716d59d2ac31ad6eed71585d78a98) from `release/FY24Q3.1.0`