### PR TITLE
APPEALS-46829: Correspondence Type Not Showing In Dropdown (Review Package)

### DIFF
--- a/client/app/queue/correspondence/ReviewPackage/ReviewForm.jsx
+++ b/client/app/queue/correspondence/ReviewPackage/ReviewForm.jsx
@@ -131,7 +131,7 @@ export const ReviewForm = (props) => {
       data: {
         correspondence: {
           notes: props.editableData.notes,
-          correspondence_type_id: props.editableData.default_select_value,
+          correspondence_type_id: correspondenceTypeID,
           va_date_of_receipt: vaDORDate
         },
         veteran: {


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-46829](https://jira.devops.va.gov/browse/APPEALS-46829)

# Description
Updated payload parameter so that the state value of the correspondence type dropdown is used to update the correspondence type in the controller. 

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Testing plan in [Jira Ticket](https://jira.devops.va.gov/browse/APPEALS-46829)