### PR TITLE
DecisionReviewCreated event API updated to populate nonrated Request Issues

### DIFF
--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -65,7 +65,8 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
                                    :contested_rating_issue_diagnostic_code,
                                    :ramp_claim_id,
                                    :rating_issue_associated_at,
-                                   :nonrating_issue_bgs_id]
+                                   :nonrating_issue_bgs_id,
+                                   :nonrating_issue_bgs_source]
                   )
   end
 end

--- a/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
+++ b/app/serializers/api/v3/issues/ama/request_issue_serializer.rb
@@ -20,7 +20,7 @@ class Api::V3::Issues::Ama::RequestIssueSerializer
              :correction_type, :created_at, :decision_date, :decision_review_id,
              :decision_review_type, :edited_description, :end_product_establishment_id,
              :ineligible_due_to_id, :ineligible_reason, :is_unidentified,
-             :nonrating_issue_bgs_id, :nonrating_issue_category, :nonrating_issue_description,
+             :nonrating_issue_bgs_id, :nonrating_issue_bgs_source, :nonrating_issue_category, :nonrating_issue_description,
              :notes, :ramp_claim_id, :split_issue_status, :unidentified_issue_text,
              :untimely_exemption, :untimely_exemption_notes, :updated_at, :vacols_id,
              :vacols_sequence_id, :verified_unidentified_issue, :veteran_participant_id

--- a/app/services/events/decision_review_created/create_request_issues.rb
+++ b/app/services/events/decision_review_created/create_request_issues.rb
@@ -44,6 +44,7 @@ class Events::DecisionReviewCreated::CreateRequestIssues
           ramp_claim_id: parser.ri_ramp_claim_id(issue),
           rating_issue_associated_at: parser.ri_rating_issue_associated_at(issue),
           nonrating_issue_bgs_id: parser.ri_nonrating_issue_bgs_id(issue),
+          nonrating_issue_bgs_source: parser.ri_nonrating_issue_bgs_source(issue),
           end_product_establishment_id: epe.id,
           veteran_participant_id: parser.veteran_participant_id,
           decision_review: decision_review

--- a/app/services/events/decision_review_created/decision_review_created_example.json
+++ b/app/services/events/decision_review_created/decision_review_created_example.json
@@ -77,7 +77,8 @@
       "contested_rating_issue_diagnostic_code": null,
       "ramp_claim_id": null,
       "rating_issue_associated_at": null,
-      "nonrating_issue_bgs_id": "13"
+      "nonrating_issue_bgs_id": "13",
+      "nonrating_issue_bgs_source": "Test Source"
     }
   ]
 }

--- a/app/services/events/decision_review_created/decision_review_created_parser.rb
+++ b/app/services/events/decision_review_created/decision_review_created_parser.rb
@@ -412,4 +412,8 @@ class Events::DecisionReviewCreated::DecisionReviewCreatedParser
   def ri_nonrating_issue_bgs_id(issue)
     issue.dig(:nonrating_issue_bgs_id)
   end
+
+  def ri_nonrating_issue_bgs_source(issue)
+    issue.dig(:nonrating_issue_bgs_source)
+  end
 end

--- a/spec/feature/events/decision_review_created/scenario_a_spec.rb
+++ b/spec/feature/events/decision_review_created/scenario_a_spec.rb
@@ -91,7 +91,8 @@ RSpec.describe Api::Events::V1::DecisionReviewCreatedController, type: :controll
             "contested_rating_issue_diagnostic_code": nil,
             "ramp_claim_id": nil,
             "rating_issue_associated_at": nil,
-            "nonrating_issue_bgs_id": "13"
+            "nonrating_issue_bgs_id": "13",
+            "nonrating_issue_bgs_source": "Test Source"
           }
         ]
       }

--- a/spec/feature/events/decision_review_created/scenario_c_spec.rb
+++ b/spec/feature/events/decision_review_created/scenario_c_spec.rb
@@ -87,7 +87,8 @@ RSpec.describe Api::Events::V1::DecisionReviewCreatedController, type: :controll
             "contested_rating_issue_diagnostic_code": nil,
             "ramp_claim_id": nil,
             "rating_issue_associated_at": nil,
-            "nonrating_issue_bgs_id": "13"
+            "nonrating_issue_bgs_id": "13",
+            "nonrating_issue_bgs_source": "Test Source"
           }
         ]
       }

--- a/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
+++ b/spec/serializers/api/v3/issues/ama/request_issue_serializer_spec.rb
@@ -33,6 +33,7 @@ describe Api::V3::Issues::Ama::RequestIssueSerializer, :postgres do
       expect(serialized_request_issue.key?(:ineligible_reason)).to eq true
       expect(serialized_request_issue.key?(:is_unidentified)).to eq true
       expect(serialized_request_issue.key?(:nonrating_issue_bgs_id)).to eq true
