### PR TITLE
APPEALS-46556

### DIFF
--- a/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
+++ b/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
@@ -202,11 +202,11 @@ const CorrespondenceTableBuilder = (props) => {
 
     const getBulkAssignArea = () => {
       return (<>
-        <p className="correspondence-table-builder-margin">Assign to mail team user</p>
+        <p className="correspondence-table-builder-margin">Assign to Inbound Ops Team user</p>
         <div className="correspondence-table-builder-searchable-dropdown-position">
           <div className= "correspondence-table-builder-searchable-dropdown-style">
             <SearchableDropdown
-              name="Assign to mail team user"
+              name="Assign to Inbound Ops Team user"
               hideLabel
               options={buildMailUserData(props.inboundOpsTeamUsers)}
               onChange={handleMailTeamUserChange}

--- a/spec/feature/queue/correspondence/correspondence_cases_batch_assignment.rb
+++ b/spec/feature/queue/correspondence/correspondence_cases_batch_assignment.rb
@@ -71,14 +71,14 @@ RSpec.feature("The Correspondence Cases page") do
     it "successfully loads the unassigned tab" do
       visit "/queue/correspondence/team?tab=correspondence_unassigned"
       expect(page).to have_content("Correspondence owned by the Mail team are unassigned to an individual:")
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Assign", disabled: true)
       expect(page).to have_button("Auto assign correspondence")
     end
 
     it "Verify the mail team user batch assignment with Assign button" do
       visit "/queue/correspondence/team?tab=correspondence_unassigned"
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Assign", disabled: true)
       expect(page).to have_selector(".cf-select__input")
       all(".cf-select__input").first.click
@@ -104,7 +104,7 @@ RSpec.feature("The Correspondence Cases page") do
       end
 
       visit "/queue/correspondence/team?tab=correspondence_unassigned"
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Assign", disabled: true)
       expect(page).to have_selector(".cf-select__input")
       all(".cf-select__input").first.click
@@ -125,13 +125,13 @@ RSpec.feature("The Correspondence Cases page") do
     it "successfully loads the assigned tab" do
       visit "/queue/correspondence/team?tab=correspondence_team_assigned"
       expect(page).to have_content("Correspondence that is currently assigned to mail team users:")
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Reassign", disabled: true)
     end
 
     it "Verify the mail team user batch reassignment with Reassign button" do
       visit "/queue/correspondence/team?tab=correspondence_team_assigned"
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Reassign", disabled: true)
       expect(page).to have_selector(".cf-select__input")
       all(".cf-select__input").first.click
@@ -157,7 +157,7 @@ RSpec.feature("The Correspondence Cases page") do
       end
 
       visit "/queue/correspondence/team?tab=correspondence_team_assigned"
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Reassign", disabled: true)
       expect(page).to have_selector(".cf-select__input")
       all(".cf-select__input").first.click
@@ -185,7 +185,7 @@ RSpec.feature("The Correspondence Cases page") do
       end
 
       visit "/queue/correspondence/team?tab=correspondence_team_assigned"
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Reassign", disabled: true)
       expect(page).to have_selector(".cf-select__input")
       all(".cf-select__input").first.click

--- a/spec/feature/queue/correspondence/correspondence_cases_spec.rb
+++ b/spec/feature/queue/correspondence/correspondence_cases_spec.rb
@@ -552,7 +552,7 @@ RSpec.feature("The Correspondence Cases page") do
     it "successfully loads the unassigned tab" do
       visit "/queue/correspondence/team?tab=correspondence_unassigned"
       expect(page).to have_content("Correspondence owned by the Mail team are unassigned to an individual:")
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Assign")
       expect(page).to have_button("Auto assign correspondence")
     end
@@ -709,7 +709,7 @@ RSpec.feature("The Correspondence Cases page") do
     it "successfully loads the assigned tab" do
       visit "/queue/correspondence/team?tab=correspondence_team_assigned"
       expect(page).to have_content("Correspondence that is currently assigned to mail team users:")
-      expect(page).to have_content("Assign to mail team user")
+      expect(page).to have_content("Assign to Inbound Ops Team user")
       expect(page).to have_button("Reassign", disabled: true)
     end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [User selection in correspondence workflow to use Inbound Ops Team](https://jira.devops.va.gov/browse/APPEALS-46556)

# Description
- Updated the title of the selection dropdown from "Assign to mail team user" to "Assign to Inbound Ops Team User"
- Updated spec tests to reflect the new title name


## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] The title of the selection dropdown is updated to the following: "Assign to Inbound Ops Team User"

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] Log in as an Inbound Ops Team Supervisor 
- [ ] The CSS IDs for these users are INBOUND_OPS_TEAM_ADMIN_USER_S1, ...USER_S2, and ...USER_S3
- [ ] Navigate to /queue/correspondence
- [ ] On the unassigned tab, the assigned correspondence dropdown should show the text "Assign to Inbound Ops Team user"
- [ ] Previously, this text showed "Assign to mail team user". Verify that the new IOPs Team text shows properly. 

Also verified in this ticket, but not changed in the code:
- [ ] Supervisor has the ability to see this assign correspondence dropdown from the Unassigned tab, but superuser does not. 
- [ ] Supervisor AND superuser have the ability to reassign correspondence from the Assigned tab.

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/95875751/c098a2e5-7470-4dc0-ac21-53892c061cc1)

 ---|---

![image](https://github.com/department-of-veterans-affairs/caseflow/assets/95875751/dfa4a1a4-0949-4d12-a558-b63efc4ae43e)
