### PR TITLE
hotfix/APPEALS-45828

### DIFF
--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -82,7 +82,7 @@ class HearingsController < HearingsApplicationController
         alias_with_host: hearing.virtual_hearing&.formatted_alias_or_alias_with_host,
         guest_link: hearing.virtual_hearing&.guest_link,
         host_link: hearing.virtual_hearing&.host_link,
-        co_host_link: hearing.virtual_hearing&.co_host_link,
+        co_host_link: hearing.virtual_hearing&.co_host_hearing_link,
         guest_pin: hearing.virtual_hearing&.guest_pin,
         host_pin: hearing.virtual_hearing&.host_pin
       }

--- a/app/controllers/hearings_controller.rb
+++ b/app/controllers/hearings_controller.rb
@@ -82,6 +82,7 @@ class HearingsController < HearingsApplicationController
         alias_with_host: hearing.virtual_hearing&.formatted_alias_or_alias_with_host,
         guest_link: hearing.virtual_hearing&.guest_link,
         host_link: hearing.virtual_hearing&.host_link,
+        co_host_link: hearing.virtual_hearing&.co_host_link,
         guest_pin: hearing.virtual_hearing&.guest_pin,
         host_pin: hearing.virtual_hearing&.host_pin
       }

--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -165,7 +165,7 @@ class HearingMailer < ActionMailer::Base
                    end
 
     # Raise an error if the link contains the old virtual hearing link 2021-11-10
-    if hearing_link.nil? || URI(hearing_link).host.include?(BAD_VIRTUAL_LINK_TEXT)
+    if hearing_link.nil? || hearing_link.include?(BAD_VIRTUAL_LINK_TEXT)
       fail BadVirtualLinkError, virtual_hearing_id: virtual_hearing&.id
     end
 

--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -165,7 +165,7 @@ class HearingMailer < ActionMailer::Base
                    end
 
     # Raise an error if the link contains the old virtual hearing link 2021-11-10
-    if hearing_link&.include?(BAD_VIRTUAL_LINK_TEXT)
+    if hearing_link.nil? || hearing_link.include?(BAD_VIRTUAL_LINK_TEXT)
       fail BadVirtualLinkError, virtual_hearing_id: virtual_hearing&.id
     end
 

--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -165,7 +165,7 @@ class HearingMailer < ActionMailer::Base
                    end
 
     # Raise an error if the link contains the old virtual hearing link 2021-11-10
-    if hearing_link.nil? || hearing_link.include?(BAD_VIRTUAL_LINK_TEXT)
+    if hearing_link.nil? || URI(hearing_link).host.include?(BAD_VIRTUAL_LINK_TEXT)
       fail BadVirtualLinkError, virtual_hearing_id: virtual_hearing&.id
     end
 

--- a/app/mailers/hearing_mailer.rb
+++ b/app/mailers/hearing_mailer.rb
@@ -165,7 +165,7 @@ class HearingMailer < ActionMailer::Base
                    end
 
     # Raise an error if the link contains the old virtual hearing link 2021-11-10
-    if hearing_link.include?(BAD_VIRTUAL_LINK_TEXT)
+    if hearing_link&.include?(BAD_VIRTUAL_LINK_TEXT)
       fail BadVirtualLinkError, virtual_hearing_id: virtual_hearing&.id
     end
 

--- a/app/models/hearings/forms/base_hearing_update_form.rb
+++ b/app/models/hearings/forms/base_hearing_update_form.rb
@@ -128,14 +128,24 @@ class BaseHearingUpdateForm
   end
 
   def start_async_job
+    # If converting hearing from virtual to non-virtual
     if start_async_job? && virtual_hearing_cancelled?
       perform_later_or_now(VirtualHearings::DeleteConferencesJob)
+      maybe_start_activate_non_virtual_job
+    # If converting hearing from non-virtual to virtual
     elsif start_async_job?
-      start_activate_job
+      start_activate_virtual_job
     end
   end
 
-  def start_activate_job
+  # If a Webex hearing, activate new Webex conference links when converting from virtual to non-virtual
+  def maybe_start_activate_non_virtual_job
+    return unless hearing.conference_provider == "webex"
+
+    perform_later_or_now(Hearings::CreateNonVirtualConferenceJob, hearing: hearing)
+  end
+
+  def start_activate_virtual_job
     hearing.virtual_hearing.establishment.submit_for_processing!
 
     job_args = {

--- a/app/models/hearings/virtual_hearing.rb
+++ b/app/models/hearings/virtual_hearing.rb
@@ -165,9 +165,11 @@ class VirtualHearing < CaseflowRecord
   def guest_link
     return guest_hearing_link if guest_hearing_link.present?
 
-    "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-    "conference=#{formatted_alias_or_alias_with_host}&" \
-    "pin=#{guest_pin}&role=guest"
+    if conference_provider == "pexip"
+      "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+      "conference=#{formatted_alias_or_alias_with_host}&" \
+      "pin=#{guest_pin}&role=guest"
+    end
   end
 
   def co_host_hearing_link
@@ -177,9 +179,11 @@ class VirtualHearing < CaseflowRecord
   def host_link
     return host_hearing_link if host_hearing_link.present?
 
-    "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
-    "conference=#{formatted_alias_or_alias_with_host}&" \
-    "pin=#{host_pin}&role=host"
+    if conference_provider == "pexip"
+      "#{VirtualHearing.base_url}?join=1&media=&escalate=1&" \
+      "conference=#{formatted_alias_or_alias_with_host}&" \
+      "pin=#{host_pin}&role=host"
+    end
   end
 
   def test_link(title)

--- a/spec/feature/hearings/hearing_details_spec.rb
+++ b/spec/feature/hearings/hearing_details_spec.rb
@@ -116,17 +116,17 @@ RSpec.feature "Hearing Details", :all_dbs do
   def check_webex_hearings_links(link, disable_link = false)
     # Confirm that the host hearing link details exist
     within "#vlj-hearings-link" do
-      find("div", text: link.host_link)
+      find("div").should have_content(link.host_link)
       ensure_link_present(link.host_link, disable_link)
     end
     # Confirm that the co-host hearing link details exist
     within "#hc-hearings-link" do
-      find("div", text: link.co_host_link)
+      find("div").should have_content(link.co_host_link)
       ensure_link_present(link.co_host_link, disable_link)
     end
     # Confirm that the guest hearing link details exist
     within "#guest-hearings-link" do
-      find("div", text: link.guest_link)
+      find("div").should have_content(link.guest_link)
       ensure_link_present(link.guest_link, disable_link)
     end
   end
@@ -370,7 +370,7 @@ RSpec.feature "Hearing Details", :all_dbs do
         )
       end
 
