### PR TITLE
Create Example Sensitivity Banner

### DIFF
--- a/client/app/styles/_main.scss
+++ b/client/app/styles/_main.scss
@@ -237,6 +237,12 @@ body {
   background-color: inherit;
 }
 
+.cf-icon-external-link {
+  path {
+    fill: $cf-link;
+  }
+}
+
 .cf-tab-window-body {
   padding-top: 20px;
   border: 1px solid $color-gray-light;

--- a/client/app/test/TestUsers.jsx
+++ b/client/app/test/TestUsers.jsx
@@ -13,6 +13,7 @@ import { BrowserRouter } from 'react-router-dom';
 import Alert from '../components/Alert';
 import { trim, escapeRegExp } from 'lodash';
 import { COLORS } from '@department-of-veterans-affairs/caseflow-frontend-toolkit/util/StyleConstants';
+import { ExternalLinkIcon } from '../components/icons/ExternalLinkIcon';
 
 export default function TestUsers(props) {
 
@@ -25,6 +26,7 @@ export default function TestUsers(props) {
   const [optionalSeedingError, setOptionalSeedingError] = useState(null);
   const [isOptionalSeeding, setIsOptionalSeeding] = useState(false);
   const [inputValue, setInputValue] = useState('');
+  const [hideSensitivityBanner, setHideSensitivityBanner] = useState(true);
 
   const handleEpSeed = (type) => ApiUtil.post(`/test/set_end_products?type=${type}`).
     catch((err) => {
@@ -169,6 +171,28 @@ export default function TestUsers(props) {
             </li>;
           })}
         </ul>
+      </div>
+      }
+      {app.name === 'Miscellaneous' && <div>
+        <button
+          onClick={() => setHideSensitivityBanner(!hideSensitivityBanner)}
+        >{hideSensitivityBanner ? 'Show' : 'Hide'} Sensitivity Mismatch Banner</button>
+        <div hidden={hideSensitivityBanner}>
+          <Alert
+            type="warning"
+            title="Additional access needed to search for this veteran ID"
+          >
+            <p>
+              Please try searching for another veteran or&nbsp;
+              <a
+                href="https://leaf.va.gov/VBA/335/sensitive_level_access_request/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >request access&nbsp;<ExternalLinkIcon className="cf-icon-external-link" /></a>
+              &nbsp;to search for this veteran ID.
+            </p>
+          </Alert>
+        </div>
       </div>
       }
     </div>;


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Create warning banner - sensitivity mismatch](https://jira.devops.va.gov/browse/APPEALS-55067)

# Description
Create an example sensitivity banner for review.

## Acceptance Criteria
- [ ] Banner matches AC in ticket.

## Testing Plan
1. Log in to Caseflow as a testing/admin user who can access the "Switch User" page.
1. Select "Switch User" from the top menu.
1. Select the "Miscellaneous" tab under "App Selector".
1. Click the "Show/Hide Sensitivity Mismatch Banner" button to view the banner.

# Frontend
## User Facing Changes
 - [ ] Screenshots of UI changes added to PR & Original Issue

 BEFORE|AFTER
![Screenshot 2024-08-21 at 11-36-03 Caseflow](https://github.com/user-attachments/assets/27722d77-e9e1-4c9b-86a9-42c16e509f7a)
|
![Screenshot 2024-08-21 at 11-25-56 Caseflow](https://github.com/user-attachments/assets/e6849b3a-52b8-49d0-a4c1-9f105accf398)

