### PR TITLE
APPEALS-47641: Docket Priority combinations not able to create an Affinity record

### DIFF
--- a/app/models/concerns/distribution_scopes.rb
+++ b/app/models/concerns/distribution_scopes.rb
@@ -83,7 +83,8 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
   def non_genpop_for_judge(judge)
     with_appeal_affinities
       .with_original_appeal_and_judge_task
-      .where("appeal_affinities.affinity_start_date > ?", CaseDistributionLever.cavc_affinity_days.days.ago)
+      .where("appeal_affinities.affinity_start_date > ? or appeal_affinities.affinity_start_date is null",
+             CaseDistributionLever.cavc_affinity_days.days.ago)
       .where(original_judge_task: { assigned_to_id: judge&.id })
   end
 
@@ -142,7 +143,8 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
   end
 
   def affinitized_ama_affinity_cases(lever_days)
-    where("appeal_affinities.affinity_start_date > ?", lever_days.to_i.days.ago)
+    where("appeal_affinities.affinity_start_date > ? or appeal_affinities.affinity_start_date is null",
+          lever_days.to_i.days.ago)
   end
 
   # Historical note: We formerly had not_tied_to_any_active_judge until CASEFLOW-1928,

--- a/app/models/docket.rb
+++ b/app/models/docket.rb
@@ -18,7 +18,7 @@ class Docket
 
     # The `ready_for_distribution` scope will functionally add a filter for active appeals, and adding it here first
     # will cause that scope to always return zero appeals.
-    scope.active unless ready
+    scope = scope.active unless ready
 
     if ready
       scope = scope.ready_for_distribution
@@ -67,8 +67,6 @@ class Docket
     appeals(priority: true, ready: true, judge: judge).limit(num).map(&:receipt_date)
   end
 
-  # this method needs to have the same name as the method in legacy_docket.rb for by_docket_date_distribution,
-  # but the judge that is passed in isn't relevant here
   def age_of_n_oldest_nonpriority_appeals_available_to_judge(judge, num)
     appeals(priority: false, ready: true, judge: judge).limit(num).map(&:receipt_date)
   end

--- a/spec/models/dockets/hearing_request_docket_spec.rb
+++ b/spec/models/dockets/hearing_request_docket_spec.rb
@@ -2,17 +2,14 @@
 
 describe HearingRequestDocket, :postgres do
   before do
-    create(:case_distribution_lever, :ama_hearing_case_affinity_days)
-    create(:case_distribution_lever, :ama_hearing_case_aod_affinity_days)
+    # these were the defaut values at time of writing tests but can change over time, so ensure they are set
+    # back to what the tests were originally written for
+    create(:case_distribution_lever, :ama_hearing_case_affinity_days, value: "60")
+    create(:case_distribution_lever, :ama_hearing_case_aod_affinity_days, value: "14")
     create(:case_distribution_lever, :request_more_cases_minimum)
     create(:case_distribution_lever, :cavc_affinity_days)
 
     FeatureToggle.enable!(:acd_distribute_by_docket_date)
-
-    # these were the defaut values at time of writing tests but can change over time, so ensure they are set
-    # back to what the tests were originally written for
-    CaseDistributionLever.find_by_item(Constants.DISTRIBUTION.ama_hearing_case_affinity_days).update!(value: "60")
-    CaseDistributionLever.find_by_item(Constants.DISTRIBUTION.ama_hearing_case_aod_affinity_days).update!(value: "14")
   end
 
   context "#ready_priority_appeals" do
@@ -118,6 +115,42 @@ describe HearingRequestDocket, :postgres do
         it "returns the receipt_date field of the oldest hearing nonpriority appeals ready for distribution" do
           expect(subject).to match_array([ready_nonpriority_appeal_hearing_cancelled.receipt_date])
         end
