### PR TITLE
Add New CE REST API REST Functionality for Vet Docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem "amoeba"
 # BGS
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "a2e055b5a52bd1e2bb8c2b3b8d5820b1a404cd3d"
-gem "ruby_claim_evidence_api", git: "https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git", branch: "feature/APPEALS-43121"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "browser"
@@ -67,6 +66,7 @@ gem "redis-namespace"
 gem "redis-rails", "~> 5.0.2"
 gem "request_store"
 gem "roo", "~> 2.7"
+gem "ruby_claim_evidence_api", git: "https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git", branch: "feature/APPEALS-43121"
 # Use SCSS for stylesheets
 gem "sass-rails", "~> 5.0"
 # Error reporting to Sentry

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "amoeba"
 # BGS
 
 gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git", ref: "a2e055b5a52bd1e2bb8c2b3b8d5820b1a404cd3d"
+gem "ruby_claim_evidence_api", git: "https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git", branch: "feature/APPEALS-43121"
 # Bootsnap speeds up app boot (and started to be a default gem in 5.2).
 gem "bootsnap", require: false
 gem "browser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,21 @@ GIT
       savon (~> 2.12)
 
 GIT
+  remote: https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git
+  revision: 2c1da40c288be1c60caaefa8de496da7345952ca
+  branch: feature/APPEALS-43121
+  specs:
+    ruby_claim_evidence_api (0.1.0)
+      activesupport
+      aws-sdk-comprehend (~> 1.77)
+      base64
+      faraday
+      faraday-multipart
+      httpi
+      railties
+      webmock (~> 3.11.0)
+
+GIT
   remote: https://github.com/department-of-veterans-affairs/sniffybara.git
   revision: 351560b5789ca638ba7c9b093c2bb1a9a6fda4b3
   specs:
