### PR TITLE
Fix Misc. Issues with Caseflow Vet Doc Updates

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -64,15 +64,17 @@ class ExternalApi::VBMSService
   def self.update_document_in_vbms(appeal, uploadable_document)
     if FeatureToggle.enabled?(:use_ce_api)
       file_update_payload = ClaimEvidenceFileUpdatePayload.new(
-        date_va_received_document: Time.zone.now,
+        date_va_received_document: Time.current.strftime("%Y-%m-%d"),
         document_type_id: uploadable_document.document_type_id,
         file_content_path: uploadable_document.pdf_location,
         file_content_source: uploadable_document.source
       )
 
+      file_uuid = uploadable_document.document_series_reference_id.delete("{}")
+
       VeteranFileUpdater.update_veteran_file(
         veteran_file_number: appeal.veteran_file_number,
-        file_uuid: uploadable_document.document_version_reference_id,
+        file_uuid: file_uuid,
         file_update_payload: file_update_payload
       )
     else

--- a/app/workflows/update_document_in_vbms.rb
+++ b/app/workflows/update_document_in_vbms.rb
@@ -3,7 +3,12 @@
 class UpdateDocumentInVbms
   include VbmsDocumentTransactionConcern
 
-  delegate :document_type, :document_subject, :document_name, :document_version_reference_id, to: :document
+  delegate :document_type,
+           :document_subject,
+           :document_name,
+           :document_version_reference_id,
+           :document_series_reference_id,
+           to: :document
 
   def initialize(document:)
     @document = document

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -86,7 +86,7 @@ describe ExternalApi::VBMSService do
         document_type_id: 1,
         pdf_location: "/path/to/test/location",
         source: "my_source",
-        document_version_reference_id: "12345"
+        document_series_reference_id: "{12345}"
       )
     end
     let(:appeal) { create(:appeal) }
@@ -112,7 +112,7 @@ describe ExternalApi::VBMSService do
     end
 
     context "with use_ce_api feature toggle disabled" do
-      let(:mock_init_update_response) { double(updated_document_token: "12345") }
+      let(:mock_init_update_response) { double(updated_document_token: "document-token") }
 
       it "calls the SOAP API implementation" do
         expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
@@ -120,7 +120,7 @@ describe ExternalApi::VBMSService do
         expect(described).to receive(:initialize_update).and_return(mock_init_update_response)
         expect(described).to receive(:update_document).with(
           appeal.veteran_file_number,
-          "12345",
+          "document-token",
           "/path/to/test/location"
         )
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Migrate: UpdateDocument](https://jira.devops.va.gov/browse/APPEALS-51401)

# Description
- Remove curly brackets around file series IDs and update call to use series ID.
- Correctly format date_va_received_document string.
- Update specs.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
- Code is currently unused, so only way to test is via specs or the Rails console:
    - Specs: `bundle exec respec spec/services/external_api/vbms_service_spec.rb`
    - CLI:
```ruby
# Do setup
FeatureToggle.enable!(:use_ce_api)
RequestStore.store[:current_user] = User.find_by(css_id: "RP_SV_283")

uploaded_doc = VbmsUploadedDocument.last
appeal = uploaded_doc.appeal
uploadable_document = UpdateDocumentInVbms.new(document: uploaded_doc)

# Do a call using the VBMS service
ExternalApi::VBMSService.update_document_in_vbms(appeal, uploadable_document)

# Do a call using the ruby_claim_evidence_api gem directly
file_update_payload = ClaimEvidenceFileUpdatePayload.new(
  date_va_received_document: Time.current.strftime("%Y-%m-%d"),
  document_type_id: uploadable_document.document_type_id,
  file_content_path: uploadable_document.pdf_location,
  file_content_source: uploadable_document.source
)

file_uuid = uploadable_document.document_series_reference_id.delete("{}")

VeteranFileUpdater.update_veteran_file(
  veteran_file_number: appeal.veteran_file_number,
  file_uuid: file_uuid,
  file_update_payload: file_update_payload
)
```