### PR TITLE
APPEALS-50692: Update Appeals Ready to Distribute CSV to include CAVC remand original judge

### DIFF
--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -206,7 +206,7 @@ class VACOLS::CaseDocket < VACOLS::Record
       order by BFD19
     ) APPEALS
     left join CORRES on APPEALS.BFCORKEY = CORRES.STAFKEY
-    left join STAFF on APPEALS.VLJ = STAFF.STAFKEY
+    left join STAFF on APPEALS.VLJ = STAFF.SATTYID
     order by BFD19
   "
   # rubocop:disable Metrics/MethodLength

--- a/app/queries/appeals_ready_for_distribution.rb
+++ b/app/queries/appeals_ready_for_distribution.rb
@@ -77,16 +77,13 @@ class AppealsReadyForDistribution
   def self.ama_rows(appeals, docket)
     appeals.map do |appeal|
       # This comes from the DistributionTask's assigned_at date
-      ready_for_distribution_at = appeal.tasks
-        .filter { |task| task.class == DistributionTask && task.status == Constants.TASK_STATUSES.assigned }
-        .first&.assigned_at
+      ready_for_distribution_at =
+        DistributionTask.assigned.where(appeal_id: appeal.id, appeal_type: Appeal.name).first&.assigned_at
 
       # only look for hearings that were held
       hearing_judge = appeal.hearings
         .filter { |hearing| hearing.disposition = Constants.HEARING_DISPOSITION_TYPES.held }
         .first&.judge&.full_name
