### PR TITLE
msteele/APPEALS-45285-v2 Fix delete_conference in PexipService

### DIFF
--- a/app/services/external_api/pexip_service.rb
+++ b/app/services/external_api/pexip_service.rb
@@ -40,10 +40,10 @@ class ExternalApi::PexipService
     ExternalApi::PexipService::CreateResponse.new(resp)
   end
 
-  def delete_conference(conference_id:)
-    return if conference_id.nil?
+  def delete_conference(virtual_hearing)
+    return if virtual_hearing.conference_id.nil?
 
-    delete_endpoint = "#{CONFERENCES_ENDPOINT}#{conference_id}/"
+    delete_endpoint = "#{CONFERENCES_ENDPOINT}#{virtual_hearing.conference_id}/"
     resp = send_pexip_request(delete_endpoint, :delete)
     return lack_of_connectivity_response if resp.nil?
 

--- a/spec/services/external_api/pexip_service_spec.rb
+++ b/spec/services/external_api/pexip_service_spec.rb
@@ -93,9 +93,11 @@ describe ExternalApi::PexipService do
   end
 
   describe "#delete_conference" do
-    let(:conference_id) { "123" }
-    subject { pexip_service.delete_conference(conference_id: conference_id) }
+  let(:virtual_hearing) do
+    create(:virtual_hearing, conference_id: "123")
+  end
 
+  subject { pexip_service.delete_conference(virtual_hearing) }
     let(:success_del_resp) { HTTPI::Response.new(204, {}, {}) }
     let(:error_del_resp) { HTTPI::Response.new(404, {}, {}) }
 
@@ -105,12 +107,12 @@ describe ExternalApi::PexipService do
     end
 
     it "passed correct arguments to #send_pexip_request" do
-      expect(pexip_service).to receive(:send_pexip_request).with("#{endpoint}#{conference_id}/", :delete)
+      expect(pexip_service).to receive(:send_pexip_request).with("#{endpoint}123/", :delete)
       subject
     end
 
     it "success response" do
-      allow(pexip_service).to receive(:send_pexip_request).with("#{endpoint}#{conference_id}/", :delete)
+      allow(pexip_service).to receive(:send_pexip_request).with("#{endpoint}123/", :delete)
         .and_return(success_del_resp)
 
       expect(subject.code).to eq(204)
@@ -119,7 +121,7 @@ describe ExternalApi::PexipService do
     end
 
     it "error response" do
-      allow(pexip_service).to receive(:send_pexip_request).with("#{endpoint}#{conference_id}/", :delete)
+      allow(pexip_service).to receive(:send_pexip_request).with("#{endpoint}123/", :delete)
         .and_return(error_del_resp)
 
       expect(subject.code).to eq(404)

--- a/spec/services/external_api/pexip_service_spec.rb
+++ b/spec/services/external_api/pexip_service_spec.rb
@@ -93,11 +93,11 @@ describe ExternalApi::PexipService do
   end
 
   describe "#delete_conference" do
-  let(:virtual_hearing) do
-    create(:virtual_hearing, conference_id: "123")
-  end
+    let(:virtual_hearing) do
+      create(:virtual_hearing, conference_id: "123")
+    end
 
-  subject { pexip_service.delete_conference(virtual_hearing) }
+    subject { pexip_service.delete_conference(virtual_hearing) }
     let(:success_del_resp) { HTTPI::Response.new(204, {}, {}) }
     let(:error_del_resp) { HTTPI::Response.new(404, {}, {}) }
 


### PR DESCRIPTION
Resolves [APPEALS-45285](https://jira.devops.va.gov/browse/APPEALS-45285)

# Description
Update the delete_conference method in ExternalApi::PexipService to fix an ArgumentError that caused this bug fix to fail validation

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. Go to [APPEALS-45815](https://jira.devops.va.gov/browse/APPEALS-45815) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?