### PR TITLE
APPEALS-50870: Add New Factory Trait to VACOLS/ Case for AOJ w/ Previous Appeal

### DIFF
--- a/spec/factories/vacols/case.rb
+++ b/spec/factories/vacols/case.rb
@@ -306,6 +306,94 @@ FactoryBot.define do
                 end
               end
             end
+
+            # judge and attorney should be the VACOLS::Staff records of those users
+            factory :legacy_aoj_appeal do
+              transient do
+                judge { nil }
+                attorney { nil }
+                cavc { false }
+                appeal_affinity { true }
+                affinity_start_date { 2.months.ago }
+                tied_to { true }
+              end
+
+              status_active
+              type_post_remand
+
+              bfdpdcn { 1.month.ago }
+              bfcurloc { "81" }
+
+              after(:create) do |new_case, evaluator|
+                original_judge = evaluator.judge || create(:user, :judge, :with_vacols_judge_record).vacols_staff
+                original_attorney = evaluator.attorney || create(:user, :with_vacols_attorney_record).vacols_staff
+
+                new_case.correspondent.update!(ssn: new_case.bfcorlid.chomp("S")) unless new_case.correspondent.ssn
+
+                veteran = Veteran.find_by_file_number_or_ssn(new_case.correspondent.ssn)
+
+                if veteran
+                  new_case.correspondent.update!(snamef: veteran.first_name, snamel: veteran.last_name)
+                else
+                  create(
+                    :veteran,
+                    first_name: new_case.correspondent.snamef,
+                    last_name: new_case.correspondent.snamel,
+                    name_suffix: new_case.correspondent.ssalut,
+                    ssn: new_case.correspondent.ssn,
+                    file_number: new_case.correspondent.ssn
+                  )
+                end
+
+                original_folder = build(
+                  :folder,
+                  new_case.folder.attributes.except!("ticknum", "tidrecv", "tidcls", "tiaduser",
+                                                     "tiadtime", "tikeywrd", "tiread2", "tioctime", "tiocuser",
+                                                     "tidktime", "tidkuser")
+                )
+
+                original_issues = new_case.case_issues.map do |issue|
+                  build(
+                    :case_issue,
+                    issue.attributes.except("isskey", "issaduser", "issadtime", "issmduser", "issmdtime", "issdcls"),
+                    issdc: "3"
+                  )
+                end
+
+                original_case = create(
+                  :case,
+                  :status_complete,
+                  :disposition_remanded,
+                  bfac: evaluator.cavc ? "7" : "1",
+                  bfcorkey: new_case.bfcorkey,
+                  bfcorlid: new_case.bfcorlid,
+                  bfdnod: new_case.bfdnod,
+                  bfdsoc: new_case.bfdsoc,
+                  bfd19: new_case.bfd19,
+                  bfcurloc: "99",
+                  bfddec: new_case.bfdpdcn,
+                  bfmemid: original_judge.sattyid,
+                  bfattid: original_attorney.sattyid,
+                  folder: original_folder,
+                  correspondent: new_case.correspondent,
+                  case_issues: original_issues
+                )
+
+                if evaluator.tied_to
+                  create(
+                    :case_hearing,
+                    :disposition_held,
+                    folder_nr: original_case.bfkey,
+                    hearing_date: original_case.bfddec - 1.month,
+                    user: User.find_by_css_id(original_judge.sdomainid)
+                  )
+                end
+
+                if evaluator.appeal_affinity
+                  create(:appeal_affinity, appeal: new_case, affinity_start_date: evaluator.affinity_start_date)
+                end
+              end
+            end
           end
         end
       end

--- a/spec/models/vacols/case_spec.rb
+++ b/spec/models/vacols/case_spec.rb
@@ -159,4 +159,120 @@ describe VACOLS::Case, :all_dbs do
       end
     end
   end
