### PR TITLE
Justin/appeals 41645 v1

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,11 +99,11 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
 
   def inbound_ops_team_superuser?
     member_of_organization?(InboundOpsTeam.singleton) &&
-    OrganizationUserPermissionChecker.new.can?(
-      permission_name: Constants.ORGANIZATION_PERMISSIONS.superuser,
-      organization: InboundOpsTeam.singleton,
-      user: self
-    )
+      OrganizationUserPermissionChecker.new.can?(
+        permission_name: Constants.ORGANIZATION_PERMISSIONS.superuser,
+        organization: InboundOpsTeam.singleton,
+        user: self
+      )
   end
 
   def mail_team_user?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -99,7 +99,11 @@ class User < CaseflowRecord # rubocop:disable Metrics/ClassLength
 
   def inbound_ops_team_superuser?
     member_of_organization?(InboundOpsTeam.singleton) &&
-      (administered_teams.include?(BvaIntake.singleton) || administered_teams.include?(MailTeam.singleton))
+    OrganizationUserPermissionChecker.new.can?(
+      permission_name: Constants.ORGANIZATION_PERMISSIONS.superuser,
+      organization: InboundOpsTeam.singleton,
+      user: self
+    )
   end
 
   def mail_team_user?

--- a/client/constants/ORGANIZATION_PERMISSIONS.json
+++ b/client/constants/ORGANIZATION_PERMISSIONS.json
@@ -1,4 +1,5 @@
 {
   "auto_assign": "auto_assign",
-  "receive_nod_mail": "receive_nod_mail"
+  "receive_nod_mail": "receive_nod_mail",
+  "superuser" : "superuser"
 }

--- a/db/seeds/correspondence_auto_assign.rb
+++ b/db/seeds/correspondence_auto_assign.rb
@@ -12,13 +12,27 @@ module Seeds
       create_mail_team_superuser
     end
 
+    private
+
     def create_auto_assign_permissions
       OrganizationPermission.valid_permission_names.each do |permission|
-        OrganizationPermission.find_or_create_by(permission: permission, organization: InboundOpsTeam.singleton) do |p|
-          p.description = Faker::Fantasy::Tolkien.poem
-          p.enabled = true
+        OrganizationPermission.find_or_create_by(
+          permission: permission,
+          organization: InboundOpsTeam.singleton
+        ) do |perm|
+          perm.enabled = true
+          perm.description = Faker::Hipster.sentence
         end
       end
+      OrganizationPermission.find_by(permission: "superuser").update!(
+        description: "Superuser: Split, Merge, and Reassign",
+        default_for_admin: true
+      )
+      OrganizationPermission.find_by(permission: "auto_assign").update!(description: "Auto-Assignment")
+      OrganizationPermission.find_by(permission: "receive_nod_mail").update!(
+        description: "Receieve \"NOD Mail\"",
+        parent_permission: OrganizationPermission.find_by(permission: "auto_assign")
+      )
     end
 
     def create_inbound_ops_team_nod_user
@@ -29,14 +43,12 @@ module Seeds
         { css_id: "INBOUND_OPS_TEAM_MAIL_INTAKE_USER_NOD4", full_name: "Olia Smith" }
       ]
       users_info.map do |user_info|
-        u = User.find_or_create_by!(
-          station_id: 101,
-          css_id: user_info[:css_id],
-          full_name: user_info[:full_name],
-          roles: ["Mail Intake"]
+        new_user = create_user(user_info)
+        org_user = OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: new_user)
+        receive_nod_mail = OrganizationPermission.find_by(
+          organization: InboundOpsTeam.singleton,
+          permission: "receive_nod_mail"
         )
-        org_user = OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: u)
-        receive_nod_mail = OrganizationPermission.find_by(organization: InboundOpsTeam.singleton, permission: "receive_nod_mail")
         OrganizationUserPermission.find_or_create_by!(
           organization_permission: receive_nod_mail,
           organizations_user: org_user
@@ -54,13 +66,8 @@ module Seeds
         { css_id: "INBOUND_OPS_TEAM_MAIL_INTAKE_USER_AUTO_ASSIGN_A4", full_name: "Blaze Hill" }
       ]
       users_info.map do |user_info|
