### PR TITLE
Allow Vet File Update via Claim Evidence API

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git
-  revision: aa3a6f65a68523d8fd6bf887e1f66cd483bea41d
+  revision: 389414d4f2b90adbe97749f874d71af82bfb7e21
   branch: feature/APPEALS-43121-efolder
   specs:
     ruby_claim_evidence_api (0.1.0)
@@ -76,6 +76,7 @@ GIT
       faraday
       faraday-multipart
       httpi
+      rack (< 3)
       railties
       webmock (~> 3.11.0)
 

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -63,7 +63,7 @@ class ExternalApi::VBMSService
 
   def self.update_document_in_vbms(appeal, uploadable_document)
     if FeatureToggle.enabled?(:use_ce_api)
-      file_update_payload = Models::FileUpdatePayload.new(
+      file_update_payload = ClaimEvidenceFileUpdatePayload.new(
         date_va_received_document: Time.zone.now,
         document_type_id: uploadable_document.document_type_id,
         file_content: File.read(uploadable_document.pdf_location),

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -62,9 +62,24 @@ class ExternalApi::VBMSService
   end
 
   def self.update_document_in_vbms(appeal, uploadable_document)
-    @vbms_client ||= init_vbms_client
-    response = initialize_update(appeal, uploadable_document)
-    update_document(appeal.veteran_file_number, response.updated_document_token, uploadable_document.pdf_location)
+    if FeatureToggle.enabled?(:use_ce_api)
+      file_update_payload = Models::FileUpdatePayload.new(
+        date_va_received_document: Time.zone.now,
+        document_type_id: uploadable_document.document_type_id,
+        file_content: File.read(uploadable_document.pdf_location),
+        file_content_source: uploadable_document.source
+      )
+
+      VeteranFileUpdater.update_veteran_file(
+        veteran_file_number: appeal.veteran_file_number,
+        file_uuid: uploadable_document.document_version_reference_id,
+        file_update_payload: file_update_payload
+      )
+    else
+      @vbms_client ||= init_vbms_client
+      response = initialize_update(appeal, uploadable_document)
+      update_document(appeal.veteran_file_number, response.updated_document_token, uploadable_document.pdf_location)
+    end
   end
 
   def self.upload_document_to_vbms(appeal, uploadable_document)

--- a/config/initializers/ruby_claim_evidence_api.rb
+++ b/config/initializers/ruby_claim_evidence_api.rb
@@ -2,3 +2,6 @@
 
 VeteranFileFetcher = ExternalApi::VeteranFileFetcher
   .new(use_canned_api_responses: ApplicationController.dependencies_faked?, logger: Rails.logger)
+
+VeteranFileUpdater = ExternalApi::VeteranFileUpdater
+  .new(use_canned_api_responses: ApplicationController.dependencies_faked?, logger: Rails.logger)

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -80,25 +80,26 @@ describe ExternalApi::VBMSService do
   end
 
   describe ".update_document_in_vbms" do
+    let(:fake_document) do
+      instance_double(
+        UpdateDocumentInVbms,
+        document_type_id: 1,
+        pdf_location: "/path/to/test/location",
+        source: "my_source",
+        document_version_reference_id: "12345"
+      )
+    end
+    let(:appeal) { create(:appeal) }
+
     context "with use_ce_api feature toggle enabled" do
       before { FeatureToggle.enable!(:use_ce_api) }
       after { FeatureToggle.disable!(:use_ce_api) }
 
-      let(:fake_document) do
-        instance_double(
-          UpdateDocumentInVbms,
-          document_type_id: 1,
-          pdf_location: "/path/to/test/location",
-          source: "my_source",
-          document_version_reference_id: "12345"
-        )
-      end
-      let(:appeal) { create(:appeal) }
-      let(:mock_file_update_payload) { instance_double(Models::FileUpdatePayload) }
+      let(:mock_file_update_payload) { instance_double(ClaimEvidenceFileUpdatePayload) }
 
       it "calls the CE API" do
         expect(File).to receive(:read).and_return("pdf byte string")
-        expect(Models::FileUpdatePayload).to receive(:new).and_return(mock_file_update_payload)
+        expect(ClaimEvidenceFileUpdatePayload).to receive(:new).and_return(mock_file_update_payload)
         expect(VeteranFileUpdater)
           .to receive(:update_veteran_file)
           .with(
@@ -106,6 +107,23 @@ describe ExternalApi::VBMSService do
             file_uuid: "12345",
             file_update_payload: mock_file_update_payload
           )
+
+        described.update_document_in_vbms(appeal, fake_document)
+      end
+    end
+
+    context "with use_ce_api feature toggle disabled" do
+      let(:mock_init_update_response) { double(updated_document_token: "12345") }
+
+      it "calls the SOAP API implementation" do
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(described).to receive(:init_vbms_client)
+        expect(described).to receive(:initialize_update).and_return(mock_init_update_response)
+        expect(described).to receive(:update_document).with(
+          appeal.veteran_file_number,
+          "12345",
+          "/path/to/test/location"
+        )
 
         described.update_document_in_vbms(appeal, fake_document)
       end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Migrate: UpdateDocument](https://jira.devops.va.gov/browse/APPEALS-51401)

# Description
Allows Caseflow to use the Claim Evidence API to update veteran documents.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
- Code is currently unused, so only way to test is via specs or the Rails console:
    - Specs: `bundle exec respec spec/services/external_api/vbms_service_spec.rb`
    - CLI:
```ruby
# Do setup
FeatureToggle.enable!(:use_ce_api)
appeals_with_docs = Appeal.all.select{ |a| a.number_of_documents > 0 }
appeal = appeals_with_docs[0]

# Do a call using the VBMS service
uploadable_document = UpdateDocumentInVbms.new(document: appeal.documents.first)
ExternalApi::VBMSService.update_document_in_vbms(appeal, uploadable_document)

# Do a call using the ruby_claim_evidence_api gem directly
file_update_payload = ClaimEvidenceFileUpdatePayload.new(
  date_va_received_document: Time.zone.now,
  document_type_id: uploadable_document.document_type_id,
  file_content: File.read(uploadable_document.pdf_location),
  file_content_source: uploadable_document.source
)
VeteranFileUpdater.update_veteran_file(
  veteran_file_number: appeal.veteran_file_number,
  file_uuid: uploadable_document.document_version_reference_id,
  file_update_payload: file_update_payload
)
```