### PR TITLE
Sync decided appeals with states table

### DIFF
--- a/app/jobs/nightly_syncs_job.rb
+++ b/app/jobs/nightly_syncs_job.rb
@@ -87,7 +87,7 @@ class NightlySyncsJob < CaseflowJob
 
   # Syncs the decision_mailed status of Legacy Appeals with a decision made
   def sync_decided_appeals
-    AppealState.where(appeal_type: "LegacyAppeal", decision_mailed: false).each do |appeal_state|
+    AppealState.legacy.where(decision_mailed: false).each do |appeal_state|
       # If there is a decision date on the VACOLS record,
       # update the decision_mailed status on the AppealState to true
       if get_decision_date(appeal_state.appeal_id).present?
@@ -103,7 +103,7 @@ class NightlySyncsJob < CaseflowJob
       legacy_appeal = LegacyAppeal.find(appeals_id)
 
       # Find the VACOLS record associated with the LegacyAppeal
-      vacols_record = VACOLS::Case.where(bfkey: legacy_appeal[:vacols_id])[0]
+      vacols_record = VACOLS::Case.find_by_bfkey!(legacy_appeal[:vacols_id])
 
       # Return the decision date
       vacols_record[:bfddec]

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -201,6 +201,23 @@ describe NightlySyncsJob, :all_dbs do
         expect(held_hearing_appeal_state.reload.hearing_scheduled).to eq false
       end
 
+      it "catches standard errors" do
+        expect([pending_hearing_appeal_state,
+                postponed_hearing_appeal_state,
+                withdrawn_hearing_appeal_state,
+                scheduled_in_error_hearing_appeal_state,
+                held_hearing_appeal_state].all?(&:hearing_scheduled)).to eq true
+
+        allow(AppealState).to receive(:where).and_raise(StandardError)
+        slack_msg = ""
+        slack_msg_error_text = "Fatal error in sync_hearing_states"
+        allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+
+        subject
+
+        expect(slack_msg.include?(slack_msg_error_text)).to be true
+      end
+
       # Hearing scheduled will be set to true to simulate Caseflow missing a
       # disposition update.
       def create_appeal_state_with_case_record_and_hearing(desired_disposition)
@@ -210,6 +227,52 @@ describe NightlySyncsJob, :all_dbs do
 
         appeal.appeal_state.tap { _1.update!(hearing_scheduled: true) }
       end
+    end
+  end
+
+  context "#sync_decided_appeals" do
+    let(:decided_appeal_state) do
+      create_decided_appeal_state_with_case_record_and_hearing(true)
+    end
+
+    let(:undecided_appeal_state) do
+      create_decided_appeal_state_with_case_record_and_hearing(false)
+    end
+
+    it "Job syncs decided appeals decision_mailed status" do
+      expect([decided_appeal_state,
+              undecided_appeal_state].all?(&:decision_mailed)).to eq false
+
+      subject
+
+      expect(decided_appeal_state.reload.decision_mailed).to eq true
+      expect(undecided_appeal_state.reload.decision_mailed).to eq false
+    end
+
+    it "catches standard errors" do
+      expect([decided_appeal_state,
+              undecided_appeal_state].all?(&:decision_mailed)).to eq false
+
+      allow(LegacyAppeal).to receive(:find_by_id).and_raise(StandardError)
+      slack_msg = ""
+      slack_msg_error_text = "Fatal error in sync_decided_appeals"
+      allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }
+
+      subject
+
+      expect(slack_msg.include?(slack_msg_error_text)).to be true
+    end
+
+    # VACOLS record's decision date will be set to simulate a decided appeal
+    # decision_mailed will be set to false for the AppealState to verify the method
+    # functionality
+    def create_decided_appeal_state_with_case_record_and_hearing(decided_appeal)
+      case_hearing = create(:case_hearing)
+      decision_date = decided_appeal ? Time.now : nil
+      vacols_case = create(:case, case_hearings: [case_hearing], bfddec: decision_date)
+      appeal = create(:legacy_appeal, vacols_case: vacols_case)
+
+      appeal.appeal_state.tap { _1.update!(decision_mailed: false) }
     end
   end
 

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -268,7 +268,7 @@ describe NightlySyncsJob, :all_dbs do
     # functionality
     def create_decided_appeal_state_with_case_record_and_hearing(decided_appeal)
       case_hearing = create(:case_hearing)
-      decision_date = decided_appeal ? Time.now : nil
+      decision_date = decided_appeal ? Time.current : nil
       vacols_case = create(:case, case_hearings: [case_hearing], bfddec: decision_date)
       appeal = create(:legacy_appeal, vacols_case: vacols_case)
 

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -260,7 +260,7 @@ describe NightlySyncsJob, :all_dbs do
               undecided_appeal_state,
               missing_vacols_case_appeal_state].all?(&:decision_mailed)).to eq false
 
-      allow(AppealState).to receive(:where).and_raise(StandardError)
+      allow(AppealState).to receive(:legacy).and_raise(StandardError)
       slack_msg = ""
       slack_msg_error_text = "Fatal error in sync_decided_appeals"
       allow_any_instance_of(SlackService).to receive(:send_notification) { |_, first_arg| slack_msg = first_arg }

--- a/spec/jobs/nightly_syncs_job_spec.rb
+++ b/spec/jobs/nightly_syncs_job_spec.rb
@@ -252,7 +252,7 @@ describe NightlySyncsJob, :all_dbs do
 
       expect(decided_appeal_state.reload.decision_mailed).to eq true
       expect(undecided_appeal_state.reload.decision_mailed).to eq false
-      expect(undecided_appeal_state.reload.decision_mailed).to eq false
+      expect(missing_vacols_case_appeal_state.reload.decision_mailed).to eq false
     end
 
     it "catches standard errors" do


### PR DESCRIPTION
Resolves [NightlySyncsJob subtask to sync decided appeals with our appeal states table](https://jira.devops.va.gov/browse/APPEALS-52882)

# Description
Added new subtask to the NightlySyncsJob so that it can sync decided appeals with appeals state table.
Added code to catch StandardErrors for the sync_hearing_states method

## Acceptance Criteria
- [x] Code compiles correctly
- [x]  New subtask (method) is added to the NightlySyncsJob
   - The method is named sync_decided_appeals
   - The method is called after sync_bgs_attorneys in the perform method
    - The method is responsible for
       - iterating over all appeal states for legacy appeals where decision_mailed: false
       - checks the corresponding vacols record BRIEFF.BFDDEC
          - if null, decision_mailed: false
          - if not null, decision_mailed:true
    - The method has a rescue block for any StandardError
       - The rescue block adds to the slack report and allows the job to continue
- [x] A rescue block for any standard error is added to the sync_hearing_states method
    - The rescue block adds to the slack report and allows the job to continue



## Testing Plan
1. To run the rspec tests use the following command 
`SINGLE_COV=true bundle exec rspec spec/jobs/nightly_syncs_job_spec.rb`
2. Run the NightlySyncsJob by running the following steps
    - rails console
    - `NightlySyncsJob.perform_now` 

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [ ] No new code climate issues added

## Monitoring, Logging, Auditing, Error, and Exception Handling Checklist
### Error Handling
- [x] Are errors being caught and handled gracefully?
- [x] Are appropriate error messages being displayed to users?
- [ ] Are critical errors being reported to an error tracking system (e.g., Sentry, ELK)?
- [ ] Are unhandled exceptions being caught at the application level ?