-        u = User.find_or_create_by!(
-          station_id: 101,
-          css_id: user_info[:css_id],
-          full_name: user_info[:full_name],
-          roles: ["Mail Intake"]
-        )
-        org_user = OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: u)
+        new_user = create_user(user_info)
+        org_user = OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: new_user)
         auto_assign = OrganizationPermission.find_by(organization: InboundOpsTeam.singleton, permission: "auto_assign")
         OrganizationUserPermission.find_or_create_by!(
           organization_permission: auto_assign,
@@ -68,6 +75,24 @@ module Seeds
         ) do |op|
           op.permitted = true
         end
+      end
+    end
+
+    def create_inbound_ops_team_supervisor
+      users_info = [
+        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S1", full_name: "Caleb Mitchell" },
+        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S2", full_name: "Scarlett Reed" },
+        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S3", full_name: "Elijah Turner" }
+      ]
+      users_info.map do |user_info|
+        user = User.find_or_create_by!(
+          station_id: 101,
+          css_id: user_info[:css_id],
+          full_name: user_info[:full_name],
+          roles: ["Mail Intake"]
+        )
+        InboundOpsTeam.singleton.add_user(user)
+        OrganizationsUser.make_user_admin(user, InboundOpsTeam.singleton)
       end
     end
 
@@ -80,48 +105,13 @@ module Seeds
         { css_id: "INBOUND_OPS_TEAM_MAIL_INTAKE_USER_NP5", full_name: "Liam Miller" }
       ]
       users_info.map do |user_info|
-        u = User.find_or_create_by!(
+        new_user = User.find_or_create_by!(
           station_id: 101,
           css_id: user_info[:css_id],
           full_name: user_info[:full_name],
           roles: ["Mail Intake"]
         )
-        OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: u)
-      end
-    end
-
-    def create_inbound_ops_team_supervisor
-      users_info = [
-        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S1", full_name: "Caleb Mitchell" },
-        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S2", full_name: "Scarlett Reed" },
-        { css_id: "INBOUND_OPS_TEAM_ADMIN_USER_S3", full_name: "Elijah Turner" }
-      ]
-      users_info.map do |user_info|
-        u = User.find_or_create_by!(
-          station_id: 101,
-          css_id: user_info[:css_id],
-          full_name: user_info[:full_name],
-          roles: ["Mail Intake"]
-        )
-        InboundOpsTeam.singleton.add_user(u)
-        OrganizationsUser.make_user_admin(u, InboundOpsTeam.singleton)
-      end
-    end
-
-    def create_mail_team_user
-      users_info = [
-        { css_id: "MAIL_TEAM_USER_U1", full_name: "Cedar Rain" },
-        { css_id: "MAIL_TEAM_USER_U2", full_name: "Ivy Stone" },
-        { css_id: "MAIL_TEAM_USER_U3", full_name: "Ocean Breeze" }
-      ]
-      users_info.map do |user_info|
-        u = User.find_or_create_by!(
-          station_id: 101,
-          css_id: user_info[:css_id],
-          full_name: user_info[:full_name],
-          roles: ["Mail Intake"]
-        )
-        MailTeam.singleton.add_user(u)
+        OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: new_user)
       end
     end
 
@@ -132,15 +122,41 @@ module Seeds
         { css_id: "MAIL_TEAM_ADMIN3", full_name: "Luna Meadows" }
       ]
       users_info.map do |user_info|
