### PR TITLE
APPEALS-49845: Add seed data

### DIFF
--- a/db/seeds/ama_affinity_cases.rb
+++ b/db/seeds/ama_affinity_cases.rb
@@ -15,6 +15,7 @@ module Seeds
       create_priority_affinity_cases
       create_nonpriority_affinity_cases
       create_set_of_affinity_cases
+      create_hearing_docket_cavc_cases
     end
 
     private
@@ -83,10 +84,40 @@ module Seeds
       end
     end
 
+    def create_hearing_docket_cavc_cases
+      judges_with_attorneys.each do |judge|
+        # Case in affinity window for both levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.cavc_affinity_days - 7)
+        # Case with affinity between the two levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days - 7)
+        # Case outside of affinity window for both levers where new hearing and previous deciding judge are the same
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days + 7)
+
+        # Case in affinity window for both levers where new hearing and previous deciding judge are different
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.cavc_affinity_days - 7)
+        # Case with affinity between the two levers where new hearing and previous deciding judge are different
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days - 7)
+        # Case outside of affinity window for both levers where new hearing and previous deciding judge are different\
+        create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge: judge, hearing_judge: hearing_judge,
+                                                     days_ago:CaseDistributionLever.ama_hearing_case_affinity_days + 7)
+      end
+    end
+
     def judges_with_attorneys
       # use judges with attorneys to minimize how many cases are distributed when testing because the
       # alternative_batch_size is higher than the batch_size for most judge teams
-      @judges_with_attorneys ||= JudgeTeam.all.reject { |jt| jt.attorneys.empty? }.map(&:judge).compact
+      @judges_with_attorneys ||=
+        JudgeTeam.all.reject { |jt| jt.attorneys.empty? }.map(&:judge).compact.filter(&:vacols_attorney_id)
+    end
+
+    def hearing_judge
+      @hearing_judge ||= User.find_by_css_id("HRNG_JUDGE") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "HRNG_JUDGE", full_name: "Judge HeldHearing")
     end
 
     # rubocop:disable Metrics/AbcSize
@@ -341,6 +372,44 @@ module Seeds
       direct_review_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
       evidence_submission_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
       hearing_cavc_remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
+    end
+
+    def create_hearing_cavc_case_ready_at_n_days_ago(affinity_judge:, hearing_judge:, days_ago:)
+      # Go back to when we want the original appeal to have been decided
+      Timecop.travel(4.years.ago)
+
+      # Create a decided appeal. all tasks are marked complete at the same time which won't affect distribution
+      source = create(:appeal, :dispatched, :hearing_docket, associated_judge: affinity_judge)
+
+      Timecop.travel(1.year.from_now)
+      remand = create(:cavc_remand, source_appeal: source).remand_appeal
+      Timecop.return
+
+      # Travel to 9 mo. ago and then in smaller increments for a more "realistic" looking task tree
+      Timecop.travel(9.months.ago)
+      remand.tasks.where(type: SendCavcRemandProcessedLetterTask.name).map(&:completed!)
+      create(:appeal_affinity, appeal: remand)
+
+      Timecop.travel(1.month.from_now)
+      # Call the creator class which will handle the task manipulation normally done by a distribution
+      jat = JudgeAssignTaskCreator.new(appeal: remand, judge: affinity_judge, assigned_by_id: affinity_judge.id).call
+      # Create and complete a ScheduleHearingColocatedTask, which will create a new DistributionTask and
+      # HearingTask subtree to mimic how this would happen in a higher environment
+      create(:colocated_task, :schedule_hearing, parent: jat, assigned_by: affinity_judge).completed!
+
+      Timecop.travel(1.month.from_now)
+      create(:hearing, :held, appeal: remand, judge: hearing_judge, adding_user: User.system_user)
+
+      Timecop.travel(3.months.from_now)
+      # Completes the remaining open HearingTask descendant tasks to make appeal ready to distribute
+      remand.tasks.where(type: AssignHearingDispositionTask.name).flat_map(&:children).map(&:completed!)
+      Timecop.return
+
+      # When a DistributionTask goes to assigned it clears the affinity start date, so restore that at the right date
+      Timecop.travel(days_ago.days.ago) { remand.appeal_affinity.update!(affinity_start_date: Time.zone.now) }
+
+      # Return the remand appeal to let us track which appeals were created when run from a rails console
+      remand
     end
     # rubocop:enable Metrics/AbcSize
   end

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -96,6 +96,7 @@ module Seeds
       add_mail_intake_to_all_bva_intake_users
       create_and_add_cda_control_group_users
       add_users_to_bva_dispatch
+      create_qa_test_users
 
       # Below originated in the VeteransHealthAdministration seed file
       setup_camo_org

--- a/spec/factories/hearing.rb
+++ b/spec/factories/hearing.rb
@@ -53,12 +53,11 @@ FactoryBot.define do
         create(:hearing_task_association,
                hearing: hearing,
                hearing_task: hearing_task)
-        appeal.tasks.find_by(type: :ScheduleHearingTask).completed!
         assign_hearing_disposition_task = create(:assign_hearing_disposition_task,
-                                                 :completed,
                                                  parent: hearing_task,
                                                  appeal: appeal)
-        appeal.tasks.find_by(type: :DistributionTask).update!(status: :on_hold)
+        appeal.tasks.find_by(type: :ScheduleHearingTask).completed!
+        appeal.tasks.open.where(type: :DistributionTask).last.update!(status: :on_hold)
         assign_hearing_disposition_task.hold!
       end
     end

--- a/spec/seeds/users_spec.rb
+++ b/spec/seeds/users_spec.rb
@@ -6,7 +6,7 @@ describe Seeds::Users do
 
     it "creates all kinds of users and organizations", :aggregate_failures do
       expect { subject }.to_not raise_error
-      expect(User.count).to eq(138)
+      expect(User.count).to eq(152)
       # This is creating 70 locally and 72 in GHA
       expect(Organization.count >= 70).to be true
       expect(VhaProgramOffice.count).to eq(5)


### PR DESCRIPTION
# Description
Add seed data to Seeds::AmaAffinityCases for testing the hotfix

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. In a local/demo rails console, run the following commands to seed only the test appeals:

```
RequestStore[:current_user] = User.system_user
Dir[Rails.root.join("db/seeds/*.rb")].sort.each { |f| require f }
Seeds::AmaAffinityCases.new.send(:create_hearing_docket_cavc_cases)
IneligibleJudgesJob.perform_now
```
2. In the UI, login as "BVAGSPORER"
3. Navigate to the judge's assign page and request more cases
4. Verify that the judge is distributed cases where they:
   - Were the original deciding judge and held the new hearing, with the appeal within the CAVC affinity window
   - Were the original deciding judge and did not hold the new hearing, with the appeal outside the CAVC affinity window and within the hearing affinity window
   - Were not the original deciding judge and didn't hold the new hearing, but the appeal was outside of the hearing affinity window
5. Login as "HRNG_JUDGE"
6. Navigate to the judge's assign page and request more cases
7. Verify that the judge is distributed cases where they:
   - Were not the original deciding judge and held the new hearing, with the appeal outside of the CAVC affinity window and within the hearing affinity window
   - Were not the original deciding judge and didn't hold the new hearing, with the appeal outside of the hearing affinity window
8. Login as "QACTVLJNOTM"
9. Navigate to the judge's assign page and request more cases
10. Verify that the judge is only distributed genpop cases (outside of both CAVC and hearing affinity windows)