### PR TITLE
Update Caseflow to Use Updated CE API Gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GIT
 
 GIT
   remote: https://github.com/department-of-veterans-affairs/ruby_claim_evidence_api.git
-  revision: 389414d4f2b90adbe97749f874d71af82bfb7e21
+  revision: b1201d5ba234b798d1ab5845880aa9059f4fd176
   branch: feature/APPEALS-43121-efolder
   specs:
     ruby_claim_evidence_api (0.1.0)

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -66,7 +66,7 @@ class ExternalApi::VBMSService
       file_update_payload = ClaimEvidenceFileUpdatePayload.new(
         date_va_received_document: Time.zone.now,
         document_type_id: uploadable_document.document_type_id,
-        file_content: File.read(uploadable_document.pdf_location),
+        file_content_path: uploadable_document.pdf_location,
         file_content_source: uploadable_document.source
       )
 

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -98,7 +98,6 @@ describe ExternalApi::VBMSService do
       let(:mock_file_update_payload) { instance_double(ClaimEvidenceFileUpdatePayload) }
 
       it "calls the CE API" do
-        expect(File).to receive(:read).and_return("pdf byte string")
         expect(ClaimEvidenceFileUpdatePayload).to receive(:new).and_return(mock_file_update_payload)
         expect(VeteranFileUpdater)
           .to receive(:update_veteran_file)


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Migrate: UpdateDocument](https://jira.devops.va.gov/browse/APPEALS-51401)

# Description
Allows Caseflow to use the Claim Evidence API to update veteran documents.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
- Code is currently unused, so only way to test is via specs or the Rails console:
    - Specs: `bundle exec respec spec/services/external_api/vbms_service_spec.rb`
    - CLI:
```ruby
# Do setup
FeatureToggle.enable!(:use_ce_api)
RequestStore.store[:current_user] = User.find_by(css_id: "RP_SV_283")

uploaded_doc = VbmsUploadedDocument.last
appeal = uploaded_doc.appeal

# Do a call using the VBMS service
uploadable_document = UpdateDocumentInVbms.new(document: uploaded_doc)
ExternalApi::VBMSService.update_document_in_vbms(appeal, uploadable_document)

# Do a call using the ruby_claim_evidence_api gem directly
file_update_payload = ClaimEvidenceFileUpdatePayload.new(
  date_va_received_document: Time.zone.now,
  document_type_id: uploadable_document.document_type_id,
  file_content_path: uploadable_document.pdf_location,
  file_content_source: uploadable_document.source
)
VeteranFileUpdater.update_veteran_file(
  veteran_file_number: appeal.veteran_file_number,
  file_uuid: uploadable_document.document_version_reference_id,
  file_update_payload: file_update_payload
)
```