### PR TITLE
Sivakesh/appeals 48375

### DIFF
--- a/app/controllers/test/correspondence_controller.rb
+++ b/app/controllers/test/correspondence_controller.rb
@@ -3,6 +3,8 @@
 require "rake"
 
 class Test::CorrespondenceController < ApplicationController
+  include RunAsyncable
+
   before_action :verify_access, only: [:index]
   before_action :verify_feature_toggle, only: [:index]
 
@@ -91,9 +93,9 @@ class Test::CorrespondenceController < ApplicationController
     { valid: valid_file_nums, invalid: invalid_file_nums }
   end
 
-  def connect_corr_with_vet(valid_veterans, count)
+  def connect_corr_with_vet(valid_file_nums, count)
     count.times do
-      valid_veterans.each do |file|
+      valid_file_nums.each do |file|
         veteran = Veteran.find_by_file_number(file)
         ActiveRecord::Base.transaction do
           correspondence = Correspondence.create!(
@@ -137,6 +139,6 @@ class Test::CorrespondenceController < ApplicationController
       batch_auto_assignment_attempt_id: batch.id
     }
 
-    perform_now(AutoAssignCorrespondenceJob, job_args)
+    perform_later_or_now(AutoAssignCorrespondenceJob, job_args)
   end
 end

--- a/app/controllers/test/correspondence_controller.rb
+++ b/app/controllers/test/correspondence_controller.rb
@@ -95,81 +95,48 @@ class Test::CorrespondenceController < ApplicationController
     count.times do
       valid_veterans.each do |file|
         veteran = Veteran.find_by_file_number(file)
-        create_correspondence(veteran)
+        ActiveRecord::Base.transaction do
+          correspondence = Correspondence.create!(
+            uuid: SecureRandom.uuid,
+            correspondence_type_id: rand(1..8),
+            va_date_of_receipt: Faker::Date.between(from: 90.days.ago, to: Time.zone.yesterday),
+            notes: "This is a test note",
+            veteran: veteran,
+            nod: rand(2).zero?
+          )
+          rand(1..5).times do
+            doc_type = Caseflow::DocumentTypes::TYPES.keys.sample
+            CorrespondenceDocument.find_or_create_by(
+              document_file_number: veteran.file_number,
+              uuid: SecureRandom.uuid,
+              correspondence_id: correspondence.id,
+              document_type: doc_type,
+              vbms_document_type_id: doc_type,
+              pages: rand(1..30)
+            )
+          end
+          if correspondence.nod?
+            correspondence.correspondence_documents.last.update!(
+              document_type: 1250,
+              vbms_document_type_id: 1250
+            )
+          end
+        end
       end
     end
-  end
 
-  # create correspondence for given veteran
-  def create_correspondence(veteran)
-    vet = veteran
-    corr_type = CorrespondenceType.all.sample
-    receipt_date = rand(1.month.ago..1.day.ago)
-    nod = [true, false].sample
-    doc_type = generate_vbms_doc_type(nod)
 
