### PR TITLE
APPEALS-55259: Return Distribution Statistics After Requesting More Cases in Lower Environments

### DIFF
--- a/app/serializers/distribution_serializer.rb
+++ b/app/serializers/distribution_serializer.rb
@@ -5,6 +5,7 @@ class DistributionSerializer
 
   attribute :distributed_cases_count
   attributes :id, :created_at, :updated_at, :status
+  attribute :distribution_stats, if: proc { !Rails.in_upper_env? }
 
   def as_json
     serializable_hash[:data][:attributes]

--- a/spec/factories/distribution.rb
+++ b/spec/factories/distribution.rb
@@ -4,10 +4,15 @@ FactoryBot.define do
   factory :distribution do
     association :judge, factory: :user
 
+    # This trait requires all case distribution levers to exist in the database
     trait :completed do
       completed_at { Time.zone.now }
+      with_stats
+
       after(:create) do |distribution|
-        distribution.update(status: :completed, statistics: { batch_size: distribution.distributed_cases.count })
+        distribution.update(status: :completed,
+                            statistics: { batch_size: distribution.distributed_cases.count,
+                                          info: "See related row in distribution_stats for additional stats" })
       end
     end
 
@@ -21,6 +26,14 @@ FactoryBot.define do
 
     trait :last_month do
       completed_at { 35.days.ago }
+    end
+
+    trait :with_stats do
+      after(:create) do |distribution|
+        distribution.instance_variable_set(:@appeals, []) if distribution.instance_variable_get(:@appeals).nil?
+
+        distribution.send(:record_distribution_stats, distribution.send(:ama_statistics))
+      end
     end
   end
 end

--- a/spec/jobs/update_appeal_affinity_dates_job_spec.rb
+++ b/spec/jobs/update_appeal_affinity_dates_job_spec.rb
@@ -21,7 +21,7 @@ describe UpdateAppealAffinityDatesJob do
   end
 
   context "#latest_receipt_dates" do
-    before { create(:case_distribution_lever, :request_more_cases_minimum) }
+    before { Seeds::CaseDistributionLevers.new.seed! }
 
     let(:judge) { create(:user, :judge, :with_vacols_judge_record) }
     let(:distribution_requested) { create(:distribution, :completed, judge: judge) }
@@ -198,7 +198,7 @@ describe UpdateAppealAffinityDatesJob do
   end
 
   context "#create_or_update_appeal_affinties" do
-    before { create(:case_distribution_lever, :request_more_cases_minimum) }
+    before { Seeds::CaseDistributionLevers.new.seed! }
 
     let(:judge) { create(:user, :judge, :with_vacols_judge_record) }
     let(:distribution) { create(:distribution, :completed, judge: judge) }
@@ -228,7 +228,7 @@ describe UpdateAppealAffinityDatesJob do
   end
 
   context "#legacy_appeals_with_no_appeal_affinities" do
-    before { create(:case_distribution_lever, :request_more_cases_minimum) }
+    before { Seeds::CaseDistributionLevers.new.seed! }
 
     let(:judge) { create(:user, :judge, :with_vacols_judge_record) }
     let(:distribution) { create(:distribution, :completed, judge: judge) }
@@ -280,7 +280,7 @@ describe UpdateAppealAffinityDatesJob do
     end
 
     context "full run" do
-      before { create(:case_distribution_lever, :request_more_cases_minimum) }
+      before { Seeds::CaseDistributionLevers.new.seed! }
 
       let!(:judge) { create(:user, :judge, :with_vacols_judge_record) }
       let!(:previous_distribution) { create(:distribution, :completed, :this_month, judge: judge) }

--- a/spec/lib/tasks/affinity_start_date_spec.rb
+++ b/spec/lib/tasks/affinity_start_date_spec.rb
@@ -3,7 +3,7 @@
 describe "affinity_start_date" do
   include_context "rake"
 
-  before { create(:case_distribution_lever, :request_more_cases_minimum) }
+  before { Seeds::CaseDistributionLevers.new.seed! }
 
   let!(:judge) { create(:user, :judge, :with_vacols_judge_record) }
   let!(:distribution) { create(:distribution, :completed, :this_month, judge: judge) }

--- a/spec/serializers/distribution_serializer_spec.rb
+++ b/spec/serializers/distribution_serializer_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe DistributionSerializer, :all_dbs do
+  let(:judge) { create(:user, :judge, :with_vacols_judge_record) }
+  let(:distribution) { create(:distribution, :completed, judge: judge) }
+
+  before { Seeds::CaseDistributionLevers.new.seed! }
+
+  subject { DistributionSerializer.new(distribution).as_json }
+
+  context "when in higher environments" do
+    before { Rails.env = "prod" }
+    after { Rails.env = "test" }
+
+    it "does not incude associated distribution_stats" do
+      expect(subject[:distribution_stats]).to be nil
+    end
+  end
+
+  context "when in lower environments" do
+    it "includes associated distribution_stats" do
+      expect(subject[:distribution_stats]).to_not be nil
+    end
+  end
+end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-55259](https://jira.devops.va.gov/browse/APPEALS-55259)

# Description
Adds a distribution's `distribution_stats` record to the serialized return to the front end when a user requests cases with the "Request more cases" button. This will allow devs and testers to validate changes to generating distribution statistics without needing to use the database or logs. This change is limited to lower environments using the existing `Rails.in_upper_env?` check from the `deploy_env` initializer, so distributions in Prodtest or Production will not serialize this data and send it to a user.]

- Adds attribute `:distribution_stats` to the `DistributionSerializer` if in lower environments
- Adds `distribution_serializer_spec.rb` for testing the serializer change
- Adds trait to Distribution factory to create a `distribution_stats record` when creating a completed distribution using the factory
- Update tests which are utilizing the modified `:completed` trait from the distribution factory

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Login as a judge user
2. Navigate to their assign page
3. Right click the page and click "inspect"
4. In the browser tools window, click the "Network" tab
5. Clear the list of requests if desired to make the tab easier to read
6. Click "Request more cases"
7. Once the green banner displays, find the entry in the network tab with the name `new?user_id={id}` and click it
8. In the window, click the "Preview" tab
9. Verify that the distribution includes a key `distribution_stats` and that it is populated with the associated distribution stats information

# Frontend
## User Facing Changes
 - [X] Screenshots of UI changes added to PR & Original Issue

![dist-stats-in-response](https://github.com/user-attachments/assets/54821823-7b48-4bcd-a564-3358825f0753)

