### PR TITLE
APPEALS-42531 - Correspondence Cases: Pending tab: FOIA request link

### DIFF
--- a/app/models/tasks/mail_tasks_not_related_to_appeal/cavc_correspondence_correspondence_task.rb
+++ b/app/models/tasks/mail_tasks_not_related_to_appeal/cavc_correspondence_correspondence_task.rb
@@ -4,4 +4,8 @@ class CavcCorrespondenceCorrespondenceTask < CorrespondenceMailTask
   def label
     COPY::FOIA_REQUEST_MAIL_TASK_LABEL
   end
+
+  def task_url
+    Constants.CORRESPONDENCE_TASK_URL.CORRESPONDENCE_TASK_DETAIL_URL.sub("uuid", correspondence.uuid)
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -736,7 +736,7 @@ ActiveRecord::Schema.define(version: 2024_07_18_184151) do
   end
 
   create_table "correspondences_appeals_tasks", force: :cascade do |t|
-    t.bigint "correspondence_id"
+    t.bigint "correspondence_appeal_id"
     t.datetime "created_at", null: false
     t.bigint "task_id", null: false
     t.datetime "updated_at", null: false
@@ -2461,7 +2461,7 @@ ActiveRecord::Schema.define(version: 2024_07_18_184151) do
   add_foreign_key "correspondence_relations", "correspondences", column: "related_correspondence_id"
   add_foreign_key "correspondences", "correspondence_types"
   add_foreign_key "correspondences", "veterans"
-  add_foreign_key "correspondences_appeals_tasks", "correspondences"
+  add_foreign_key "correspondences_appeals_tasks", "correspondence_appeals"
   add_foreign_key "correspondences_appeals_tasks", "tasks"
   add_foreign_key "dispatch_tasks", "legacy_appeals", column: "appeal_id"
   add_foreign_key "dispatch_tasks", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -736,7 +736,7 @@ ActiveRecord::Schema.define(version: 2024_07_18_184151) do
   end
 
   create_table "correspondences_appeals_tasks", force: :cascade do |t|
-    t.bigint "correspondence_appeal_id"
+    t.bigint "correspondence_id"
     t.datetime "created_at", null: false
     t.bigint "task_id", null: false
     t.datetime "updated_at", null: false
@@ -2461,7 +2461,7 @@ ActiveRecord::Schema.define(version: 2024_07_18_184151) do
   add_foreign_key "correspondence_relations", "correspondences", column: "related_correspondence_id"
   add_foreign_key "correspondences", "correspondence_types"
   add_foreign_key "correspondences", "veterans"
-  add_foreign_key "correspondences_appeals_tasks", "correspondence_appeals"
+  add_foreign_key "correspondences_appeals_tasks", "correspondences"
   add_foreign_key "correspondences_appeals_tasks", "tasks"
   add_foreign_key "dispatch_tasks", "legacy_appeals", column: "appeal_id"
   add_foreign_key "dispatch_tasks", "users"

--- a/spec/models/tasks/correspondence_tasks/cavc_correspondence_correspondence_task_spec.rb
+++ b/spec/models/tasks/correspondence_tasks/cavc_correspondence_correspondence_task_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe CavcCorrespondenceCorrespondenceTask, :postgres do
   let(:user) { create(:user) }
   let(:inbound_ops_team) { InboundOpsTeam.singleton }

--- a/spec/models/tasks/correspondence_tasks/cavc_correspondence_correspondence_task_spec.rb
+++ b/spec/models/tasks/correspondence_tasks/cavc_correspondence_correspondence_task_spec.rb
@@ -1,0 +1,36 @@
+describe CavcCorrespondenceCorrespondenceTask, :postgres do
+  let(:user) { create(:user) }
+  let(:inbound_ops_team) { InboundOpsTeam.singleton }
+  let(:correspondence) { create(:correspondence) }
+
+  before do
+    inbound_ops_team.add_user(user)
+  end
+
+  describe ".create_url" do
+    let(:task) do
+      CavcCorrespondenceCorrespondenceTask.create!(
+        appeal_type: "correspondence",
+        appeal: correspondence,
+        parent_id: correspondence.root_task.id,
+        assigned_to: user
+      )
+    end
+
+    context "FOIA request directs to UUID" do
+      it "routes user to correspondence details page" do
+        expect(task.task_url).to eq(
+          Constants.CORRESPONDENCE_TASK_URL.CORRESPONDENCE_TASK_DETAIL_URL.sub("uuid", correspondence.uuid)
+        )
+      end
+    end
+
+    context "FOIA Request Mail Task Label" do
+      it "displays FOIA label" do
+        expect(task.label).to eq(
+          COPY::FOIA_REQUEST_MAIL_TASK_LABEL
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves [Correspondence Cases: Pending tab: FOIA request link](https://jira.devops.va.gov/browse/APPEALS-42531)

# Description
As an Inbound Ops Team Superuser or Supervisors, I need the ability to access the Correspondence Details page after clicking a correspondence FOIA Request Tasks so that I can view additional information. 

## Acceptance Criteria
- When an Inbound Ops Team Superuser or Supervisor clicks on a Correspondence with a FOIA Request task in the Pending tab on Correspondence Cases queue, they are directed to that correspondence's Details page at /queue/correspondence/:correspondence_uuid