### PR TITLE
APPEALS-45883 - Remove End Product Establishment records within the Event Records table in Caseflow

### DIFF
--- a/app/models/end_product_establishment.rb
+++ b/app/models/end_product_establishment.rb
@@ -20,7 +20,6 @@ class EndProductEstablishment < CaseflowRecord
   has_many :effectuations, class_name: "BoardGrantEffectuation"
   has_many :end_product_updates
   has_one :priority_end_product_sync_queue
-  has_one :event_record, as: :evented_record
   belongs_to :vbms_ext_claim, foreign_key: "reference_id", primary_key: "claim_id", optional: true
 
   # :block  => 1    # Specify in seconds how long you want to wait for the lock to be released.

--- a/app/services/events/decision_review_created.rb
+++ b/app/services/events/decision_review_created.rb
@@ -56,7 +56,7 @@ class Events::DecisionReviewCreated
           # claim_review can either be a higher_level_revew or supplemental_claim
           epe = Events::DecisionReviewCreated::CreateEpEstablishment.process!(parser: parser,
                                                                               claim_review: decision_review,
-                                                                              user: user, event: event)
+                                                                              user: user)
 
           # Note: 'epe' arg is the obj created as a result of the CreateEpEstablishment service class
           Events::DecisionReviewCreated::CreateRequestIssues.process!(event: event, parser: parser, epe: epe,

--- a/app/services/events/decision_review_created/create_ep_establishment.rb
+++ b/app/services/events/decision_review_created/create_ep_establishment.rb
@@ -10,7 +10,7 @@ class Events::DecisionReviewCreated::CreateEpEstablishment
     # are referring to the backfill objects being created from other sub service
     # class. claim_review can be either a supplemental claim or higher level review
     # rubocop:disable Metrics/MethodLength
-    def process!(parser:, claim_review:, user:, event:)
+    def process!(parser:, claim_review:, user:)
       end_product_establishment = EndProductEstablishment.create!(
         payee_code: parser.epe_payee_code,
         source: claim_review,

--- a/app/services/events/decision_review_created/create_ep_establishment.rb
+++ b/app/services/events/decision_review_created/create_ep_establishment.rb
@@ -31,7 +31,6 @@ class Events::DecisionReviewCreated::CreateEpEstablishment
         user_id: user.id,
         claimant_participant_id: parser.claimant_participant_id
       )
-      EventRecord.create!(event: event, evented_record: end_product_establishment)
       end_product_establishment
     rescue StandardError => error
       raise Caseflow::Error::DecisionReviewCreatedEpEstablishmentError, error.message

--- a/spec/models/events/event_record_spec.rb
+++ b/spec/models/events/event_record_spec.rb
@@ -38,9 +38,6 @@ describe EventRecord, :postgres do
         veteran_file_number: veteran_file_number
       )
     end
-    let!(:end_product_establishment_event_record) do
-      EventRecord.create!(event: event2, evented_record: end_product_establishment)
-    end
     # Claimant
     let!(:appeal) { create(:appeal, receipt_date: 1.year.ago) }
     let!(:claimant) { create(:claimant, decision_review: appeal) }
@@ -68,18 +65,13 @@ describe EventRecord, :postgres do
     let(:session) { { "user" => { "id" => "BrockPurdy", "station_id" => "310", "name" => "Brock Purdy" } } }
     let(:user) { User.from_session(session) }
     let!(:user_event_record) { EventRecord.create!(event: event2, evented_record: user) }
-    it "10 Event Records Backfilled ID and Type correctly match" do
+    it "9 Event Records Backfilled ID and Type correctly match" do
       expect(higher_level_review_event_record.evented_record_type).to eq("HigherLevelReview")
       expect(higher_level_review_event_record.evented_record_id).to eq(higher_level_review.id)
       expect(higher_level_review.event_record).to eq higher_level_review_event_record
 
       intake.update!(detail: higher_level_review)
       expect(higher_level_review.from_decision_review_created_event?).to eq(true)
-
-      expect(end_product_establishment_event_record.evented_record_type).to eq("EndProductEstablishment")
-      expect(end_product_establishment_event_record.evented_record_id).to eq(end_product_establishment.id)
-      expect(end_product_establishment.event_record).to eq end_product_establishment_event_record
-      expect(end_product_establishment.from_decision_review_created_event?).to eq(true)
 
       expect(claimant_event_record.evented_record_type).to eq("Claimant")
       expect(claimant_event_record.evented_record_id).to eq(claimant.id)
