### PR TITLE
APPEALS-49845: Hearing CAVC Appeals are not respecting CAVC affinity

### DIFF
--- a/app/models/concerns/distribution_scopes.rb
+++ b/app/models/concerns/distribution_scopes.rb
@@ -122,8 +122,8 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
   end
 
   def tied_to_distribution_judge(judge)
-    with_appeal_affinities
-      .where(hearings: { disposition: "held", judge_id: judge.id })
+    with_appeal_affinities.where(hearings: { disposition: "held", judge_id: judge.id })
+      .or(with_appeal_affinities.where(original_judge_task: { assigned_to_id: judge.id }))
   end
 
   def tied_to_ineligible_judge

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -5,12 +5,12 @@ class HearingRequestDocket < Docket
     Constants.AMA_DOCKETS.hearing
   end
 
-  def ready_priority_appeals
-    appeals(priority: true, ready: true)
+  def ready_priority_appeals(judge: nil)
+    appeals(priority: true, ready: true, judge: judge)
   end
 
-  def ready_nonpriority_appeals
-    appeals(priority: false, ready: true)
+  def ready_nonpriority_appeals(judge: nil)
+    appeals(priority: false, ready: true, judge: judge)
   end
 
   def age_of_n_oldest_genpop_priority_appeals(num)
@@ -23,7 +23,7 @@ class HearingRequestDocket < Docket
   # but the judge that is passed in isn't relevant here
   def age_of_n_oldest_nonpriority_appeals_available_to_judge(judge, num)
     hearing_distribution_query(
-      base_relation: ready_nonpriority_appeals.limit(num), genpop: "only_genpop", judge: judge
+      base_relation: ready_nonpriority_appeals(judge: judge).limit(num), genpop: "only_genpop", judge: judge
     ).call.map(&:receipt_date)
   end
 
@@ -35,7 +35,7 @@ class HearingRequestDocket < Docket
 
   def age_of_n_oldest_priority_appeals_available_to_judge(judge, num)
     hearing_distribution_query(
-      base_relation: ready_priority_appeals.limit(num), genpop: "only_genpop", judge: judge
+      base_relation: ready_priority_appeals(judge: judge).limit(num), genpop: "only_genpop", judge: judge
     ).call.flatten.map(&:receipt_date)
   end
 

--- a/db/seeds/ama_affinity_cases.rb
+++ b/db/seeds/ama_affinity_cases.rb
@@ -15,6 +15,7 @@ module Seeds
       create_priority_affinity_cases
       create_nonpriority_affinity_cases
       create_set_of_affinity_cases
+      create_hearing_docket_cavc_cases
     end
 
     private
@@ -83,10 +84,40 @@ module Seeds
       end
     end
 
+    def create_hearing_docket_cavc_cases
+      judges_with_attorneys.each do |judge|
+        # Case in affinity window for both levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.cavc_affinity_days - 7)
+        # Case with affinity between the two levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days - 7)
+        # Case outside of affinity window for both levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days + 7)
+
+        # Case in affinity window for both levers where new hearing and previous deciding judge are different
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.cavc_affinity_days - 7)
+        # Case with affinity between the two levers where new hearing and previous deciding judge are different
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days - 7)
+        # Case outside of affinity window for both levers where new hearing and previous deciding judge are different\
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days + 7)
+      end
+    end
+
     def judges_with_attorneys
       # use judges with attorneys to minimize how many cases are distributed when testing because the
       # alternative_batch_size is higher than the batch_size for most judge teams
-      @judges_with_attorneys ||= JudgeTeam.all.reject { |jt| jt.attorneys.empty? }.map(&:judge).compact
+      @judges_with_attorneys ||=
+        JudgeTeam.all.reject { |jt| jt.attorneys.empty? }.map(&:judge).compact.filter(&:vacols_attorney_id)
+    end
+
+    def hearing_judge
+      @hearing_judge ||= User.find_by_css_id("HRNG_JUDGE") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "HRNG_JUDGE", full_name: "Judge HeldHearing")
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -341,6 +372,44 @@ module Seeds
       direct_review_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
       evidence_submission_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
       hearing_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
+    end
+
+    def create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge:, hearing_judge:, days_ago:)
+      # Go back to when we want the original appeal to have been decided
+      Timecop.travel(4.years.ago)
+
+      # Create a decided appeal. all tasks are marked complete at the same time which won't affect distribution
+      source = create(:appeal, :dispatched, :hearing_docket, associated_judge: affinity_judge)
+
+      Timecop.travel(1.year.from_now)
+      remand = create(:cavc_remand, source_appeal: source).remand_appeal
+      Timecop.return
+
+      # Travel to 9 mo. ago and then in smaller increments for a more "realistic" looking task tree
+      Timecop.travel(9.months.ago)
+      remand.tasks.where(type: SendCavcRemandProcessedLetterTask.name).map(&:completed!)
+      create(:appeal_affinity, appeal: remand)
+
+      Timecop.travel(1.month.from_now)
+      # Call the creator class which will handle the task manipulation normally done by a distribution
+      jat = JudgeAssignTaskCreator.new(appeal: remand, judge: affinity_judge, assigned_by_id: affinity_judge.id).call
+      # Create and complete a ScheduleHearingColocatedTask, which will create a new DistributionTask and
+      # HearingTask subtree to mimic how this would happen in a higher environment
+      create(:colocated_task, :schedule_hearing, parent: jat, assigned_by: affinity_judge).completed!
+
+      Timecop.travel(1.month.from_now)
+      create(:hearing, :held, appeal: remand, judge: hearing_judge, adding_user: User.system_user)
+
+      Timecop.travel(3.months.from_now)
+      # Completes the remaining open HearingTask descendant tasks to make appeal ready to distribute
+      remand.tasks.where(type: AssignHearingDispositionTask.name).flat_map(&:children).map(&:completed!)
+      Timecop.return
+
+      # When a DistributionTask goes to assigned it clears the affinity start date, so restore that at the right date
+      Timecop.travel(days_ago.days.ago) { remand.appeal_affinity.update!(affinity_start_date: Time.zone.now) }
+
+      # Return the remand appeal to let us track which appeals were created when run from a rails console
+      remand
     end
     # rubocop:enable Metrics/AbcSize
   end

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -96,6 +96,7 @@ module Seeds
       add_mail_intake_to_all_bva_intake_users
       create_and_add_cda_control_group_users
       add_users_to_bva_dispatch