+      end
+    end
+
+    context "when cases don't have an appeal_affinity record" do
+      let(:other_judge) { create(:user, :judge, :with_vacols_judge_record) }
+      let!(:ready_aod_appeal_tied_to_judge_without_appeal_affinity) do
+        create_ready_aod_appeal_no_appeal_affinity(tied_judge: requesting_judge, created_date: 7.days.ago)
+      end
+      let!(:ready_aod_appeal_tied_to_other_judge_without_appeal_affinity) do
+        create_ready_aod_appeal_no_appeal_affinity(tied_judge: other_judge, created_date: 7.days.ago)
+      end
+      let!(:ready_nonpriority_appeal_tied_to_judge_without_appeal_affinity) do
+        create_ready_nonpriority_appeal_no_appeal_affinity(tied_judge: requesting_judge, created_date: 5.days.ago)
+      end
+      let!(:ready_nonpriority_appeal_tied_to_other_judge_without_appeal_affinity) do
+        create_ready_nonpriority_appeal_no_appeal_affinity(tied_judge: other_judge, created_date: 5.days.ago)
+      end
+
+      before { FeatureToggle.enable!(:acd_exclude_from_affinity) }
+
+      subject { described_class.new }
+
+      it "priority appeals tied to the requesting judge are still selected" do
+        expect(subject.age_of_n_oldest_priority_appeals_available_to_judge(requesting_judge, 3)).to match_array(
+          [ready_aod_appeal_tied_to_judge.receipt_date,
+           ready_aod_appeal_tied_to_judge_without_appeal_affinity.receipt_date,
+           ready_aod_appeal_hearing_cancelled.receipt_date]
+        )
+      end
+
+      it "nonpriority appeals tied to the requesting judge are still selected" do
+        expect(subject.age_of_n_oldest_nonpriority_appeals_available_to_judge(requesting_judge, 3)).to match_array(
+          [ready_nonpriority_appeal_tied_to_judge.receipt_date,
+           ready_nonpriority_appeal_tied_to_judge_without_appeal_affinity.receipt_date,
+           ready_nonpriority_appeal_hearing_cancelled.receipt_date]
+        )
       end
     end
   end
@@ -617,6 +650,10 @@ describe HearingRequestDocket, :postgres do
       let!(:ready_aod_tied_to_other_judge_out_of_window_20_days) do
         create_ready_aod_appeal(tied_judge: other_judge, created_date: 20.days.ago)
       end
+      let!(:ready_aod_tied_to_requesting_judge_no_appeal_affinity) do
+        create_ready_aod_appeal_no_appeal_affinity(tied_judge: requesting_judge_no_attorneys,
+                                                   created_date: 10.days.ago)
+      end
 
       # appeal which is always genpop
       let!(:ready_aod_hearing_cancelled) do
@@ -647,6 +684,7 @@ describe HearingRequestDocket, :postgres do
              ready_aod_tied_to_requesting_judge_in_window.uuid,
              ready_aod_tied_to_requesting_judge_out_of_window_20_days.uuid,
              ready_aod_tied_to_other_judge_out_of_window_20_days.uuid,
+             ready_aod_tied_to_requesting_judge_no_appeal_affinity.uuid,
              ready_aod_hearing_cancelled.uuid,
              sct_ready_priority_appeal_not_tied_to_a_judge.uuid]
           )
@@ -665,6 +703,20 @@ describe HearingRequestDocket, :postgres do
       :with_post_intake_tasks,
       :held_hearing_and_ready_to_distribute,
       :with_appeal_affinity,
+      tied_judge: tied_judge || create(:user, :judge, :with_vacols_judge_record)
+    )
+    Timecop.return
+    appeal
+  end
+
+  def create_ready_aod_appeal_no_appeal_affinity(tied_judge: nil, created_date: 1.year.ago)
+    Timecop.travel(created_date)
+    appeal = create(
+      :appeal,
+      :hearing_docket,
+      :advanced_on_docket_due_to_age,
+      :with_post_intake_tasks,
+      :held_hearing_and_ready_to_distribute,
       tied_judge: tied_judge || create(:user, :judge, :with_vacols_judge_record)
     )
     Timecop.return
@@ -715,6 +767,19 @@ describe HearingRequestDocket, :postgres do
       :with_post_intake_tasks,
       :held_hearing_and_ready_to_distribute,
       :with_appeal_affinity,
+      tied_judge: tied_judge || create(:user, :judge, :with_vacols_judge_record)
+    )
+    Timecop.return
+    appeal
+  end
+
+  def create_ready_nonpriority_appeal_no_appeal_affinity(tied_judge: nil, created_date: 1.year.ago)
+    Timecop.travel(created_date)
+    appeal = create(
+      :appeal,
+      :hearing_docket,
+      :with_post_intake_tasks,
+      :held_hearing_and_ready_to_distribute,
       tied_judge: tied_judge || create(:user, :judge, :with_vacols_judge_record)
     )
     Timecop.return


