### PR TITLE
Appeals 46350: Team Management Selection: Inbound Ops Team Verbiage Adjustment

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -188,7 +188,7 @@ class ApplicationController < ApplicationBaseController
   def manage_teams_menu_items
     current_user.administered_teams.map do |team|
       {
-        title: "#{team.name} team management",
+        title: (team.type == InboundOpsTeam.singleton.type) ? "#{team.name} management" : "#{team.name} team management",
         link: team.user_admin_path
       }
     end

--- a/spec/feature/queue/correspondence/inbound_ops_team_management_spec.rb
+++ b/spec/feature/queue/correspondence/inbound_ops_team_management_spec.rb
@@ -22,7 +22,7 @@ RSpec.feature "InboundOpsTeamManagement" do
       scenario "link does not appear in dropdown menu" do
         visit("/queue")
         find("#menu-trigger").click
-        expect(page).to_not have_content("Inbound Ops Team team management")
+        expect(page).to_not have_content("Inbound Ops Team management")
       end
 
       scenario "user is denied access to team management page" do
@@ -81,8 +81,8 @@ RSpec.feature "InboundOpsTeamManagement" do
     visit("/queue")
 
     find("#menu-trigger").click
-    expect(page).to have_content("Inbound Ops Team team management")
-    click_on("Inbound Ops Team team management")
+    expect(page).to have_content("Inbound Ops Team management")
+    click_on("Inbound Ops Team management")
     expect(current_path).to eq("/organizations/inbound-ops-team/users")
   end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Team Management Selection: Inbound Ops Team Verbiage Adjustment](https://jira.devops.va.gov/browse/APPEALS-46350)

# Description
Update verbiage from the team management page selection from the user dropdown for Inbound Ops Team Organization management page, so that the verbiage is accurate in the UI

# Frontend
## User Facing Changes
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/107133331/84fdfef3-2b03-4b96-9937-fe3938ef2c20)