+      expect(serialized_request_issue.key?(:nonrating_issue_bgs_source)).to eq true
       expect(serialized_request_issue.key?(:nonrating_issue_category)).to eq true
       expect(serialized_request_issue.key?(:nonrating_issue_description)).to eq true
       expect(serialized_request_issue.key?(:notes)).to eq true

--- a/spec/services/events/decision_review_created/create_request_issues_spec.rb
+++ b/spec/services/events/decision_review_created/create_request_issues_spec.rb
@@ -33,6 +33,7 @@ describe Events::DecisionReviewCreated::CreateRequestIssues do
         expect(ri1.nonrating_issue_category).to eq("DIC")
         expect(ri1.decision_date).to eq(parser.logical_date_converter(20_240_314))
         expect(ri1.nonrating_issue_bgs_id).to eq("12")
+        expect(ri1.nonrating_issue_bgs_source).to eq("Test Source")
         expect(ri1.end_product_establishment_id).to eq(epe.id)
         expect(ri1.decision_review_id).to eq(higher_level_review.id)
         expect(ri1.decision_review_type).to eq("HigherLevelReview")
@@ -44,6 +45,7 @@ describe Events::DecisionReviewCreated::CreateRequestIssues do
         expect(ri2.nonrating_issue_category).to eq(nil)
         expect(ri2.decision_date).to eq(parser.logical_date_converter(20_240_314))
         expect(ri2.nonrating_issue_bgs_id).to eq(nil)
+        expect(ri2.nonrating_issue_bgs_source).to eq(nil)
         expect(ri2.end_product_establishment_id).to eq(epe.id)
         expect(ri2.decision_review_id).to eq(higher_level_review.id)
         expect(ri2.decision_review_type).to eq("HigherLevelReview")
@@ -123,7 +125,8 @@ describe Events::DecisionReviewCreated::CreateRequestIssues do
             "contested_rating_issue_diagnostic_code": nil,
             "ramp_claim_id": nil,
             "rating_issue_associated_at": nil,
-            "nonrating_issue_bgs_id": "12"
+            "nonrating_issue_bgs_id": "12",
+            "nonrating_issue_bgs_source": "Test Source"
           },
           {
             "benefit_type": "pension",

--- a/spec/services/events/decision_review_created/decision_review_created_parser_spec.rb
+++ b/spec/services/events/decision_review_created/decision_review_created_parser_spec.rb
@@ -125,6 +125,7 @@ describe Events::DecisionReviewCreated::DecisionReviewCreatedParser do
       expect(parser.ri_ramp_claim_id(issue)).to eq response_hash.request_issues.first["ramp_claim_id"]
       expect(parser.ri_rating_issue_associated_at(issue)).to eq response_hash.request_issues.first["rating_issue_associated_at"]
       expect(parser.ri_nonrating_issue_bgs_id(issue)).to eq response_hash.request_issues.first["nonrating_issue_bgs_id"]
+      expect(parser.ri_nonrating_issue_bgs_source(issue)).to eq response_hash.request_issues.first["nonrating_issue_bgs_source"]
     end
   end
   def read_json_payload


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [DecisionReviewCreated event API updated to populate nonrated Request Issues](https://jira.devops.va.gov/browse/APPEALS-45149)

# Description
This PR adds the attribute **ri_nonrating_issue_bgs_source** for the DecisionReviewCreated API as well as updating the parser to consume this attribute.

## Acceptance Criteria
- [x] DecisionReviewCreatedEvent API will need to be updated to populate the nonrating_issue_bgs_source for nonrated request issues from the appeals-consumer

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Test Plan for APPEALS-45831](https://jira.devops.va.gov/browse/APPEALS-45831)
2. Go to [XRAY for APPEALS-45832](https://jira.devops.va.gov/browse/APPEALS-45832)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

### RSPEC TESTING

<img width="1254" alt="Screen Shot 2024-05-13 at 9 19 05 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/6579225/b703ef07-1da9-4d93-93c6-2c6bad42a8d1">
<img width="1247" alt="Screen Shot 2024-05-13 at 9 18 15 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/6579225/e367cf0d-e058-4308-987a-b976e1ee4258">
<img width="1267" alt="Screen Shot 2024-05-13 at 9 12 15 AM" src="https://github.com/department-of-veterans-affairs/caseflow/assets/6579225/8946c869-19fb-43df-8f5a-e1cb1a2e524f">
