### PR TITLE
added specific logic to throw errors for certain fiel numberes and cl…

### DIFF
--- a/app/services/events/decision_review_created.rb
+++ b/app/services/events/decision_review_created.rb
@@ -28,6 +28,14 @@ class Events::DecisionReviewCreated
         # Use the consumer_event_id to retrieve/create the Event object
         event = find_or_create_event(consumer_event_id)
 
+        if headers["X-VA-File-Number"] == "123458312"
+          fail RedisMutex::LockError, "DRC RedisMutex::LockError message"
+        elsif headers["X-VA-File-Number"] == "786637934"
+          fail Caseflow::Error::RedisLockFailed, "DRC RedisLockFailed message"
+        elsif headers["X-VA-File-Number"] == "700056101"
+          fail StandardError, "DRC StandardError message"
+        end
+
         ActiveRecord::Base.transaction do
           # Initialize the Parser object that will be passed around as an argument
           parser = Events::DecisionReviewCreated::DecisionReviewCreatedParser.new(headers, payload)

--- a/app/services/events/decision_review_created_error.rb
+++ b/app/services/events/decision_review_created_error.rb
@@ -28,6 +28,14 @@ class Events::DecisionReviewCreatedError
          is already in the Redis Cache"
       end
 
+      if errored_claim_id == 4
+        fail RedisMutex::LockError, "DRCE RedisMutex::LockError message"
+      elsif errored_claim_id == 5
+        fail Caseflow::Error::RedisLockFailed, "DRCE RedisLockFailed message"
+      elsif errored_claim_id == 6
+        fail StandardError, "DRCE StandardError message"
+      end
+
       RedisMutex.with_lock("EndProductEstablishment:#{errored_claim_id}", block: 60, expire: 100) do
         ActiveRecord::Base.transaction do
           event&.update!(error: error_message, info: { "errored_claim_id" => errored_claim_id })


### PR DESCRIPTION
This branch includes additional logic that will throw various errors depending on the file number or claim id passed in. This will give us the ability to test how Appeals-Consumer handles different types of response codes and errors.