-      # include_examples "always updatable fields"
+      include_examples "always updatable fields"
 
       context "User switches hearing type from Virtual back to original type" do
         let!(:virtual_hearing) do
@@ -474,14 +474,9 @@ RSpec.feature "Hearing Details", :all_dbs do
         end
 
         context "when hearing conference type is webex" do
-          let!(:hearing) { create(:hearing, :with_webex_non_virtual_conference_link) }
-
           before { hearing.meeting_type.update(service_name: "webex") }
 
           scenario "links display correctly" do
-            FeatureToggle.enable!(:pexip_conference_service)
-            hearing.update(hearing_day_id: hearing_day.id)
-
             visit "hearings/" + hearing.external_id.to_s + "/details"
 
             click_dropdown(name: "hearingType", index: 0)

--- a/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
@@ -88,7 +88,7 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
       expect(TranscriptionFileIssuesMailer).to receive(:issue_notification)
         .with(error_details)
       expect_any_instance_of(described_class).to receive(:log_error).once
-      perform_enqueued_jobs { described_class.perform_later(id: id, file_name: file_name) }
+      perform_enqueued_jobs { described_class.perform_later(id: id) }
     end
 
     context "mailer fails to send email" do
@@ -96,7 +96,7 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
         allow(TranscriptionFileIssuesMailer).to receive(:issue_notification).with(error_details)
           .and_raise(GovDelivery::TMS::Request::Error.new(500))
         expect_any_instance_of(described_class).to receive(:log_error).twice
-        perform_enqueued_jobs { described_class.perform_later(id: id, file_name: file_name) }
+        perform_enqueued_jobs { described_class.perform_later(id: id) }
       end
     end
   end

--- a/spec/mailers/hearing_mailer_spec.rb
+++ b/spec/mailers/hearing_mailer_spec.rb
@@ -193,8 +193,14 @@ describe HearingMailer do
         vh.meeting_type.update!(service_name: "webex")
       end
     end
+    let(:hearing_link) { double("hearing_link") }
+
+    before do
+      allow(hearing_link).to receive(:nil?).and_return(false)
+    end
 
     it "Webex test link appears" do
+      allow(virtual_hearing).to receive(:guest_link).and_return("link")
       expect(subject.html_part.body).to include("https://instant-usgov.webex.com/mediatest")
     end
   end

--- a/spec/mailers/hearing_mailer_spec.rb
+++ b/spec/mailers/hearing_mailer_spec.rb
@@ -193,14 +193,9 @@ describe HearingMailer do
         vh.meeting_type.update!(service_name: "webex")
       end
     end
-    let(:hearing_link) { double("hearing_link") }
-
-    before do
-      allow(hearing_link).to receive(:nil?).and_return(false)
-    end
 
     it "Webex test link appears" do
-      allow(virtual_hearing).to receive(:guest_link).and_return("link")
+      allow(virtual_hearing).to receive(:guest_link).and_return("linK")
       expect(subject.html_part.body).to include("https://instant-usgov.webex.com/mediatest")
     end
   end

--- a/spec/mailers/hearing_mailer_spec.rb
+++ b/spec/mailers/hearing_mailer_spec.rb
@@ -660,7 +660,9 @@ describe HearingMailer do
             )
           end
 
-          include_context "test link for a webex conference"
+          context "webex conference" do
+            include_context "test link for a webex conference"
+          end
         end
 
         context "regional office is in eastern timezone" do
@@ -741,7 +743,9 @@ describe HearingMailer do
             )
           end
 
-          include_context "test link for a webex conference"
+          context "webex conference" do
+            include_context "test link for a webex conference"
+          end
         end
 
         context "regional office is in eastern timezone" do
@@ -1223,7 +1227,9 @@ describe HearingMailer do
             )
           end
 
-          include_context "test link for a webex conference"
+          context "webex conference" do
+            include_context "test link for a webex conference"
+          end
         end
 
         context "regional office is in eastern timezone" do


### PR DESCRIPTION
Resolves [APPEALS-45828: Non-virtual links not present when converting virtual to video](https://jira.devops.va.gov/browse/APPEALS-45828)

# Description
Defect Summary: When a user converts a Webex hearing from virtual to video, the new hearing links do not display on the hearing details page

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The new hearing links display on the hearing details page

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [APPEALS-45886](https://jira.devops.va.gov/browse/APPEALS-45886)