### PR TITLE
Revert "hotfix/APPEALS-42701: Hearings: Incorrect date is displayed which should match the hearing details when Hovering Over Hearing Badge in Judge Queue"

### DIFF
--- a/client/app/components/badges/HearingBadge/HearingBadge.jsx
+++ b/client/app/components/badges/HearingBadge/HearingBadge.jsx
@@ -60,7 +60,7 @@ class HearingBadge extends React.PureComponent {
       </ul>
     </div>;
 
-    return <Badge name="hearing" displayName="H" color={COLORS.GREEN} tooltipText={tooltipText} id={hearing.externalId}
+    return <Badge name="hearing" displayName="H" color={COLORS.GREEN} tooltipText={tooltipText} id={hearing.id}
       ariaLabel={_.startCase(hearing.disposition) ?? ''} />;
   }
 }


### PR DESCRIPTION
Reverts department-of-veterans-affairs/caseflow#22267