### PR TITLE
Move update_document Feature Flag Logic

### DIFF
--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -62,26 +62,7 @@ class ExternalApi::VBMSService
   end
 
   def self.update_document_in_vbms(appeal, uploadable_document)
-    if FeatureToggle.enabled?(:use_ce_api)
-      file_update_payload = ClaimEvidenceFileUpdatePayload.new(
-        date_va_received_document: Time.current.strftime("%Y-%m-%d"),
-        document_type_id: uploadable_document.document_type_id,
-        file_content_path: uploadable_document.pdf_location,
-        file_content_source: uploadable_document.source
-      )
-
-      file_uuid = uploadable_document.document_series_reference_id.delete("{}")
-
-      VeteranFileUpdater.update_veteran_file(
-        veteran_file_number: appeal.veteran_file_number,
-        file_uuid: file_uuid,
-        file_update_payload: file_update_payload
-      )
-    else
-      @vbms_client ||= init_vbms_client
-      response = initialize_update(appeal, uploadable_document)
-      update_document(appeal.veteran_file_number, response.updated_document_token, uploadable_document.pdf_location)
-    end
+    update_document(appeal, uploadable_document)
   end
 
   def self.upload_document_to_vbms(appeal, uploadable_document)
@@ -148,13 +129,34 @@ class ExternalApi::VBMSService
     send_and_log_request(appeal.veteran_file_number, request)
   end
 
-  def self.update_document(vbms_id, upload_token, filepath)
-    request = VBMS::Requests::UpdateDocument.new(
-      upload_token: upload_token,
-      filepath: filepath
-    )
-    send_and_log_request(vbms_id, request)
+  # rubocop:disable Metrics/MethodLength
+  def self.update_document(appeal, uploadable_document)
+    if FeatureToggle.enabled?(:use_ce_api)
+      file_update_payload = ClaimEvidenceFileUpdatePayload.new(
+        date_va_received_document: Time.current.strftime("%Y-%m-%d"),
+        document_type_id: uploadable_document.document_type_id,
+        file_content_path: uploadable_document.pdf_location,
+        file_content_source: uploadable_document.source
+      )
+
+      file_uuid = uploadable_document.document_series_reference_id.delete("{}")
+
+      VeteranFileUpdater.update_veteran_file(
+        veteran_file_number: appeal.veteran_file_number,
+        file_uuid: file_uuid,
+        file_update_payload: file_update_payload
+      )
+    else
+      @vbms_client ||= init_vbms_client
+      response = initialize_update(appeal, uploadable_document)
+      request = VBMS::Requests::UpdateDocument.new(
+        upload_token: response.updated_document_token,
+        filepath: uploadable_document.pdf_location
+      )
+      send_and_log_request(appeal.veteran_file_number, request)
+    end
   end
+  # rubocop:enable Metrics/MethodLength
 
   def self.clean_document(location)
     File.delete(location)

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -118,11 +118,8 @@ describe ExternalApi::VBMSService do
         expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
         expect(described).to receive(:init_vbms_client)
         expect(described).to receive(:initialize_update).and_return(mock_init_update_response)
-        expect(described).to receive(:update_document).with(
-          appeal.veteran_file_number,
-          "document-token",
-          "/path/to/test/location"
-        )
+        expect(described).to receive(:send_and_log_request)
+          .with(appeal.veteran_file_number, instance_of(VBMS::Requests::UpdateDocument))
 
         described.update_document_in_vbms(appeal, fake_document)
       end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Migrate: UpdateDocument](https://jira.devops.va.gov/browse/APPEALS-51401)

# Description
Move to wrap call to the legacy SOAP request. Previously, the legacy request could still be used if users called update_document directly, but this PR closes that loophole.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
- Code is currently unused, so only way to test is via specs or the Rails console:
    - Specs: `bundle exec rspec spec/services/external_api/vbms_service_spec.rb`
    - CLI:
```ruby
# Do setup
FeatureToggle.enable!(:use_ce_api)
RequestStore.store[:current_user] = User.find_by(css_id: "RP_SV_283")

uploaded_doc = VbmsUploadedDocument.last
appeal = uploaded_doc.appeal
uploadable_document = UpdateDocumentInVbms.new(document: uploaded_doc)

# Do a call using the VBMS service
ExternalApi::VBMSService.update_document_in_vbms(appeal, uploadable_document)

# Do a call using the ruby_claim_evidence_api gem directly
file_update_payload = ClaimEvidenceFileUpdatePayload.new(
  date_va_received_document: Time.current.strftime("%Y-%m-%d"),
  document_type_id: uploadable_document.document_type_id,
  file_content_path: uploadable_document.pdf_location,
  file_content_source: uploadable_document.source
)

file_uuid = uploadable_document.document_series_reference_id.delete("{}")

VeteranFileUpdater.update_veteran_file(
  veteran_file_number: appeal.veteran_file_number,
  file_uuid: file_uuid,
  file_update_payload: file_update_payload
)
```