### PR TITLE
Fix nil Series_id for GetDocumentContent

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -103,14 +103,21 @@ class Document < CaseflowRecord
   end
 
   def self.from_vbms_document(vbms_document, file_number)
-    new(type: type_from_vbms_type(vbms_document.doc_type),
-        alt_types: (vbms_document.alt_doc_types || []).map { |type| ALT_TYPES[type] },
-        received_at: vbms_document.received_at,
-        upload_date: vbms_document.upload_date,
-        vbms_document_id: vbms_document.document_id,
-        series_id: vbms_document.series_id,
-        filename: vbms_document.filename,
-        file_number: file_number)
+    document = new(
+      type: type_from_vbms_type(vbms_document.doc_type),
+      alt_types: (vbms_document.alt_doc_types || []).map { |type| ALT_TYPES[type] },
+      received_at: vbms_document.received_at,
+      upload_date: vbms_document.upload_date,
+      vbms_document_id: vbms_document.document_id,
+      filename: vbms_document.filename,
+      file_number: file_number
+    )
+
+    if FeatureToggle.enabled?(:use_ce_api)
+      document.assign_attributes(series_id: vbms_document.series_id)
+    end
+
+    document
   end
 
   def self.type_id(type)

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -108,6 +108,7 @@ class Document < CaseflowRecord
         received_at: vbms_document.received_at,
         upload_date: vbms_document.upload_date,
         vbms_document_id: vbms_document.document_id,
+        series_id: vbms_document.series_id,
         filename: vbms_document.filename,
         file_number: file_number)
   end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -232,6 +232,19 @@ describe Document, :postgres do
         expect(subject.type).to eq("VA Form 20-0995 Supplemental Claim Application")
       end
     end
+
+    context "when use_ce_api Featuretoggle is enabled" do
+      before { FeatureToggle.enable!(:use_ce_api) }
+      let(:vbms_document) do
+        OpenStruct.new(
+          document_id: "1",
+          series_id: "2"
+        )
+      end
+      it "assigns the series_id" do
+        expect(subject.series_id).to eq("2")
+      end
+    end
   end
 
   context "content tests" do


### PR DESCRIPTION
Resolves [46956](https://jira.devops.va.gov/browse/APPEALS-46956)

# Description
Added series_id to initial document fetch from VBMS for instance where we fetching content from documents not created and saved in Caseflow

## Acceptance Criteria
- [x] Code compiles correctly

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added


