### PR TITLE
APPEALS-53603: Modify logic to always show recipient information if present

### DIFF
--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+  import React from 'react';
 import COPY from '../../../COPY';
 import NOTIFICATION_CONFIG from '../../../constants/NOTIFICATION_CONFIG';
 import EVENT_TYPE_FILTERS from '../../../constants/EVENT_TYPE_FILTERS';
@@ -81,7 +81,7 @@ export const recipientInformationColumn = (notifications) => {
     tableData: notifications,
     valueName: 'Recipient Information',
     // eslint-disable-next-line no-negated-condition
-    valueFunction: (notification) => notification.status !== 'delivered' ? '—' : notification.recipient_information
+    valueFunction: (notification) => notification.recipient_information ?? '-'
   };
 };
 

--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -1,4 +1,4 @@
-  import React from 'react';
+import React from 'react';
 import COPY from '../../../COPY';
 import NOTIFICATION_CONFIG from '../../../constants/NOTIFICATION_CONFIG';
 import EVENT_TYPE_FILTERS from '../../../constants/EVENT_TYPE_FILTERS';

--- a/client/app/queue/components/NotificationTableColumns.jsx
+++ b/client/app/queue/components/NotificationTableColumns.jsx
@@ -81,7 +81,7 @@ export const recipientInformationColumn = (notifications) => {
     tableData: notifications,
     valueName: 'Recipient Information',
     // eslint-disable-next-line no-negated-condition
-    valueFunction: (notification) => notification.recipient_information ?? '-'
+    valueFunction: (notification) => notification.recipient_information ?? '—'
   };
 };
 

--- a/client/test/app/queue/NotificationTable.test.js
+++ b/client/test/app/queue/NotificationTable.test.js
@@ -64,13 +64,6 @@ describe('NotificationTable', () => {
     expect(row[7].textContent).toBe('Text');
   });
 
-  it('first recipient information row should be a dashed line', async () => {
-    setup();
-    const row = await screen.findAllByRole('gridcell');
-
-    expect(row[3].textContent).toBe('—');
-  });
-
   it('second recipient information row should be a phone number', async () => {
     setup();
     const row = await screen.findAllByRole('gridcell');

--- a/client/test/app/queue/NotificationTable.test.js
+++ b/client/test/app/queue/NotificationTable.test.js
@@ -68,7 +68,7 @@ describe('NotificationTable', () => {
     setup();
     const row = await screen.findAllByRole('gridcell');
 
-    expect(row[3].textContent).toBe('-');
+    expect(row[3].textContent).toBe('—');
   });
 
   it('second recipient information row should be a phone number', async () => {

--- a/client/test/app/queue/NotificationTable.test.js
+++ b/client/test/app/queue/NotificationTable.test.js
@@ -64,6 +64,13 @@ describe('NotificationTable', () => {
     expect(row[7].textContent).toBe('Text');
   });
 
+  it('first recipient information row should be a dashed line', async () => {
+    setup();
+    const row = await screen.findAllByRole('gridcell');
+
+    expect(row[3].textContent).toBe('-');
+  });
+
   it('second recipient information row should be a phone number', async () => {
     setup();
     const row = await screen.findAllByRole('gridcell');

--- a/client/test/data/notifications.js
+++ b/client/test/data/notifications.js
@@ -118,9 +118,9 @@ export const notifications = [
       notification_type: 'Email and SMS',
       event_date: '2022-10-27',
       event_type: 'Appeal decision mailed (Non-contested claims)',
-      recipient_email: 'test@caseflow.com',
+      recipient_email: null,
       recipient_phone_number: '2468012345',
-      email_notification_status: 'sent',
+      email_notification_status: 'temporary-failure',
       sms_notification_status: 'delivered',
       notification_content: 'string'
     }


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Modify logic to always show recipient information if present](https://jira.devops.va.gov/browse/APPEALS-53603)

# Description
Please explain the changes you made here.
The logic in NotificationTableColumns.jsx is modified to show recipient information if it is present in the database.
The recipientInformationColumn valueFunction no longer relies on notification status when determining whether to show the recipient information or a dash.
See implementation note for suggestion.

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to https://jira.devops.va.gov/browse/APPEALS-53933

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [x] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
