### PR TITLE
eli/APPEALS-28087-36678-prod-test-branch

### DIFF
--- a/app/services/events/decision_review_created.rb
+++ b/app/services/events/decision_review_created.rb
@@ -25,6 +25,13 @@ class Events::DecisionReviewCreated
              message: "Key RedisMutex:EndProductEstablishment:#{reference_id} is already in the Redis Cache"
       end
 
+      # Throws error for specific Consumer Event IDs to test Consumer error handling
+      if consumer_event_id == 20
+        fail Caseflow::Error::RedisLockFailed, "DRC RedisLockFailed message"
+      elsif consumer_event_id == 21
+        fail StandardError, "DRC StandardError message"
+      end
+
       RedisMutex.with_lock("EndProductEstablishment:#{reference_id}", block: 60, expire: 100) do
         # key => "EndProductEstablishment:reference_id" aka "claim ID"
         # Use the consumer_event_id to retrieve/create the Event object

--- a/app/services/events/decision_review_created_error.rb
+++ b/app/services/events/decision_review_created_error.rb
@@ -17,6 +17,7 @@ class Events::DecisionReviewCreatedError
   # :expire => 10   # Specify in seconds when the lock should be considered stale when something went wrong
   #                 # with the one who held the lock and failed to unlock. (default: 10)
   class << self
+    # rubocop:disable Metrics/MethodLength
     def handle_service_error(consumer_event_id, errored_claim_id, error_message)
       # check if consumer_event_id Event.reference_id exist if not Create DecisionReviewCreated Event
       event = DecisionReviewCreatedEvent.find_or_create_by(reference_id: consumer_event_id)
@@ -48,4 +49,5 @@ class Events::DecisionReviewCreatedError
       raise error
     end
   end
+  # rubocop:enable Metrics/MethodLength
 end

--- a/app/services/events/decision_review_created_error.rb
+++ b/app/services/events/decision_review_created_error.rb
@@ -28,6 +28,13 @@ class Events::DecisionReviewCreatedError
          is already in the Redis Cache"
       end
 
+      # Throws error for specific Consumer Event IDs to test Consumer error handling
+      if consumer_event_id == 18
+        fail Caseflow::Error::RedisLockFailed, "DRCE RedisLockFailed message"
+      elsif consumer_event_id == 19
+        fail StandardError, "DRCE StandardError message"
+      end
+
       RedisMutex.with_lock("EndProductEstablishment:#{errored_claim_id}", block: 60, expire: 100) do
         ActiveRecord::Base.transaction do
           event&.update!(error: error_message, info: { "errored_claim_id" => errored_claim_id })


### PR DESCRIPTION
Logic has been added to `services/events/decision_review_created.rb` and `services/events/decision_review_created_error.rb` to conditionally throw two errors: `Caseflow::Error::RedisLockError` and `StandardError`. These errors are triggered based on the Appeals-Consumer Event ID being processed. This change allows us to validate how Appeals-Consumer handles 409 and 422 response codes received from the Event API during the backfilling of DecisionReviewCreated event records.

