### PR TITLE
Create rake task to seed UAT-Legacy

### DIFF
--- a/lib/generators/vacols/case.rb
+++ b/lib/generators/vacols/case.rb
@@ -136,7 +136,7 @@ class Generators::Vacols::Case
       Generators::Vacols::CaseIssue.create(case_issue_attrs)
 
       # Default to zero hearings
-      case_hearing_attrs = attrs[:case_hearing_attrs].nil? ? [] : attrs[:case_hearing_attrs]
+      case_hearing_attrs = attrs[:case_hearing_attrs].nil? ? [{}] : attrs[:case_hearing_attrs]
       case_hearing_attrs.each { |hearing| hearing[:folder_nr] = custom_case_attrs[:bfkey] }
       Generators::Vacols::CaseHearing.create(case_hearing_attrs)
 

--- a/lib/tasks/seed_AMA_appeal_hearing.rake
+++ b/lib/tasks/seed_AMA_appeal_hearing.rake
@@ -46,7 +46,7 @@ namespace :db do
 
     list_id.each do |current_id|
       current_appeal = Appeal.where(id: current_id)
-      $stdout.puts("queue/appeal/#{current_appeal[0].uuid}")
+      $stdout.puts("queue/appeals/#{current_appeal[0].uuid}")
     end
   end
 end

--- a/lib/tasks/seed_AMA_appeal_hearing.rake
+++ b/lib/tasks/seed_AMA_appeal_hearing.rake
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-# to create  5 AMA Appeals with hearing type video, run "bundle exec rake 'db:generate_ama_hearing[5, video, user]'""
-# to create  10 AMA Appeals with hearing type virtual, run "bundle exec rake 'db:generate_ama_hearing[10, virtual, user]'""
+# to create 5 AMA Appeals with hearing type video, run "bundle exec rake 'db:generate_ama_hearing[5, video, user]'""
+# to create 5 AMA Appeals with hearing type virtual, run "bundle exec rake 'db:generate_ama_hearing[5, virtual, user]'""
 namespace :db do
   desc "Create a seed data for AMA Appeals with hearing type video and virtual"
   task :generate_ama_hearing, [:number_of_appeals, :hearing_request_type, :user_id] => :environment do |_, args|
     num_appeals = args.number_of_appeals.to_i
-    HEARING_REQUEST_TYPE = args.hearing_request_type.to_s
-    USER_ID = args.user_id
-    RequestStore[:current_user] = User.find_by_css_id(USER_ID)
+    hearing_request = args.hearing_request_type.to_s
+    user_id = args.user_id
+    RequestStore[:current_user] = User.find_by_css_id(user_id)
 
-    def create_ama_appeals(file_number, docket_number)
+    def create_ama_appeals(file_number, docket_number, hearing_request)
       request_issue = RequestIssue.create!(
         decision_review_type: "Appeal",
         nonrating_issue_category: "Unknown Issue Categor",
@@ -19,30 +19,30 @@ namespace :db do
       )
       appeal = Appeal.create!(
         docket_type: "hearing",
-        original_hearing_request_type: HEARING_REQUEST_TYPE,
+        original_hearing_request_type: hearing_request,
         stream_type: "original",
         veteran_file_number: file_number,
         stream_docket_number: docket_number,
         request_issues: [request_issue],
-        receipt_date: 1.months.ago
+        receipt_date: 1.month.ago
       )
 
       InitialTasksFactory.new(appeal).create_root_and_sub_tasks!
       appeal.id
     end
 
-    vets = Veteran.order(Arel.sql('RANDOM()')).first(10)
+    vets = Veteran.order(Arel.sql("RANDOM()")).first(10)
     list_id = []
 
     veterans_file_number = vets[0..10].pluck(:file_number)
     docket_number = 9_000_000
 
-    begin
+    while num_appeals > 0
       num_appeals -= 1
       docket_number += 1
       file_number = veterans_file_number[rand(veterans_file_number.count)]
-      list_id << create_ama_appeals(file_number, docket_number)
-    end while num_appeals > 0
+      list_id << create_ama_appeals(file_number, docket_number, hearing_request)
+    end
 
     list_id.each do |current_id|
       current_appeal = Appeal.where(id: current_id)

--- a/lib/tasks/seed_legacy_hearing.rake
+++ b/lib/tasks/seed_legacy_hearing.rake
@@ -12,7 +12,7 @@ namespace :db do
       # The offset should start at 100 to avoid collisions
       offsets = (100..(100 + number_of_appeals_to_create - 1)).to_a
       # Use a hearings user so the factories don't try to create one (and sometimes fail)
-      user = User.find_by_css_id("BVASYELLOW")
+      user = User.system_user
       # Set this for papertrail when creating vacols_case
       RequestStore[:current_user] = user
 

