### PR TITLE
APPEALS-55525: Disable tests for seed files and lock Chrome version to v127 in Github Actions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,6 +73,7 @@ jobs:
         KNAPSACK_PRO_CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         KNAPSACK_PRO_LOG_LEVEL: info
         KNAPSACK_PRO_FIXED_QUEUE_SPLIT: true
+        KNAPSACK_PRO_TEST_FILE_EXCLUDE_PATTERN: "spec/seeds/**/*_spec.rb"
         WD_INSTALL_DIR: .webdrivers
         CI: true
         REDIS_URL_CACHE: redis://redis:6379/0/cache/
@@ -215,7 +216,7 @@ jobs:
           touch log/selenium-chrome.log
           chmod -R 777 ${GITHUB_WORKSPACE}
           export GHA_NODE_INDEX=${{matrix.ci_node_index}}
-          runuser -u circleci bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter --tty --exclude-pattern 'spec/seeds/**/*_spec.rb']"
+          runuser -u circleci bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter --tty]"
       # --format RSpec::Github::Formatter use in Rspec-github gem, adds more detailed info to GHA "Annotations"
       # --tty forces Rspec to produce color
       # circleci is the USER

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -126,7 +126,7 @@ jobs:
       - name: Install Chrome
         run: |
           apt-get update
-          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb \
+          wget --no-verbose -O /tmp/chrome.deb https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_127.0.6533.119-1_amd64.deb \
           && apt install -y /tmp/chrome.deb \
           && rm /tmp/chrome.deb
           echo "Chrome exe name: $(ls /usr/bin | chrome)"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -215,7 +215,7 @@ jobs:
           touch log/selenium-chrome.log
           chmod -R 777 ${GITHUB_WORKSPACE}
           export GHA_NODE_INDEX=${{matrix.ci_node_index}}
-          runuser -u circleci bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter --tty]"
+          runuser -u circleci bundle exec rake "knapsack_pro:queue:rspec[--format documentation --format RSpec::Github::Formatter --tty --exclude-pattern 'spec/seeds/**/*_spec.rb']"
       # --format RSpec::Github::Formatter use in Rspec-github gem, adds more detailed info to GHA "Annotations"
       # --tty forces Rspec to produce color
       # circleci is the USER


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-55525](https://jira.devops.va.gov/browse/APPEALS-55525)

# Description
Adds `--exclude-pattern 'spec/seeds/**/*_spec.rb'` to the Github Actions rspec command to skip running the tests in the spec/seeds folder. Tech leads on the project agreed that the value provided by running seed file specs is not worth the time and complexity.

Additionally, this modifies the Github Actions `.workflow.yml` file to lock the Chrome version to 127.0.6533.119. The release of 128.0.6613.84 caused an error `Selenium::WebDriver::Error::InvalidSessionIdError: invalid session id` and the subsequent failure of all feature tests in the test suite. Locking the version is a temporary solution until we can update Webdrivers or switch that dependency. 

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] No seed file tests are run
