### PR TITLE
MattT/APPEALS-49212

### DIFF
--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -98,7 +98,7 @@ class NightlySyncsJob < CaseflowJob
     Parallel.each(states_to_examine, in_threads: 10) do |state|
       RequestStore[:current_user] = User.system_user
 
-      if state.appeal.hearings.max_by(&:scheduled_for)&.disposition == Contants.HEARING_DISPOSITION_TYPES.held
+      if state.appeal&.hearings&.max_by(&:scheduled_for)&.disposition == Constants.HEARING_DISPOSITION_TYPES.held
         state.hearing_held_appeal_state_update_action!
       end
     end

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -93,11 +93,7 @@ class NightlySyncsJob < CaseflowJob
   # Adjusts any appeal states appropriately if it is found that a seemingly pending
   #  hearing has been marked with a disposition in VACOLS without Caseflow's knowledge.
   def sync_hearing_states
-    states_to_examine = AppealState.where(appeal_type: "LegacyAppeal", hearing_scheduled: true)
-
-    Parallel.each(states_to_examine, in_threads: 10) do |state|
-      RequestStore[:current_user] = User.system_user
-
+    AppealState.where(appeal_type: "LegacyAppeal", hearing_scheduled: true).each do |state|
       case state.appeal&.hearings&.max_by(&:scheduled_for)&.disposition
       when Constants.HEARING_DISPOSITION_TYPES.held
         state.hearing_held_appeal_state_update_action!

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -11,7 +11,7 @@ class NightlySyncsJob < CaseflowJob
     RequestStore.store[:current_user] = User.system_user
     @slack_report = []
 
-    sync_held_hearing_states
+    sync_hearing_states
     sync_vacols_cases
     sync_vacols_users
     sync_decision_review_tasks
@@ -90,16 +90,23 @@ class NightlySyncsJob < CaseflowJob
     reporter.buffer.map { |vacols_id| LegacyAppeal.find_by(vacols_id: vacols_id) }
   end
 
-  # Adjusts any appeal states appropriately if it is found that a hearing has been marked
-  #  with a held disposition in VACOLS without Caseflow's knowledge.
-  def sync_held_hearing_states
+  # Adjusts any appeal states appropriately if it is found that a seemingly pending
+  #  hearing has been marked with a disposition in VACOLS without Caseflow's knowledge.
+  def sync_hearing_states
     states_to_examine = AppealState.where(appeal_type: "LegacyAppeal", hearing_scheduled: true)
 
     Parallel.each(states_to_examine, in_threads: 10) do |state|
       RequestStore[:current_user] = User.system_user
 
-      if state.appeal&.hearings&.max_by(&:scheduled_for)&.disposition == Constants.HEARING_DISPOSITION_TYPES.held
+      case state.appeal&.hearings&.max_by(&:scheduled_for)&.disposition
+      when Constants.HEARING_DISPOSITION_TYPES.held
         state.hearing_held_appeal_state_update_action!
+      when Constants.HEARING_DISPOSITION_TYPES.cancelled
+        state.hearing_withdrawn_appeal_state_update_action!
+      when Constants.HEARING_DISPOSITION_TYPES.postponed
+        state.hearing_postponed_appeal_state_update_action!
+      when Constants.HEARING_DISPOSITION_TYPES.scheduled_in_error
+        state.scheduled_in_error_appeal_state_update_action!
       end
     end
   end

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -90,6 +90,8 @@ class NightlySyncsJob < CaseflowJob
     reporter.buffer.map { |vacols_id| LegacyAppeal.find_by(vacols_id: vacols_id) }
   end
 
+  # Adjusts any appeal states appropriately if it is found that a hearing has been marked
+  #  with a held disposition in VACOLS without Caseflow's knowledge.
   def sync_held_hearing_states
     states_to_examine = AppealState.where(appeal_type: "LegacyAppeal", hearing_scheduled: true)
 

--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -98,7 +98,7 @@ class NightlySyncsJob < CaseflowJob
     Parallel.each(states_to_examine, in_threads: 10) do |state|
       RequestStore[:current_user] = User.system_user
 
