### PR TITLE
Revert "APPEALS-51189: Fix error Errno::EISDIR which occurs in testing during Rails.cache.clear"

### DIFF
--- a/spec/support/clear_cache.rb
+++ b/spec/support/clear_cache.rb
@@ -18,7 +18,7 @@ RSpec.configure do |config|
   config.after(:each) do
     Rails.cache.clear
     REDIS_NAMESPACES.each { |namespace| delete_matched(namespace: namespace) }
-  rescue Errno::ENOENT, Errno::ENOTEMPTY, Errno::EISDIR => error
+  rescue Errno::ENOENT, Errno::ENOTEMPTY => error
     # flakey at CircleCI. Don't fail tests because of this.
     Rails.logger.error(error)
   end


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#22114