### PR TITLE
APPEALS-49005 - Bugfix: Reassign Correspondence Allows Reassignment to Admins

### DIFF
--- a/app/controllers/correspondence_queue_controller.rb
+++ b/app/controllers/correspondence_queue_controller.rb
@@ -37,6 +37,7 @@ class CorrespondenceQueueController < CorrespondenceController
     respond_to do |format|
       format.html do
         @inbound_ops_team_users = User.inbound_ops_team_users.pluck(:css_id)
+        @inbound_ops_team_non_admin = inbound_ops_team_non_admins
         correspondence_team_html_response(inbound_ops_team_user, task_ids, tab)
       end
       format.json { correspondence_team_json_response }
@@ -54,6 +55,11 @@ class CorrespondenceQueueController < CorrespondenceController
     elsif %w[continue_later cancel_intake].include?(action_type)
       intake_cancel_message(action_type)
     end
+  end
+
+  def inbound_ops_team_non_admins
+    all_iot = User.inbound_ops_team_users.reject(&:admin?)
+    all_iot.pluck(:css_id)
   end
 
   def action_type

--- a/app/controllers/correspondence_queue_controller.rb
+++ b/app/controllers/correspondence_queue_controller.rb
@@ -37,7 +37,7 @@ class CorrespondenceQueueController < CorrespondenceController
     respond_to do |format|
       format.html do
         @inbound_ops_team_users = User.inbound_ops_team_users.pluck(:css_id)
-        @inbound_ops_team_non_admin = inbound_ops_team_non_admins
+        @inbound_ops_team_non_admin = User.inbound_ops_team_users.select(&:inbound_ops_team_user?).pluck(:css_id)
         correspondence_team_html_response(inbound_ops_team_user, task_ids, tab)
       end
       format.json { correspondence_team_json_response }
@@ -55,11 +55,6 @@ class CorrespondenceQueueController < CorrespondenceController
     elsif %w[continue_later cancel_intake].include?(action_type)
       intake_cancel_message(action_type)
     end
-  end
-
-  def inbound_ops_team_non_admins
-    all_iot = User.inbound_ops_team_users.reject(&:admin?)
-    all_iot.pluck(:css_id)
   end
 
   def action_type

--- a/app/views/correspondence/correspondence_team.html.erb
+++ b/app/views/correspondence/correspondence_team.html.erb
@@ -15,6 +15,7 @@
     isInboundOpsSupervisor: current_user.inbound_ops_team_supervisor?,
     isInboundOpsSuperuser: current_user.inbound_ops_team_superuser?,
     inboundOpsTeamUsers: @inbound_ops_team_users,
+    inboundOpsTeamNonAdmin: @inbound_ops_team_non_admin,
     responseType: @response_type,
     responseHeader: @response_header,
     responseMessage: @response_message,

--- a/client/app/queue/correspondence/CorrespondenceCases.jsx
+++ b/client/app/queue/correspondence/CorrespondenceCases.jsx
@@ -129,7 +129,7 @@ const CorrespondenceCases = (props) => {
         className = {`cf-margin-left-2rem img reassign ${styles.optSelect}`}
         label="Assign to person"
         onChangeMethod={(val) => setSelectedMailTeamUser(val.value)}
-        options={buildMailUserData(props.inboundOpsTeamUsers)}
+        options={buildMailUserData(props.inboundOpsTeamNonAdmin)}
       />
     </div>);
 
@@ -269,6 +269,7 @@ const CorrespondenceCases = (props) => {
         {config &&
         <CorrespondenceTableBuilder
           inboundOpsTeamUsers={props.inboundOpsTeamUsers}
+          inboundOpsTeamNonAdmin={props.inboundOpsTeamNonAdmin}
           isInboundOpsTeamUser={props.isInboundOpsTeamUser}
           isInboundOpsSuperuser={props.isInboundOpsSuperuser}
           isInboundOpsSupervisor={props.isInboundOpsSupervisor} />}
@@ -321,6 +322,7 @@ CorrespondenceCases.propTypes = {
   currentAction: PropTypes.object,
   configUrl: PropTypes.string,
   inboundOpsTeamUsers: PropTypes.arrayOf(string),
+  inboundOpsTeamNonAdmin: PropTypes.arrayOf(string),
   responseType: PropTypes.string,
   responseHeader: PropTypes.string,
   responseMessage: PropTypes.string,

--- a/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
+++ b/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
@@ -356,7 +356,6 @@ CorrespondenceTableBuilder.propTypes = {
   isVhaOrg: PropTypes.bool,
   featureToggles: PropTypes.object,
   inboundOpsTeamUsers: PropTypes.array,
-  inboundOpsTeamNonAdmin: PropTypes.array,
   selectedTasks: PropTypes.array,
   isInboundOpsTeamUser: PropTypes.bool,
   isInboundOpsSuperuser: PropTypes.bool,

--- a/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
+++ b/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
@@ -356,6 +356,7 @@ CorrespondenceTableBuilder.propTypes = {
   isVhaOrg: PropTypes.bool,
   featureToggles: PropTypes.object,
   inboundOpsTeamUsers: PropTypes.array,
+  inboundOpsTeamNonAdmin: PropTypes.array,
   selectedTasks: PropTypes.array,
   isInboundOpsTeamUser: PropTypes.bool,
   isInboundOpsSuperuser: PropTypes.bool,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-49005 - Reassign Correspondence Allows Reassignment to Admins](https://jira.devops.va.gov/browse/APPEALS-49005)

# Description
Bugfix for Reassign modal on Correspondence Cases page.
-correspondence_queue_controller updated to populate array of non-admin Inbound Ops Team users
-Passed NonAdmin prop through to Reassign modal dropdown

Note: For this bug ticket, CSS updates were not included.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Navigate to Correspondence Cases Page
2. On Action Required tab, find correspondence with Action Type of "Reassign"
3. Click on Link to pop up Modal
4. Select "Approve Request" from radial options
5. Select Dropdown under "Assign to person"
6. Validate that Inbound Ops Team Admin users are no longer populating

# Frontend
## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue
![Screenshot 2024-07-25 at 3 21 53 PM](https://github.com/user-attachments/assets/583cd2e0-1991-4df2-bf0c-bf1f8ec65398)