### PR TITLE
Piedram/appeals 52730 v2

### DIFF
--- a/lib/tasks/seed_AMA_appeal_hearing.rake
+++ b/lib/tasks/seed_AMA_appeal_hearing.rake
@@ -13,7 +13,6 @@ namespace :db do
     def create_ama_appeals(file_number, docket_number)
       request_issue = RequestIssue.create!(
         decision_review_type: "Appeal",
-        # decision_review: appeal,
         nonrating_issue_category: "Unknown Issue Categor",
         type: "RequestIssue", benefit_type: "compensation",
         nonrating_issue_description: "testing"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-52730](https://jira.devops.va.gov/browse/APPEALS-52730)

# Description
As a Caseflow developer, I need to create a rake task to seed UAT with AMA appeals of hearing type (Video and Virtual), so that it will generate appeals to schedule a veteran.

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
Fix the Hearing location dropdown, when create an AMA hearing appeals using the script for UAT

![image](https://github.com/user-attachments/assets/2f3eca72-eaf2-49d8-b474-7bdd9ce73f13)

