### PR TITLE
Hotfix/APPEALS-49624

### DIFF
--- a/app/jobs/hearings/fetch_webex_recordings_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_details_job.rb
@@ -21,7 +21,8 @@ class Hearings::FetchWebexRecordingsDetailsJob < CaseflowJob
       provider: "webex",
       recording_id: recording_id,
       host_email: host_email,
-      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}/#{recording_id}#{query}",
+      api_call:
+        "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}recordings/#{recording_id}#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
       docket_number: nil
     }

--- a/app/jobs/hearings/fetch_webex_recordings_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_details_job.rb
@@ -15,16 +15,17 @@ class Hearings::FetchWebexRecordingsDetailsJob < CaseflowJob
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
     recording_id = job.arguments&.first&.[](:recording_id)
     host_email = job.arguments&.first&.[](:host_email)
+    meeting_title = job.arguments&.first&.[](:meeting_title)
     query = "?hostEmail=#{host_email}"
     error_details = {
       error: { type: "retrieval", explanation: "retrieve recording details from Webex" },
       provider: "webex",
-      recording_id: recording_id,
-      host_email: host_email,
       api_call:
         "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}recordings/#{recording_id}#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
-      docket_number: nil
+      recording_id: recording_id,
+      host_email: host_email,
+      meeting_title: meeting_title
     }
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)

--- a/app/jobs/hearings/fetch_webex_recordings_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_list_job.rb
@@ -15,7 +15,7 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
     max = 100
     id = job.arguments&.first&.[](:meeting_id)
     meeting_title = job.arguments&.first&.[](:meeting_title)
-    query = "?max=#{max}?meetingId=#{id}"
+    query = "?max=#{max}&meetingId=#{id}"
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
       provider: "webex",

--- a/app/jobs/hearings/fetch_webex_recordings_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_list_job.rb
@@ -14,6 +14,7 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
     max = 100
     id = job.arguments&.first&.[](:meeting_id)
+    meeting_title = job.arguments&.first&.[](:meeting_title)
     query = "?max=#{max}?meetingId=#{id}"
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
@@ -22,7 +23,7 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
         "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}admin/recordings/#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
       meeting_id: id,
-      docket_number: nil
+      meeting_title: meeting_title
     }
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)

--- a/app/jobs/hearings/fetch_webex_recordings_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_recordings_list_job.rb
@@ -18,7 +18,8 @@ class Hearings::FetchWebexRecordingsListJob < CaseflowJob
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
       provider: "webex",
-      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}#{query}",
+      api_call:
+        "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}admin/recordings/#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
       meeting_id: id,
       docket_number: nil

--- a/app/jobs/hearings/fetch_webex_room_meeting_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_room_meeting_details_job.rb
@@ -12,14 +12,15 @@ class Hearings::FetchWebexRoomMeetingDetailsJob < CaseflowJob
 
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
     room_id = job.arguments&.first&.[](:room_id)
+    meeting_title = job.arguments&.first&.[](:meeting_title)
     error_details = {
       error: { type: "retrieval", explanation: "retrieve details of room from Webex" },
       provider: "webex",
       api_call:
         "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms/#{room_id}/meetingInfo",
       response: { status: exception.code, message: exception.message }.to_json,
-      times: nil,
-      docket_number: nil
+      room_id: room_id,
+      meeting_title: meeting_title
     }
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)

--- a/app/jobs/hearings/fetch_webex_room_meeting_details_job.rb
+++ b/app/jobs/hearings/fetch_webex_room_meeting_details_job.rb
@@ -11,10 +11,12 @@ class Hearings::FetchWebexRoomMeetingDetailsJob < CaseflowJob
   attr_reader :room_id, :meeting_title
 
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
+    room_id = job.arguments&.first&.[](:room_id)
     error_details = {
       error: { type: "retrieval", explanation: "retrieve details of room from Webex" },
       provider: "webex",
-      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}",
+      api_call:
+        "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms/#{room_id}/meetingInfo",
       response: { status: exception.code, message: exception.message }.to_json,
       times: nil,
       docket_number: nil

