### PR TITLE
cmartine/APPEALS-46861

### DIFF
--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationController
+  # rubocop:disable Layout/LineLength
   def decision_review_created
     consumer_event_id = drc_params[:event_id]
 
@@ -15,6 +16,7 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
   rescue StandardError => error
     render json: { message: error.message }, status: :unprocessable_entity
   end
+  # rubocop:enable Layout/LineLength
 
   def decision_review_created_error
     event_id = drc_error_params[:event_id]

--- a/app/controllers/api/events/v1/decision_review_created_controller.rb
+++ b/app/controllers/api/events/v1/decision_review_created_controller.rb
@@ -4,7 +4,7 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
   def decision_review_created
     consumer_event_id = drc_params[:event_id]
 
-    return render json: { message: "Record already exists in Caseflow" }, status: :ok if event_exists_and_is_completed?(consumer_event_id)
+    return render json: { message: "Record already exists in Caseflow" }, status: :ok if Event.exists_and_is_completed?(consumer_event_id)
 
     claim_id = drc_params[:claim_id]
     headers = request.headers
@@ -73,8 +73,4 @@ class Api::Events::V1::DecisionReviewCreatedController < Api::ApplicationControl
                                    :nonrating_issue_bgs_source])
   end
   # rubocop:enable Metrics/MethodLength
-
-  def event_exists_and_is_completed?(consumer_event_id)
-    Event.where(reference_id: consumer_event_id).where.not(completed_at: nil).exists?
-  end
 end

--- a/app/models/events/event.rb
+++ b/app/models/events/event.rb
@@ -16,4 +16,10 @@ class Event < CaseflowRecord
       .where("info ->> 'errored_claim_id' = ?", claim_id)
       .pluck(:error)
   end
+
+  # Check if there's already a CF Event that references that Appeals-Consumer EventID and
+    # was successfully completed
+  def self.exists_and_is_completed?(consumer_event_id)
+    where(reference_id: consumer_event_id).where.not(completed_at: nil).exists?
+  end
 end

--- a/app/models/events/event.rb
+++ b/app/models/events/event.rb
@@ -18,7 +18,7 @@ class Event < CaseflowRecord
   end
 
   # Check if there's already a CF Event that references that Appeals-Consumer EventID and
-    # was successfully completed
+  # was successfully completed
   def self.exists_and_is_completed?(consumer_event_id)
     where(reference_id: consumer_event_id).where.not(completed_at: nil).exists?
   end

--- a/app/services/events/decision_review_created.rb
+++ b/app/services/events/decision_review_created.rb
@@ -15,7 +15,7 @@ class Events::DecisionReviewCreated
   class << self
     # rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Lint/UselessAssignment
     def create!(consumer_event_id, reference_id, headers, payload)
-      return if event_exists_and_is_completed?(consumer_event_id)
+      return if Event.exists_and_is_completed?(consumer_event_id)
 
       redis = Redis.new(url: Rails.application.secrets.redis_url_cache)
 
@@ -85,12 +85,6 @@ class Events::DecisionReviewCreated
       raise error
     end
     # rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Lint/UselessAssignment
-
-    # Check if there's already a CF Event that references that Appeals-Consumer EventID and
-    # was successfully completed
-    def event_exists_and_is_completed?(consumer_event_id)
-      Event.where(reference_id: consumer_event_id).where.not(completed_at: nil).exists?
-    end
 
     # Check if there's already a CF Event that references that Appeals-Consumer EventID
     # We will update the existing Event instead of creating a new one

--- a/spec/controllers/api/events/v1/decision_review_created_controller_spec.rb
+++ b/spec/controllers/api/events/v1/decision_review_created_controller_spec.rb
@@ -16,12 +16,12 @@ RSpec.describe Api::Events::V1::DecisionReviewCreatedController, type: :controll
         expect(response).to have_http_status(:created)
       end
 