@@ -368,8 +383,8 @@ GEM
     aws-sdk-cognitosync (1.36.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-comprehend (1.62.0)
-      aws-sdk-core (~> 3, >= 3.127.0)
+    aws-sdk-comprehend (1.82.0)
+      aws-sdk-core (~> 3, >= 3.193.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-comprehendmedical (1.36.0)
       aws-sdk-core (~> 3, >= 3.127.0)
@@ -401,11 +416,11 @@ GEM
     aws-sdk-controltower (1.0.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
-    aws-sdk-core (3.131.0)
-      aws-eventstream (~> 1, >= 1.0.2)
-      aws-partitions (~> 1, >= 1.525.0)
-      aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
+    aws-sdk-core (3.196.1)
+      aws-eventstream (~> 1, >= 1.3.0)
+      aws-partitions (~> 1, >= 1.651.0)
+      aws-sigv4 (~> 1.8)
+      jmespath (~> 1, >= 1.6.1)
     aws-sdk-costandusagereportservice (1.41.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)
@@ -1440,6 +1455,7 @@ GEM
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
     backport (1.2.0)
+    base64 (0.2.0)
     benchmark-ips (2.7.2)
     bootsnap (1.7.5)
       msgpack (~> 1.0)
@@ -1580,6 +1596,8 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (2.4.1)
       faraday (>= 0.8)
+    faraday-multipart (1.0.4)
+      multipart-post (~> 2)
     faraday_middleware (0.13.1)
       faraday (>= 0.7.4, < 1.0)
     fast_jsonapi (1.5)
@@ -1636,7 +1654,7 @@ GEM
     immigrant (0.3.6)
       activerecord (>= 3.0)
     jaro_winkler (1.5.6)
-    jmespath (1.3.1)
+    jmespath (1.6.2)
     jquery-rails (4.5.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -1987,7 +2005,7 @@ GEM
       nokogiri (~> 1.6)
       rubyzip (>= 1.3.0)
       selenium-webdriver (~> 4.0, < 4.11)
-    webmock (3.6.2)
+    webmock (3.11.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
@@ -2098,6 +2116,7 @@ DEPENDENCIES
   ruby-debug-ide
   ruby-oci8 (~> 2.2)
   ruby-prof (~> 1.4)
+  ruby_claim_evidence_api!
   sass-rails (~> 5.0)
   scss_lint
   sentry-raven

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -39,7 +39,12 @@ class ExternalApi::VBMSService
   end
 
   def self.fetch_document_series_for(appeal)
-    ExternalApi::VbmsDocumentSeriesForAppeal.new(file_number: appeal.veteran_file_number).fetch
+    if FeatureToggle.enabled?(:use_ce_api)
+      response = VeteranFileFetcher.fetch_veteran_file_list(veteran_file_number: appeal.veteran_file_number)
+      JsonApiResponseAdapter.new.adapt_fetch_document_series_for(response)
+    else
+      ExternalApi::VbmsDocumentSeriesForAppeal.new(file_number: appeal.veteran_file_number).fetch
+    end
   end
 
   def self.update_document_in_vbms(appeal, uploadable_document)

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -19,8 +19,8 @@ class JsonApiResponseAdapter
     provider_data = file_json["currentVersion"]["providerData"]
 
     OpenStruct.new(
-      document_id: file_json["currentVersionUuid"],
-      series_id: file_json["uuid"],
+      document_id: "{#{file_json["currentVersionUuid"].upcase}}",
+      series_id: "{#{file_json["uuid"].upcase}}",
       version: "1",
       type_description: provider_data["subject"],
       type_id: provider_data["documentTypeId"],

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -26,7 +26,9 @@ class JsonApiResponseAdapter
       type_id: provider_data["documentTypeId"],
       doc_type: provider_data["documentTypeId"],
       subject: provider_data["subject"],
-      received_at: provider_data["dateVaReceivedDocument"],
+      # gsub here so that JS will correctly handle this date
+      # (with dashes the date is 1 day off due to UTC issues)
+      received_at: provider_data["dateVaReceivedDocument"]&.gsub("-", "/"),
       source: provider_data["contentSource"],
       mime_type: system_data["mimeType"],
       alt_doc_types: nil,

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -19,8 +19,8 @@ class JsonApiResponseAdapter
     provider_data = file_json["currentVersion"]["providerData"]
 
     OpenStruct.new(
-      document_id: "{#{file_json["currentVersionUuid"].upcase}}",
-      series_id: "{#{file_json["uuid"].upcase}}",
+      document_id: "{#{file_json['currentVersionUuid'].upcase}}",
+      series_id: "{#{file_json['uuid'].upcase}}",
       version: "1",
       type_description: provider_data["subject"],
       type_id: provider_data["documentTypeId"],

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -5,6 +5,9 @@
 class JsonApiResponseAdapter
   def adapt_fetch_document_series_for(json_response)
     documents = []
+
+    return documents unless valid_json_response?(json_response)
+
     json_response.body["files"].each do |file_resp|
       documents.push(fetch_document_series_for_response(file_resp))
     end
@@ -13,6 +16,12 @@ class JsonApiResponseAdapter
   end
 
   private
+
+  def valid_json_response?(json_response)
+    return false if json_response&.body.blank?
+
+    json_response.body.key?("files")
+  end
 
   def fetch_document_series_for_response(file_json)
     system_data = file_json["currentVersion"]["systemData"]

--- a/app/services/json_api_response_adapter.rb
+++ b/app/services/json_api_response_adapter.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Translates JSON API responses into a format that's compatible with the legacy SOAP responses expected
+# by most of Caseflow
+class JsonApiResponseAdapter
+  def adapt_fetch_document_series_for(json_response)
+    documents = []
+    json_response.body["files"].each do |file_resp|
+      documents.push(fetch_document_series_for_response(file_resp))
+    end
+
+    documents
+  end
+
+  private
+
+  def fetch_document_series_for_response(file_json)
+    system_data = file_json["currentVersion"]["systemData"]
+    provider_data = file_json["currentVersion"]["providerData"]
+
+    OpenStruct.new(
+      document_id: file_json["currentVersionUuid"],
+      series_id: file_json["uuid"],
+      version: "1",
+      type_description: provider_data["subject"],
+      type_id: provider_data["documentTypeId"],
+      doc_type: provider_data["documentTypeId"],
+      subject: provider_data["subject"],
+      received_at: provider_data["dateVaReceivedDocument"],
+      source: provider_data["contentSource"],
+      mime_type: system_data["mimeType"],
+      alt_doc_types: nil,
+      restricted: nil,
+      upload_date: system_data["uploadedDateTime"]
+    )
+  end
+end

--- a/config/initializers/ruby_claim_evidence_api.rb
+++ b/config/initializers/ruby_claim_evidence_api.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 VeteranFileFetcher = ExternalApi::VeteranFileFetcher
-  .new(use_canned_api_responses: ApplicationController.dependencies_faked?)
+  .new(use_canned_api_responses: ApplicationController.dependencies_faked?, logger: Rails.logger)

--- a/config/initializers/ruby_claim_evidence_api.rb
+++ b/config/initializers/ruby_claim_evidence_api.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+VeteranFileFetcher = ExternalApi::VeteranFileFetcher
+  .new(use_canned_api_responses: ApplicationController.dependencies_faked?)

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -8,13 +8,35 @@ describe JsonApiResponseAdapter do
   let(:api_response) { instance_double(ExternalApi::Response) }
 
   describe "#adapt_fetch_document_series_for" do
+    context "with invalid responses" do
+      it "handles blank responses" do
+        parsed = described.adapt_fetch_document_series_for(nil)
+
+        expect(parsed.length).to eq 0
+      end
+
+      it "handles blank response bodies" do
+        response = instance_double(ExternalApi::Response, body: nil)
+        parsed = described.adapt_fetch_document_series_for(response)
+
+        expect(parsed.length).to eq 0
+      end
+
+      it "handles response bodies with no files" do
+        response = instance_double(ExternalApi::Response, body: {})
+        parsed = described.adapt_fetch_document_series_for(response)
+
+        expect(parsed.length).to eq 0
+      end
+    end
+
     it "correctly parses an API response" do
       file = File.open(Rails.root.join("spec/support/api_responses/ce_api_folders_files_search.json"))
       data_hash = JSON.parse(File.read(file))
       file.close
 
       expect(api_response).to receive(:body)
-        .and_return(data_hash)
+        .exactly(3).times.and_return(data_hash)
 
       parsed = described.adapt_fetch_document_series_for(api_response)
 

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -20,11 +20,11 @@ describe JsonApiResponseAdapter do
 
       expect(parsed.length).to eq 2
 
-      expect(parsed[0].document_id).to eq "03223945-468b-4e8a-b79b-82fa73c2d2d9"
+      expect(parsed[0].document_id).to eq "{03223945-468B-4E8A-B79B-82FA73C2D2D9}"
       expect(parsed[0].received_at).to eq "2018-03-08"
       expect(parsed[0].mime_type).to eq "application/pdf"
 
-      expect(parsed[1].document_id).to eq "7d6afd8c-3bf7-4224-93ae-e1f07ac43c71"
+      expect(parsed[1].document_id).to eq "{7D6AFD8C-3BF7-4224-93AE-E1F07AC43C71}"
       expect(parsed[1].received_at).to eq "2018-12-08"
       expect(parsed[1].mime_type).to eq "application/pdf"
     end

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require "json"
+
+describe JsonApiResponseAdapter do
+  subject(:described) { described_class.new }
+
+  let(:api_response) { instance_double(ExternalApi::Response) }
+
+  describe "#adapt_fetch_document_series_for" do
+    it "correctly parses an API response" do
+      file = File.open(Rails.root.join("spec/support/api_responses/ce_api_folders_files_search.json"))
+      data_hash = JSON.parse(File.read(file))
+      file.close
+
+      expect(api_response).to receive(:body)
+        .and_return(data_hash)
+
+      parsed = described.adapt_fetch_document_series_for(api_response)
+
+      expect(parsed.length).to eq 2
+
+      expect(parsed[0].document_id).to eq "03223945-468b-4e8a-b79b-82fa73c2d2d9"
+      expect(parsed[0].received_at).to eq "2018-03-08"
+      expect(parsed[0].mime_type).to eq "application/pdf"
+
+      expect(parsed[1].document_id).to eq "7d6afd8c-3bf7-4224-93ae-e1f07ac43c71"
+      expect(parsed[1].received_at).to eq "2018-12-08"
+      expect(parsed[1].mime_type).to eq "application/pdf"
+    end
+  end
+end

--- a/spec/services/json_api_response_adapter_spec.rb
+++ b/spec/services/json_api_response_adapter_spec.rb
@@ -21,11 +21,11 @@ describe JsonApiResponseAdapter do
       expect(parsed.length).to eq 2
 
       expect(parsed[0].document_id).to eq "{03223945-468B-4E8A-B79B-82FA73C2D2D9}"
-      expect(parsed[0].received_at).to eq "2018-03-08"
+      expect(parsed[0].received_at).to eq "2018/03/08"
       expect(parsed[0].mime_type).to eq "application/pdf"
 
       expect(parsed[1].document_id).to eq "{7D6AFD8C-3BF7-4224-93AE-E1F07AC43C71}"
-      expect(parsed[1].received_at).to eq "2018-12-08"
+      expect(parsed[1].received_at).to eq "2018/12/08"
       expect(parsed[1].mime_type).to eq "application/pdf"
     end
   end

--- a/spec/support/api_responses/ce_api_folders_files_search.json
+++ b/spec/support/api_responses/ce_api_folders_files_search.json
@@ -1,0 +1,84 @@
+{
+  "page": {
+    "totalPages": 1,
+    "requestedResultsPerPage": 20,
+    "currentPage": 1,
+    "totalResults": 2
+  },
+  "files": [
+    {
+      "owner": {
+        "type": "VETERAN",
+        "id": "123456789"
+      },
+      "uuid": "23e7ae3b-5489-4fa9-b6e3-b1f953287138",
+      "currentVersionUuid": "03223945-468b-4e8a-b79b-82fa73c2d2d9",
+      "currentVersion": {
+        "systemData": {
+          "uploadedDateTime": "2018-03-08T14:21:40",
+          "contentName": "20180308091849 - codesheet.pdf",
+          "mimeType": "application/pdf",
+          "uploadSource": "RATING"
+        },
+        "providerData": {
+          "subject": "Rating Decision - Codesheet",
+          "documentTypeId": 338,
+          "ocrStatus": "Failure to Process",
+          "newMail": false,
+          "bookmarks": {
+            "VBA": {
+              "isDefaultRealm": true
+            }
+          },
+          "systemSource": "RATING",
+          "isAnnotated": false,
+          "modifiedDateTime": "2018-03-08T14:21:40",
+          "numberOfContentions": 0,
+          "readByCurrentUser": false,
+          "dateVaReceivedDocument": "2018-03-08",
+          "hasContentionAnnotations": false,
+          "contentSource": "VBMS-R",
+          "actionable": false,
+          "lastOpenedDocument": false
+        }
+      }
+    },
+    {
+      "owner": {
+        "type": "VETERAN",
+        "id": "123456789"
+      },
+      "uuid": "a001424d-99f9-4a96-977d-ee06ec4ef3a7",
+      "currentVersionUuid": "7d6afd8c-3bf7-4224-93ae-e1f07ac43c71",
+      "currentVersion": {
+        "systemData": {
+          "uploadedDateTime": "2018-03-08T14:21:43",
+          "contentName": "20180308091852 - narrative.pdf",
+          "mimeType": "application/pdf",
+          "uploadSource": "RATING"
+        },
+        "providerData": {
+          "subject": "Rating Decision - Narrative",
+          "documentTypeId": 339,
+          "ocrStatus": "Failure to Process",
+          "newMail": false,
+          "bookmarks": {
+            "VBA": {
+              "isDefaultRealm": true
+            }
+          },
+          "systemSource": "RATING",
+          "isAnnotated": false,
+          "modifiedDateTime": "2018-03-08T14:21:43",
+          "numberOfContentions": 0,
+          "readByCurrentUser": false,
+          "dateVaReceivedDocument": "2018-12-08",
+          "hasContentionAnnotations": false,
+          "contentSource": "VBMS-R",
+          "actionable": false,
+          "lastOpenedDocument": false
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Migrate FindDocumentSeriesReference Service](https://jira.devops.va.gov/browse/APPEALS-46841)

# Description
- Add feature toggle to enable/disable new functionality.

- Call REST endpoint for veteran docs when the use_ce_api feature toggle is enabled.

- Add supporting services and specs.

## Acceptance Criteria
- [ ] All specs passing.

## Testing Plan
- Run specs for changed files:
- `bundle exec rspec spec/services/external_api/vbms_service_spec.rb`
- `bundle exec rspec spec/services/json_api_response_adapter_spec.rb`


# Backend
## Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
  * [ ] Check that calls are wrapped in MetricService record block
* [ ] Check that all configuration is coming from ENV variables
  * [ ] Listed all new ENV variables in description
  * [ ] Worked with or notified System Team that new ENV variables need to be set
* [ ] Update Fakes
* [ ] For feature branches: Was this tested in Caseflow UAT

# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added