--- a/app/jobs/hearings/fetch_webex_rooms_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_rooms_list_job.rb
@@ -9,11 +9,10 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
   queue_with_priority :low_priority
   application_attr :hearings_schedule
 
-  # rubocop:disable Naming/VariableName
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
-    sortBy = "created"
+    sort_by = "created"
     max = 1000
-    query = "?sortBy=#{sortBy}?max=#{max}"
+    query = "?sortBy=#{sort_by}&max=#{max}"
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },
       provider: "webex",
@@ -23,7 +22,6 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)
   end
-  # rubocop:enable Naming/VariableName
 
   def perform
     ensure_current_user_is_set

--- a/app/jobs/hearings/fetch_webex_rooms_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_rooms_list_job.rb
@@ -16,7 +16,7 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },
       provider: "webex",
-      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}#{query}",
+      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms?#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
       times: nil,
       docket_number: nil

--- a/app/jobs/hearings/fetch_webex_rooms_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_rooms_list_job.rb
@@ -18,9 +18,7 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
       error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },
       provider: "webex",
       api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms#{query}",
-      response: { status: exception.code, message: exception.message }.to_json,
-      times: nil,
-      docket_number: nil
+      response: { status: exception.code, message: exception.message }.to_json
     }
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)

--- a/app/jobs/hearings/fetch_webex_rooms_list_job.rb
+++ b/app/jobs/hearings/fetch_webex_rooms_list_job.rb
@@ -9,14 +9,15 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
   queue_with_priority :low_priority
   application_attr :hearings_schedule
 
+  # rubocop:disable Naming/VariableName
   retry_on(Caseflow::Error::WebexApiError, wait: :exponentially_longer) do |job, exception|
-    sort_by = "created"
+    sortBy = "created"
     max = 1000
-    query = { "sortBy": sort_by, "max": max }
+    query = "?sortBy=#{sortBy}?max=#{max}"
     error_details = {
       error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },
       provider: "webex",
-      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms?#{query}",
+      api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms#{query}",
       response: { status: exception.code, message: exception.message }.to_json,
       times: nil,
       docket_number: nil
@@ -24,6 +25,7 @@ class Hearings::FetchWebexRoomsListJob < CaseflowJob
     job.log_error(exception)
     job.send_transcription_issues_email(error_details)
   end
+  # rubocop:enable Naming/VariableName
 
   def perform
     ensure_current_user_is_set

--- a/app/workflows/transcription_transformer.rb
+++ b/app/workflows/transcription_transformer.rb
@@ -136,7 +136,7 @@ class TranscriptionTransformer
   #       count - amount of line breaks to add
   def insert_line_breaks(row, count)
     breaks = 0
-    while i < count
+    while breaks < count
       row.line_break
       breaks += 1
     end

--- a/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
@@ -58,7 +58,8 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
         provider: "webex",
         recording_id: id,
         host_email: email,
-        api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}/#{id}#{query}",
+        api_call:
+          "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}recordings/#{id}#{query}",
         response: { status: exception.code, message: exception.message }.to_json,
         docket_number: nil
       }

--- a/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_details_job_spec.rb
@@ -56,12 +56,12 @@ describe Hearings::FetchWebexRecordingsDetailsJob, type: :job do
       {
         error: { type: "retrieval", explanation: "retrieve recording details from Webex" },
         provider: "webex",
-        recording_id: id,
-        host_email: email,
         api_call:
           "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}recordings/#{id}#{query}",
         response: { status: exception.code, message: exception.message }.to_json,
-        docket_number: nil
+        recording_id: id,
+        host_email: email,
+        meeting_title: meeting_title
       }
     end
 

--- a/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
@@ -39,7 +39,7 @@ describe Hearings::FetchWebexRecordingsListJob, type: :job do
 
   context "job errors" do
     let(:exception) { Caseflow::Error::WebexApiError.new(code: 400, message: "Fake Error") }
-    let(:query) { "?max=100?meetingId=#{id}" }
+    let(:query) { "?max=100&meetingId=#{id}" }
     let(:error_details) do
       {
         error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },

--- a/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
@@ -3,7 +3,7 @@
 describe Hearings::FetchWebexRecordingsListJob, type: :job do
   include ActiveJob::TestHelper
   let(:id) { "f91b6edce9864428af084977b7c68291_I_166641849979635652" }
-  let(:title) { "Virtual Visit - 221218-977_933_Hearing-20240508 1426-1" }
+  let(:title) { "221218-977_933_Hearing" }
 
   subject { described_class.perform_now(meeting_id: id, meeting_title: title) }
 
@@ -48,7 +48,7 @@ describe Hearings::FetchWebexRecordingsListJob, type: :job do
           "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}admin/recordings/#{query}",
         response: { status: exception.code, message: exception.message }.to_json,
         meeting_id: id,
-        docket_number: nil
+        meeting_title: title
       }
     end
 

--- a/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_recordings_list_job_spec.rb
@@ -44,7 +44,8 @@ describe Hearings::FetchWebexRecordingsListJob, type: :job do
       {
         error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
         provider: "webex",
-        api_call: "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}#{query}",
+        api_call:
+          "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}admin/recordings/#{query}",
         response: { status: exception.code, message: exception.message }.to_json,
         meeting_id: id,
         docket_number: nil

--- a/spec/jobs/hearings/fetch_webex_room_meeting_details_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_room_meeting_details_job_spec.rb
@@ -17,7 +17,7 @@ describe Hearings::FetchWebexRoomMeetingDetailsJob, type: :job do
   let(:room_id) do
     "Y2lzY29zcGFyazovL3VybjpURUFNOnVzLWdvdi13ZXN0LTFfYTEvUk9PTS85YTZjZTRjMC0xNmM5LTExZWYtYjIxOC1iMWE5YTQ2"
   end
-  let(:meeting_title) { "Virtual Visit - 221218-977_933_Hearing-20240508 1426-1" }
+  let(:meeting_title) { "221218-977_933_Hearing" }
   let(:exception) { Caseflow::Error::WebexApiError.new(code: 300, message: "Error", title: "Bad Error") }
   let(:error_details) do
     {
@@ -26,8 +26,8 @@ describe Hearings::FetchWebexRoomMeetingDetailsJob, type: :job do
       api_call:
         "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms/#{room_id}/meetingInfo",
       response: { status: exception.code, message: exception.message }.to_json,
-      times: nil,
-      docket_number: nil
+      room_id: room_id,
+      meeting_title: meeting_title
     }
   end
 

--- a/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
@@ -26,8 +26,6 @@ describe Hearings::FetchWebexRoomsListJob, type: :job do
         api_call:
           "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms#{query}",
         response: { status: 400, message: "Fake Error" }.to_json,
-        times: nil,
-        docket_number: nil
       }
     end
 

--- a/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
@@ -25,7 +25,7 @@ describe Hearings::FetchWebexRoomsListJob, type: :job do
         provider: "webex",
         api_call:
           "GET #{ENV['WEBEX_HOST_MAIN']}#{ENV['WEBEX_DOMAIN_MAIN']}#{ENV['WEBEX_API_MAIN']}rooms#{query}",
-        response: { status: 400, message: "Fake Error" }.to_json,
+        response: { status: 400, message: "Fake Error" }.to_json
       }
     end
 

--- a/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
+++ b/spec/jobs/hearings/fetch_webex_rooms_list_job_spec.rb
@@ -18,7 +18,7 @@ describe Hearings::FetchWebexRoomsListJob, type: :job do
   # rubocop:enable Layout/LineLength
 
   context "job errors" do
-    let(:query) { "?sortBy=created?max=1000" }
+    let(:query) { "?sortBy=created&max=1000" }
     let(:error_details) do
       {
         error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },

--- a/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
+++ b/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
@@ -52,8 +52,11 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
 
+  # rubocop:disable Naming/VariableName
   def webex_rooms_list_issues