+      create_qa_test_users
 
       # Below originated in the VeteransHealthAdministration seed file
       setup_camo_org

--- a/spec/factories/case_distribution_lever.rb
+++ b/spec/factories/case_distribution_lever.rb
@@ -196,6 +196,32 @@ FactoryBot.define do
       lever_group_order { 3002 }
     end
 
+    trait :cavc_aod_affinity_days do
+      item { "cavc_aod_affinity_days" }
+      title { "CAVC AOD Affinity Days" }
+      description do
+        "Sets the number of days a case returned from CAVC respects the affinity to the judge who authored a decision "\
+        "before distributing the appeal to any available judge. This does not include Legacy CAVC Remand Appeals with "\
+        "a hearing held."
+      end
+      data_type { "radio" }
+      value { "14" }
+      unit { "days" }
+      options do
+        [{ item: "value",
+           data_type: "number",
+           value: 14,
+           text: "Attempt distribution to current judge for max of:",
+           unit: "days",
+           selected: true },
+         { item: "infinite", value: "infinite", text: "Always distribute to current judge" },
+         { item: "omit", value: "omit", text: "Omit variable from distribution rules" }]
+      end
+      algorithms_used { %w[docket proportion] }
+      lever_group { "affinity" }
+      lever_group_order { 3003 }
+    end
+
     trait :ama_hearing_case_aod_affinity_days do
       item { "ama_hearing_case_aod_affinity_days" }
       title { "AMA Hearing Case AOD Affinity Days" }

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -53,12 +53,11 @@ FactoryBot.define do
         create(:hearing_task_association,
                hearing: hearing,
                hearing_task: hearing_task)
-        appeal.tasks.find_by(type: :ScheduleHearingTask).completed!
         assign_hearing_disposition_task = create(:assign_hearing_disposition_task,
-                                                 :completed,
                                                  parent: hearing_task,
                                                  appeal: appeal)
-        appeal.tasks.find_by(type: :DistributionTask).update!(status: :on_hold)
+        appeal.tasks.find_by(type: :ScheduleHearingTask).completed!
+        appeal.tasks.open.where(type: :DistributionTask).last.update!(status: :on_hold)
         assign_hearing_disposition_task.hold!
       end
     end

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -6,7 +6,7 @@ describe Seeds::Users do
 
     it "creates all kinds of users and organizations", :aggregate_failures do
       expect { subject }.to_not raise_error
-      expect(User.count).to eq(138)
+      expect(User.count).to eq(152)
       # This is creating 70 locally and 72 in GHA
       expect(Organization.count >= 70).to be true
       expect(VhaProgramOffice.count).to eq(5)


### PR DESCRIPTION
Resolves [APPEALS-49845](https://jira.devops.va.gov/browse/APPEALS-49845)

# Description
- Passes judge into the distribution related methods on the `HearingRequestDocket` to enable proper filtering of CAVC appeals based on affinities. 
- Modify DistributionScopes to allow a hearing docket CAVC appeal to be distributed to the judge who decided the original appeal, even if they didn't hold the hearing on the remand appeal.
- Add unit tests

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. In a local/demo rails console, run the following commands to seed only the test appeals:

```
RequestStore[:current_user] = User.system_user
Dir[Rails.root.join("db/seeds/*.rb")].sort.each { |f| require f }
Seeds::AmaAffinityCases.new.send(:create_hearing_docket_cavc_cases)
IneligibleJudgesJob.perform_now
```
2. In the UI, login as "BVAGSPORER"
3. Navigate to the judge's assign page and request more cases
4. Verify that the judge is distributed cases where they:
   - Were the original deciding judge and held the new hearing, with the appeal within the CAVC affinity window
   - Were the original deciding judge and did not hold the new hearing, with the appeal outside the CAVC affinity window and within the hearing affinity window
   - Were not the original deciding judge and didn't hold the new hearing, but the appeal was outside of the hearing affinity window
5. Login as "HRNG_JUDGE"
6. Navigate to the judge's assign page and request more cases
7. Verify that the judge is distributed cases where they:
   - Were not the original deciding judge and held the new hearing, with the appeal outside of the CAVC affinity window and within the hearing affinity window
   - Were not the original deciding judge and didn't hold the new hearing, with the appeal outside of the hearing affinity window
8. Login as "QACTVLJNOTM"
9. Navigate to the judge's assign page and request more cases
10. Verify that the judge is only distributed genpop cases (outside of both CAVC and hearing affinity windows)