-        u = User.find_or_create_by!(
+        new_user = User.find_or_create_by!(
           station_id: 101,
           css_id: user_info[:css_id],
           full_name: user_info[:full_name],
           roles: ["Mail Intake"]
         )
-        MailTeam.singleton.add_user(u)
-        OrganizationsUser.make_user_admin(u, MailTeam.singleton)
+        MailTeam.singleton.add_user(new_user)
+        OrganizationsUser.make_user_admin(new_user, MailTeam.singleton)
       end
+    end
+
+    def create_mail_team_user
+      users_info = [
+        { css_id: "MAIL_TEAM_USER_U1", full_name: "Cedar Rain" },
+        { css_id: "MAIL_TEAM_USER_U2", full_name: "Ivy Stone" },
+        { css_id: "MAIL_TEAM_USER_U3", full_name: "Ocean Breeze" }
+      ]
+      users_info.map do |user_info|
+        new_user = User.find_or_create_by!(
+          station_id: 101,
+          css_id: user_info[:css_id],
+          full_name: user_info[:full_name],
+          roles: ["Mail Intake"]
+        )
+        MailTeam.singleton.add_user(new_user)
+      end
+    end
+
+    def create_user(user_info)
+      User.find_or_create_by!(
+        station_id: 101,
+        css_id: user_info[:css_id],
+        full_name: user_info[:full_name],
+        roles: ["Mail Intake"]
+      )
     end
   end
 end

--- a/db/seeds/correspondence_auto_assign.rb
+++ b/db/seeds/correspondence_auto_assign.rb
@@ -8,8 +8,8 @@ module Seeds
       create_inbound_ops_team_auto_assign_user
       create_inbound_ops_team_user_with_no_permissions
       create_inbound_ops_team_supervisor
+      create_inbound_ops_team_superuser
       create_mail_team_user
-      create_mail_team_superuser
     end
 
     private
@@ -92,12 +92,6 @@ module Seeds
         )
         InboundOpsTeam.singleton.add_user(user)
         OrganizationsUser.make_user_admin(user, InboundOpsTeam.singleton)
-        superuser_permission = OrganizationPermission.find_by(permission: 'superuser', organization_id: InboundOpsTeam.singleton.id)
-        OrganizationUserPermission.find_or_create_by!(
-          organization_permission: superuser_permission,
-          organizations_user: OrganizationsUser.find_by(user_id: new_user.id),
-          permitted: true
-        )
       end
     end
 
@@ -120,11 +114,11 @@ module Seeds
       end
     end
 
-    def create_mail_team_superuser
+    def create_inbound_ops_team_superuser
       users_info = [
-        { css_id: "MAIL_TEAM_ADMIN1", full_name: "Willow Green" },
-        { css_id: "MAIL_TEAM_ADMIN2", full_name: "Jasper Bloom" },
-        { css_id: "MAIL_TEAM_ADMIN3", full_name: "Luna Meadows" }
+        { css_id: "INBOUND_OPS_TEAM_SUPERUSER1", full_name: "Willow Green" },
+        { css_id: "INBOUND_OPS_TEAM_SUPERUSER2", full_name: "Jasper Bloom" },
+        { css_id: "INBOUND_OPS_TEAM_SUPERUSER3", full_name: "Luna Meadows" }
       ]
       users_info.map do |user_info|
         new_user = User.find_or_create_by!(
@@ -133,8 +127,13 @@ module Seeds
           full_name: user_info[:full_name],
           roles: ["Mail Intake"]
         )
-        MailTeam.singleton.add_user(new_user)
-        OrganizationsUser.make_user_admin(new_user, MailTeam.singleton)
+        InboundOpsTeam.singleton.add_user(new_user)
+        superuser_permission = OrganizationPermission.find_by(permission: 'superuser', organization_id: InboundOpsTeam.singleton.id)
+        OrganizationUserPermission.find_or_create_by!(
+          organization_permission: superuser_permission,
+          organizations_user: OrganizationsUser.find_by(user_id: new_user.id),
+          permitted: true
+        )
       end
     end
 

--- a/db/seeds/correspondence_auto_assign.rb
+++ b/db/seeds/correspondence_auto_assign.rb
@@ -92,6 +92,12 @@ module Seeds
         )
         InboundOpsTeam.singleton.add_user(user)
         OrganizationsUser.make_user_admin(user, InboundOpsTeam.singleton)
+        superuser_permission = OrganizationPermission.find_by(permission: 'superuser', organization_id: InboundOpsTeam.singleton.id)
+        OrganizationUserPermission.find_or_create_by!(
+          organization_permission: superuser_permission,
+          organizations_user: OrganizationsUser.find_by(user_id: new_user.id),
+          permitted: true
+        )
       end
     end
 