-    query = "?sortBy=created?max=1000"
+    sortBy = "created"
+    max = 1000
+    query = "?sortBy=#{sortBy}?max=#{max}"
 
     details = {
       error: { type: "retrieval", expalantion: "retrieve a list of rooms from Webex" },
@@ -81,7 +84,9 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
   end
 
   def webex_recording_list_issues
-    query = "?max=100?meetingId=123abc"
+    max = 100
+    meetindId = "123abc"
+    query = "?max=#{max}?meetingId=#{meetindId}"
 
     details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
@@ -93,6 +98,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
+  # rubocop:enable Naming/VariableName
 
   def webex_recording_details_issues
     recording_id = "12345"

--- a/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
+++ b/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
@@ -5,6 +5,8 @@
 #   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/file_upload_issues
 #   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/file_conversion_issues
 #   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/file_name_issues
+#   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/webex_rooms_list_issues
+#   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/webex_room_meeting_details_issues
 #   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/webex_recording_list_issues
 #   http://localhost:3000/rails/mailers/transcription_file_issues_mailer/webex_recording_details_issues
 class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
@@ -50,13 +52,41 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
 
+  def webex_rooms_list_issues
+    query = "?sortBy=created?max=1000"
+
+    details = {
+      error: { type: "retrieval", expalantion: "retrieve a list of rooms from Webex" },
+      provider: "webex",
+      api_call: "GET https://api-usgov.webex.com/v1/rooms#{query}",
+      response: { status: 400, message: "Sample error message" }.to_json,
+      times: nil,
+      docket_number: nil
+    }
+    TranscriptionFileIssuesMailer.issue_notification(details)
+  end
+
+  def webex_room_meeting_details_issues
+    room_id = "1234567"
+
+    details = {
+      error: { type: "retrieval", expalantion: "retrieve a list of room details from Webex" },
+      provider: "webex",
+      api_call: "GET https://api-usgov.webex.com/v1/rooms/#{room_id}/meetingInfo",
+      response: { status: 400, message: "Sample error message" }.to_json,
+      times: nil,
+      docket_number: nil
+    }
+    TranscriptionFileIssuesMailer.issue_notification(details)
+  end
+
   def webex_recording_list_issues
     query = "?max=100?meetingId=123abc"
 
     details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
       provider: "webex",
-      api_call: "GET webex.com/recordings/list/#{query}",
+      api_call: "GET https://api-usgov.webex.com/v1/admin/recordings/#{query}",
       response: { status: 400, message: "Sample error message" }.to_json,
       meeting_id: "123abc",
       docket_number: nil
@@ -73,7 +103,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
       provider: "webex",
       recording_id: recording_id,
       host_email: host_email,
-      api_call: "GET webex.com/recordings/details/#{recording_id}#{query}",
+      api_call: "GET https://api-usgov.webex.com/v1/recordings/#{recording_id}#{query}",
       response: { status: 400, message: "Sample error message" }.to_json,
       docket_number: nil
     }

--- a/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
+++ b/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
@@ -52,14 +52,13 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
 
-  # rubocop:disable Naming/VariableName
   def webex_rooms_list_issues
-    sortBy = "created"
+    sort_by = "created"
     max = 1000