-
-      original_judge = appeal.cavc? ? ama_cavc_original_deciding_judge(appeal) : nil
 
       {
         docket_number: appeal.docket_number,
@@ -96,7 +93,7 @@ class AppealsReadyForDistribution
         receipt_date: appeal.receipt_date,
         ready_for_distribution_at: ready_for_distribution_at,
         hearing_judge: hearing_judge,
-        original_judge: original_judge,
+        original_judge: appeal.cavc? ? ama_cavc_original_deciding_judge(appeal) : nil,
         veteran_file_number: appeal.veteran_file_number,
         veteran_name: appeal.veteran&.name.to_s,
         affinity_start_date: appeal.appeal_affinity&.affinity_start_date

--- a/app/queries/appeals_ready_for_distribution.rb
+++ b/app/queries/appeals_ready_for_distribution.rb
@@ -112,6 +112,7 @@ class AppealsReadyForDistribution
   end
 
   def self.legacy_original_deciding_judge(appeal)
-    VACOLS::Staff.find_by(sattyid: appeal["prev_deciding_judge"]).sdomainid
+    staff = VACOLS::Staff.find_by(sattyid: appeal["prev_deciding_judge"])
+    staff&.sdomainid || appeal["prev_deciding_judge"]
   end
 end

--- a/spec/queries/appeals_ready_for_distribution.rb
+++ b/spec/queries/appeals_ready_for_distribution.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+describe AppealsReadyForDistribution do
+  let(:hearing_judge) { create(:user, :judge, :with_vacols_judge_record) }
+  let(:original_deciding_judge) { create(:user, :judge, :with_vacols_judge_record) }
+
+  context "#process and #ready_appeals" do
+    let!(:not_ready_ama_original_appeal) { create(:appeal, :evidence_submission_docket, :with_post_intake_tasks) }
+    let!(:ama_original_direct_review_appeal) { create(:appeal, :direct_review_docket, :ready_for_distribution) }
+    let!(:ama_original_evidence_submission_appeal) { create(:appeal, :evidence_submission_docket, :ready_for_distribution) }
+    let!(:ama_original_hearing_appeal) do
+      create(:appeal, :hearing_docket, :held_hearing_and_ready_to_distribute, tied_judge: hearing_judge)
+    end
+    let!(:ama_cavc_direct_review_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.direct_review) }
+    let!(:ama_cavc_evidence_submission_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.evidence_submission) }
+    let!(:ama_cavc_hearing_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.hearing) }
+    let!(:not_ready_legacy_original_appeal) { create(:case_with_form_9, :type_original, :travel_board_hearing_requested) }
+    let!(:legacy_original_appeal_no_hearing) { create(:case, :type_original, :ready_for_distribution) }
+    let!(:legacy_original_appeal_with_hearing) do
+      create(:case, :type_original, :ready_for_distribution, case_hearings: [legacy_original_appeal_case_hearing])
+    end
+    let(:legacy_original_appeal_case_hearing) { build(:case_hearing, :disposition_held, user: hearing_judge) }
+    let!(:legacy_cavc_appeal_no_hearing) do
+      original = create(:legacy_cavc_appeal, judge: original_deciding_judge.vacols_staff)
+      VACOLS::Case.find_by(bfcorlid: original.bfcorlid, bfmpro: "ACT")
+    end
+    let!(:legacy_cavc_appeal_with_hearing) do
+      original = create(:legacy_cavc_appeal, judge: original_deciding_judge.vacols_staff)
+      create(:case_hearing, :disposition_held, folder_nr: original.bfkey, user: hearing_judge)
+      VACOLS::Case.find_by(bfcorlid: original.bfcorlid, bfmpro: "ACT")
+    end
+
+    it "selects all ready to distribute appeals for all dockets and generates the CSV" do
+      expect { described_class.process }.not_to raise_error
+      expect(described_class.ready_appeals.size).to eq 10
+    end
+  end
+
+  context "legacy_rows" do
+    let!(:legacy_appeal_with_attributes) do
+      create(:case, :type_original, :aod, :ready_for_distribution, :with_appeal_affinity, case_hearings: [case_hearing])
+    end
+    let(:case_hearing) { build(:case_hearing, :disposition_held, user: hearing_judge) }
+    let(:query_result) { VACOLS::CaseDocket.ready_to_distribute_appeals }
+
+    subject { described_class.legacy_rows(query_result, :legacy).first }
+
+    it "correctly uses attributes to create a hash for the row" do
+      expect(subject[:docket_number]).to eq legacy_appeal_with_attributes.folder.tinum
+      expect(subject[:docket]).to eq "legacy"
+      expect(subject[:aod]).to be true
+      expect(subject[:cavc]).to be false
+      expect(subject[:receipt_date]).to eq legacy_appeal_with_attributes.bfd19
+      expect(subject[:ready_for_distribution_at]).to eq legacy_appeal_with_attributes.bfdloout
+      expect(subject[:hearing_judge]).to eq hearing_judge.full_name
+      expect(subject[:original_judge]).to be nil
+      expect(subject[:veteran_file_number]).to eq legacy_appeal_with_attributes.bfcorlid
+      expect(subject[:veteran_name]).to eq "#{legacy_appeal_with_attributes.correspondent.snamef} #{legacy_appeal_with_attributes.correspondent.snamel}"
+      expect(subject[:affinity_start_date]).to eq legacy_appeal_with_attributes.appeal_affinity.affinity_start_date
+    end
+  end
+
+  context "ama_rows" do
+    let!(:ama_appeal_with_attributes) do
+      create(
+        :appeal,
+        :hearing_docket,
+        :advanced_on_docket_due_to_motion,
+        :held_hearing_and_ready_to_distribute,
+        :with_appeal_affinity,
+        tied_judge: hearing_judge)
+    end
+    let(:query_result) { HearingRequestDocket.new.ready_to_distribute_appeals }
+
+    subject { described_class.ama_rows(query_result, :hearing).first }
+
+    it "correctly uses the attributes to create a hash for the row" do
+      # Reload to update the appeal_affinity record correctly in memory because of eager loading
+      ama_appeal_with_attributes.reload
+
+      expect(subject[:docket_number]).to eq ama_appeal_with_attributes.docket_number
+      expect(subject[:docket]).to eq "hearing"
+      expect(subject[:aod]).to be true
+      expect(subject[:cavc]).to be false
+      expect(subject[:receipt_date]).to eq ama_appeal_with_attributes.receipt_date
+      expect(subject[:ready_for_distribution_at])
+        .to eq ama_appeal_with_attributes.tasks.where(type: DistributionTask.name).first.assigned_at
+      expect(subject[:hearing_judge]).to eq ama_appeal_with_attributes.hearings.first.judge.full_name
+      expect(subject[:original_judge]).to be nil
+      expect(subject[:veteran_file_number]).to eq ama_appeal_with_attributes.veteran_file_number
+      expect(subject[:veteran_name]).to eq ama_appeal_with_attributes.veteran.name.to_s
+      expect(subject[:affinity_start_date]).to eq ama_appeal_with_attributes.appeal_affinity.affinity_start_date
+    end
+  end
+
+  context "ama_cavc_original_deciding_judge" do
+    let!(:appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.direct_review) }
+
+    it "returns the original judge's CSS_ID" do
+      expect(described_class.ama_cavc_original_deciding_judge(appeal)).to eq original_deciding_judge.css_id
+    end
+  end
+
+  context "legacy_original_deciding_judge" do
+    let!(:legacy_appeal) do
+      { "bfkey" => "test_key_pls_ignore", "prev_deciding_judge" => original_deciding_judge.vacols_staff.sattyid }
+    end
+
+    it "returns the original judge's SDOMAINID if present" do
+      expect(described_class.legacy_original_deciding_judge(legacy_appeal)).to eq original_deciding_judge.css_id
+    end
+
+    context "when the original judge has no SDOMAINID" do
+      before { original_deciding_judge.vacols_staff.update!(sdomainid: nil) }
+
+      it "returns the prev_deciding_judge value from the query" do
+        expect(described_class.legacy_original_deciding_judge(legacy_appeal))
+          .to eq legacy_appeal["prev_deciding_judge"]
+      end
+    end
+  end
+
+  def create_realistic_cavc_case(docket)
+    docket_trait = "#{docket}_docket".to_s
+    source = Timecop.travel(1.year.ago) do
+      create(:appeal, docket_trait, :dispatched, associated_judge: original_deciding_judge)
+    end
+    remand = create(:cavc_remand, source_appeal: source)
+    remand.remand_appeal.tasks.where(type: SendCavcRemandProcessedLetterTask.name).first.completed!
+    create(:appeal_affinity, appeal: remand.remand_appeal)
+    remand.remand_appeal
+  end
+end

