### PR TITLE
SeanC/APPEALS-50711 | Refactor RSpecs - 2

### DIFF
--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -369,11 +369,10 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "appellant receives email notification" do
-          sleep 5
-
-          hearing = video_appeal.reload.hearings.first
-
-          expect(hearing.email_events.count).to eq 1
+          using_wait_time(5) do
+            hearing = video_appeal.reload.hearings.first
+            expect(hearing.email_events.count).to eq 1
+          end
         end
 
         step "update hearing to have a representative email address" do

--- a/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
+++ b/spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb
@@ -369,10 +369,11 @@ RSpec.feature "Convert hearing request type" do
         end
 
         step "appellant receives email notification" do
-          using_wait_time(5) do
-            hearing = video_appeal.reload.hearings.first
-            expect(hearing.email_events.count).to eq 1
-          end
+          sleep 5
+
+          hearing = video_appeal.reload.hearings.first
+
+          expect(hearing.email_events.count).to eq 1
         end
 
         step "update hearing to have a representative email address" do

--- a/spec/feature/intake/appeal/edit_spec.rb
+++ b/spec/feature/intake/appeal/edit_spec.rb
@@ -1101,8 +1101,6 @@ feature "Appeal Edit issues", :all_dbs do
       expect(withdrawn_issue).to_not be_nil
       expect(withdrawn_issue.closed_at).to eq(1.day.ago.to_date.to_datetime)
 
-      sleep 1
-
       # reload to verify that the new issues populate the form
       visit "appeals/#{appeal.uuid}/edit/"
 

--- a/spec/feature/intake/higher_level_review_spec.rb
+++ b/spec/feature/intake/higher_level_review_spec.rb
@@ -1236,7 +1236,7 @@ feature "Higher-Level Review", :all_dbs do
 
           # should redirect to tasks review page
           expect(page).to have_content("Reviews needing action")
-          expect(page).not_to have_content("It may take up to 24 hours for the claim to establish")
+          expect(page.has_no_content?("It may take up to 24 hours for the claim to establish")).to eq(true)
           expect(current_path).to eq("/decision_reviews/education")
           expect(OrganizationsUser.existing_record(current_user, Organization.find_by(url: "education"))).to_not be_nil
           expect(page).to have_content("Success!")

--- a/spec/feature/queue/cavc_dashboard_spec.rb
+++ b/spec/feature/queue/cavc_dashboard_spec.rb
@@ -73,7 +73,7 @@ RSpec.feature "CAVC Dashboard", :all_dbs do
 
       expect(page).to have_current_path "/queue/appeals/#{cavc_remand.remand_appeal.uuid}"
       click_button "CAVC Dashboard"
-      expect(page).not_to have_content("Abandoned")
+      expect(page.has_no_content?("Abandoned")).to eq(true)
     end
 
     it "cancel modal functions properly when changes have not been saved" do

--- a/spec/feature/queue/search_spec.rb
+++ b/spec/feature/queue/search_spec.rb
@@ -511,7 +511,7 @@ feature "Search", :all_dbs do
         context "when user represents substitute appellant" do
           it "does not short-circuit to the helpful error message" do
             perform_search(other_substitute_appeal.docket_number)
-            expect(page).not_to have_content("You do not have access to this claims file number")
+            expect(page.has_no_content?("You do not have access to this claims file number")).to eq(true)
           end
         end
 
@@ -674,7 +674,7 @@ feature "Search", :all_dbs do
       caseflow_appeal.reload.tasks.update_all(status: Constants.TASK_STATUSES.cancelled)
       perform_search
       expect(page).to have_content("Cancelled")
-      expect(page).not_to have_content("Assigned to you")
+      expect(page.has_no_content?("Assigned to you")).to eq(true)
     end
   end
 end

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -114,7 +114,7 @@ describe BgsPowerOfAttorney do
         end
       end
 
-      it "does not raise an error on unique constraint violation" do
+      it "does not raise an error on unique constraint violation", skip: "Test is flaky" do
         threads = []
         concurrency.times do
           threads << Thread.new do

--- a/spec/models/bgs_power_of_attorney_spec.rb
+++ b/spec/models/bgs_power_of_attorney_spec.rb
@@ -110,12 +110,11 @@ describe BgsPowerOfAttorney do
 
       before do
         allow(BgsPowerOfAttorney).to receive(:fetch_bgs_poa_by_participant_id) do
-          sleep 1
           bgs_record
         end
       end
 
-      it "does not raise an error on unique constraint violation", skip: "Test is flaky" do
+      it "does not raise an error on unique constraint violation" do
         threads = []
         concurrency.times do
           threads << Thread.new do


### PR DESCRIPTION
Resolves [APPEALS-50711: Refactor RSpecs - 2](https://jira.devops.va.gov/browse/APPEALS-50711)

Parent Jira Task: [APPEALS-49006: Optimize Feature tests](https://jira.devops.va.gov/browse/APPEALS-49006)

# Description
Refactored the following lines to not use capybara's `have_content` with an RSpec negative matcher or `sleep`:
- spec/feature/intake/higher_level_review_spec.rb:1239
- spec/feature/intake/appeal/edit_spec.rb:1104
- spec/models/bgs_power_of_attorney_spec.rb:175
- spec/feature/queue/cavc_dashboard_spec.rb:76
- spec/feature/queue/search_spec.rb:514
- spec/feature/queue/search_spec.rb:677

Note: spec/feature/hearings/convert_hearing_request_type/edit_hearsched_spec.rb:372 will be addressed in [this ticket](https://jira.devops.va.gov/browse/APPEALS-50714)

## Acceptance Criteria
- [x] Code compiles correctly
- [x] Tests that were passing before are still passing

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Run the above spec files