-    query = "?sortBy=#{sortBy}?max=#{max}"
+    query = "?sortBy=#{sort_by}&max=#{max}"
 
     details = {
-      error: { type: "retrieval", expalantion: "retrieve a list of rooms from Webex" },
+      error: { type: "retrieval", explanation: "retrieve a list of rooms from Webex" },
       provider: "webex",
       api_call: "GET https://api-usgov.webex.com/v1/rooms#{query}",
       response: { status: 400, message: "Sample error message" }.to_json
@@ -71,7 +70,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     room_id = "1234567"
     meeting_title = "221218-977_933_Hearing"
     details = {
-      error: { type: "retrieval", expalantion: "retrieve a list of room details from Webex" },
+      error: { type: "retrieval", explanation: "retrieve a list of room details from Webex" },
       provider: "webex",
       api_call: "GET https://api-usgov.webex.com/v1/rooms/#{room_id}/meetingInfo",
       response: { status: 400, message: "Sample error message" }.to_json,
@@ -83,9 +82,9 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
 
   def webex_recording_list_issues
     max = 100
-    meetindId = "123abc"
+    meeting_id = "123abc"
     meeting_title = "221218-977_933_Hearing"
-    query = "?max=#{max}?meetingId=#{meetindId}"
+    query = "?max=#{max}&meetingId=#{meeting_id}"
 
     details = {
       error: { type: "retrieval", explanation: "retrieve a list of recordings from Webex" },
@@ -97,7 +96,6 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
-  # rubocop:enable Naming/VariableName
 
   def webex_recording_details_issues
     recording_id = "12345"

--- a/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
+++ b/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
@@ -62,7 +62,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
       error: { type: "retrieval", expalantion: "retrieve a list of rooms from Webex" },
       provider: "webex",
       api_call: "GET https://api-usgov.webex.com/v1/rooms#{query}",
-      response: { status: 400, message: "Sample error message" }.to_json,
+      response: { status: 400, message: "Sample error message" }.to_json
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end

--- a/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
+++ b/spec/mailers/previews/transcription_file_issues_mailer_preview.rb
@@ -63,22 +63,20 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
       provider: "webex",
       api_call: "GET https://api-usgov.webex.com/v1/rooms#{query}",
       response: { status: 400, message: "Sample error message" }.to_json,
-      times: nil,
-      docket_number: nil
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
 
   def webex_room_meeting_details_issues
     room_id = "1234567"
-
+    meeting_title = "221218-977_933_Hearing"
     details = {
       error: { type: "retrieval", expalantion: "retrieve a list of room details from Webex" },
       provider: "webex",
       api_call: "GET https://api-usgov.webex.com/v1/rooms/#{room_id}/meetingInfo",
       response: { status: 400, message: "Sample error message" }.to_json,
-      times: nil,
-      docket_number: nil
+      room_id: room_id,
+      meeting_title: meeting_title
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
@@ -86,6 +84,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
   def webex_recording_list_issues
     max = 100
     meetindId = "123abc"
+    meeting_title = "221218-977_933_Hearing"
     query = "?max=#{max}?meetingId=#{meetindId}"
 
     details = {
@@ -94,7 +93,7 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
       api_call: "GET https://api-usgov.webex.com/v1/admin/recordings/#{query}",
       response: { status: 400, message: "Sample error message" }.to_json,
       meeting_id: "123abc",
-      docket_number: nil
+      meeting_title: meeting_title
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end
@@ -103,15 +102,16 @@ class TranscriptionFileIssuesMailerPreview < ActionMailer::Preview
   def webex_recording_details_issues
     recording_id = "12345"
     host_email = "fake@email.com"
+    meeting_title = "221218-977_933_Hearing"
     query = "?hostEmail=#{host_email}"
     details = {
       error: { type: "retrieval", explanation: "retrieve recording details from Webex" },
       provider: "webex",
-      recording_id: recording_id,
-      host_email: host_email,
       api_call: "GET https://api-usgov.webex.com/v1/recordings/#{recording_id}#{query}",
       response: { status: 400, message: "Sample error message" }.to_json,
-      docket_number: nil
+      recording_id: recording_id,
+      host_email: host_email,
+      meeting_title: meeting_title
     }
     TranscriptionFileIssuesMailer.issue_notification(details)
   end


### PR DESCRIPTION
## Resolves FileConversionError occurring for Webex VTT file
https://jira.devops.va.gov/browse/APPEALS-49624

# Description
Sentry reports a NameError when converting a Webex VTT to RTF
Steps to Reproduce: Kick off Hearings::FetchWebexRecordingsDetailsJob from the UAT rails console, manually supplying the recording id, host email, and room title.
Expected Results: 3 files are downloaded and inserted into Transcription Files table, one addition RTF file is created and inserted into the Transcription Files table by converting the existing VTT to RTF.

## Acceptance Criteria
- [x] Code compiles correctly
- [x] 'i' changed to 'breaks' at line 139 of transcription_transformer.rb

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-49624

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added