### PR TITLE
Correspondence CSS Issues - Using Glamor instead of classnames

### DIFF
--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmCorrespondenceView.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmCorrespondenceView.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { css } from 'glamor';
 import PropTypes from 'prop-types';
 import { PencilIcon } from '../../../../../components/icons/PencilIcon';
 import Button from '../../../../../components/Button';
@@ -8,7 +7,6 @@ import CorrespondenceDetailsTable from './CorrespondenceDetailsTable';
 import ConfirmTasksNotRelatedToAnAppeal from './ConfirmTasksNotRelatedToAnAppeal';
 import Table from '../../../../../components/Table';
 import ConfirmTasksRelatedToAnAppeal from './ConfirmTasksRelatedToAnAppeal';
-import { COLORS } from '../../../../../constants/AppConstants';
 import { formatDateStr } from 'app/util/DateUtil';
 
 export const ConfirmCorrespondenceView = (props) => {
@@ -154,8 +152,8 @@ export const ConfirmCorrespondenceView = (props) => {
             </Button>
           </div>
         </div>
-        <div {...css({ backgroundColor: COLORS.GREY_BACKGROUND })}>
-          <div {...css({ backgroundColor: COLORS.GREY_BACKGROUND, paddingTop: '20px', paddingBottom: '20px' })}>
+        <div className="correspondence-letters-table-container" >
+          <div className="correspondence-letters-table">
             <table className="correspondence-response-letters-table">
               <tbody>
                 <tr>

--- a/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
+++ b/client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { css } from 'glamor';
 
 const ConfirmTasksNotRelatedToAnAppeal = () => {
   const tasks = useSelector((state) => state.intakeCorrespondence.unrelatedTasks);
@@ -21,11 +20,7 @@ const ConfirmTasksNotRelatedToAnAppeal = () => {
 
   const renderNonRelatedTask = () => {
     if (tasks.length === 0) {
-      const rendererOfNonRelatedTask = <div {...css({
-        marginBottom: '150px',
-        paddingTop: '10px',
-        fontWeight: 'bold'
-      })}> </div>;
+      const rendererOfNonRelatedTask = <div className="non-related-task"> </div>;
 
       return rendererOfNonRelatedTask;
     }

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
@@ -3,8 +3,6 @@ import TextareaField from '../../../../../components/TextareaField';
 import ReactSelectDropdown from '../../../../../components/ReactSelectDropdown';
 import Checkbox from '../../../../../components/Checkbox';
 import PropTypes from 'prop-types';
-import { css } from 'glamor';
-import { COLORS } from '../../../../../constants/AppConstants';
 
 const AddEvidenceSubmissionTaskView = (props) => {
   const task = props.task;
@@ -43,7 +41,7 @@ const AddEvidenceSubmissionTaskView = (props) => {
             name="content"
             label="Provide context and instruction on this task"
             disabled
-            textAreaStyling={css({ cursor: 'not-allowed', backgroundColor: COLORS.GREY_BACKGROUND })}
+            textAreaStyling={{ style: { cursor: 'not-allowed' } }}
           />
           <Checkbox
             name={`${task.id}`}

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx
@@ -3,7 +3,6 @@ import TextareaField from '../../../../../components/TextareaField';
 import CheckboxModal from '../CheckboxModal';
 import Button from '../../../../../components/Button';
 import Select from 'react-select';
-import { css } from 'glamor';
 import PropTypes from 'prop-types';
 
 const customSelectStyless = {
@@ -62,10 +61,6 @@ const customSelectStyless = {
     }
   })
 };
-const selectContainerStyless = css({
-  width: '100%',
-  display: 'inline-block',
-});
 
 const AddTaskView = (props) => {
   const task = props.task;
@@ -127,7 +122,7 @@ const AddTaskView = (props) => {
           <div className=" task-selection-box-for-new-tasks">
             <div className="task-selection-dropdown-box">
               <div id="reactSelectContainer"
-                {...selectContainerStyless}>
+                className="select-container-styles">
                 <label className="task-selection-title">Task</label>
                 <Select
                   placeholder="Select..."

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -1181,6 +1181,26 @@ $color-bg-hsl-a: hsl(0, 0%, 80%);
   }
 }
 
+.select-container-styles {
+  width: 100%;
+  display: inline-block;
+}
+
+.non-related-task {
+margin-bottom: 150px;
+padding-top: 10px;
+font-weight: bold;
+}
+
+.correspondence-letters-table-container {
+  background-color: $color-gray-inverse-base;
+}
+
+.correspondence-letters-table {
+  padding-top: 20px;
+  padding-bottom: 20px;
+}
+
 .myletters {
   width: 100%;
   display: inline-block;

--- a/client/app/styles/queue/_correspondence.scss
+++ b/client/app/styles/queue/_correspondence.scss
@@ -1187,9 +1187,9 @@ $color-bg-hsl-a: hsl(0, 0%, 80%);
 }
 
 .non-related-task {
-margin-bottom: 150px;
-padding-top: 10px;
-font-weight: bold;
+  margin-bottom: 150px;
+  padding-top: 10px;
+  font-weight: bold;
 }
 
 .correspondence-letters-table-container {


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Correspondence CSS Issues - Using Glamor instead of classnames](https://jira.devops.va.gov/browse/APPEALS-44429)

# Description
This PR removes the use of all glamor objects, and also places all Colors object references so that they use CSS instead, or in the case that components are not compatible with classnames, uses an object to hold the style. The files changed are

1. client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmCorrespondenceView.jsx
2. client/app/queue/correspondence/intake/components/ConfirmCorrespondence/ConfirmTasksNotRelatedToAnAppeal.jsx
3. client/app/queue/correspondence/intake/components/TasksAppeals/AddEvidenceSubmissionTaskView.jsx
4. client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskView.jsx

The ticket also mentions other components to remove glamor from, but they are not using glamor so it's assumed it was removed via changes that this ticket didn't track. AddEvidenceSubmissionView.jsx is the only component that had to use an object instead of class names.

## Acceptance Criteria
- [X] Code compiles correctly
