### PR TITLE
[APPEALS-44296] - JAWS does not read info

### DIFF
--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -303,7 +303,7 @@ export const vaDor = () => {
     enableFilter: true,
     getSortValue: (task) => task.vaDor,
     name: QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.name,
-    label: QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.name,
+    label: QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.label,
     valueFunction: (task) => {
       return moment(task.vaDor).format('MM/DD/YYYY');
     }
@@ -321,7 +321,7 @@ export const packageDocumentType = (filterOptions) => {
     anyFiltersAreSet: true,
     getSortValue: (task) => task.nod,
     name: QUEUE_CONFIG.COLUMNS.PACKAGE_DOCUMENT_TYPE.name,
-    label: QUEUE_CONFIG.COLUMNS.PACKAGE_DOCUMENT_TYPE.name,
+    label: QUEUE_CONFIG.COLUMNS.PACKAGE_DOCUMENT_TYPE.label,
     valueFunction: (task) => {
       return task.nod ? 'NOD' : 'Non-NOD';
     }

--- a/client/app/queue/components/TaskTableColumns.jsx
+++ b/client/app/queue/components/TaskTableColumns.jsx
@@ -303,7 +303,7 @@ export const vaDor = () => {
     enableFilter: true,
     getSortValue: (task) => task.vaDor,
     name: QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.name,
-    label: QUEUE_CONFIG.COLUMNS.VA_DATE_OF_RECEIPT.label,
+    label: 'Filter by VA Date of Receipt',
     valueFunction: (task) => {
       return moment(task.vaDor).format('MM/DD/YYYY');
     }
@@ -321,7 +321,7 @@ export const packageDocumentType = (filterOptions) => {
     anyFiltersAreSet: true,
     getSortValue: (task) => task.nod,
     name: QUEUE_CONFIG.COLUMNS.PACKAGE_DOCUMENT_TYPE.name,
-    label: QUEUE_CONFIG.COLUMNS.PACKAGE_DOCUMENT_TYPE.label,
+    label: 'Filter by Package Document Type',
     valueFunction: (task) => {
       return task.nod ? 'NOD' : 'Non-NOD';
     }

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -152,14 +152,16 @@
       "name": "notes"
     },
     "VA_DATE_OF_RECEIPT": {
-      "name": "vaDor"
+      "name": "vaDor",
+      "label": "Filter by VA Date of Receipt"
     },
     "VETERAN_DETAILS": {
       "name": "veteranDetails"
     },
     "PACKAGE_DOCUMENT_TYPE": {
       "filterable": true,
-      "name": "packageDocTypeColumn"
+      "name": "packageDocTypeColumn",
+      "label": "Filter by Package Document Type"
     },
     "VETERAN_PARTICIPANT_ID": {
       "name": "veteranParticipantIdColumn"

--- a/client/constants/QUEUE_CONFIG.json
+++ b/client/constants/QUEUE_CONFIG.json
@@ -152,16 +152,14 @@
       "name": "notes"
     },
     "VA_DATE_OF_RECEIPT": {
-      "name": "vaDor",
-      "label": "Filter by VA Date of Receipt"
+      "name": "vaDor"
     },
     "VETERAN_DETAILS": {
       "name": "veteranDetails"
     },
     "PACKAGE_DOCUMENT_TYPE": {
       "filterable": true,
-      "name": "packageDocTypeColumn",
-      "label": "Filter by Package Document Type"
+      "name": "packageDocTypeColumn"
     },
     "VETERAN_PARTICIPANT_ID": {
       "name": "veteranParticipantIdColumn"

--- a/spec/feature/queue/correspondence/correspondence_cases_spec.rb
+++ b/spec/feature/queue/correspondence/correspondence_cases_spec.rb
@@ -1507,13 +1507,13 @@ RSpec.feature("The Correspondence Cases page") do
 
     it "correctly filters NOD type" do
       visit "queue/correspondence/team?tab=correspondence_unassigned&page=1&sort_by=vaDor&order=asc"
-      find("[aria-label='packageDocTypeColumn']").click
+      find("[aria-label='Filter by Package Document Type']").click
       all(".cf-filter-option-row")[1].click
       expect(page).to_not have_content("Non-NOD")
       visit "queue/correspondence/team?tab=correspondence_unassigned&page=1&sort_by=vaDor&order=asc"
-      find("[aria-label='packageDocTypeColumn']").click
+      find("[aria-label='Filter by Package Document Type']").click
       all(".cf-filter-option-row")[1].click
-      find("[aria-label='packageDocTypeColumn. Filtering by true']").click
+      find("[aria-label='Filter by Package Document Type. Filtering by true']").click
       all(".cf-filter-option-row")[2].click
       expect(page).to have_content("Package Document Type (2)")
       expect(page).to have_content("Viewing 1-10 of 10 total")


### PR DESCRIPTION
Resolves [508 Test](https://jira.devops.va.gov/browse/APPEALS-44296)

# Description
- Updated labels for both Package Document Type and VA DOR, in return that will update aria-label.
- Used Mac Voice Over to test the same

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
1. Log into caseflow.
2. Click on the Switch user button
3. Click on Your Queue
4. On Your cases page, click on the Switch views button and select *Your correspondence*
5. With JAWS activated, click on the Tab key until you get to the filter icon on Package Document Type or VA DOR
6. Then you should hear `Filter by Package Document Type` or `Filter by VA DOR`

