### PR TITLE
Konstantin/appeals 45180

### DIFF
--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -11,7 +11,7 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
     render json: { message: error.message }, status: :conflict
   rescue StandardError => error
     if error.message.include?("already exists")
-      render json: { message: "DecisionReviewCreatedEvent successfully processed and backfilled" }, status: :ok
+      render json: { message: "Record already exists in Caseflow" }, status: :ok
     else
       render json: { message: error.message }, status: :unprocessable_entity
     end

--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -10,7 +10,7 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
   rescue Caseflow::Error::RedisLockFailed => error
     render json: { message: error.message }, status: :conflict
   rescue StandardError => error
-# check if record already in Caseflow
+# check if error.message about record already exists in Caseflow
     if error.message.include?("already exists")
       render json: { message: "Record already exists in Caseflow" }, status: :ok
     else

--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -10,7 +10,11 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
   rescue Caseflow::Error::RedisLockFailed => error
     render json: { message: error.message }, status: :conflict
   rescue StandardError => error
-    render json: { message: error.message }, status: :unprocessable_entity
+    if error.message.include?("already exists")
+      render json: { message: "DecisionReviewCreatedEvent successfully processed and backfilled" }, status: :ok
+    else
+      render json: { message: error.message }, status: :unprocessable_entity
+    end
   end
 
   def decision_review_created_error

--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -10,6 +10,7 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
   rescue Caseflow::Error::RedisLockFailed => error
     render json: { message: error.message }, status: :conflict
   rescue StandardError => error
+# check if record already in Caseflow
     if error.message.include?("already exists")
       render json: { message: "Record already exists in Caseflow" }, status: :ok
     else

--- a/spec/controllers/api/events/v1/decision_review_created_controller_spec.rb
+++ b/spec/controllers/api/events/v1/decision_review_created_controller_spec.rb
@@ -15,6 +15,14 @@ RSpec.describe Api::Events::V1::DecisionReviewCreatedController, type: :controll
         post :decision_review_created, params: JSON.parse(payload)
         expect(response).to have_http_status(:created)
       end
+
+      it "returns ok response on second post with the same parameters" do
+        request.headers["Authorization"] = "Token token=#{api_key.key_string}"
+        load_headers
+        allow(::Events::DecisionReviewCreated).to receive(:create!).and_raise(StandardError.new("already exists"))
+        post :decision_review_created, params: JSON.parse(payload)
+        expect(response).to have_http_status(:ok)
+      end
     end
 
     context "when claim_id is already in Redis Cache" do


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
ResolvesCaseflow: Create a 200 response when DecisionreviewEvent API record already exist with caseflow. (https://jira.devops.va.gov/browse/APPEALS-451805)

# Description
That PR changes the response from Caseflow when a user tries to pass intake from Appeals-Consumer with data already in Caseflow.

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
There is no testing plan for now. 1 unit test in the PR.





# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec


### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added