### PR DESCRIPTION
Resolves [APPEALS-47641](https://jira.devops.va.gov/browse/APPEALS-47641)

# Description
- Modifies the non-genpop scopes in DistributionScopes to check for start dates newer than the lever values **or nil**, when the requesting judge has an affinity to that case. 
- Fix the change to `scope.active` in docket.rb
- Add/fix tests for docket_spec.rb and hearing_request_docket_spec.rb to specifically test selecting an appeal with affinity to a judge that has no associated AppealAffinity record

This resolves a scenario which could potentially happen in production where if all ready-to-distribute appeals for a docket/priority combination have been distributed _prior to setting the affinity_start_date of another appeal_, that the UpdateAppealAffinityDatesJob would no longer try to create/update AppealAffinity records for that docket/priority combination. This would cause appeals which _could_ have an affinity on that combination to never again be selected for distributions. 

By adding `or appeal_affinities.affinity_start_date is null` to the non-genpop queries, any appeal which has an affinity to a judge can be selected if distributing to that judge, regardless of if it has had an AppealAffinity created for it. This will allow the UpdateAppealAffinityDatesJob to continue to eventually create new AppealAffinity records for all docket/priority combinations, even if the entire combination runs out of appeals with existing AppealAffinity records.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan

1. In a local/demo environment, run these rails console commands to create two appeals:
```
FactoryBot.create(:appeal, :hearing_docket, :advanced_on_docket_due_to_age, :held_hearing_and_ready_to_distribute, :with_appeal_affinity, receipt_date: 10.days.ago, tied_judge: User.find_by_css_id("BVAGSPORER"))

FactoryBot.create(:appeal, :hearing_docket, :advanced_on_docket_due_to_age, :held_hearing_and_ready_to_distribute, receipt_date: 9.days.ago, tied_judge: User.find_by_css_id("BVAGSPORER"))

appeal = FactoryBot.create(:appeal, :hearing_docket, :advanced_on_docket_due_to_age, :held_hearing_and_ready_to_distribute, receipt_date: 9.days.ago, tied_judge: User.find_by_css_id("BVABDANIEL"))

appeal.uuid # note this for checking the case distribution page later
```
2. Login as BVAGSPORER
3. Navigate to the judge's assign page and request more cases
4. Observe that both appeals tied to BVAGSPORER distributed
5. Navigate to the case details page for the appeal tied to BVABDANIEL
6. Verify that it was not distributed and has an appeal_affinity added to it (via the DistributionTask instructions)

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
 ---|---

## Storybook Story
*For Frontend (Presentation) Components*
* [ ] Add a [Storybook](https://github.com/department-of-veterans-affairs/caseflow/wiki/Documenting-React-Components-with-Storybook) file alongside the component file (e.g. create `MyComponent.stories.js` alongside `MyComponent.jsx`)
* [ ] Give it a title that reflects the component's location within the overall Caseflow hierarchy
* [ ] Write a separate story (within the same file) for each discrete variation of the component

# Backend
## Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/master/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] For queries using raw sql was an explain plan run by System Team
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)

## Integrations: Adding endpoints for external APIs
* [ ] Check that Caseflow's external API code for the endpoint matches the code in the relevant integration repo
  * [ ] Request: Service name, method name, input field names
  * [ ] Response: Check expected data structure
  * [ ] Check that calls are wrapped in MetricService record block
* [ ] Check that all configuration is coming from ENV variables
  * [ ] Listed all new ENV variables in description
  * [ ] Worked with or notified System Team that new ENV variables need to be set
* [ ] Update Fakes
* [ ] For feature branches: Was this tested in Caseflow UAT

# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

## Monitoring, Logging, Auditing, Error, and Exception Handling Checklist

### Monitoring
- [ ] Are performance metrics (e.g., response time, throughput) being tracked?
- [ ] Are key application components monitored (e.g., database, cache, queues)?
- [ ] Is there a system in place for setting up alerts based on performance thresholds?

### Logging
- [ ] Are logs being produced at appropriate log levels (debug, info, warn, error, fatal)?
- [ ] Are logs structured (e.g., using log tags) for easier querying and analysis?
- [ ] Are sensitive data (e.g., passwords, tokens) redacted or omitted from logs?
- [ ] Is log retention and rotation configured correctly?
- [ ] Are logs being forwarded to a centralized logging system if needed?

### Auditing
- [ ] Are user actions being logged for audit purposes?
- [ ] Are changes to critical data being tracked ?
- [ ] Are logs being securely stored and protected from tampering or exposing protected data?

### Error Handling
- [ ] Are errors being caught and handled gracefully?
- [ ] Are appropriate error messages being displayed to users?
- [ ] Are critical errors being reported to an error tracking system (e.g., Sentry, ELK)?
- [ ] Are unhandled exceptions being caught at the application level ?

### Exception Handling
- [ ] Are custom exceptions defined and used where appropriate?
- [ ] Is exception handling consistent throughout the codebase?
- [ ] Are exceptions logged with relevant context and stack trace information?
- [ ] Are exceptions being grouped and categorized for easier analysis and resolution?

