### PR TITLE
Ki/APPEALS-45367 - Intake - Confirm 3 - Package Document Type

### DIFF
--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/CorrespondenceDetailsTable.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/CorrespondenceDetailsTable.jsx
@@ -16,7 +16,9 @@ export const CorrespondenceDetailsTable = (props) => {
             <th className="corr-table-borderless-last-item"><strong>Correspondence Type</strong></th>
           </tr>
           <tr>
-            <td className="corr-table-borderless-first-item">{props.correspondence.packageDocumentType}</td>
+            <td className="corr-table-borderless-first-item">
+              {props.correspondence.packageDocumentType.includes('10182') ? 'NOD' : 'Non-NOD'}
+            </td>
             <td>{moment(props.correspondence.vaDateOfReceipt).format('MM/DD/YYYY')}</td>
             <td>{props.correspondence.veteranFullName} ({props.correspondence.veteranFileNumber})</td>
             <td className="corr-table-borderless-last-item">{props.correspondence.correspondenceType}</td>

--- a/spec/feature/queue/correspondence/intake_spec.rb
+++ b/spec/feature/queue/correspondence/intake_spec.rb
@@ -379,15 +379,15 @@ RSpec.feature("The Correspondence Intake page") do
       end
     end
 
-    it "successfully loads the in progress tab" do
-      visit "/queue/correspondence?tab=correspondence_in_progress&page=1&sort_by=vaDor&order=asc"
-      expect(page).to have_content("Correspondence in progress")
+    it "successfully loads the assigned tab" do
+      visit "/queue/correspondence/team?tab=correspondence_team_assigned&page=1&sort_by=vaDor&order=asc"
+      expect(page).to have_content("Correspondence that is currently assigned to mail team users")
     end
 
     it "navigates to intake form from in-progress tab to step 3 and checks for failed to upload to the eFolder banner" \
        " from the Centralized Mail Portal, if it needs to be processed." do
-      visit "/queue/correspondence?tab=correspondence_in_progress"
-      find("tbody > tr:last-child > td:nth-child(1)").click
+      visit "/queue/correspondence/team?tab=correspondence_team_assigned&page=1&sort_by=vaDor&order=asc"
+      find("tbody > tr:last-child > td:nth-child(2)").click
       using_wait_time(15) do
         click_on("button-continue")
       end
@@ -399,6 +399,9 @@ RSpec.feature("The Correspondence Intake page") do
       click_on("button-Return-to-queue")
       page.all(".cf-form-radio-option")[1].click
       click_on("Return-To-Queue-button-id-1")
+      using_wait_time(15) do
+        expect(page).to have_content("You have successfully saved the intake form")
+      end
       visit intake_path
       expect(page).to have_content("The correspondence's documents have failed to upload to the eFolder")
     end

--- a/spec/support/correspondence_helpers.rb
+++ b/spec/support/correspondence_helpers.rb
@@ -14,7 +14,7 @@ module CorrespondenceHelpers
 
   def setup_access
     FeatureToggle.enable!(:correspondence_queue)
-    MailTeam.singleton.add_user(current_user)
+    InboundOpsTeam.singleton.add_user(current_user)
     User.authenticate!(user: current_user)
 
     mock_doc_uploader = instance_double(CorrespondenceDocumentsEfolderUploader)
@@ -89,7 +89,6 @@ module CorrespondenceHelpers
       va_date_of_receipt: Time.zone.local(2023, 1, 1)
     )
     find_and_route_to_intake
-
     click_button("Continue")
     click_button("+ Add tasks")
     all("#reactSelectContainer")[0].click


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-45367 - Intake - Confirm 3 - Package Document Type](https://jira.devops.va.gov/browse/APPEALS-45367)

# Description
This is a simple change for Step 3 of the Correspondence intake process.
-If the package document type is a 10182, display "NOD", otherwise display "Non-NOD"
-Updated some failing, unrelated RSpecs

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Navigate to Correspondence Cases
2. Select a Correspondence to navigate to Review Package page
3. Note Package Type
4. Click on Create Record
5. "Continue" through to page 3
6. Under Review and Confirm Correspondence, the Package Document Type should display either:
    1. NOD
    2. Non-NOD


# Frontend
## User Facing Changes
 - [X] Screenshot
![Screenshot 2024-05-07 at 9 30 07 AM](https://github.com/department-of-veterans-affairs/caseflow/assets/108023343/11bcf214-7dcc-4d68-80ce-62c8bc10fb70)
s of UI changes added to PR & Original Issue
![Screenshot 2024-05-07 at 9 30 12 AM](https://github.com/department-of-veterans-affairs/caseflow/assets/108023343/4bcadb44-46c1-44ac-95c5-ed0d10f80ff5)

