### PR TITLE
APPEALS-49507: NOD on Correspondence Seed Data Inconsistent with Document Type

### DIFF
--- a/db/seeds/correspondence.rb
+++ b/db/seeds/correspondence.rb
@@ -177,7 +177,6 @@ module Seeds
 
     def create_correspondence_with_unassigned_review_package_task(user = {}, veteran = {})
       corres = create_correspondence(user, veteran)
-      create_correspondence_document(corres, veteran, doc_type)
       # vary days waiting to be able to test column sorting
       rpt = ReviewPackageTask.find_by(appeal_id: corres.id)
       rpt.update(assigned_at: corres.va_date_of_receipt)

--- a/db/seeds/correspondence.rb
+++ b/db/seeds/correspondence.rb
@@ -177,7 +177,7 @@ module Seeds
 
     def create_correspondence_with_unassigned_review_package_task(user = {}, veteran = {})
       corres = create_correspondence(user, veteran)
-      create_correspondence_document(corres, veteran)
+      create_correspondence_document(corres, veteran, doc_type)
       # vary days waiting to be able to test column sorting
       rpt = ReviewPackageTask.find_by(appeal_id: corres.id)
       rpt.update(assigned_at: corres.va_date_of_receipt)

--- a/db/seeds/helpers/queue_helpers.rb
+++ b/db/seeds/helpers/queue_helpers.rb
@@ -23,15 +23,17 @@ module QueueHelpers
     user = user.blank? ? InboundOpsTeam.singleton.users.first : user
     corr_type = CorrespondenceType.all.sample
     receipt_date = rand(1.month.ago..1.day.ago)
+    nod = [true, false].sample
+    doc_type = generate_vbms_doc_type(nod)
 
     correspondence = ::Correspondence.create!(
       uuid: SecureRandom.uuid,
       va_date_of_receipt: receipt_date,
       notes: generate_notes([corr_type, receipt_date, user]),
       veteran_id: vet.id,
-      nod: nod_doc.id
+      nod: nod
     )
-    create_correspondence_document(correspondence, vet)
+    create_correspondence_document(correspondence, vet, doc_type)
 
     return correspondence
   end
@@ -57,15 +59,14 @@ module QueueHelpers
   end
 
   # :reek:UtilityFunction
-  def create_correspondence_document(correspondence, veteran)
+  def create_correspondence_document(correspondence, veteran, doc_type)
     CorrespondenceDocument.find_or_create_by!(
       document_file_number: veteran.file_number,
       uuid: SecureRandom.uuid,
-      vbms_document_type_id: 1250,
-      document_type: 1250,
-      pages: 30,
+      vbms_document_type_id: doc_type[:id],
+      document_type: doc_type[:id],
+      pages: rand(1..30),
       correspondence_id: correspondence.id
-      nod: generate_vbms_doc_type
     )
   end
 
@@ -179,5 +180,47 @@ module QueueHelpers
       pages: 5,
       vbms_document_type_id: 18
     )
+  end
+  def generate_vbms_doc_type(nod)
+    return nod_doc if nod
+
+    non_nod_docs.sample
+  end
+
+  def nod_doc
+    {
+      id: 1250,
+      description: "VA Form 10182, Decision Review Request: Board Appeal (Notice of Disagreement)"
+    }
+  end
+
+  # rubocop:disable Metrics/MethodLength
+  def non_nod_docs
+    [
+      {
+        id: 1419,
+        description: "Reissuance Beneficiary Notification Letter"
+      },
+      {
+        id: 1430,
+        description: "Bank Letter Beneficiary"
+      },
+      {
+        id: 1448,
+        description: "VR-69 Chapter 36 Decision Letter"
+      },
+      {
+        id: 1452,
+        description: "Apportionment - notice to claimant"
+      },
+      {
+        id: 1505,
+        description: "Higher-Level Review (HLR) Not Timely Letter"
+      },
+      {
+        id: 1578,
+        description: "Pension End of Day Letter"
+      }
+    ]
   end
 end

--- a/db/seeds/helpers/queue_helpers.rb
+++ b/db/seeds/helpers/queue_helpers.rb
@@ -29,7 +29,7 @@ module QueueHelpers
       va_date_of_receipt: receipt_date,
       notes: generate_notes([corr_type, receipt_date, user]),
       veteran_id: vet.id,
-      nod: [true, false].sample,
+      nod: doc_type.id == 1250
     )
     create_correspondence_document(correspondence, vet)
 
@@ -65,6 +65,7 @@ module QueueHelpers
       document_type: 1250,
       pages: 30,
       correspondence_id: correspondence.id
+      nod: generate_vbms_doc_type
     )
   end
 

--- a/db/seeds/helpers/queue_helpers.rb
+++ b/db/seeds/helpers/queue_helpers.rb
@@ -29,7 +29,7 @@ module QueueHelpers
       va_date_of_receipt: receipt_date,
       notes: generate_notes([corr_type, receipt_date, user]),
       veteran_id: vet.id,
-      nod: doc_type.id == 1250
+      nod: nod_doc.id
     )
     create_correspondence_document(correspondence, vet)
 

--- a/lib/tasks/correspondence.rake
+++ b/lib/tasks/correspondence.rake
@@ -53,7 +53,7 @@ namespace :correspondence do
         corr_type = CorrespondenceType.all.sample
         receipt_date = rand(1.month.ago..1.day.ago)
 
-        nod = [true, false].sample
+        nod = doc_type.id
 
         doc_type = generate_vbms_doc_type(nod)
 

--- a/lib/tasks/correspondence.rake
+++ b/lib/tasks/correspondence.rake
@@ -53,7 +53,7 @@ namespace :correspondence do
         corr_type = CorrespondenceType.all.sample
         receipt_date = rand(1.month.ago..1.day.ago)
 
-        nod = doc_type.id
+        nod = [true, false].sample
 
         doc_type = generate_vbms_doc_type(nod)
 


### PR DESCRIPTION
Test Plan:

1. log in as *INBOUND_OPS_TEAM_ADMIN_USER*
2. Click on the *Switch user* button
3. Click on *Your Queue*
4. On *Your Cases* page, click on the Switch views dropdown and select *Correspondence cases*
5. On the Correspondence cases page, navigate to the Unassigned tab.
6. Select a NOD correspondence from the list
7. On the review package page, and scroll down to the document section of the page. Notice the document type is *VA form 10182 Notice of Disagreement*
8. Repeat steps 6-8 with a Non-NOD correspondence.