### PR TITLE
APPEALS-52981 - Inbound Ops Team Admins show in Assign and Reassign dropdowns

### DIFF
--- a/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
+++ b/client/app/queue/correspondence/CorrespondenceTableBuilder.jsx
@@ -208,7 +208,7 @@ const CorrespondenceTableBuilder = (props) => {
             <SearchableDropdown
               name="Assign to Inbound Ops Team user"
               hideLabel
-              options={buildMailUserData(props.inboundOpsTeamUsers)}
+              options={buildMailUserData(props.inboundOpsTeamNonAdmin)}
               onChange={handleMailTeamUserChange}
             />
           </div>
@@ -356,7 +356,7 @@ CorrespondenceTableBuilder.propTypes = {
   userCanBulkAssign: PropTypes.bool,
   isVhaOrg: PropTypes.bool,
   featureToggles: PropTypes.object,
-  inboundOpsTeamUsers: PropTypes.array,
+  inboundOpsTeamNonAdmin: PropTypes.array,
   selectedTasks: PropTypes.array,
   isInboundOpsTeamUser: PropTypes.bool,
   isInboundOpsSuperuser: PropTypes.bool,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-52981 - Inbound Ops Team Admins show in Assign and Reassign dropdowns](https://jira.devops.va.gov/browse/APPEALS-52981)

# Description
Additional fix for BulkAssignArea on Unassigned and Assigned (for reassignment) Correspondence Cases dropdowns to use Non-Admin logic instead of including _all_ Inbound Ops Team members.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Navigate to Correspondence Cases page
2. Click on Unassigned tab/Assigned Tab
3. Validate that the users in the dropdown lists no longer have Admin users

# Frontend
## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue
![Screenshot 2024-07-26 at 11 22 27 AM](https://github.com/user-attachments/assets/dcf53848-70be-42b0-967f-33af2bf02f56)
![Screenshot 2024-07-26 at 11 22 42 AM](https://github.com/user-attachments/assets/6f4aadcf-b5c1-4b25-b4f2-9ec190edcef5)