-    correspondence = ::Correspondence.create!(
-      uuid: SecureRandom.uuid,
-      va_date_of_receipt: receipt_date,
-      notes: "This is a test note",
-      veteran_id: vet.id,
-      nod: nod
+    # Auto Assign Correspondences
+    batch = BatchAutoAssignmentAttempt.create!(
+      user: current_user,
+      status: Constants.CORRESPONDENCE_AUTO_ASSIGNMENT.statuses.started
     )
-    create_correspondence_document(correspondence, vet, doc_type)
-  end
 
-  def generate_vbms_doc_type(nod)
-    return nod_doc if nod
-
-    non_nod_docs.sample
-  end
-
-  # :reek:UtilityFunction
-  def create_correspondence_document(correspondence, veteran, doc_type)
-    CorrespondenceDocument.find_or_create_by!(
-      document_file_number: veteran.file_number,
-      uuid: SecureRandom.uuid,
-      vbms_document_type_id: doc_type[:id],
-      document_type: doc_type[:id],
-      pages: rand(1..30),
-      correspondence_id: correspondence.id
-    )
-  end
-
-  def nod_doc
-    {
-      id: 1250,
-      description: "VA Form 10182, Decision Review Request: Board Appeal (Notice of Disagreement)"
+    job_args = {
+      current_user_id: current_user.id,
+      batch_auto_assignment_attempt_id: batch.id
     }
-  end
 
-  # rubocop:disable Metrics/MethodLength
-  def non_nod_docs
-    [
-      {
-        id: 1419,
-        description: "Reissuance Beneficiary Notification Letter"
-      },
-      {
-        id: 1430,
-        description: "Bank Letter Beneficiary"
-      },
-      {
-        id: 1448,
-        description: "VR-69 Chapter 36 Decision Letter"
-      },
-      {
-        id: 1452,
-        description: "Apportionment - notice to claimant"
-      },
-      {
-        id: 1505,
-        description: "Higher-Level Review (HLR) Not Timely Letter"
-      },
-      {
-        id: 1578,
-        description: "Pension End of Day Letter"
-      }
-    ]
+    perform_now(AutoAssignCorrespondenceJob, job_args)
   end
 end

--- a/app/controllers/test/correspondence_controller.rb
+++ b/app/controllers/test/correspondence_controller.rb
@@ -98,24 +98,9 @@ class Test::CorrespondenceController < ApplicationController
       valid_file_nums.each do |file|
         veteran = Veteran.find_by_file_number(file)
         ActiveRecord::Base.transaction do
-          correspondence = Correspondence.create!(
-            uuid: SecureRandom.uuid,
-            correspondence_type_id: rand(1..8),
-            va_date_of_receipt: Faker::Date.between(from: 90.days.ago, to: Time.zone.yesterday),
-            notes: "This is a test note",
-            veteran: veteran,
-            nod: rand(2).zero?
-          )
+          correspondence = create_correspondence(veteran)
           rand(1..5).times do
-            doc_type = Caseflow::DocumentTypes::TYPES.keys.sample
-            CorrespondenceDocument.find_or_create_by(
-              document_file_number: veteran.file_number,
-              uuid: SecureRandom.uuid,
-              correspondence_id: correspondence.id,
-              document_type: doc_type,
-              vbms_document_type_id: doc_type,
-              pages: rand(1..30)
-            )
+            create_correspondence_document(veteran, correspondence)
           end
           if correspondence.nod?
             correspondence.correspondence_documents.last.update!(
@@ -127,8 +112,33 @@ class Test::CorrespondenceController < ApplicationController
       end
     end
 
+    auto_assign_correspondence
+  end
 
-    # Auto Assign Correspondences
+  def create_correspondence(veteran)
+    Correspondence.create!(
+      uuid: SecureRandom.uuid,
+      correspondence_type_id: rand(1..8),
+      va_date_of_receipt: Faker::Date.between(from: 90.days.ago, to: Time.zone.yesterday),
+      notes: "This is a test note",
+      veteran: veteran,
+      nod: rand(2).zero?
+    )
+  end
+
+  def create_correspondence_document(veteran, correspondence)
+    doc_type = Caseflow::DocumentTypes::TYPES.keys.sample
+    CorrespondenceDocument.find_or_create_by(
+      document_file_number: veteran.file_number,
+      uuid: SecureRandom.uuid,
+      correspondence_id: correspondence.id,
+      document_type: doc_type,
+      vbms_document_type_id: doc_type,
+      pages: rand(1..30)
+    )
+  end
+
+  def auto_assign_correspondence
     batch = BatchAutoAssignmentAttempt.create!(
       user: current_user,
       status: Constants.CORRESPONDENCE_AUTO_ASSIGNMENT.statuses.started

--- a/app/models/correspondence_document.rb
+++ b/app/models/correspondence_document.rb
@@ -37,7 +37,9 @@ class CorrespondenceDocument < CaseflowRecord
 
   def update_correspondence_nod
     documents = correspondence.correspondence_documents
-    nod = documents.any? { |doc| Caseflow::DocumentTypes::TYPES[doc["vbms_document_type_id"]].include?("10182") }
+    nod = documents.any? do |doc|
+      doc["vbms_document_type_id"] && Caseflow::DocumentTypes::TYPES[doc["vbms_document_type_id"]].include?("10182")
+    end
     correspondence.update!(
       nod: nod
     )

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1567,7 +1567,7 @@
   "CORRESPONDENCE_ADMIN": {
     "HEADER": "Correspondence admin",
     "SUB_HEADER": "Correspondence generation process",
-    "DESCRIPTION": "Unassigned correspondence can be created below by entering the veteran file number(s) and the number of correspondence needed. This number of correspondence will appear in the unassigned tab of the Correspondence Team Queue and will be associated to the specific veteran(s) listed below.",
+    "DESCRIPTION": "All generated correspondence will be assigned out using the auto assign algorithm. If any correspondence were not assigned due to users not meeting the rules/permissions, they will be placed in the unassigned tab",
     "COUNT_LABEL": "Enter the number of correspondence to be generated (Value must be between 1 and 40):",
     "SUBMIT_BUTTON_TEXT": "Generate correspondence",
     "INVALID_ERROR": {

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1567,8 +1567,6 @@
   "CORRESPONDENCE_ADMIN": {
     "HEADER": "Correspondence admin",
     "SUB_HEADER": "Correspondence generation process",
-    "AUTO_ASSIGN_HEADER": "Auto assign correspondence",
-    "AUTO_ASSIGN_LABEL": "Process any generated correspondence through the auto assign algorithm and assign out to users (optional)",
     "DESCRIPTION": "Unassigned correspondence can be created below by entering the veteran file number(s) and the number of correspondence needed. This number of correspondence will appear in the unassigned tab of the Correspondence Team Queue and will be associated to the specific veteran(s) listed below.",
     "COUNT_LABEL": "Enter the number of correspondence to be generated (Value must be between 1 and 40):",
     "SUBMIT_BUTTON_TEXT": "Generate correspondence",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1568,7 +1568,7 @@
     "HEADER": "Correspondence admin",
     "SUB_HEADER": "Correspondence generation process",
     "DESCRIPTION": "Unassigned correspondence can be created below by entering the veteran file number(s) and the number of correspondence needed. This number of correspondence will appear in the unassigned tab of the Correspondence Team Queue and will be associated to the specific veteran(s) listed below.",
-    "COUNT_LABEL": "Enter the number of correspondence to be generated:",
+    "COUNT_LABEL": "Enter the number of correspondence to be generated (Value must be between 1 and 40):",
     "SUBMIT_BUTTON_TEXT": "Generate correspondence",
     "INVALID_ERROR": {
       "TITLE": "Invalid file numbers",

--- a/client/COPY.json
+++ b/client/COPY.json
@@ -1567,6 +1567,8 @@
   "CORRESPONDENCE_ADMIN": {
     "HEADER": "Correspondence admin",
     "SUB_HEADER": "Correspondence generation process",
+    "AUTO_ASSIGN_HEADER": "Auto assign correspondence",
+    "AUTO_ASSIGN_LABEL": "Process any generated correspondence through the auto assign algorithm and assign out to users (optional)",
     "DESCRIPTION": "Unassigned correspondence can be created below by entering the veteran file number(s) and the number of correspondence needed. This number of correspondence will appear in the unassigned tab of the Correspondence Team Queue and will be associated to the specific veteran(s) listed below.",
     "COUNT_LABEL": "Enter the number of correspondence to be generated (Value must be between 1 and 40):",
     "SUBMIT_BUTTON_TEXT": "Generate correspondence",

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -1246,6 +1246,9 @@ $color-black: #323a45;
       max-width: 300%;
       margin-bottom: 15px;
     }
+    label {
+      max-width: none;
+    }
   }
   button {
     margin-top: 10px;

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -1250,6 +1250,18 @@ $color-black: #323a45;
       max-width: none;
     }
   }
+
+  .auto-assign-container {
+    h3 {
+      margin: 15px 0;
+    }
+    label {
+      max-width: none;
+      span {
+        margin-left: 10px;
+      }
+    }
+  }
   button {
     margin-top: 10px;
   }

--- a/client/app/test/TestCorrespondence.jsx
+++ b/client/app/test/TestCorrespondence.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from '../components/Button';
 import TextareaField from '../components/TextareaField';
@@ -20,6 +20,7 @@ export default function TestCorrespondence(props) {
   const [invalidFileNumbers, setInvalidFileNumbers] = useState('');
   const [validFileNumbers, setValidFileNumbers] = useState('');
   const [correspondenceSize, setCorrespondenceSize] = useState(0);
+  const [disabled, setDisabled] = useState(true);
 
   const handleVeteranFileNumbers = (inputValue) => {
     // Allow only digits and commas
@@ -70,8 +71,16 @@ export default function TestCorrespondence(props) {
   };
 
   const handleSubmit = () => {
-    generateCorrespondence();
+    generateCorrespondence().then((res) => res);
   };
+
+  useEffect(() => {
+    if (veteranFileNumbers && correspondenceCount > 0) {
+      setDisabled(false);
+    } else {
+      setDisabled(true);
+    }
+  }, [veteranFileNumbers, correspondenceCount]);
 
   return <BrowserRouter>
     <div>
@@ -127,6 +136,7 @@ export default function TestCorrespondence(props) {
             <Button
               name="Generate correspondence"
               onClick={handleSubmit}
+              disabled={disabled}
             />
           </div>
         </AppSegment>

--- a/client/app/test/TestCorrespondence.jsx
+++ b/client/app/test/TestCorrespondence.jsx
@@ -13,7 +13,7 @@ import COPY from '../../COPY';
 import Alert from 'app/components/Alert';
 
 export default function TestCorrespondence(props) {
-  const [correspondenceCount, setCorrespondenceCount] = useState(0);
+  const [correspondenceCount, setCorrespondenceCount] = useState(null);
   const [veteranFileNumbers, setVeteranFileNumbers] = useState('');
   const [showInvalidVeteransBanner, setShowInvalidVeteransBanner] = useState(false);
   const [showSuccessBanner, setShowSuccessBanner] = useState(false);
@@ -36,7 +36,16 @@ export default function TestCorrespondence(props) {
     }
   };
   const handleCorrespondenceCountChange = (value) => {
-    setCorrespondenceCount(value);
+    // setCorrespondenceCount(value === '' ? null : Number(value));
+    if (value === '') {
+      setCorrespondenceCount(null);
+    } else {
+      const num = Number(value);
+
+      if (num >= 1 && num <= 40) {
+        setCorrespondenceCount(num);
+      }
+    }
   };
 
   const generateCorrespondence = async () => {
@@ -62,7 +71,7 @@ export default function TestCorrespondence(props) {
       setShowSuccessBanner(true);
       setCorrespondenceSize(correspondenceCount);
 
-      setCorrespondenceCount(0);
+      setCorrespondenceCount(null);
       setVeteranFileNumbers('');
     } else {
       setValidFileNumbers('');
@@ -129,9 +138,11 @@ export default function TestCorrespondence(props) {
             <NumberField
               name={COPY.CORRESPONDENCE_ADMIN.COUNT_LABEL}
               type="number"
-              value={correspondenceCount}
+              value={correspondenceCount === null ? '' : correspondenceCount}
               onChange={handleCorrespondenceCountChange}
               className={['correspondence-number']}
+              min={1}
+              max={40}
             />
             <Button
               name="Generate correspondence"

--- a/client/app/test/TestCorrespondence.jsx
+++ b/client/app/test/TestCorrespondence.jsx
@@ -11,7 +11,6 @@ import { COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import ApiUtil from '../util/ApiUtil';
 import COPY from '../../COPY';
 import Alert from 'app/components/Alert';
-import Checkbox from 'app/components/Checkbox';
 
 export default function TestCorrespondence(props) {
   const [correspondenceCount, setCorrespondenceCount] = useState(null);
@@ -22,7 +21,6 @@ export default function TestCorrespondence(props) {
   const [validFileNumbers, setValidFileNumbers] = useState('');
   const [correspondenceSize, setCorrespondenceSize] = useState(0);
   const [disabled, setDisabled] = useState(true);
-  const [autoAssign, setAutoAssign] = useState(true);
 
   const handleVeteranFileNumbers = (inputValue) => {
     // Allow only digits and commas
@@ -146,15 +144,6 @@ export default function TestCorrespondence(props) {
               min={1}
               max={40}
             />
-            <div className="auto-assign-container">
-              <h3>{COPY.CORRESPONDENCE_ADMIN.AUTO_ASSIGN_HEADER}</h3>
-              <Checkbox
-                name="autoAssign"
-                label={COPY.CORRESPONDENCE_ADMIN.AUTO_ASSIGN_LABEL}
-                onChange={(val) => setAutoAssign(val)}
-                value={autoAssign}
-              />
-            </div>
             <Button
               name="Generate correspondence"
               onClick={handleSubmit}

--- a/client/app/test/TestCorrespondence.jsx
+++ b/client/app/test/TestCorrespondence.jsx
@@ -11,6 +11,7 @@ import { COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolki
 import ApiUtil from '../util/ApiUtil';
 import COPY from '../../COPY';
 import Alert from 'app/components/Alert';
+import Checkbox from 'app/components/Checkbox';
 
 export default function TestCorrespondence(props) {
   const [correspondenceCount, setCorrespondenceCount] = useState(null);
@@ -21,6 +22,7 @@ export default function TestCorrespondence(props) {
   const [validFileNumbers, setValidFileNumbers] = useState('');
   const [correspondenceSize, setCorrespondenceSize] = useState(0);
   const [disabled, setDisabled] = useState(true);
+  const [autoAssign, setAutoAssign] = useState(true);
 
   const handleVeteranFileNumbers = (inputValue) => {
     // Allow only digits and commas
@@ -144,6 +146,15 @@ export default function TestCorrespondence(props) {
               min={1}
               max={40}
             />
+            <div className="auto-assign-container">
+              <h3>{COPY.CORRESPONDENCE_ADMIN.AUTO_ASSIGN_HEADER}</h3>
+              <Checkbox
+                name="autoAssign"
+                label={COPY.CORRESPONDENCE_ADMIN.AUTO_ASSIGN_LABEL}
+                onChange={(val) => setAutoAssign(val)}
+                value={autoAssign}
+              />
+            </div>
             <Button
               name="Generate correspondence"
               onClick={handleSubmit}

--- a/spec/controllers/test/correspondence_controller_spec.rb
+++ b/spec/controllers/test/correspondence_controller_spec.rb
@@ -157,9 +157,9 @@ describe Test::CorrespondenceController, :postgres, type: :controller do
       end
 
       it "creates correspondences and associated documents for each valid file number" do
-        expect {
+        expect do
           controller.send(:connect_corr_with_vet, valid_file_nums, count)
-        }.to change(Correspondence, :count).by(valid_file_nums.size * count)
+        end.to change(Correspondence, :count).by(valid_file_nums.size * count)
           .and change(CorrespondenceDocument, :count)
 
         valid_veterans.each do |veteran|
@@ -185,9 +185,9 @@ describe Test::CorrespondenceController, :postgres, type: :controller do
       end
 
       it "creates a BatchAutoAssignmentAttempt and enqueues AutoAssignCorrespondenceJob" do
-        expect {
+        expect do
           controller.send(:connect_corr_with_vet, valid_file_nums, count)
-        }.to change(BatchAutoAssignmentAttempt, :count).by(1)
+        end.to change(BatchAutoAssignmentAttempt, :count).by(1)
 
         batch = BatchAutoAssignmentAttempt.last
         expect(batch.user).to eq(user)

--- a/spec/controllers/test/correspondence_controller_spec.rb
+++ b/spec/controllers/test/correspondence_controller_spec.rb
@@ -177,7 +177,7 @@ describe Test::CorrespondenceController, :postgres, type: :controller do
 
         valid_veterans.each do |veteran|
           veteran.reload
-          veteran.correspondences.where(nod: true).each do |correspondence|
+          veteran.correspondences.where(nod: true).find_each do |correspondence|
             expect(correspondence.correspondence_documents.last.document_type).to eq(1250)
             expect(correspondence.correspondence_documents.last.vbms_document_type_id).to eq(1250)
           end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Correspondence Admin Page Restrictions/Enhancements](https://jira.devops.va.gov/browse/APPEALS-48375)

# Description
- `Generate Correspondence button` is greyed out until both textboxes are populated
- Number of correspondence textbox is made blank until the user types in a number
- User is now limited to insert a number between 1-40
- Documents are created and added to each correspondence generated once `Generate Correspondence button` is clicked
- All generated correspondences will go through the auto assignment algorithm, assigning correspondences to users

## Testing Plan

Navigate to the Caseflow Admin page
Switch User to Admin or Bva or Inbound Ops Team Supervisor
Find Correspondence Admin link under Queue Tab, Click the same
And navigate to Correspondence Admin Page
Enter Veteran File Numbers and Count to Generate Correspondence.

- [ ] For feature branches merging into master: Was this deployed to UAT?

# Frontend
## User Facing Changes
![image](https://github.com/department-of-veterans-affairs/caseflow/assets/168677299/6aa7fc76-cd6e-4d6e-9d1b-f37d1a295f02)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [X] RSpec
- [x] Jest

### Error Handling
- [X] Are errors being caught and handled gracefully?
- [X] Are appropriate error messages being displayed to users?
