### PR TITLE
APPEALS-51175: Auto Assign Veteran Sensitivity Breaks When a Veteran Has No Sensitivity

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -62,7 +62,10 @@ class ExternalApi::BGSService
       ) do
         response = client.security.find_sensitivity_level_by_participant_id(participant_id)
 
-        response.key?(:scrty_level_type_cd) ? Integer(response[:scrty_level_type_cd]) : 0
+        # guard clause for no response
+        return 0 if response.blank?
+
+        response&.key?(:scrty_level_type_cd) ? Integer(response[:scrty_level_type_cd]) : 0
       rescue BGS::ShareError
         0
       end


### PR DESCRIPTION
Resolves [APPEALS-51175](https://jira.devops.va.gov/browse/APPEALS-51175)

# Description
Added guard clause to **bgs_service.rb#sensitivity_level_for_veteran** that was returning **nil** in UAT. 