### PR TITLE
APPEALS-45346: Populate Polymorphic Association Columns When Creating New Notifications

### DIFF
--- a/app/jobs/send_notification_job.rb
+++ b/app/jobs/send_notification_job.rb
@@ -130,7 +130,8 @@ class SendNotificationJob < CaseflowJob
       appeals_type: @message.appeal_type,
       event_type: event_type,
       event_date: Time.zone.today,
-      notification_type: notification_type
+      notification_type: notification_type,
+      notifiable: appeal
     }
 
     if legacy_appeal_docketed_event? && FeatureToggle.enabled?(:appeal_docketed_event)

--- a/app/models/prepend/va_notify/appellant_notification.rb
+++ b/app/models/prepend/va_notify/appellant_notification.rb
@@ -191,7 +191,8 @@ module AppellantNotification
         event_type: template_name,
         notification_type: notification_type,
         participant_id: msg_bdy.participant_id,
-        event_date: Time.zone.today
+        event_date: Time.zone.today,
+        notifiable: appeal
       )
     end
     SendNotificationJob.perform_later(msg_bdy.to_json)

--- a/spec/factories/notification.rb
+++ b/spec/factories/notification.rb
@@ -18,6 +18,7 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { nil }
     sms_notification_external_id { nil }
+    notifiable { nil }
   end
 
   factory :notification_email_only do
@@ -37,6 +38,7 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { md5(uniqid(time)) }
     sms_notification_external_id { nil }
+    notifiable { nil }
   end
 
   factory :notification_sms_only do
@@ -56,6 +58,7 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { nil }
     sms_notification_external_id { md5(uniqid(time)) }
+    notifiable { nil }
   end
 
   factory :notification_email_and_sms do
@@ -75,5 +78,6 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { md5(uniqid(time)) }
     sms_notification_external_id { md5(uniqid(time)) }
+    notifiable { nil }
   end
 end

--- a/spec/factories/notification.rb
+++ b/spec/factories/notification.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { md5(uniqid(time)) }
     sms_notification_external_id { nil }
-    notifiable { nil }
+    notifiable { appeal }
   end
 
   factory :notification_sms_only do
@@ -58,7 +58,7 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { nil }
     sms_notification_external_id { md5(uniqid(time)) }
-    notifiable { nil }
+    notifiable { appeal }
   end
 
   factory :notification_email_and_sms do
@@ -78,6 +78,6 @@ FactoryBot.define do
     updated_at { Time.zone.now }
     email_notification_external_id { md5(uniqid(time)) }
     sms_notification_external_id { md5(uniqid(time)) }
-    notifiable { nil }
+    notifiable { appeal }
   end
 end

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -9,7 +9,8 @@ describe SendNotificationJob, type: :job do
            appeals_type: "Appeal",
            event_type: "Hearing scheduled",
            event_date: Time.zone.today,
-           notification_type: "Email")
+           notification_type: "Email",
+           notifiable: appeal)
   end
   let(:legacy_appeal_notification) do
     create(:notification,
@@ -17,7 +18,8 @@ describe SendNotificationJob, type: :job do
            appeals_type: "LegacyAppeal",
            event_type: "Appeal docketed",
            event_date: Time.zone.today,
-           notification_type: "SMS")
+           notification_type: "SMS",
+           notifiable: appeal)
   end
   let(:appeal) do
     create(:appeal,

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -51,16 +51,16 @@ describe SendNotificationJob, type: :job do
     {
       participant_id: "123456789",
       status: success_status,
-      appeal_id: "5d70058f-8641-4155-bae8-5af4b61b1576",
-      appeal_type: "Appeal"
+      appeal_id: appeal.external_id,
+      appeal_type: appeal.class.name
     }
   }
   let(:success_legacy_message_attributes) {
     {
       participant_id: "123456789",
       status: success_status,
-      appeal_id: "123456",
-      appeal_type: "LegacyAppeal"
+      appeal_id: appeal.external_id,
+      appeal_type: appeal.class.name
     }
   }
   let(:deceased_legacy_message_attributes) {
@@ -76,7 +76,7 @@ describe SendNotificationJob, type: :job do
       participant_id: "246813579",
       status: success_status,
       appeal_id: no_name_appeal.uuid,
-      appeal_type: "Appeal"
+      appeal_type: appeal.class.name
     }
   }
   let(:error_message_attributes) {

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -28,6 +28,7 @@ describe SendNotificationJob, type: :job do
            homelessness: false,
            veteran_file_number: "123456789")
   end
+  let(:legacy_appeal) { create(:legacy_appeal) }
   let!(:no_name_appeal) do
     create(:appeal,
            docket_type: "Appeal",
@@ -59,8 +60,8 @@ describe SendNotificationJob, type: :job do
     {
       participant_id: "123456789",
       status: success_status,
-      appeal_id: appeal.external_id,
-      appeal_type: appeal.class.name
+      appeal_id: legacy_appeal.external_id,
+      appeal_type: legacy_appeal.class.name
     }
   }
   let(:deceased_legacy_message_attributes) {
@@ -432,7 +433,6 @@ describe SendNotificationJob, type: :job do
   end
 
   context "feature flags for sending legacy notifications" do
-    let(:legacy_appeal) { create(:legacy_appeal) }
 
     it "should only send notifications when feature flag is turned on" do
       FeatureToggle.enable!(:appeal_docketed_notification)

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -83,8 +83,8 @@ describe SendNotificationJob, type: :job do
     {
       participant_id: nil,
       status: error_status,
-      appeal_id: "5d70058f-8641-4155-bae8-5af4b61b1578",
-      appeal_type: "Appeal"
+      appeal_id: appeal.external_id,
+      appeal_type: appeal.class.name
     }
   }
   let(:deceased_message_attributes) {

--- a/spec/jobs/send_notification_job_spec.rb
+++ b/spec/jobs/send_notification_job_spec.rb
@@ -433,7 +433,6 @@ describe SendNotificationJob, type: :job do
   end
 
   context "feature flags for sending legacy notifications" do
-
     it "should only send notifications when feature flag is turned on" do
       FeatureToggle.enable!(:appeal_docketed_notification)
       job = SendNotificationJob.new(legacy_message.to_json)


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/APPEALS-45346)

# Description
In all instances where a `Notification` model is created, the `notifiable` attribute for that object is set to one of two values:
An Appeal object that the notification pertains to
A LegacyAppeal object that the notification pertains to
Tests are created and/or updated to account for this new value
The [Notification factory](https://github.com/department-of-veterans-affairs/caseflow/blob/d09390e1a9a6a0744ad999f519d9cd3f1a50d342/spec/factories/notification.rb) is updated to account for the notifiable association.
Notification records created using this factory should by default have an AMA appeal's id and type set to their notifiable columns.
An appeal can be passed into the factory explicitly to override the default behavior.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. TBD

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Backend

# Best practices
## Code Documentation Updates
- [x ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x ] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ x] No new code climate issues added

