### PR TITLE
add error rules to demo builds (#21496)

### DIFF
--- a/docker-bin/build.sh
+++ b/docker-bin/build.sh
@@ -48,8 +48,13 @@ cp /etc/ssl/certs/ca-certificates.crt docker-bin/ca-certs/cacert.pem
 # Build Docker
 echo -e "\tCreating Caseflow App Docker Image"
 docker build -t caseflow .
-
+result=$?
 echo -e "\tCleaning Up..."
 rm -rf config/datadog.key
-rm -rf docker-bin/oracle_libs/
-echo -e "\tBuilding Caseflow Docker App: Completed"
+rm -rf docker-bin/oracle_libs
+if [ $result == 0 ]; then
+  echo -e "\tBuilding Caseflow Docker App: Completed"
+else
+  echo -e "\tBuilding Caseflow failed"
+fi
+exit $result


### PR DESCRIPTION
Description
The docker build is inside of a build script which completes no matter what. When the docker build fails it errors but still does clean up so the pipeline continues as normal. With this change it will still clean up but store the exit result as a var and if exit is not 0 it will pick up in jenkins and not move on.