### PR TITLE
Hotfix/APPEALS-45818

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2185,6 +2185,7 @@ GEM
     ziptz (2.1.6)
 
 PLATFORMS
+  x86_64-darwin-21
   x86_64-darwin-22
   x86_64-linux
 

--- a/app/jobs/hearings/fetch_webex_recordings_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_details_job.rb
@@ -62,7 +62,12 @@ class Hearings::FetchWebexRecordingsDetailsJob < CaseflowJob
   end
 
   def create_file_name(topic, extension)
-    subject = topic.scan(/\d*-\d*_\d*_[A-Za-z]+?(?=-)/).first
+    type = topic.scan(/[A-Za-z]+?(?=-)/).first
+    subject = if type == "Hearing"
+                topic.scan(/\d*-\d*_\d*_[A-Za-z]+?(?=-)/).first
+              else
+                topic.split("-").second.lstrip
+              end
     counter = topic.split("-").last
     "#{subject}-#{counter}.#{extension}"
   end

--- a/app/jobs/hearings/fetch_webex_recordings_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_details_job.rb
@@ -24,9 +24,8 @@ class Hearings::FetchWebexRecordingsDetailsJob < CaseflowJob
     job.log_error(exception)
   end
 
-  def perform(id:, file_name:)
+  def perform(id:)
     ensure_current_user_is_set
-    @file_name ||= file_name
     data = fetch_recording_details(id)
     topic = data.topic
 
@@ -63,7 +62,7 @@ class Hearings::FetchWebexRecordingsDetailsJob < CaseflowJob
   end
 
   def create_file_name(topic, extension)
-    subject = topic.split("-").second.lstrip
+    subject = topic.scan(/\d*-\d*_\d*_[A-Za-z]+?(?=-)/).first
     counter = topic.split("-").last
     "#{subject}-#{counter}.#{extension}"
   end

--- a/app/jobs/hearings/fetch_webex_recordings_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_list_job.rb
@@ -26,12 +26,8 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
 
   def perform
     ensure_current_user_is_set
-    response = fetch_recordings_list
-    topics = response.topics
-    topic_num = 0
-    response.ids.each do |id|
-      Hearings::FetchWebexRecordingsDetailsJob.perform_later(id: id)
-      topic_num += 1
+    fetch_recordings_list.ids.each do |n|
+      Hearings::FetchWebexRecordingsDetailsJob.perform_later(id: n)
     end
   end
 

--- a/app/jobs/hearings/fetch_webex_recordings_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_list_job.rb
@@ -30,7 +30,7 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
     topics = response.topics
     topic_num = 0
     response.ids.each do |id|
-      Hearings::FetchWebexRecordingsDetailsJob.perform_later(id: id, topic: topics[topic_num])
+      Hearings::FetchWebexRecordingsDetailsJob.perform_later(id: id)
       topic_num += 1
     end
   end

--- a/app/services/external_api/webex_service.rb
+++ b/app/services/external_api/webex_service.rb
@@ -94,7 +94,7 @@ class ExternalApi::WebexService
   def fetch_recordings_list
     body = nil
     method = "GET"
-    @api_endpoint += "recordings"
+    @api_endpoint += "admin/recordings"
     ExternalApi::WebexService::RecordingsListResponse.new(send_webex_request(body, method))
   end
 

--- a/app/services/external_api/webex_service/recording_details_response.rb
+++ b/app/services/external_api/webex_service/recording_details_response.rb
@@ -6,7 +6,7 @@ class ExternalApi::WebexService::RecordingDetailsResponse < ExternalApi::WebexSe
   end
 
   def vtt_link
-    data["temporaryDirectDownloadLinks"]["transcriptionDownloadLink"]
+    data["temporaryDirectDownloadLinks"]["transcriptDownloadLink"]
   end
 
   def mp3_link

--- a/app/services/external_api/webex_service/recordings_list_response.rb
+++ b/app/services/external_api/webex_service/recordings_list_response.rb
@@ -4,8 +4,4 @@ class ExternalApi::WebexService::RecordingsListResponse < ExternalApi::WebexServ
   def ids
     data.nil? ? [] : data["items"].pluck("id")
   end
-
-  def topics
-    data.nil? ? [] : data["items"].pluck("topic")
-  end
 end

--- a/lib/fakes/webex_service.rb
+++ b/lib/fakes/webex_service.rb
@@ -205,7 +205,7 @@ class Fakes::WebexService
       "temporaryDirectDownloadLinks": {
         "recordingDownloadLink": "https://www.learningcontainer.com/mp4-sample-video-files-download/#",
         "audioDownloadLink": "https://freetestdata.com/audio-files/mp3/",
-        "transcriptionDownloadLink": "https://www.capsubservices.com/assets/downloads/web/WebVTT.vtt",
+        "transcriptDownloadLink": "https://www.capsubservices.com/assets/downloads/web/WebVTT.vtt",
         "expiration": "2022-05-01T10:30:25Z"
       },
       "format": "ARF",

--- a/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
@@ -10,11 +10,9 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
   let(:mp4_file_name) { "180000304_1_LegacyHearing-1.mp4" }
   let(:vtt_file_name) { "180000304_1_LegacyHearing-1.vtt" }
   let(:mp3_file_name) { "180000304_1_LegacyHearing-1.mp3" }
-  let(:hearing) { create(:hearing) }
-  let(:file_name) { "#{hearing.docket_number}_#{hearing.id}_#{hearing.class}" }
   let(:access_token) { "sample_#{Rails.deploy_env}_token" }
 
-  subject { described_class.perform_now(id: id, file_name: file_name) }
+  subject { described_class.perform_now(id: id) }
 
   before do
     allow(CredStash).to receive(:get).with("webex_#{Rails.deploy_env}_access_token").and_return(access_token)
@@ -70,7 +68,7 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
     it "retries and logs errors" do
       subject
       expect(Rails.logger).to receive(:error).at_least(:once)
-      perform_enqueued_jobs { described_class.perform_later(id: id, file_name: file_name) }
+      perform_enqueued_jobs { described_class.perform_later(id: id) }
     end
   end
 end


### PR DESCRIPTION
## Resolves APPEALS-45818: FetchWebexRecordingsDetailsJob failing to retrieve VTT files
https://jira.devops.va.gov/browse/APPEALS-45818

# Description
Defect Summary:

When FetchWebexRecordingsDetailsJob is called from within FetchWebexRecordingsListJob, it is given a keyword argument of topic but is expecting a keyword argument of file_name

This is causing the FetchWebexRecordingsDetailsJob to not be called correctly resulting in an argument error

When reading the response from the Webex API, the ExternalApi::WebexService::RecordingDetailsResponse expects the vtt_file download link to be located at data["temporaryDirectDownloadLinks"]["transcriptionDownloadLink"] but it is actually located at data["temporaryDirectDownloadLinks"]["transcriptDownloadLink"]

This is causing nil to be present as the download link when the DownloadTranscriptionFileLinkJob is called

File name parsed incorrectly

## Acceptance Criteria
- [x] Code compiles correctly
- [x] File name parsed correctly
- [x] transcriptionDownloadLink changed to transcriptDownloadLink
- [x] 'file_name' param removed from FetchWebexRecordingsListJob 
- [x] 'admin' is added to the recordings list endpoint

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-45912