--- a/spec/queries/appeals_ready_for_distribution.rb
+++ b/spec/queries/appeals_ready_for_distribution.rb
@@ -7,14 +7,20 @@ describe AppealsReadyForDistribution do
   context "#process and #ready_appeals" do
     let!(:not_ready_ama_original_appeal) { create(:appeal, :evidence_submission_docket, :with_post_intake_tasks) }
     let!(:ama_original_direct_review_appeal) { create(:appeal, :direct_review_docket, :ready_for_distribution) }
-    let!(:ama_original_evidence_submission_appeal) { create(:appeal, :evidence_submission_docket, :ready_for_distribution) }
+    let!(:ama_original_evidence_submission_appeal) do
+      create(:appeal, :evidence_submission_docket, :ready_for_distribution)
+    end
     let!(:ama_original_hearing_appeal) do
       create(:appeal, :hearing_docket, :held_hearing_and_ready_to_distribute, tied_judge: hearing_judge)
     end
     let!(:ama_cavc_direct_review_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.direct_review) }
-    let!(:ama_cavc_evidence_submission_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.evidence_submission) }
+    let!(:ama_cavc_evidence_submission_appeal) do
+      create_realistic_cavc_case(Constants.AMA_DOCKETS.evidence_submission)
+    end
     let!(:ama_cavc_hearing_appeal) { create_realistic_cavc_case(Constants.AMA_DOCKETS.hearing) }
-    let!(:not_ready_legacy_original_appeal) { create(:case_with_form_9, :type_original, :travel_board_hearing_requested) }
+    let!(:not_ready_legacy_original_appeal) do
+      create(:case_with_form_9, :type_original, :travel_board_hearing_requested)
+    end
     let!(:legacy_original_appeal_no_hearing) { create(:case, :type_original, :ready_for_distribution) }
     let!(:legacy_original_appeal_with_hearing) do
       create(:case, :type_original, :ready_for_distribution, case_hearings: [legacy_original_appeal_case_hearing])
@@ -46,6 +52,8 @@ describe AppealsReadyForDistribution do
     subject { described_class.legacy_rows(query_result, :legacy).first }
 
     it "correctly uses attributes to create a hash for the row" do
+      corres = legacy_appeal_with_attributes.reload.correspondent
+
       expect(subject[:docket_number]).to eq legacy_appeal_with_attributes.folder.tinum
       expect(subject[:docket]).to eq "legacy"
       expect(subject[:aod]).to be true
@@ -55,7 +63,7 @@ describe AppealsReadyForDistribution do
       expect(subject[:hearing_judge]).to eq hearing_judge.full_name
       expect(subject[:original_judge]).to be nil
       expect(subject[:veteran_file_number]).to eq legacy_appeal_with_attributes.bfcorlid
-      expect(subject[:veteran_name]).to eq "#{legacy_appeal_with_attributes.correspondent.snamef} #{legacy_appeal_with_attributes.correspondent.snamel}"
+      expect(subject[:veteran_name]).to eq "#{corres.snamef} #{corres.snamel}"
       expect(subject[:affinity_start_date]).to eq legacy_appeal_with_attributes.appeal_affinity.affinity_start_date
     end
   end
@@ -68,7 +76,8 @@ describe AppealsReadyForDistribution do
         :advanced_on_docket_due_to_motion,
         :held_hearing_and_ready_to_distribute,
         :with_appeal_affinity,
-        tied_judge: hearing_judge)
+        tied_judge: hearing_judge
+      )
     end
     let(:query_result) { HearingRequestDocket.new.ready_to_distribute_appeals }
 


### PR DESCRIPTION
Resolves [APPEALS-50692](https://jira.devops.va.gov/browse/APPEALS-50692)

# Description
- Add original deciding judge to the AppealsReadyForDistribution query, which adds the column to the generated CSV file on the `/acd-controls/test` page
- Add new test file for AppealsReadyForDistribution to cover each method
- Fix `SELECT_READY_TO_DISTRIBUTE_APPEALS_ORDER_BY_BFD19` query to join the STAFF table on `SATTYID` instead of `STAFKEY` for the hearing VLJ

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
1. In a local/demo environment, seed legacy and AMA CAVC appeals with the files `ama_affinity_cases` and `legacy_affinity_cases`
2. Go to `/acd-controls/test`
3. Download the ready to distribute CSV
4. Verify that the "Original deciding judge" column is present and displays the judge's CSS_ID value

- [ ] For feature branches merging into master: Was this deployed to UAT?
