### PR TITLE
MattT/APPEALS-49085

### DIFF
--- a/app/models/appeal_state.rb
+++ b/app/models/appeal_state.rb
@@ -79,29 +79,27 @@ class AppealState < CaseflowRecord
 
   # Locates appeal states related to appeals whose hearings have been scheduled and waiting to be held.
   #
-  # @return [ActiveRecord::Relation]
+  # @return [Array<AppealState>]
   #   Appeal states for appeals with scheduled hearings without dispositions
   scope :hearing_scheduled, lambda {
-    where(
-      hearing_scheduled: true,
-      privacy_act_pending: false,
-      hearing_postponed: false,
-      scheduled_in_error: false
+    hearing_scheduled_ama.where(
+      privacy_act_pending: false
+    ) + validated_hearing_scheduled_legacy_states.where(
+      privacy_act_pending: false
     )
   }
 
   # Locates appeal states related to appeals whose hearings have been scheduled and waiting to be held.
   #  In addition, these appeals have an active Privacy Act/FOIA request in their trees.
   #
-  # @return [ActiveRecord::Relation]
+  # @return [Array<AppealState>]
   #   Appeal states for appeals with scheduled hearings without dispositions, and those appeals
   #     have open Privacy Act/FOIA-related tasks in their task trees.
   scope :hearing_scheduled_privacy_pending, lambda {
-    where(
-      hearing_scheduled: true,
-      privacy_act_pending: true,
-      hearing_postponed: false,
-      scheduled_in_error: false
+    hearing_scheduled_ama.where(
+      privacy_act_pending: true
+    ) + validated_hearing_scheduled_legacy_states.where(
+      privacy_act_pending: true
     )
   }
 
@@ -321,6 +319,115 @@ class AppealState < CaseflowRecord
   end
 
   private
+
+  # A base set of conditions for identifying if an appeal's most recent milestone was its
+  #  hearing being scheduled. This scope can be utilized for any variation on this
+  #  status, such as whether or not certain mail or FOIA tasks also exist for the appeal.
+  #
+  # @return [AppealState::ActiveRecord_Relation]
+  #   An ActiveRecord_Relation that can be changes with other AR scopes, clauses, methods, etc..
+  #     in order to construct a SQL query.
+  scope :hearing_scheduled_base, lambda {
+    where(
+      hearing_scheduled: true,
+      hearing_postponed: false,
+      scheduled_in_error: false
+    )
+  }
+
+  # @return [AppealState::ActiveRecord_Relation]
+  #   The base hearing scheduled status query scoped only to AMA appeals.
+  scope :hearing_scheduled_ama, lambda {
+    task_join.hearing_scheduled_base.where(appeal_type: "Appeal").with_assigned_assign_hearing_disposition_task
+  }
+
+
+  # @return [AppealState::ActiveRecord_Relation]
+  #   The base hearing scheduled status query scoped only to legacy appeals.
+  scope :hearing_scheduled_legacy_base, lambda {
+    hearing_scheduled_base.where(appeal_type: "LegacyAppeal")
+  }
+
+  # Represents an inner join between the appeal_states and tasks tables. This allows for utilizing
+  #   tasks to further inform us of where an appeal is in its lifecycle.
+  #
+  # @return [AppealState::ActiveRecord_Relation]
+  #   An ActiveRecord_Relation that can be changes with other AR scopes, clauses, methods, etc..
+  #     in order to construct a SQL query.
+  scope :task_join, lambda {
+    joins(
+      "join tasks on tasks.appeal_id = appeal_states.appeal_id and tasks.appeal_type = appeal_states.appeal_type"
+    )
+  }
+
+  # Represents an inner join between the appeal_states and legacy_appeals tables.
+  #  This association is used to then pull relevant data from VACOLS to validate an appeal's state.
+  #
+  # @return [AppealState::ActiveRecord_Relation]
+  #   An ActiveRecord_Relation that can be changes with other AR scopes, clauses, methods, etc..
+  #     in order to construct a SQL query.
+  scope :legacy_appeals_join, lambda {
+    joins(
+      "join legacy_appeals on legacy_appeals.id = appeal_states.appeal_id " \
+      "and appeal_states.appeal_type = 'LegacyAppeal'"
+    )
+  }
+
+  # A clause to enforce the need for an assigned AssignHearingDispositionTask to be
+  #   associated with the same appeal as an appeal state record.
+  #
+  # If constraints are met, then it should mean that there is a pending hearing for the appeal
+  #  that is waiting for a disposition, and therefore has not been held. This is key
+  #  for us in determining which appeals are in a state of hearing_scheduled.
+  #
+  # At this time this task is not possible to be placed into a status of in_progress, and on_hold
+  #   often means that it has a child EvidenceSubmissionWindowTask (as long as the evidence submission wasn't waived)
+  #   and/or TranscriptionTask. This occurs after a hearing is held.
+  #
+  # @return [AppealState::ActiveRecord_Relation]
+  #   An ActiveRecord_Relation that can be changes with other AR scopes, clauses, methods, etc..
+  #     in order to construct a SQL query.
+  scope :with_assigned_assign_hearing_disposition_task, lambda {
+    where(
+      "tasks.type = ? and tasks.status = ?",
+      AssignHearingDispositionTask.name,
+      Constants.TASK_STATUSES.assigned
+    )
+  }
+
+  class << self
+    # Utilizes the appeal states that we have recorded as being hearing_scheduled = true
+    #  and then reaches out to VACOLS to validate that the related hearings do not yet have
+    #  a disposition.
+    #
+    # This is to combat instances where VACOLS is updated without Caseflow's knowledge and other
+    #   difficulties around synchronizing the appeals states table for legacy appeals and hearings.
+    #
+    # @note The in_groups_of size must not exceed 1k due to Oracle database limitations.
+    #
+    # @return [AppealState::ActiveRecord_Relation]
+    #   Either an AR relation signifying appeal states where the hearing has been confirmed to have a pending
+    #   disposition in VACOLS, or simply nothing (none). Regardless, the relation returned can be safely chained to
+    #   other ActiveRecord query building methods.
+    def validated_hearing_scheduled_legacy_states
+      ids_to_validate = hearing_scheduled_legacy_base.legacy_appeals_join.pluck(:vacols_id)
+      validated_vacols_ids = []
+
+      ids_to_validate.in_groups_of(500, false) do |ids_to_examine|
+        validated_vacols_ids.concat(VACOLS::CaseHearing.where(
+          folder_nr: ids_to_examine,
+          hearing_disp: nil
+        ).pluck(:folder_nr))
+      end
+
+      return none if validated_vacols_ids.empty?
+
+      where(
+        appeal_type: "LegacyAppeal",
+        appeal_id: LegacyAppeal.where(vacols_id: validated_vacols_ids).pluck(:id)
+      )
+    end
+  end
 
   def update_appeal_state_action!(new_state)
     update!({}.merge(DEFAULT_STATE).tap { |state| state[new_state] = true })

--- a/app/models/appeal_state.rb
+++ b/app/models/appeal_state.rb
@@ -341,7 +341,6 @@ class AppealState < CaseflowRecord
     task_join.hearing_scheduled_base.where(appeal_type: "Appeal").with_assigned_assign_hearing_disposition_task
   }
 
-
   # @return [AppealState::ActiveRecord_Relation]
   #   The base hearing scheduled status query scoped only to legacy appeals.
   scope :hearing_scheduled_legacy_base, lambda {

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -277,7 +277,7 @@ describe AppealState do
       let!(:hearing_scheduled_privacy_pending_state) do
         appeal.appeal_state.tap do
           _1.update!(hearing_scheduled: true,
-          privacy_act_pending: true)
+                     privacy_act_pending: true)
         end
       end
 

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -235,7 +235,6 @@ describe AppealState do
         let!(:legacy_state) { legacy_appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
 
         context "An AMA and legacy hearings are both pending" do
-
           it "both appeal states are returned by the query" do
             is_expected.to match_array([ama_state.id, legacy_state.id])
           end

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -8,7 +8,7 @@ describe AppealState do
   context "State scopes" do
     let(:user) { create(:user) }
 
-    let!(:appeal_docketed_state) do
+    let(:appeal_docketed_state) do
       create(
         :appeal_state,
         :ama,
@@ -18,7 +18,7 @@ describe AppealState do
       )
     end
 
-    let!(:hearing_withdrawn_docketed_appeal_state) do
+    let(:hearing_withdrawn_docketed_appeal_state) do
       create(
         :appeal_state,
         :ama,
@@ -29,7 +29,7 @@ describe AppealState do
       )
     end
 
-    let!(:privacy_pending_state) do
+    let(:privacy_pending_state) do
       create(
         :appeal_state,
         :ama,
@@ -41,7 +41,7 @@ describe AppealState do
       )
     end
 
-    let!(:ihp_pending_state) do
+    let(:ihp_pending_state) do
       create(
         :appeal_state,
         :ama,
@@ -53,7 +53,7 @@ describe AppealState do
       )
     end
 
-    let!(:ihp_pending_privacy_pending_state) do
+    let(:ihp_pending_privacy_pending_state) do
       create(
         :appeal_state,
         :ama,
@@ -65,17 +65,7 @@ describe AppealState do
       )
     end
 
-    let!(:hearing_scheduled_state) do
-      create(
-        :appeal_state,
-        :ama,
-        created_by_id: user.id,
-        updated_by_id: user.id,
-        hearing_scheduled: true
-      )
-    end
-
-    let!(:hearing_scheduled_privacy_pending_state) do
+    let(:hearing_scheduled_privacy_pending_state) do
       create(
         :appeal_state,
         :ama,
@@ -86,7 +76,7 @@ describe AppealState do
       )
     end
 
-    let!(:hearing_to_be_rescheduled_postponed_state) do
+    let(:hearing_to_be_rescheduled_postponed_state) do
       create(
         :appeal_state,
         :ama,
@@ -96,7 +86,7 @@ describe AppealState do
       )
     end
 
-    let!(:hearing_to_be_rescheduled_scheduled_in_error_state) do
+    let(:hearing_to_be_rescheduled_scheduled_in_error_state) do
       create(
         :appeal_state,
         :ama,
@@ -106,7 +96,7 @@ describe AppealState do
       )
     end
 
-    let!(:hearing_to_be_rescheduled_privacy_pending_state) do
+    let(:hearing_to_be_rescheduled_privacy_pending_state) do
       create(
         :appeal_state,
         :ama,
@@ -117,7 +107,7 @@ describe AppealState do
       )
     end
 
-    let!(:appeal_decided_state) do
+    let(:appeal_decided_state) do
       create(
         :appeal_state,
         :ama,
@@ -127,7 +117,7 @@ describe AppealState do
       )
     end
 
-    let!(:appeal_cancelled_state) do
+    let(:appeal_cancelled_state) do
       create(
         :appeal_state,
         :ama,
@@ -157,11 +147,137 @@ describe AppealState do
       end
     end
 
+    shared_context "staged hearing task tree" do
+      let(:appeal) { create(:appeal, :active) }
+      let(:distribution_task) { DistributionTask.create!(appeal: appeal, parent: appeal.root_task) }
+      let(:hearing_task) { HearingTask.create!(appeal: appeal, parent: distribution_task) }
+      let!(:assign_disp_task) do
+        AssignHearingDispositionTask.create!(appeal: appeal, parent: hearing_task, assigned_to: Bva.singleton)
+      end
+    end
+
+    shared_context "vacols case with case hearing" do
+      let(:case_hearing) { create(:case_hearing) }
+      let(:vacols_case) { create(:case, case_hearings: [case_hearing]) }
+      let!(:legacy_appeal) { create(:legacy_appeal, vacols_case: vacols_case) }
+    end
+
     context "#hearing_scheduled" do
       subject { described_class.hearing_scheduled.pluck(:id) }
 
-      it "Only appeals in hearing scheduled state are included" do
-        is_expected.to match_array([hearing_scheduled_state.id])
+      context "ama" do
+        subject do
+          AppealState.find_by_appeal_id(appeal.id).update!(hearing_scheduled: true)
+
+          described_class.hearing_scheduled.pluck(:id)
+        end
+
+        let!(:appeal_state) { appeal.appeal_state }
+
+        context "Whenever the expected task is absent" do
+          let(:appeal) { create(:appeal, :active) }
+
+          it "The appeal state isn't retrieved by the query" do
+            is_expected.to be_empty
+          end
+        end
+
+        context "Whenever the hearing has been held and the evidence submission window is open" do
+          include_context "staged hearing task tree"
+
+          let!(:evidence_task) do
+            EvidenceSubmissionWindowTask.create!(
+              appeal: appeal,
+              parent: assign_disp_task,
+              assigned_to: MailTeam.singleton
+            )
+          end
+
+          it "The appeal state isn't retrieved by the query" do
+            is_expected.to be_empty
+          end
+        end
+
+        context "Whenever the hearing has not been held" do
+          include_context "staged hearing task tree"
+
+          it "The appeal state is returned" do
+            is_expected.to match_array([appeal_state.id])
+          end
+        end
+      end
+
+      context "legacy" do
+        include_context "vacols case with case hearing"
+
+        let!(:appeal_state) { legacy_appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
+
+        context "hearing has not been held" do
+          it "the appeal state is returned" do
+            is_expected.to match_array([appeal_state.id])
+          end
+        end
+
+        context "hearing has been held" do
+          it "the appeal state is not returned" do
+            case_hearing.update!(hearing_disp: "H")
+
+            is_expected.to be_empty
+          end
+        end
+      end
+
+      context "ama and legacy" do
+        include_context "vacols case with case hearing"
+        include_context "staged hearing task tree"
+
+        let!(:ama_state) { appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
+        let!(:legacy_state) { legacy_appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
+
+        context "An AMA and legacy hearings are both pending" do
+
+          it "both appeal states are returned by the query" do
+            is_expected.to match_array([ama_state.id, legacy_state.id])
+          end
+        end
+
+        context "An AMA and legacy hearings have been held" do
+          let!(:evidence_task) do
+            EvidenceSubmissionWindowTask.create!(
+              parent: assign_disp_task,
+              appeal: appeal,
+              assigned_to: MailTeam.singleton
+            )
+          end
+
+          it "neither appeal states are returned by the query" do
+            case_hearing.update!(hearing_disp: "H")
+
+            is_expected.to be_empty
+          end
+        end
+
+        context "An AMA hearing is pending and the legacy hearing has been held" do
+          it "only the AMA appeal state is returned by the query" do
+            case_hearing.update!(hearing_disp: "H")
+
+            is_expected.to match_array([ama_state.id])
+          end
+        end
+
+        context "A legacy hearing is pending and an AMA hearing has been held" do
+          let!(:evidence_task) do
+            EvidenceSubmissionWindowTask.create!(
+              assigned_to: MailTeam.singleton,
+              parent: assign_disp_task,
+              appeal: appeal
+            )
+          end
+
+          it "only the legacy appeal state is returned by the query" do
+            is_expected.to match_array([legacy_state.id])
+          end
+        end
       end
     end
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-49085](https://jira.devops.va.gov/browse/APPEALS-49085)

# Description
Filter Appeals Whose Hearings Have Already Been Held from hearing_scheduled Appeal State Scope.

## Acceptance Criteria
- [ ] The hearing_scheduled Quarterly Notification status is only transmitted to appellants if:
    - [ ] Their appeal's associated appeal_state record has:
       - [ ] hearing_scheduled: true
       - [ ] hearing_postponed: false
       - [ ] scheduled_in_error: false
       - [ ] privacy_act_pending: false
   - [ ] Their most recent hearing has not been held:
       - [ ] AMA
          - [ ] There is an assigned AssignHearingDispositionTask on the appeal.
             - [ ] This is to allow for unfinalized dispositions to still be reported as "hearing_scheduled".
          - [ ] NOT an in_progress one, as that indicates that there is a post-hearing evidence submission window active.
       - [ ] Legacy
          - [ ] The related HEARSCHED table's hearing_disp value is null.