--- a/db/seeds/correspondence_auto_assign.rb
+++ b/db/seeds/correspondence_auto_assign.rb
@@ -25,8 +25,7 @@ module Seeds
         end
       end
       OrganizationPermission.find_by(permission: "superuser").update!(
-        description: "Superuser: Split, Merge, and Reassign",
-        default_for_admin: true
+        description: "Superuser: Split, Merge, and Reassign"
       )
       OrganizationPermission.find_by(permission: "auto_assign").update!(description: "Auto-Assignment")
       OrganizationPermission.find_by(permission: "receive_nod_mail").update!(

--- a/db/seeds/organization_user_permissions.rb
+++ b/db/seeds/organization_user_permissions.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Seeds
+  class OrganizationUserPermissions
+    def seed!
+      create_inbound_ops_team_superuser_permissions
+    end
+    private
+
+    def create_inbound_ops_team_superuser_permissions
+      superuser_permission = OrganizationPermission.find_by(permission: 'superuser', organization_id: InboundOpsTeam.singleton.id)
+
+      OrganizationUserPermission.find_or_create_by!(
+        organization_permission: superuser_permission,
+        organizations_user: OrganizationsUser.find_by(user_id: 72),
+        permitted: true
+      )
+      OrganizationUserPermission.find_or_create_by!(
+        organization_permission: superuser_permission,
+        organizations_user: OrganizationsUser.find_by(user_id: 73),
+        permitted: true
+      )
+    end
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -64,8 +64,11 @@ FactoryBot.define do
       trait :super_user do
         after(:create) do |u|
           OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: u).update!(admin: true)
-          OrganizationsUser.find_or_create_by!(organization: BvaIntake.singleton, user: u).update!(admin: true)
-          OrganizationsUser.find_or_create_by!(organization: MailTeam.singleton, user: u).update!(admin: true)
+          OrganizationUserPermission.find_or_create_by!(
+            permission_name: Constants.ORGANIZATION_PERMISSIONS.superuser,
+            organization: InboundOpsTeam.singleton,
+            user: u
+          )
         end
       end
 

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -64,10 +64,17 @@ FactoryBot.define do
       trait :super_user do
         after(:create) do |u|
           OrganizationsUser.find_or_create_by!(organization: InboundOpsTeam.singleton, user: u).update!(admin: true)
-          OrganizationUserPermission.find_or_create_by!(
-            permission_name: Constants.ORGANIZATION_PERMISSIONS.superuser,
+          permission = OrganizationPermission.find_or_create_by!(
+            permission: Constants.ORGANIZATION_PERMISSIONS.superuser,
             organization: InboundOpsTeam.singleton,
-            user: u
+            enabled: true,
+            description: "Superuser: Split, Merge, Reassign"
+          )
+
+          OrganizationUserPermission.find_or_create_by!(
+            organization_permission: permission,
+            permitted: true,
+            organizations_user: OrganizationsUser.find_or_create_by(user_id: u.id)
           )
         end
       end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Auto-Assign: Mail Superuser capacity calculation](https://jira.devops.va.gov/browse/APPEALS-41645)

# Description
Changed the superuser definitions to calculate based on the "Superuser: Split, Merge, Reassign" permissions.
Added a seed file for test users with the superuser permissions
Updated/Refactored the auto assignable 

NOTES:
The users that now meet the new definition of superusers are the following:
- INBOUND_OPS_TEAM_ADMIN_USER
- INBOUND_OPS_TEAM_MAIL_INTAKE_USER 

## Acceptance Criteria
- [ ] Check that the capacity rule for super users is calculating correctly
- [ ] Change the super user definitions to match users with "Superuser: Split, Merge, and Reassign" permissions
- [ ] Verify tests are passing

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

1. Log in as Jolly Postman and navigate to /queue/correspondence (which can either be appended to the address bar, or you can click "queue" and then choose "your correspondence" from the switch views dropdown). This will show you what the view should look like for a standard user. 
2. Using a new tab, you can navigate to /test/users and sign in to INBOUND_OPS_TEAM_ADMIN_USER (Jon Mailteam Snow Admin). 
3. Once you see the new user is logged in in the top right corner, you can navigate back to the first tab and refresh your page (in the /queue/correspondence tab). This should change the views and open the team view of the correspondence cases.
4. Since this user is now a superuser, the Auto assign correspondences button should show up and appear blue. 
5. Using the /test/users tab, now log in as INBOUND_OPS_TEAM_MAIL_INTAKE_USER (Jon Mailteam Snow Mail Intake)
6. Once you see the new user is logged in in the top right corner, you can navigate back to the first tab and navigate to /queue/correspondence. This should again change the views and open the team view of the correspondence cases.
7. Since this user is also a superuser, the Auto assign correspondences button should show up and appear blue. 