--- a/lib/tasks/seed_legacy_hearing.rake
+++ b/lib/tasks/seed_legacy_hearing.rake
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+# to create 2 Legacy Appeals with hearing, run "bundle exec rake 'db:generate_legacy_hearing[1]'""
+namespace :db do
+  desc "Create a seed data for Legacy Appeals with hearing type"
+  task :generate_legacy_hearing, [:number_of_appeals] => :environment do |_, args|
+    num_appeals = args.number_of_appeals.to_i
+    vacols_ids = []
+    # RequestStore[:current_user] = User.find_by_css_id("BVASYELLOW")
+
+    def create_legacy_appeals_with_open_schedule_hearing_task(regional_office, number_of_appeals_to_create, vacols_ids)
+      # The offset should start at 100 to avoid collisions
+      offsets = (100..(100 + number_of_appeals_to_create - 1)).to_a
+      # Use a hearings user so the factories don't try to create one (and sometimes fail)
+      user = User.find_by_css_id("BVASYELLOW")
+      # Set this for papertrail when creating vacols_case
+      RequestStore[:current_user] = user
+
+      offsets.each do |offset|
+        docket_number = "160000#{offset}"
+        # next unless VACOLS::Folder.find_by(tinum: docket_number).nil?
+
+        # Create the veteran for this legacy appeal
+        vets = []
+        (1..10).each do |_|
+          vets << Veteran.find(Random.new.rand(1..Veteran.count))
+        end
+
+        veterans_file_number = vets[0..10].pluck(:file_number)
+        vacols_titrnum = veterans_file_number[rand(veterans_file_number.count)]
+
+        # Create some video and some travel hearings
+        type = offset.even? ? "travel" : "video"
+
+        # Create the folder, case, and appeal, there's a lot of retry logic in here
+        # because the way FactoryBot sequences work isn't quite right for this case
+        legacy_appeal = create_vacols_entries(vacols_titrnum, docket_number, regional_office, type)
+        vacols_ids << legacy_appeal.vacols_id
+
+        # Create the task tree, need to create each task like this to avoid user creation and index conflicts
+        create_open_schedule_hearing_task_for_legacy(legacy_appeal, user)
+      end
+    end
+
+    def create_video_vacols_case(vacols_titrnum, vacols_folder, correspondent)
+      FactoryBot.create(
+        :case,
+        :video_hearing_requested,
+        :type_original,
+        correspondent: correspondent,
+        bfcorlid: vacols_titrnum,
+        bfcurloc: "CASEFLOW",
+        folder: vacols_folder
+      )
+    end
+
+    def create_travel_vacols_case(vacols_titrnum, vacols_folder, correspondent)
+      FactoryBot.create(
+        :case,
+        :travel_board_hearing_requested,
+        :type_original,
+        correspondent: correspondent,
+        bfcorlid: vacols_titrnum,
+        bfcurloc: "CASEFLOW",
+        folder: vacols_folder
+      )
+    end
+
+    def create_vacols_entries(vacols_titrnum, docket_number, regional_office, type)
+      # We need these retries because the sequence for FactoryBot comes out of
+      # sync with what's in the DB. This just essentially updates the FactoryBot
+      # sequence to match what's in the DB.
+      # Note: Because the sequences in FactoryBot are global, these retrys won't happen
+      # every time you call this, probably only the first time.
+      retry_max = 100
+
+      # Create the vacols_folder
+      begin
+        retries ||= 0
+        vacols_folder = FactoryBot.create(:folder, tinum: docket_number, titrnum: vacols_titrnum)
+      rescue ActiveRecord::RecordNotUnique
+        retry if (retries += 1) < retry_max
+      end
+
+      # Create the correspondent (where the name in the UI comes from)
+      begin
+        retries ||= 0
+        correspondent = FactoryBot.create(
+          :correspondent,
+          snamef: Faker::Name.first_name,
+          snamel: Faker::Name.last_name,
+          ssalut: ""
+        )
+      rescue ActiveRecord::RecordNotUnique
+        retry if (retries += 1) < retry_max
+      end
+
+      # Create the vacols_case
+      begin
+        retries ||= 0
+        if type == "video"
+          vacols_case = create_video_vacols_case(vacols_titrnum, vacols_folder, correspondent)
+        end
+        if type == "travel"
+          vacols_case = create_travel_vacols_case(vacols_titrnum, vacols_folder, correspondent)
+        end
+      rescue ActiveRecord::RecordNotUnique
+        retry if (retries += 1) < retry_max
+      end
+
+      # Create the legacy_appeal, this doesn't fail with index problems, so no need to retry
+      legacy_appeal = FactoryBot.create(
+        :legacy_appeal,
+        vacols_case: vacols_case,
+        closest_regional_office: regional_office
+      )
+      FactoryBot.create(:available_hearing_locations, regional_office, appeal: legacy_appeal)
+
+      # Return the legacy_appeal
+      legacy_appeal
+    end
+
+    def create_open_schedule_hearing_task_for_legacy(legacy_appeal, user)
+      root_task = RootTask.create!(appeal: legacy_appeal)
+      distribution_task = DistributionTask.create!(
+        appeal: legacy_appeal,
+        parent: root_task
+      )
+      parent_hearing_task = HearingTask.create!(
+        assigned_by: user,
+        assigned_to: user,
+        parent: distribution_task,
+        appeal: legacy_appeal
+      )
+      # ScheduleHearingTask.create!(appeal: appeal, parent: root_task)
+      FactoryBot.create(
+        :schedule_hearing_task,
+        :in_progress,
+        assigned_to: user,
+        assigned_by: user,
+        parent: parent_hearing_task,
+        appeal: legacy_appeal
+      )
+    end
+
+    %w[RO17 RO21 RO26 RO27 RO40 RO45 RO46 RO47 RO55 RO58 RO59 RO63 RO62 RO49 RO38].each do |regional_office|
+      create_legacy_appeals_with_open_schedule_hearing_task(regional_office, num_appeals, vacols_ids)
+    end
+
+    vacols_ids.each do |current_id|
+      $stdout.puts("queue/appeals/#{current_id}")
+    end
+  end
+end