-      if state.appeal.hearings.max_by(&:scheduled_for)&.disposition == "H"
+      if state.appeal.hearings.max_by(&:scheduled_for)&.disposition == Contants.HEARING_DISPOSITION_TYPES.held
         state.hearing_held_appeal_state_update_action!
       end
     end

--- a/app/models/appeal_state.rb
+++ b/app/models/appeal_state.rb
@@ -16,7 +16,6 @@ class AppealState < CaseflowRecord
   # Purpose: Default state of a hash of attributes for an appeal_state, all set to false.
   #          This will be used in the `update_appeal_state` method.
   DEFAULT_STATE = ActiveSupport::HashWithIndifferentAccess.new(decision_mailed: false,
-                                                               appeal_docketed: false,
                                                                hearing_postponed: false,
                                                                hearing_withdrawn: false,
                                                                hearing_scheduled: false,

--- a/app/models/appeal_state.rb
+++ b/app/models/appeal_state.rb
@@ -254,6 +254,16 @@ class AppealState < CaseflowRecord
   end
 
   # Purpose: Method to update appeal_state in the case of
+  # a hearing being marked as having been held.
+  #
+  # Params: None
+  #
+  # Response: None
+  def hearing_held_appeal_state_update_action!
+    update!(hearing_scheduled: false)
+  end
+
+  # Purpose: Method to update appeal_state in the case of
   # a hearing being withdrawn.
   #
   # Params: None

--- a/app/models/hearing.rb
+++ b/app/models/hearing.rb
@@ -32,10 +32,12 @@ class Hearing < CaseflowRecord
   include HearingConcern
   include HasHearingEmailRecipientsConcern
 
+  # VA Notify Hooks
   prepend HearingScheduled
   prepend HearingPostponed
   prepend HearingWithdrawn
   prepend HearingScheduledInError
+  prepend HearingHeld
 
   belongs_to :hearing_day
   belongs_to :appeal

--- a/app/models/hearings/forms/hearing_update_form.rb
+++ b/app/models/hearings/forms/hearing_update_form.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 class HearingUpdateForm < BaseHearingUpdateForm
+  # VA Notify Hooks
   prepend DocketHearingPostponed
   prepend DocketHearingWithdrawn
+  prepend DocketHearingHeld
+
   attr_accessor :advance_on_docket_motion_attributes,
                 :evidence_window_waived, :hearing_issue_notes_attributes,
                 :transcript_sent_date, :transcription_attributes

--- a/app/models/legacy_hearing.rb
+++ b/app/models/legacy_hearing.rb
@@ -35,10 +35,13 @@ class LegacyHearing < CaseflowRecord
   include UpdatedByUserConcern
   include HearingConcern
   include HasHearingEmailRecipientsConcern
+
+  # VA Notify Hooks
   prepend HearingScheduled
   prepend HearingWithdrawn
   prepend HearingPostponed
   prepend HearingScheduledInError
+  prepend HearingHeld
 
   # When these instance variable getters are called, first check if we've
   # fetched the values from VACOLS. If not, first fetch all values and save them

--- a/app/models/prepend/va_notify/docket_hearing_held.rb
+++ b/app/models/prepend/va_notify/docket_hearing_held.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# == Overview
+#
+# This module is used to intercept events triggered via the Daily Docket page to place a 'Held'
+#  disposition onto a hearing.
+module DocketHearingHeld
+  # If a hearing is being assigned a disposition of 'Held' then this method will ensure that the
+  #  hearing's appeal's appeal_states record has its hearing_scheduled attribute set back to false,
+  #  as the appeal's latest milestone is no longer that its hearing has been scheduled, but rather that it's
+  #  awaiting a decision.
+  #
+  # @return [AdvanceOnDocketMotion]
+  #   If advance_on_docket_motion_attributes is non-nil.
+  #   @see HearingsController#advance_on_docket_motion_params for information on what these params/attributes are.
+  # @return [nil]
+  #   If advance_on_docket_motion_attributes is nil/blank.
+  def update_hearing
+    super_return_value = super
+
+    if hearing_updates[:disposition] == Constants.HEARING_DISPOSITION_TYPES.held
+      hearing.appeal.appeal_state.hearing_held_appeal_state_update_action!
+    end
+
+    super_return_value
+  end
+end

--- a/app/models/prepend/va_notify/hearing_held.rb
+++ b/app/models/prepend/va_notify/hearing_held.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# == Overview
+#
+# This module is used to intercept events triggered either on the Daily Docket or Case Details pages
+#   that cause a hearing's state to shift (and by extension the appeal's state also). It is particularly
+#   set up to look for instances where a hearing is being marked with a "Held" disposition.
+module HearingHeld
+  # Legacy Hearing Postponed from the Daily Docket
+  # original method defined in app/models/legacy_hearing.rb
+  def update_caseflow_and_vacols(hearing_hash)
+    original_disposition = vacols_record.hearing_disp
+    super_return_value = super
+    new_disposition = vacols_record.hearing_disp
+    if new_disposition == "H" && original_disposition != new_disposition
+      appeal = LegacyAppeal.find(appeal_id)
+
+      appeal&.appeal_state&.hearing_held_appeal_state_update_action!
+    end
+    super_return_value
+  end
+
+  # Legacy OR AMA Hearing Marked as "Held" from Queue
+  # original method defined in app/models/tasks/assign_hearing_disposition_task.rb
+  def update_hearing(hearing_hash)
+    super_return_value = super
+
+    if hearing_hash[:disposition] == Constants.HEARING_DISPOSITION_TYPES.held
+      appeal.appeal_state.hearing_held_appeal_state_update_action!
+    end
+
+    super_return_value
+  end
+
+  # Purpose: Callback method when a hearing updates to also update appeal_states table
+  #
+  # Params: none
+  #
+  # Response: none
+  def update_appeal_states_on_hearing_hled
+    appeal.appeal_state.hearing_held_appeal_state_update_action! if ama_hearing_held? || legacy_hearing_held?
+  end
+
+  private
+
+  # Checks to see if the current object is an instance of a Hearing, and if its disposition has
+  #  been set to "Held".
+  #
+  # @return [Boolean]
+  #   True if self is an AMA hearing and its disposition is set to "Held". False otherwise.
+  def ama_hearing_held?
+    is_a?(Hearing) && disposition == Constants.HEARING_DISPOSITION_TYPES.held
+  end
+
+  # Checks to see if the current object is an instance of a LegacyHearing, and if its disposition has
+  #  been set to "Held".
+  #
+  # @note The dispotion for a legacy hearing is located in the HEARSCHED table's hearing_disp column in
+  #   in the VACOLS database.
+  #
+  # @return [Boolean]
+  #   True if self is an AMA hearing and its disposition is set to "Held". False otherwise.
+  def legacy_hearing_held?
+    is_a?(LegacyHearing) && VACOLS::CaseHearing.find_by(hearing_pkseq: vacols_id)&.hearing_disp == "H"
+  end
+end

--- a/app/models/tasks/assign_hearing_disposition_task.rb
+++ b/app/models/tasks/assign_hearing_disposition_task.rb
@@ -23,6 +23,7 @@ class AssignHearingDispositionTask < Task
   prepend HearingWithdrawn
   prepend HearingPostponed
   prepend HearingScheduledInError
+  prepend HearingHeld
 
   validates :parent, presence: true, parentTask: { task_type: HearingTask }, on: :create
   delegate :hearing, to: :hearing_task, allow_nil: true

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 namespace :appeal_state_synchronizer do
-  desc "Used to synchronize appeal_states table records with cases in VACOLS."
+  desc "Used to synchronize appeal_states table using data from other sources."
   task sync_appeal_states: :environment do
     Rails.application.eager_load!
 
     adjust_legacy_hearing_statuses
-
+    adjust_ama_hearing_statuses
     locate_unrecorded_docketed_states
   end
 

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -118,10 +118,10 @@ namespace :appeal_state_synchronizer do
     def adjust_ama_hearing_statuses
       incorrect_appeal_states = AppealState.find_by_sql(incorrect_hearing_scheduled_appeal_states_query)
 
-      Parallel.each(incorrect_appeal_states, in_threads: 10) do |_state_to_correct|
+      Parallel.each(incorrect_appeal_states, in_threads: 10) do |state_to_correct|
         RequestStore[:current_user] = User.system_user
 
-        incorrect_appeal_states.update!(hearing_scheduled: false)
+        state_to_correct.update!(hearing_scheduled: false)
       end
     end
   end

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -77,7 +77,7 @@ namespace :appeal_state_synchronizer do
   def locate_unrecorded_docketed_states
     appeals_missing_states = LegacyAppeal.find_by_sql(
       <<-SQL
-        SELECT la.*
+        SELECT DISTINCT la.*
         FROM legacy_appeals la
         JOIN notifications n ON la.vacols_id = n.appeals_id AND event_type = 'Appeal docketed'
         LEFT JOIN appeal_states states ON la.id = states.appeal_id AND states.appeal_type = 'LegacyAppeal'

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -3,6 +3,8 @@
 namespace :appeal_state_synchronizer do
   desc "Used to synchronize appeal_states table records with cases in VACOLS."
   task sync_appeal_states: :environment do
+    Rails.application.eager_load!
+
     adjust_legacy_hearing_statuses
 
     locate_unrecorded_docketed_states

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -100,6 +100,7 @@ namespace :appeal_state_synchronizer do
       SELECT DISTINCT *
       FROM appeal_states
       WHERE hearing_scheduled IS TRUE
+      AND appeal_type = 'Appeal'
       AND id NOT IN (
           SELECT s.id
           FROM appeals

--- a/lib/tasks/appeal_state_synchronizer.rake
+++ b/lib/tasks/appeal_state_synchronizer.rake
@@ -109,7 +109,7 @@ namespace :appeal_state_synchronizer do
           INNER JOIN appeal_states s ON s.appeal_id = appeals.id AND s.appeal_type = 'Appeal'
           WHERE tasks.appeal_type = 'Appeal'
           AND tasks.type = 'AssignHearingDispositionTask'
-          AND tasks.status IN ('assigned')
+          AND tasks.status = 'assigned'
           AND appeals.docket_type = 'hearing'
           AND h.disposition IS NULL
       )

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HearingsController, type: :controller do
         prepped: true
       }
 
-      expect(appeal_state.hearing_scheduled).to eq true
+      expect(legacy_appeal_state.hearing_scheduled).to eq true
 
       patch :update, as: :json, params: { id: legacy_hearing.external_id, hearing: params }
       expect(response.status).to eq 200
@@ -40,7 +40,7 @@ RSpec.describe HearingsController, type: :controller do
       expect(response_body["disposition"]).to eq "held"
       expect(response_body["location"]["facility_id"]).to eq "vba_301"
       expect(response_body["prepped"]).to eq true
-      expect(appeal_state.reload.hearing_scheduled).to eq false
+      expect(legacy_appeal_state.reload.hearing_scheduled).to eq false
     end
 
     context "when updating an ama hearing" do

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe HearingsController, type: :controller do
   let!(:vso_participant_id) { "12345" }
 
   describe "PATCH update" do
-    let(:legacy_appeal_state) { hearing.appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
+    let(:legacy_appeal_state) { legacy_hearing.appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
 
     it "should be successful", :aggregate_failures do
       params = {

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -13,6 +13,8 @@ RSpec.describe HearingsController, type: :controller do
   let!(:vso_participant_id) { "12345" }
 
   describe "PATCH update" do
+    let(:legacy_appeal_state) { hearing.appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
+
     it "should be successful", :aggregate_failures do
       params = {
         notes: "Test",
@@ -25,6 +27,9 @@ RSpec.describe HearingsController, type: :controller do
         },
         prepped: true
       }
+
+      expect(appeal_state.hearing_scheduled).to eq true
+
       patch :update, as: :json, params: { id: legacy_hearing.external_id, hearing: params }
       expect(response.status).to eq 200
       response_body = JSON.parse(response.body)["data"]
@@ -35,10 +40,12 @@ RSpec.describe HearingsController, type: :controller do
       expect(response_body["disposition"]).to eq "held"
       expect(response_body["location"]["facility_id"]).to eq "vba_301"
       expect(response_body["prepped"]).to eq true
+      expect(appeal_state.reload.hearing_scheduled).to eq true
     end
 
     context "when updating an ama hearing" do
       let!(:hearing) { create(:hearing, :with_tasks) }
+      let(:appeal_state) { hearing.appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) } }
 
       it "should update an ama hearing", :aggregate_failures do
         params = {
@@ -51,6 +58,9 @@ RSpec.describe HearingsController, type: :controller do
           prepped: true,
           evidence_window_waived: true
         }
+
+        expect(appeal_state.hearing_scheduled).to eq true
+
         patch :update, as: :json, params: { id: hearing.external_id, hearing: params }
         expect(response.status).to eq 200
         response_body = JSON.parse(response.body)["data"]
@@ -60,6 +70,7 @@ RSpec.describe HearingsController, type: :controller do
         expect(response_body["prepped"]).to eq true
         expect(response_body["location"]["facility_id"]).to eq "vba_301"
         expect(response_body["evidence_window_waived"]).to eq true
+        expect(appeal_state.reload.hearing_scheduled).to eq true
       end
     end
 

--- a/spec/controllers/hearings_controller_spec.rb
+++ b/spec/controllers/hearings_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe HearingsController, type: :controller do
       expect(response_body["disposition"]).to eq "held"
       expect(response_body["location"]["facility_id"]).to eq "vba_301"
       expect(response_body["prepped"]).to eq true
-      expect(appeal_state.reload.hearing_scheduled).to eq true
+      expect(appeal_state.reload.hearing_scheduled).to eq false
     end
 
     context "when updating an ama hearing" do
@@ -70,7 +70,7 @@ RSpec.describe HearingsController, type: :controller do
         expect(response_body["prepped"]).to eq true
         expect(response_body["location"]["facility_id"]).to eq "vba_301"
         expect(response_body["evidence_window_waived"]).to eq true
-        expect(appeal_state.reload.hearing_scheduled).to eq true
+        expect(appeal_state.reload.hearing_scheduled).to eq false
       end
     end
 

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -2,12 +2,10 @@
 
 describe AppealState do
   it_behaves_like "AppealState belongs_to polymorphic appeal" do
-    let!(:_user) { create(:user) } # A User needs to exist for `appeal_state` factories
+    let!(:user) { create(:user) } # A User needs to exist for `appeal_state` factories
   end
 
   context "State scopes" do
-    let(:user) { create(:user) }
-
     let!(:appeal_docketed_state) do
       create(
         :appeal_state,
@@ -343,8 +341,6 @@ describe AppealState do
   end
 
   context "#appeal_docketed_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.appeal_docketed_appeal_state_update_action! }
 
     context "updates the appeal_docketed attribute" do
@@ -369,8 +365,6 @@ describe AppealState do
   end
 
   context "#vso_ihp_pending_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.vso_ihp_pending_appeal_state_update_action! }
 
     context "updates the vso_ihp_pending attribute" do
@@ -396,8 +390,6 @@ describe AppealState do
   end
 
   context "#vso_ihp_cancelled_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.vso_ihp_cancelled_appeal_state_update_action! }
 
     context "updates the vso_ihp_pending attribute" do
@@ -422,8 +414,6 @@ describe AppealState do
   end
 
   context "#vso_ihp_complete_appeal_state_update_action!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.vso_ihp_complete_appeal_state_update_action! }
 
     context "updates the vso_ihp_complete attribute" do
@@ -448,8 +438,6 @@ describe AppealState do
   end
 
   context "#privacy_act_pending_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.privacy_act_pending_appeal_state_update_action! }
 
     context "updates the privacy_act_pending attribute" do
@@ -472,8 +460,6 @@ describe AppealState do
   end
 
   context "#privacy_act_cancelled_appeal_state_update_action!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.privacy_act_cancelled_appeal_state_update_action! }
 
     context "updates the privacy_act_pending attribute" do
@@ -496,8 +482,6 @@ describe AppealState do
   end
 
   context "#privacy_act_complete_appeal_state_update_action!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.privacy_act_complete_appeal_state_update_action! }
 
     context "updates the privacy_act_complete attribute" do
@@ -523,8 +507,6 @@ describe AppealState do
   end
 
   context "#decision_mailed_appeal_state_update_action!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.decision_mailed_appeal_state_update_action! }
 
     context "updates the decision_mailed attribute" do
@@ -549,8 +531,6 @@ describe AppealState do
   end
 
   context "#appeal_cancelled_appeal_state_update_action!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.appeal_cancelled_appeal_state_update_action! }
 
     context "updates the appeal_cancelled attribute" do
@@ -574,9 +554,8 @@ describe AppealState do
       end
     end
   end
-  context "#hearing_postponed_appeal_state_update!" do
-    let(:user) { create(:user) }
 
+  context "#hearing_postponed_appeal_state_update!" do
     subject { appeal_state.hearing_postponed_appeal_state_update_action! }
 
     context "updates the hearing_postponed attribute" do
@@ -602,8 +581,6 @@ describe AppealState do
   end
 
   context "#hearing_withdrawn_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.hearing_withdrawn_appeal_state_update_action! }
 
     context "updates the hearing_withdrawn attribute" do
@@ -628,8 +605,6 @@ describe AppealState do
     end
   end
   context "#hearing_scheduled_appeal_state_update!" do
-    let(:user) { create(:user) }
-
     subject { appeal_state.hearing_scheduled_appeal_state_update_action! }
 
     context "updates the hearing_scheduled attribute" do
@@ -654,9 +629,33 @@ describe AppealState do
     end
   end
 
-  context "#scheduled_in_error_appeal_state_update!" do
-    let(:user) { create(:user) }
+  context "hearing_held_appeal_state_update_action!" do
+    subject { appeal_state.hearing_held_appeal_state_update_action! }
 
+    context "updates the hearing_scheduled attribute" do
+      include_examples "privacy_act_pending status remains active upon update"
+
+      let(:appeal_state) do
+        create(
+          :appeal_state,
+          :ama,
+          created_by_id: user.id,
+          updated_by_id: user.id,
+          hearing_scheduled: true
+        )
+      end
+
+      it "sets hearing_scheduled to true and all others false" do
+        expect(appeal_state.hearing_scheduled).to eq true
+
+        subject
+
+        expect(appeal_state.hearing_scheduled).to eq false
+      end
+    end
+  end
+
+  context "#scheduled_in_error_appeal_state_update!" do
     subject { appeal_state.scheduled_in_error_appeal_state_update_action! }
 
     context "updates the scheduled_in_error attribute" do

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -5,6 +5,8 @@ describe AppealState do
     let!(:user) { create(:user) } # A User needs to exist for `appeal_state` factories
   end
 
+  let!(:user) { create(:user) }
+
   context "State scopes" do
     let!(:appeal_docketed_state) do
       create(

--- a/spec/models/appeal_state_spec.rb
+++ b/spec/models/appeal_state_spec.rb
@@ -382,10 +382,9 @@ describe AppealState do
         )
       end
 
-      it "sets vso_ihp_pending to true and all others false" do
+      it "sets vso_ihp_pending to true" do
         subject
 
-        expect(appeal_state.appeal_docketed).to eq false
         expect(appeal_state.vso_ihp_pending).to eq true
       end
     end
@@ -622,10 +621,9 @@ describe AppealState do
         )
       end
 
-      it "sets hearing_scheduled to true and all others false" do
+      it "sets hearing_scheduled to true" do
         subject
 
-        expect(appeal_state.appeal_docketed).to eq false
         expect(appeal_state.hearing_scheduled).to eq true
       end
     end

--- a/spec/models/tasks/assign_hearing_disposition_task_spec.rb
+++ b/spec/models/tasks/assign_hearing_disposition_task_spec.rb
@@ -221,9 +221,13 @@ describe AssignHearingDispositionTask, :all_dbs do
       it "sets the hearing disposition and calls hold!", :aggregate_failures do
         expect(disposition_task).to receive(:hold!).exactly(1).times.and_call_original
 
+        state = appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) }
+        expect(state.hearing_scheduled).to eq true
+
         subject
 
         expect(hearing.disposition).to eq Constants.HEARING_DISPOSITION_TYPES.held
+        expect(state.reload.hearing_scheduled).to eq false
 
         if appeal.is_a? Appeal
           expect(Hearing.count).to eq 1


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-49212](https://jira.devops.va.gov/browse/APPEALS-49212)

# Description
Introduces a synchronization script to sync appeal_states records using data from other tables/data stores.

Also ensures `hearing_scheduled` is set to false whenever hearings are marked as held in and out (VAOCLS directly) of Caseflow.