@@ -116,7 +108,7 @@ describe EventRecord, :postgres do
       expect(user.event_record).to eq user_event_record
       expect(user.from_decision_review_created_event?).to eq(true)
 
-      expect(EventRecord.count).to eq 10
+      expect(EventRecord.count).to eq 9
     end
 
     it "SupplementalClaim not associated to a backfill Intake should fail #from_decision_review_created_event?" do

--- a/spec/services/events/decision_review_created/create_ep_establishment_spec.rb
+++ b/spec/services/events/decision_review_created/create_ep_establishment_spec.rb
@@ -6,7 +6,6 @@ describe Events::DecisionReviewCreated::CreateEpEstablishment do
   context "Events::DecisionReviewCreated::CreateEpEstablishment.process!" do
     # set up variables station_id, end_product_establishment, claim_review, user, event
     let!(:user_double) { double("User", id: 1) }
-    let!(:event_double) { double("Event") }
     let!(:claim_review) { create(:higher_level_review) }
     # conversions to mimic parser logic
     let!(:converted_long) { Time.zone.at(171_046_496_764_2) }
@@ -29,10 +28,8 @@ describe Events::DecisionReviewCreated::CreateEpEstablishment do
              epe_development_item_reference_id: nil,
              claimant_participant_id: "1826209")
     end
-    let(:event_record_double) { double("EventRecord") }
     it "creates an a End Product Establishment and Event Record" do
       allow(EndProductEstablishment).to receive(:create!).and_return(parser_double)
-      allow(EventRecord).to receive(:create!).and_return(event_record_double)
       expect(EndProductEstablishment).to receive(:create!).with(
         payee_code: "00",
         source: claim_review,
@@ -53,7 +50,7 @@ describe Events::DecisionReviewCreated::CreateEpEstablishment do
         development_item_reference_id: nil,
         claimant_participant_id: "1826209"
       ).and_return(parser_double)
-      described_class.process!(parser: parser_double, claim_review: claim_review, user: user_double, event: event_double)
+      described_class.process!(parser: parser_double, claim_review: claim_review, user: user_double)
     end
 
     # needed to convert the logical date int for the expect block
@@ -71,7 +68,7 @@ describe Events::DecisionReviewCreated::CreateEpEstablishment do
         allow(EndProductEstablishment).to receive(:create!).and_raise(Caseflow::Error::DecisionReviewCreatedEpEstablishmentError)
         expect do
           described_class.process!(parser: parser_double,
-                                   claim_review: claim_review, user: user_double, event: event_double)
+                                   claim_review: claim_review, user: user_double)
         end.to raise_error(Caseflow::Error::DecisionReviewCreatedEpEstablishmentError)
       end
     end

--- a/spec/services/events/decision_review_created/create_ep_establishment_spec.rb
+++ b/spec/services/events/decision_review_created/create_ep_establishment_spec.rb
@@ -53,8 +53,6 @@ describe Events::DecisionReviewCreated::CreateEpEstablishment do
         development_item_reference_id: nil,
         claimant_participant_id: "1826209"
       ).and_return(parser_double)
-      expect(EventRecord).to receive(:create!)
-        .with(event: event_double, evented_record: parser_double).and_return(event_record_double)
       described_class.process!(parser: parser_double, claim_review: claim_review, user: user_double, event: event_double)
     end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-45883](https://jira.devops.va.gov/browse/APPEALS-45883)

# Description
As a developer, I will need to remove End Product Establishment records that is currently being stored within the Event Records table, these can be identified via association to intake record stored within Event Record table. Based on association there is no need to create an Event Record of the EP creation. Removed  :evented_record from the end_product_establishment model, and removed all Rspec related code regarding these changes. 

## Acceptance Criteria

- [x] Remove evented_record from end_product_establishment model
- [x] Update decision_review_created with changes to epe changes
- [x]  Remove all Rspec regarding the epe event_record creation
- [x] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. [Test Plan Link](https://jira.devops.va.gov/browse/APPEALS-46429)
2. [Test Execution](https://jira.devops.va.gov/browse/APPEALS-46432)
3. [Xray Link](https://jira.devops.va.gov/secure/XrayExecuteTest!default.jspa?testExecIssueKey=APPEALS-46432&testIssueKey=APPEALS-46429)

# Best practices

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

