### PR TITLE
Revert "Appeals-53208: Inbound Ops Task Override in Task model instead of Mail Task model"

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -185,6 +185,9 @@ class Task < CaseflowRecord
     end
 
     def verify_user_can_create!(user, parent)
+      # guard clause to allow InboundOpsTeam members to create mail/appeal tasks within Correspondence Intake
+      return true if InboundOpsTeam.singleton.user_has_access?(user)
+
       can_create = parent&.available_actions(user)&.map do |action|
         parent.build_action_hash(action, user)
       end&.any? do |action|

--- a/app/models/tasks/mail_task.rb
+++ b/app/models/tasks/mail_task.rb
@@ -60,12 +60,6 @@ class MailTask < Task
       parent_task
     end
 
-    def verify_user_can_create!(user, parent)
-      return true if InboundOpsTeam.singleton.user_has_access?(user)
-
-      super(user, parent)
-    end
-
     def create_from_params(params, user)
       parent_task = Task.find(params[:parent_id])
 


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#22376