### PR TITLE
Create new Workflow transcription_packages: Step Two

### DIFF
--- a/app/workflows/transcription_packages.rb
+++ b/app/workflows/transcription_packages.rb
@@ -14,18 +14,33 @@ class TranscriptionPackages
   def call
     create_work_order
     create_zip_file
+    create_BoM_file
+    create_transcription_package
+    upload_transcription_package
   end
 
   private
 
   def create_work_order
     # call job work_order
-    Hearings::WorkOrderJob.perform(@work_order_params)
+    Hearings::WorkOrderFileJob.perform_now(@work_order_params)
   end
 
   def create_zip_file
     # call job to create a zip File
-    Hearings::ZipAndUploadTranscriptionFilesJob.perform(@work_order_params.hearings)
+    Hearings::ZipAndUploadTranscriptionFilesJob.perform_now(@work_order_params.hearings)
+  end
+
+  def create_BoM_file
+    # TODO -- call to job
+  end
+
+  def create_transcription_package
+    # TODO -- call to job
+  end
+
+  def upload_transcription_package
+    # TODO -- call to job
   end
 end
 

--- a/app/workflows/transcription_packages.rb
+++ b/app/workflows/transcription_packages.rb
@@ -33,14 +33,17 @@ class TranscriptionPackages
 
   def create_BoM_file
     # TODO -- call to job
+    Hearings::CreateBomFileJob.perform_now(@work_order_params)
   end
 
   def create_transcription_package
     # TODO -- call to job
+    Hearings::CreateTranscriptionPackageJob.perform_now(@work_order_params)
   end
 
   def upload_transcription_package
     # TODO -- call to job
+    Hearings::UploadTranscriptionPackageJob.perform_now(@work_order_params)
   end
 end
 

--- a/spec/workflows/transcription_packages_spec.rb
+++ b/spec/workflows/transcription_packages_spec.rb
@@ -5,26 +5,35 @@ describe TranscriptionPackages do
     context "start to execute all jobs" do
       let(:hearings) {(1..5).map{ create(:hearing, :with_transcription_files)}}
       let(:legacy_hearings) {(1..5).map{ create(:hearing, :with_transcription_files)}}
+
+      def hearings_in_work_order(all_hearings)
+        all_hearings.map { |hearing| { hearing_id: hearing.id, hearing_type: hearing.class.to_s } }
+      end
+
       let(:work_order_params) do
         {
           work_order_name: "#1234567",
           return_date: "05/07/2024",
           contractor: "Contractor A",
-          hearings: hearings + legacy_hearings
+          hearings: hearings_in_work_order(hearings + legacy_hearings)
         }
       end
+
       subject { TranscriptionPackages.new(work_order_params) }
 
       it "Call to initialize method" do
         expect(subject.instance_variable_get(:@work_order_params)[:work_order_name]).to eq("#1234567")
         expect(subject.instance_variable_get(:@work_order_params)[:return_date]).to eq("05/07/2024")
         expect(subject.instance_variable_get(:@work_order_params)[:contractor]).to eq("Contractor A")
-        expect(subject.instance_variable_get(:@work_order_params)[:hearings]).to eq(hearings + legacy_hearings)
+        expect(subject.instance_variable_get(:@work_order_params)[:hearings]).to eq(hearings_in_work_order(hearings + legacy_hearings))
       end
 
       it "Call to Call method " do
         allow_any_instance_of(TranscriptionPackages).to receive(:create_work_order).and_return(true)
         allow_any_instance_of(TranscriptionPackages).to receive(:create_zip_file).and_return(true)
+        allow_any_instance_of(TranscriptionPackages).to receive(:create_BoM_file).and_return(true)
+        allow_any_instance_of(TranscriptionPackages).to receive(:create_transcription_package).and_return(true)
+        allow_any_instance_of(TranscriptionPackages).to receive(:upload_transcription_package).and_return(true)
         expect { subject.call }.not_to raise_error
       end
     end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-44897](https://jira.devops.va.gov/browse/APPEALS-44897), [APPEALS-44898](https://jira.devops.va.gov/browse/APPEALS-44898)

# Description
As a Caseflow Developer when event "Dispatch work order" is triggered I need to;
1 Create additional methods for the transcription_packages.rb
  - A bom = create_new_bom_file(params_from_appeal_zip) <kicks off JOB to Create the BoM.json file>
  - B transcription_package = create_new_tanscription_package(params_from_bom) <kicks off JOB to Create the Transcription Package>
  - C transcription_uploaded = transcription_upload_to_box <kicks off JOB to Upload Transcription Package to QAT box.com folder endpoint>

`The helper methods called in the call method will temporarily return true until the job classes are implemented in other tickets.`

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan

1- When user click on `Dispatch Work Order` button, this jobs start to running.

![image](https://github.com/department-of-veterans-affairs/caseflow/assets/110848569/a03a6bb6-b613-4c1e-a2bd-b7bdb50e905b)

**Total jobs execute in this workflow**
- First job: `Create XLS file`
- Second job: `Zip And Upload Transcription Files`
- Third job: `Create BoM file`
- Fourth job: `Create transcription package`
- Fifth job: `Upload transcription package`


## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other
