### PR TITLE
APPEALS-47211: Improve Performance of Distribution Queries

### DIFF
--- a/app/models/concerns/distribution_scopes.rb
+++ b/app/models/concerns/distribution_scopes.rb
@@ -9,7 +9,8 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
   extend ActiveSupport::Concern
 
   def with_appeal_affinities
-    joins("LEFT OUTER JOIN appeal_affinities ON appeals.uuid::text = appeal_affinities.case_id")
+    joins("LEFT OUTER JOIN appeal_affinities ON appeals.uuid::text = appeal_affinities.case_id
+      and appeal_affinities.case_type = 'Appeal'")
   end
 
   # From docket.rb
@@ -40,9 +41,7 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
 
   def ready_for_distribution
     joins(:tasks)
-      .group("appeals.id")
-      .having("count(case when tasks.type = ? and tasks.status = ? then 1 end) >= ?",
-              DistributionTask.name, Constants.TASK_STATUSES.assigned, 1)
+      .where(tasks: { type: DistributionTask.name, status: Constants.TASK_STATUSES.assigned })
   end
 
   def genpop

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -14,7 +14,11 @@ class Docket
   def appeals(priority: nil, genpop: nil, ready: nil, judge: nil)
     fail "'ready for distribution' value cannot be false" if ready == false
 
-    scope = docket_appeals.active
+    scope = docket_appeals
+
+    # The `ready_for_distribution` scope will functionally add a filter for active appeals, and adding it here first
+    # will cause that scope to always return zero appeals.
+    scope.active unless ready
 
     if ready
       scope = scope.ready_for_distribution
@@ -40,7 +44,7 @@ class Docket
 
   # currently this is used for reporting needs
   def ready_to_distribute_appeals
-    docket_appeals.active.ready_for_distribution
+    docket_appeals.ready_for_distribution
   end
 
   def genpop_priority_count

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -63,14 +63,14 @@ class Docket
     appeals(priority: true, ready: true).limit(num).map(&:ready_for_distribution_at)
   end
 
-  def age_of_n_oldest_priority_appeals_available_to_judge(_judge, num)
-    appeals(priority: true, ready: true).limit(num).map(&:receipt_date)
+  def age_of_n_oldest_priority_appeals_available_to_judge(judge, num)
+    appeals(priority: true, ready: true, judge: judge).limit(num).map(&:receipt_date)
   end
 
   # this method needs to have the same name as the method in legacy_docket.rb for by_docket_date_distribution,
   # but the judge that is passed in isn't relevant here
-  def age_of_n_oldest_nonpriority_appeals_available_to_judge(_judge, num)
-    appeals(priority: false, ready: true).limit(num).map(&:receipt_date)
+  def age_of_n_oldest_nonpriority_appeals_available_to_judge(judge, num)
+    appeals(priority: false, ready: true, judge: judge).limit(num).map(&:receipt_date)
   end
 
   def age_of_oldest_priority_appeal

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -106,7 +106,7 @@ describe Docket, :all_dbs do
           subject { DirectReviewDocket.new.appeals(ready: true, genpop: "not_genpop", judge: other_judge) }
 
           it "returns no appeals" do
-            expect(subject.count.size).to eq 0
+            expect(subject.to_a.length).to eq 0
           end
         end
 
@@ -249,35 +249,35 @@ describe Docket, :all_dbs do
             expect(subject).to include with_blocking_but_closed_tasks
           end
         end
-
-        context "nonblocking mail tasks but closed Root Task" do
-          it "excludes those appeals" do
-            inactive_appeal = create(:appeal,
-                                     :with_post_intake_tasks,
-                                     docket_type: Constants.AMA_DOCKETS.direct_review)
-            AodMotionMailTask.create_from_params({
-                                                   appeal: inactive_appeal,
-                                                   parent_id: inactive_appeal.root_task.id
-                                                 }, user)
-            inactive_appeal.root_task.update!(status: "completed")
-
-            expect(subject).to_not include inactive_appeal
-          end
-        end
       end
     end
 
     context "count" do
       let(:priority) { nil }
-      subject { DirectReviewDocket.new.count(priority: priority) }
+      let(:ready) { nil }
+      subject { DirectReviewDocket.new.count(priority: priority, ready: ready) }
 
-      it "counts appeals" do
-        expect(subject).to eq(6)
+      it "counts all appeals on the docket" do
+        expect(subject).to eq(7)
+      end
+
+      context "when looking for ready appeals" do
+        let(:ready) { true }
+        it "counts only ready appeals" do
+          expect(subject).to eq(6)
+        end
       end
 
       context "when looking for nonpriority appeals" do
         let(:priority) { false }
         it "counts nonpriority appeals" do
+          expect(subject).to eq(4)
+        end
+      end
+
+      context "when looking for priority appeals" do
+        let(:priority) { true }
+        it "counts priority appeals" do
           expect(subject).to eq(3)
         end
       end

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -302,6 +302,8 @@ describe Docket, :all_dbs do
     end
 
     context "age_of_n_oldest_priority_appeals_available_to_judge" do
+      # Set cavc_appeal to be outside its affinity window
+      let(:affinity_start_date) { (CaseDistributionLever.cavc_affinity_days + 7).days.ago }
       let(:judge) { create(:user, :with_vacols_judge_record) }
 
       subject { DirectReviewDocket.new.age_of_n_oldest_priority_appeals_available_to_judge(judge, 5) }


### PR DESCRIPTION
Resolves [APPEALS-47211](https://jira.devops.va.gov/browse/APPEALS-47211)

# Description
- Add `and appeal_affinities.case_type = 'Appeal'` to `with_appeal_affinities` scope to ensure that it always joins on the composite index of `[case_id, case_type]`.
- Modify the DistributionScope `ready_for_distribution` to be a simple `where` clause instead of a `case` expression operating on the grouped tasks.
- Modify the `appeals()` method in docket.rb to not apply the `active` scope if getting appeals which are ready for distribution. This is necessary because the `active` Appeal scope joins all tasks, groups by appeal ID, then uses a `case` expression to count if there is a RootTask in an open status. The end result of this is that prior to grouping by appeal ID, _all tasks for the appeal are retrieved in the query_, which in the distribution queries causes the number of rows returned (and therefore needing to run through the provided filters) to increase multiplicatively as more tables are joined to the query.
- Update docket.rb tests, removed test context "nonblocking mail tasks but closed Root Task" because distributions will technically be able to distribute appeals where the root task is closed, though functionally this is unlikely to occur. 
  - As of 6/7/2024, there were four appeals in production that would be affected by this. Their DistributionTasks are being set to `on_hold` while we investigate what caused the Appeal's task tree to get to that state.

Running the new queries through an `explain analyze` command shows the total rows retrieved and filtered. In ProdTest, after deploying the affinity calculation updates which included the `appeal_affinities` table, the original query returned and filtered **271,907,020 rows of data**, taking 92 _seconds_; the default timeout is 30 seconds, so this plan had to be executed in the ProdTest rails console where we could increase the default timeout. With the new query, 51750 rows were returned and filtered in 1.5 seconds.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?
