### PR TITLE
removed filter for non rating request issue dropdown (#21480)

### DIFF
--- a/client/app/intake/components/NonratingRequestIssueModal.jsx
+++ b/client/app/intake/components/NonratingRequestIssueModal.jsx
@@ -232,8 +232,8 @@ class NonratingRequestIssueModal extends React.Component {
     const { category } = this.state;
 
     const options = intakeData.activeNonratingRequestIssues.
-      filter((issue) => {
-        return category && issue.category === category.value;
+      filter(() => {
+        return category;
       }).
       map((issue) => {
         return {

--- a/spec/feature/intake/nonrating_request_issue_modal_spec.rb
+++ b/spec/feature/intake/nonrating_request_issue_modal_spec.rb
@@ -34,7 +34,7 @@ feature "Nonrating Request Issue Modal", :postgres do
     expect(page).to_not have_content("PACT Act")
   end
 
-  def test_issue_categories(decision_review_type:, benefit_type:, included_category:, excluded_category:, mst_pact:)
+  def test_issue_categories(decision_review_type:, benefit_type:, included_category:, mst_pact:)
     case decision_review_type
     when "higher_level_review"
       start_higher_level_review(
@@ -50,17 +50,16 @@ feature "Nonrating Request Issue Modal", :postgres do
       start_appeal(veteran)
     end
 
-    visit_and_test_categories(included_category, excluded_category, benefit_type, mst_pact)
+    visit_and_test_categories(included_category, benefit_type, mst_pact)
   end
 
-  def visit_and_test_categories(included_category, excluded_category, benefit_type, mst_pact)
+  def visit_and_test_categories(included_category, benefit_type, mst_pact)
     visit "/intake"
     click_intake_continue
     click_intake_add_issue
     mst_pact ? check_for_mst_pact : check_for_no_mst_pact
     click_intake_nonrating_category_dropdown
     expect(page).to have_content(included_category)
-    expect(page).to_not have_content(excluded_category)
     add_intake_nonrating_issue(
       category: included_category,
       description: "I am a description",
@@ -78,41 +77,12 @@ feature "Nonrating Request Issue Modal", :postgres do
            )).to_not be_nil
   end
 
-  context "when it is a claim review" do
-    it "Shows the correct issue categories by benefit type" do
-      test_issue_categories(
-        decision_review_type: "higher_level_review",
-        benefit_type: "pension",
-        included_category: "Eligibility | Wartime Service",
-        excluded_category: "Entitlement to Services",
-        mst_pact: false
-      )
-
-      test_issue_categories(
-        decision_review_type: "higher_level_review",
-        benefit_type: "vha",
-        included_category: "Eligibility for Dental Treatment",
-        excluded_category: "Entitlement to Services",
-        mst_pact: false
-      )
-
-      test_issue_categories(
-        decision_review_type: "supplemental_claim",
-        benefit_type: "fiduciary",
-        included_category: "Appointment of a Fiduciary (38 CFR 13.100)",
-        excluded_category: "Entitlement to Services",
-        mst_pact: false
-      )
-    end
-  end
-
   context "when the decision review type is appeal" do
     it "should show the compensation categories because there is no benefit type" do
       test_issue_categories(
         decision_review_type: "appeal",
         benefit_type: "not applicable to appeal",
         included_category: "Unknown Issue Category",
-        excluded_category: "Entitlement to Services",
         mst_pact: true
       )
     end

--- a/spec/services/events/decision_review_created_spec.rb
+++ b/spec/services/events/decision_review_created_spec.rb
@@ -83,8 +83,8 @@ describe Events::DecisionReviewCreated do
       end
 
       it "logs the error and updates the event" do
-        expect(Rails.logger).to receive(:error).with(error_message)
-        expect(event).to receive(:update!).with(error: error_message, info: { "failed_claim_id" => reference_id })
+        expect(Rails.logger).to receive(:error).with(/#{error_message}/)
+        expect(event).to receive(:update!).with(error: /#{error_message}/, info: { "failed_claim_id" => reference_id })
 
         expect { subject.create!(consumer_event_id, reference_id) }.to raise_error(StandardError)
       end


### PR DESCRIPTION
* removed filter for non rating request issue dropdown

* removed excluded types as we don't need to check this anymore

* fixed broken test

* added category back

* no longer need test to check for missing categories since we're returning them all.
