### PR TITLE
Create a Rails Migration to Add a 'scheduled_datetime' 

### DIFF
--- a/db/migrate/20240805162358_add_scheduled_datetime_to_hearings.rb
+++ b/db/migrate/20240805162358_add_scheduled_datetime_to_hearings.rb
@@ -1,7 +1,7 @@
 class AddScheduledDatetimeToHearings < ActiveRecord::Migration[6.0]
   def up
     safety_assured do
-      add_column :hearings, :scheduled_datetime, :timestamptz, null: true, comment: "Date and time a hearing is scheduled to take place in UTC"
+      add_column :hearings, :scheduled_datetime, :timestamptz, null: true, comment: "Timestamp with zone datatype a hearing is scheduled to take place in UTC. Intended to eventually replace scheduled_time column."
     end
   end
 

--- a/db/migrate/20240805162358_add_scheduled_datetime_to_hearings.rb
+++ b/db/migrate/20240805162358_add_scheduled_datetime_to_hearings.rb
@@ -1,0 +1,13 @@
+class AddScheduledDatetimeToHearings < ActiveRecord::Migration[6.0]
+  def up
+    safety_assured do
+      add_column :hearings, :scheduled_datetime, :timestamptz, null: true, comment: "Date and time a hearing is scheduled to take place in UTC"
+    end
+  end
+
+  def down
+    safety_assured do
+      remove_column :hearings, :scheduled_datetime
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1071,7 +1071,7 @@ ActiveRecord::Schema.define(version: 2024_08_05_162358) do
     t.boolean "prepped", comment: "Determines whether the judge has checked the hearing as prepped"
     t.string "representative_name", comment: "Name of Appellant's representative if applicable"
     t.string "room", comment: "The room at BVA where the hearing will take place; ported from associated HearingDay"
-    t.datetime "scheduled_datetime", comment: "Date and time a hearing is scheduled to take place in UTC"
+    t.datetime "scheduled_datetime", comment: "Timestamp with zone datatype a hearing is scheduled to take place in UTC. Intended to eventually replace scheduled_time column."
     t.string "scheduled_in_timezone", comment: "Named TZ string that the hearing will have to provide accurate hearing times."
     t.time "scheduled_time", null: false, comment: "Date and Time when hearing will take place"
     t.text "summary", comment: "Summary of hearing"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_06_13_202232) do
+ActiveRecord::Schema.define(version: 2024_08_05_162358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -1071,6 +1071,7 @@ ActiveRecord::Schema.define(version: 2024_06_13_202232) do
     t.boolean "prepped", comment: "Determines whether the judge has checked the hearing as prepped"
     t.string "representative_name", comment: "Name of Appellant's representative if applicable"
     t.string "room", comment: "The room at BVA where the hearing will take place; ported from associated HearingDay"
+    t.datetime "scheduled_datetime", comment: "Date and time a hearing is scheduled to take place in UTC"
     t.string "scheduled_in_timezone", comment: "Named TZ string that the hearing will have to provide accurate hearing times."
     t.time "scheduled_time", null: false, comment: "Date and Time when hearing will take place"
     t.text "summary", comment: "Summary of hearing"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-53507](https://jira.devops.va.gov/browse/APPEALS-53507)

# Description
As a Hearings Division user, I need to be able to view AMA hearings times accurately so that I can appropriately manage our dockets and operations.

As a BAC Program Analyst, I need information about AMA hearing times to be stored in such a way that our reporting tools can correctly obtain and display the times for each of the hearings so that I can provide reports and recommendations to the Hearings Division about their operations.

A Rails migration is generated that targets our primary Postgres database that performs the following schema updates:
- up
  Adds a new column named scheduled_datetime to the hearings table with the following attributes:
    type: timestamptz
    null: true
    comment: Something that describes how this column will be utilized to store hearing datetimes.
- down
 Drops/removes the scheduled_datetime column from the hearings table if the need for the migration to be rolled back arises.

## Acceptance Criteria
- [X] Code compiles correctly