+
+  describe "Factory" do
+    describe "legacy_aoj_appeal" do
+      def check_common_assertions(new_case, original_case) # rubocop:disable Metrics/AbcSize
+        expect(original_case.attributes.except!(*not_shared_brieff_attributes))
+          .to eq(new_case.attributes.except!(*not_shared_brieff_attributes))
+        expect(original_folder.attributes.except!(*not_shared_folder_attributes))
+          .to eq(new_folder.attributes.except!(*not_shared_folder_attributes))
+
+        expect(original_case.bfddec).to eq new_case.bfdpdcn
+        expect(original_case.bfmpro).to eq "HIS"
+        expect(original_case.bfcurloc).to eq "99"
+        expect(new_case.bfmpro).to eq "ACT"
+        expect(new_case.bfac).to eq "3"
+        expect(new_case.bfcurloc).to eq "81"
+      end
+
+      let(:params) { {} }
+      let(:traits) { [] }
+      let!(:new_case) { create(:legacy_aoj_appeal, *traits, params) }
+      let!(:original_case) { VACOLS::Case.where(bfcorlid: new_case.bfcorlid).where.not(bfkey: new_case.bfkey).first }
+      let(:new_folder) { new_case.folder }
+      let(:original_folder) { original_case.folder }
+
+      let(:not_shared_brieff_attributes) do
+        %w[bfkey bfmpro bfac bfcurloc bfddec bfdpdcn bfattid bfmemid bfdc bfdrodec bfcallup]
+      end
+      let(:not_shared_folder_attributes) do
+        %w[tidrecv tidcls tiaduser tiadtime tikeywrd tiread2 tioctime tiocuser tidktime tidkuser ticknum]
+      end
+
+      describe "when provided no extra params", :aggregate_failures do
+        it "creates a new and original appeal with correct shared attributes" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(VACOLS::Note.find_by(tsktknm: new_case.bfkey, tskactcd: "B")).to be nil
+          expect(original_case.case_hearings.count).to eq 1
+          expect(new_case.appeal_affinity).to be_truthy
+        end
+      end
+
+      describe "when provided only AOD trait", :aggregate_failures do
+        let(:traits) { [:aod] }
+
+        it "creates a new and original appeal with correct shared attributes" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(VACOLS::Note.find_by(tsktknm: new_case.bfkey, tskactcd: "B")).to be_truthy
+        end
+      end
+
+      describe "when provided only CAVC param", :aggregate_failures do
+        let(:params) { { cavc: true } }
+
+        it "creates a new and original appeal with correct shared attributes" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "7"
+        end
+      end
+
+      describe "when provided AOD trait and CAVC param", :aggregate_failures do
+        let(:traits) { [:aod] }
+        let(:params) { { cavc: true } }
+
+        it "creates a new and original appeal with correct shared attributes" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "7"
+          expect(VACOLS::Note.find_by(tsktknm: new_case.bfkey, tskactcd: "B")).to be_truthy
+        end
+      end
+
+      describe "when tied to is false" do
+        let(:params) { { tied_to: false } }
+
+        it "does not create a hearing on the original case" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(original_case.case_hearings.count).to eq 0
+        end
+      end
+
+      describe "when appeal affinity is false" do
+        let(:params) { { appeal_affinity: false } }
+
+        it "does not create an appeal affinity" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(new_case.appeal_affinity).to be nil
+        end
+      end
+
+      describe "when affinity start date is nil" do
+        let(:params) { { affinity_start_date: nil } }
+
+        it "creates appeal_affinity with nil start date" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(new_case.appeal_affinity.affinity_start_date).to be nil
+        end
+      end
+
+      describe "when a judge and attorney are provided" do
+        let(:params) { { judge: judge, attorney: attorney } }
+        let(:judge) { create(:user, :judge, :with_vacols_judge_record).vacols_staff }
+        let(:attorney) { create(:user, :with_vacols_attorney_record).vacols_staff }
+
+        it "ties the original case/ hearing to the judge and attorney" do
+          check_common_assertions(new_case, original_case)
+          expect(original_case.bfac).to eq "1"
+          expect(original_case.bfattid).to eq attorney.sattyid
+          expect(original_case.bfmemid).to eq judge.sattyid
+          expect(original_case.case_hearings.first.board_member).to eq judge.sattyid
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-50870](https://jira.devops.va.gov/browse/APPEALS-50870)

# Description
Adds the `:legacy_aoj_factory` for creating `VACOLS::Case` records that are the post remand type action (`BFAC = '3'`) which have a previous appeal tied to them via `folder.tinum`, `folder.titrnum`, and the original case `brieff.bfddec` equaling the new case `brieff.bfdpdcn`
Adds tests to `spec/models/vacols/case_spec.rb` for the new factory

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

# Best practices
## Code Documentation Updates
- [ ] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [ ] Jest
- [ ] Other