-      it "returns ok response on second post with the same parameters" do
+      it "returns ok response if record already exists and is completed" do
         request.headers["Authorization"] = "Token token=#{api_key.key_string}"
         load_headers
-        allow(::Events::DecisionReviewCreated).to receive(:create!).and_raise(StandardError.new("already exists"))
-        post :decision_review_created, params: JSON.parse(payload)
+        2.times { post :decision_review_created, params: JSON.parse(payload) }
         expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["message"]).to eq("Record already exists in Caseflow")
       end
     end
 

--- a/spec/models/events/event_spec.rb
+++ b/spec/models/events/event_spec.rb
@@ -3,6 +3,10 @@
 require "rails_helper"
 
 RSpec.describe Event, type: :model do
+  let!(:consumer_event_id) { "123" }
+  let(:event_created) { DecisionReviewCreatedEvent.create!(reference_id: consumer_event_id, completed_at: nil) }
+  let!(:completed_event) { DecisionReviewCreatedEvent.create!(reference_id: "999", completed_at: Time.zone.now) }
+
   describe "attributes" do
     it { expect(described_class.new.info).to be_an_instance_of(Hash) }
 
@@ -22,6 +26,21 @@ RSpec.describe Event, type: :model do
 
         expect(events).to include(event_with_errored_claim)
         expect(events).not_to include(event_without_errored_claim)
+      end
+    end
+  end
+
+  describe "#exists_and_is_completed?" do
+
+    context "When there is no previous Event" do
+      it "should return false" do
+        expect(described_class.exists_and_is_completed?(consumer_event_id)).to be_falsey
+      end
+    end
+
+    context "Where there is a previous Event that was completed" do
+      it "should return true" do
+        expect(described_class.exists_and_is_completed?("999")).to be_truthy
       end
     end
   end

--- a/spec/models/events/event_spec.rb
+++ b/spec/models/events/event_spec.rb
@@ -31,7 +31,6 @@ RSpec.describe Event, type: :model do
   end
 
   describe "#exists_and_is_completed?" do
-
     context "When there is no previous Event" do
       it "should return false" do
         expect(described_class.exists_and_is_completed?(consumer_event_id)).to be_falsey

--- a/spec/services/events/decision_review_created_spec.rb
+++ b/spec/services/events/decision_review_created_spec.rb
@@ -10,22 +10,6 @@ describe Events::DecisionReviewCreated do
   let!(:headers) { sample_headers }
   let!(:parser) { Events::DecisionReviewCreated::DecisionReviewCreatedParser.load_example }
 
-  describe "#event_exists_and_is_completed?" do
-    subject { described_class.event_exists_and_is_completed?(consumer_event_id) }
-
-    context "When there is no previous Event" do
-      it "should return false" do
-        expect(subject).to be_falsey
-      end
-    end
-
-    context "Where there is a previous Event that was completed" do
-      it "should return true" do
-        expect(Events::DecisionReviewCreated.event_exists_and_is_completed?("999")).to be_truthy
-      end
-    end
-  end
-
   describe "#create!" do
     subject { described_class.create!(consumer_event_id, reference_id, headers, read_json_payload) }
 


### PR DESCRIPTION
Resolves [Update Caseflow to Only Send 200 OK Response Code to Appeals-Consumer When Events Already Exists and Successfully Created All evented_records](https://jira.devops.va.gov/browse/APPEALS-46861)

# Description
`DecisionReviewCreatedController` was edited to return a status of ok/200 if the event it receives has already been created in Caseflow.

A method that checks if the event exists and is completed was moved to the `Event` model since it is used in both `DecisionReviewCreatedController` and `Events::DecisionReviewCreated`

## Acceptance Criteria
- [x] decision_review_created_controller#decision_review_created is updated to only send 200 OK response code when the Event already exists and successfully created all evented_records

## Testing Plan
1. Go to [Test Update Caseflow to Only Send 200 OK Response Code to Appeals-Consumer When Events Already Exists and Successfully Created All evented_records](https://jira.devops.va.gov/browse/APPEALS-47039)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