--- a/lib/tasks/seed_legacy_hearing.rake
+++ b/lib/tasks/seed_legacy_hearing.rake
@@ -15,7 +15,6 @@ namespace :db do
 
       offsets.each do |offset|
         docket_number = "160000#{offset}"
-        # next unless VACOLS::Folder.find_by(tinum: docket_number).nil?
 
         # Create the veteran for this legacy appeal
         vets = Veteran.order(Arel.sql("RANDOM()")).first(10)

--- a/lib/tasks/seed_legacy_hearing.rake
+++ b/lib/tasks/seed_legacy_hearing.rake
@@ -7,6 +7,8 @@ namespace :db do
   task :generate_legacy_hearing, [:number_of_appeals] => :environment do |_, args|
     num_appeals = args.number_of_appeals.to_i
     legacy_ids = []
+    user = User.system_user
+    RequestStore[:current_user] = user
 
     def create_legacy_appeals_with_open_schedule_hearing_task(regional_office, number_of_appeals_to_create, legacy_ids)
       offsets = (100..(100 + number_of_appeals_to_create - 1)).to_a
@@ -16,10 +18,7 @@ namespace :db do
         # next unless VACOLS::Folder.find_by(tinum: docket_number).nil?
 
         # Create the veteran for this legacy appeal
-        vets = []
-        (1..10).each do |_|
-          vets << Veteran.find(Random.new.rand(1..Veteran.count))
-        end
+        vets = Veteran.order(Arel.sql("RANDOM()")).first(10)
 
         veterans_file_number = vets[0..10].pluck(:file_number)
         vacols_titrnum = veterans_file_number[rand(veterans_file_number.count)]
@@ -72,9 +71,6 @@ namespace :db do
     end
 
     def build_the_cases_in_caseflow(cases)
-      user = User.system_user
-      RequestStore[:current_user] = user
-
       vacols_ids = cases.map(&:bfkey)
       issues = VACOLS::CaseIssue.where(isskey: vacols_ids).group_by(&:isskey)
 
@@ -119,7 +115,7 @@ namespace :db do
       type = docket_number.to_i.even? ? "T" : "V"
 
       cases = Array.new(num_appeals_to_create).each_with_index.map do |_element|
-        key = VACOLS::Folder.maximum(:ticknum).next
+        key = VACOLS::Case.pluck(:bfkey).map(&:to_i).max + 1
         Generators::Vacols::Case.create(
           corres_exists: true,
           folder_attrs: Generators::Vacols::Folder.folder_attrs.merge(
@@ -135,7 +131,7 @@ namespace :db do
       legacy_ids << legacy_appeal[0].vacols_id
     end
 
-    %w[RO17].each do |regional_office|
+    %w[RO17 RO21 RO26 RO27 RO40 RO45 RO46 RO47 RO55 RO58 RO59 RO63 RO62 RO49 RO38].each do |regional_office|
       create_legacy_appeals_with_open_schedule_hearing_task(regional_office, num_appeals, legacy_ids)
     end
 

--- a/lib/tasks/seed_legacy_hearing.rake
+++ b/lib/tasks/seed_legacy_hearing.rake
@@ -79,7 +79,7 @@ namespace :db do
           appeal.issues = (issues[appeal.vacols_id] || []).map { |issue| Issue.load_from_vacols(issue.attributes) }
         end.save!
         legacy_appeal = LegacyAppeal.last
-        create_open_schedule_hearing_task_for_legacy(legacy_appeal, user)
+        create_open_schedule_hearing_task_for_legacy(legacy_appeal, RequestStore[:current_user])
         legacy_appeal
       end
     end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-53016](https://jira.devops.va.gov/browse/APPEALS-53016)

# Description
As a Caseflow developer, I need to create a rake task to seed UAT with Legacy appeals of hearing type (Video and Virtual), so that it will generate appeals to schedule a veteran. 
1- Generate seed script for Legacy appeals with hearing types
  - Video
  - Travel

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
To create 1 Legacy Appeal for each regional office, run bundle exec rake 'db:generate_legacy_hearing[1], to create more than one pass the number in `generate_legacy_hearing[]`

The script is going to return the path of the appeals, copy the link from the terminal, and paste it in the browser, see in the UI.

![image](https://github.com/user-attachments/assets/3c8c5202-3cb8-496b-a44b-9887ddf9d3a5)




