### PR TITLE
APPEALS-52222: Add seed data file for AOJ remand return feature development

### DIFF
--- a/db/seeds/aoj_remand_return_legacy_appeals.rb
+++ b/db/seeds/aoj_remand_return_legacy_appeals.rb
@@ -21,28 +21,28 @@ module Seeds
       end
     end
 
-    def create_correspondent
-      @ssn += 1
+    def create_correspondent(options = {})
+      @ssn += 1 unless options[:ssn]
 
-      correspondent = VACOLS::Correspondent.find_by(ssn: @ssn) ||
-        create(
-          :correspondent,
-          stafkey: @ssn,
-          ssn: @ssn,
-          susrtyp: "VETERAN",
-          ssalut: nil,
-          snamef: Faker::Name.first_name,
-          snamemi: Faker::Name.initials(number: 1),
-          snamel: Faker::Name.last_name,
-          saddrst1: Faker::Address.street_name,
-          saddrcty: Faker::Address.city,
-          saddrstt: Faker::Address.state_abbr,
-          saddrzip: Faker::Address.zip,
-          staduser: "FAKEUSER",
-          stadtime: 10.years.ago.to_datetime,
-          sdob: 50.years.ago,
-          sgender: Faker::Gender.short_binary_type,
-        )
+      params = {
+        stafkey: @ssn,
+        ssn: @ssn,
+        susrtyp: "VETERAN",
+        ssalut: nil,
+        snamef: Faker::Name.first_name,
+        snamemi: Faker::Name.initials(number: 1),
+        snamel: Faker::Name.last_name,
+        saddrst1: Faker::Address.street_name,
+        saddrcty: Faker::Address.city,
+        saddrstt: Faker::Address.state_abbr,
+        saddrzip: Faker::Address.zip,
+        staduser: "FAKEUSER",
+        stadtime: 10.years.ago.to_datetime,
+        sdob: 50.years.ago,
+        sgender: Faker::Gender.short_binary_type
+      }
+
+      correspondent = VACOLS::Correspondent.find_by(ssn: options[:ssn] || @ssn) || create(:correspondent, params.merge(options))
 
       unless Veteran.find_by(ssn: @ssn)
         create(

--- a/db/seeds/aoj_remand_return_legacy_appeals.rb
+++ b/db/seeds/aoj_remand_return_legacy_appeals.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Seeds
+  class AojRemandReturnLegacyAppeals < Base
+    def initialize
+      RequestStore[:current_user] = User.system_user
+      initialize_ssn
+    end
+
+    def seed!
+      # call new seed methods here
+    end
+
+    private
+
+    def initialize_ssn
+      @ssn ||= 210_000_000
+      # n is (@file_number + 1) because @file_number is incremented before using it in factories in calling methods
+      while VACOLS::Correspondent.find_by(ssn: format("%<n>09d", n: @ssn + 1))
+        @ssn += 1000
+      end
+    end
+
+    def create_correspondent
+      @ssn += 1
+
+      correspondent = VACOLS::Correspondent.find_by(ssn: @ssn) ||
+        create(
+          :correspondent,
+          stafkey: @ssn,
+          ssn: @ssn,
+          susrtyp: "VETERAN",
+          ssalut: nil,
+          snamef: Faker::Name.first_name,
+          snamemi: Faker::Name.initials(number: 1),
+          snamel: Faker::Name.last_name,
+          saddrst1: Faker::Address.street_name,
+          saddrcty: Faker::Address.city,
+          saddrstt: Faker::Address.state_abbr,
+          saddrzip: Faker::Address.zip,
+          staduser: "FAKEUSER",
+          stadtime: 10.years.ago.to_datetime,
+          sdob: 50.years.ago,
+          sgender: Faker::Gender.short_binary_type,
+        )
+
+      unless Veteran.find_by(ssn: @ssn)
+        create(
+          :veteran,
+          first_name: correspondent.snamef,
+          last_name: correspondent.snamel,
+          name_suffix: correspondent.ssalut,
+          ssn: correspondent.ssn,
+          participant_id: correspondent.ssn,
+          file_number: correspondent.ssn
+        )
+      end
+
+      correspondent
+    end
+
+    # add new seed methods below
+  end
+end


### PR DESCRIPTION
Resolves [APPEALS-52222](https://jira.devops.va.gov/browse/APPEALS-52222)

# Description
Added initial seed data file `aoj_remand_return_legacy_appeals.rb` which includes a `create_correspondent` method that creates a correspondent record and associated Caseflow veteran record.

## Acceptance Criteria
- [ ] Code compiles correctly

