### PR TITLE
APPEALS-46858: Correspondence Demo Seed Data Failing in multi_correspondences.rb

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -73,6 +73,8 @@ class SeedDB
     call_and_log_seed_step Seeds::VbmsExtClaim
     call_and_log_seed_step Seeds::CorrespondenceTypes
     call_and_log_seed_step Seeds::PackageDocumentTypes
+    call_and_log_seed_step Seeds::CorrespondenceAutoAssignmentLevers
+    call_and_log_seed_step Seeds::CorrespondenceAutoAssign
     call_and_log_seed_step Seeds::Correspondence
     call_and_log_seed_step Seeds::MultiCorrespondences
     call_and_log_seed_step Seeds::QueueCorrespondences
@@ -80,8 +82,6 @@ class SeedDB
     call_and_log_seed_step Seeds::CasesTiedToJudgesNoLongerWithBoard
     call_and_log_seed_step Seeds::VhaChangeHistory
     call_and_log_seed_step Seeds::CorrespondenceAutoTexts
-    call_and_log_seed_step Seeds::CorrespondenceAutoAssignmentLevers
-    call_and_log_seed_step Seeds::CorrespondenceAutoAssign
     call_and_log_seed_step Seeds::AmaAffinityCases
     call_and_log_seed_step Seeds::BgsServiceRecordMaker
     call_and_log_seed_step Seeds::MstPactLegacyCaseAppeals

--- a/db/seeds/multi_correspondences.rb
+++ b/db/seeds/multi_correspondences.rb
@@ -39,17 +39,16 @@ module Seeds
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
     def create_multi_correspondences(user = {}, veteran = {})
       if user.blank?
-        # grab list of inbound ops team base users
-        users = InboundOpsTeam.singleton.users.each {|user| user.inbound_ops_team_user? }
+        # grab inbound ops base user
+        user = InboundOpsTeam.singleton.users.select { |user| user.inbound_ops_team_user? }.first
         # create veterans
         west = create_veteran(first_name: "Adam", last_name: "West")
         bale = create_veteran(first_name: "Christian", last_name: "Bale")
         keaton = create_veteran(first_name: "Michael", last_name: "Keaton")
-
-        # build correspondences for different users
-        build_correspondences(west, users.first, 5)
-        build_correspondences(bale, users.second, 10)
-        build_correspondences(keaton, users.third, 20)
+        # build correspondences for user
+        build_correspondences(west, user, 5)
+        build_correspondences(bale, user, 10)
+        build_correspondences(keaton, user, 20)
         return
       end
 

--- a/db/seeds/queue_correspondences.rb
+++ b/db/seeds/queue_correspondences.rb
@@ -20,7 +20,7 @@ module Seeds
     end
 
     def mail_team_superuser
-      @mail_team_superuser ||= User.find_by_css_id("AMBRISVACO")
+      @mail_team_superuser ||= InboundOpsTeam.singleton.users.select { |user| user.inbound_ops_team_superuser? }.first
     end
 
     # seed with values for UAT rake task correspondence.rake


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-46858](https://jira.devops.va.gov/browse/APPEALS-46858)

# Description
Resolved bug in seed data where multi_correspondences.rb was trying to assign correspondences to 3 Inbound Ops Team users when only 2 inbound ops team users existed. 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] `make reset` can complete in full

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Run `make reset` 
2. Validate that no errors occurred. 
