### PR TITLE
APPEALS-55159: Parameter Requirements Are Too Stringent Given What We Will Expect from VA Notify

### DIFF
--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -19,16 +19,8 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   private
 
   def required_params
-    if params[:status].casecmp("delivered") == 0
-      id_param, notification_type_param,
-      status_param = params.require([:id, :notification_type, :status])
-      to_param = params[:to]
-      status_reason_param = params[:status_reason]
-    else
-      id_param, notification_type_param,
-      to_param, status_param,
-      status_reason_param = params.require([:id, :notification_type, :to, :status, :status_reason])
-    end
+    id_param, notification_type_param, status_param = params.require([:id, :notification_type, :status])
+    status_reason_param, to_param = params.permit(:status_reason, :to)
     {
       external_id: id_param,
       notification_type: notification_type_param,

--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -19,9 +19,16 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   private
 
   def required_params
-    id_param, notification_type_param,
-    to_param, status_param,
-    status_reason_param = params.require([:id, :notification_type, :to, :status, :status_reason])
+    if params[:status].casecmp("delivered") == 0
+      id_param, notification_type_param,
+      status_param = params.require([:id, :notification_type, :status])
+      to_param = params[:to]
+      status_reason_param = params[:status_reason]
+    else
+      id_param, notification_type_param,
+      to_param, status_param,
+      status_reason_param = params.require([:id, :notification_type, :to, :status, :status_reason])
+    end
     {
       external_id: id_param,
       notification_type: notification_type_param,

--- a/app/controllers/api/v1/va_notify_controller.rb
+++ b/app/controllers/api/v1/va_notify_controller.rb
@@ -19,7 +19,7 @@ class Api::V1::VaNotifyController < Api::ApplicationController
   private
 
   def va_notify_params
-    permitted_params = params.permit(:id, :notification_type, :status, :status_reason, :to)
+    params.permit(:id, :notification_type, :status, :status_reason, :to)
   end
 
   def build_message_body

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -221,7 +221,7 @@ describe Api::V1::VaNotifyController, type: :controller do
       request.headers["Authorization"] = "Bearer #{api_key}"
       post :notifications_update, params: payload_email
 
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(200)
 
       perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
     end
@@ -297,7 +297,7 @@ describe Api::V1::VaNotifyController, type: :controller do
       post :notifications_update, params: payload
 
       perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(200)
     end
   end
 
@@ -315,7 +315,7 @@ describe Api::V1::VaNotifyController, type: :controller do
       post :notifications_update, params: payload
 
       perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(200)
     end
   end
 
@@ -333,7 +333,7 @@ describe Api::V1::VaNotifyController, type: :controller do
       post :notifications_update, params: payload
 
       perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
-      expect(response.status).to eq(400)
+      expect(response.status).to eq(200)
     end
   end
 

--- a/spec/controllers/api/v1/va_notify_controller_spec.rb
+++ b/spec/controllers/api/v1/va_notify_controller_spec.rb
@@ -227,6 +227,116 @@ describe Api::V1::VaNotifyController, type: :controller do
     end
   end
 
+  context "payload status is delivered and status_reason and to are null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "delivered"
+        payload[:status_reason] = nil
+        payload[:to] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "payload status is delivered and status_reason is null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "delivered"
+        payload[:status_reason] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "payload status is delivered and to is null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "delivered"
+        payload[:to] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "payload status is NOT delivered and status reason and to are null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "Pending Delivery"
+        payload[:to] = nil
+        payload[:status_reason] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(400)
+    end
+  end
+
+  context "payload status is NOT delivered and status reason is null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "Pending Delivery"
+        payload[:status_reason] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(400)
+    end
+  end
+
+  context "payload status is NOT delivered and to is null" do
+    before { Seeds::NotificationEvents.new.seed! }
+    let(:payload) do
+      error_payload1.deep_dup.tap do |payload|
+        payload[:status] = "Pending Delivery"
+        payload[:to] = nil
+      end
+    end
+
+    it "updates status of notification" do
+      request.headers["Authorization"] = "Bearer #{api_key}"
+      post :notifications_update, params: payload
+
+      perform_enqueued_jobs { ProcessNotificationStatusUpdatesJob.perform_later }
+      expect(response.status).to eq(400)
+    end
+  end
+
   def create_queue(name, fifo = false)
     sqs_client.create_queue({
                               queue_name: "caseflow_test_#{name}#{fifo ? '.fifo' : ''}".to_sym,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/APPEALS-55159)

# Description
Defect Summary: We are requiring [to and status_reason](https://github.com/department-of-veterans-affairs/caseflow/blob/45c73afb1cf0c5a06f09ae812ef652402b592fe2/app/controllers/api/v1/va_notify_controller.rb#L24) parameters in status update request bodies received by VA Notify. In cases where a status is "delivered" we will not receive a status_reason. We can also not always guarantee we'll receive a recipient (to) value.

## Acceptance Criteria
- [x] Code compiles correctly