### PR TITLE
Code changes to account for duplicates from base query

### DIFF
--- a/app/jobs/return_legacy_appeals_to_board_job.rb
+++ b/app/jobs/return_legacy_appeals_to_board_job.rb
@@ -13,9 +13,7 @@ class ReturnLegacyAppealsToBoardJob < CaseflowJob
       returned_appeal_job = create_returned_appeal_job
       fail if fail_job
 
-      # Logic to process legacy appeals and return to the board
-      appeals = select_two_appeals_to_move(LegacyDocket.new.appeals_tied_to_non_ssc_avljs)
-      VACOLS::Case.batch_update_vacols_location("63", appeals.map { |appeal| appeal["bfkey"] })
+      move_qualifying_appeals(LegacyDocket.new.appeals_tied_to_non_ssc_avljs)
       complete_returned_appeal_job(returned_appeal_job, "Job completed successfully", appeals)
       send_job_slack_report
     rescue StandardError => error
@@ -35,13 +33,34 @@ class ReturnLegacyAppealsToBoardJob < CaseflowJob
 
   private
 
-  def select_two_appeals_to_move(appeals)
-    appeals = appeals.sort_by { |appeal| [-appeal["priority"], appeal["bfd19"]] } unless appeals.empty?
-    if appeals.count < 2
-      appeals
-    else
-      appeals[0..1]
+  def move_qualifying_appeals(appeals)
+    qualifying_appeals = []
+
+    non_ssc_avljs.each do |non_ssc_avlj|
+      tied_appeals = appeals.select { |appeal| appeal["vlj"] == non_ssc_avlj.sattyid }
+
+      unless tied_appeals.empty?
+        tied_appeals = tied_appeals.sort_by { |t_appeal| [-t_appeal["priority"], t_appeal["bfd19"]] }
+      end
+
+      if appeals.count < 2
+        qualifying_appeals.push(tied_appeals).flatten
+      else
+        qualifying_appeals.push(tied_appeals[0..1]).flatten
+      end
     end
+
+    unless qualifying_appeals.empty?
+      qualifying_appeals = qualifying_appeals
+        .flatten
+        .sort_by { |appeal| [-appeal["priority"], appeal["bfd19"]] }
+    end
+
+    VACOLS::Case.batch_update_vacols_location("63", qualifying_appeals.map { |q_appeal| q_appeal["bfkey"] })
+  end
+
+  def non_ssc_avljs
+    VACOLS::Staff.where("sactive = 'A' AND svlj = 'A' AND sattyid <> smemgrp")
   end
 
   def create_returned_appeal_job

--- a/app/jobs/return_legacy_appeals_to_board_job.rb
+++ b/app/jobs/return_legacy_appeals_to_board_job.rb
@@ -48,9 +48,8 @@ class ReturnLegacyAppealsToBoardJob < CaseflowJob
         .select { |q_appeal| qualifying_appeals_bfkeys.include? q_appeal["bfkey"] }
         .flatten
         .sort_by { |appeal| [-appeal["priority"], appeal["bfd19"]] }
+      VACOLS::Case.batch_update_vacols_location("63", qualifying_appeals.map { |q_appeal| q_appeal["bfkey"] })
     end
-
-    VACOLS::Case.batch_update_vacols_location("63", qualifying_appeals.map { |q_appeal| q_appeal["bfkey"] })
 
     qualifying_appeals
   end

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -90,7 +90,8 @@ class VACOLS::CaseDocket < VACOLS::Record
   "
 
   # Judges 000, 888, and 999 are not real judges, but rather VACOLS codes.
-
+  # This query will create multiple records/rows for each BRIEFF if the BRIEFF has multiple hearings
+  # This may need to be accounted for by making sure the resultant set is filtered by BFKEY
   JOIN_ASSOCIATED_VLJS_BY_HEARINGS = "
     left join (
       select distinct TITRNUM, TINUM, HEARING_DATE,

--- a/app/queries/appeals_in_location_63_in_past_2_days.rb
+++ b/app/queries/appeals_in_location_63_in_past_2_days.rb
@@ -43,7 +43,7 @@ class AppealsInLocation63InPast2Days
       .flat_map do |sym, docket|
         if sym == :legacy
           appeals = docket.loc_63_appeals
-          legacy_rows(appeals)
+          legacy_rows(appeals).uniq { |record| record[:docket_number] }
         else
           []
         end

--- a/app/queries/appeals_tied_to_non_ssc_avlj_query.rb
+++ b/app/queries/appeals_tied_to_non_ssc_avlj_query.rb
@@ -43,7 +43,7 @@ class AppealsTiedToNonSscAvljQuery
       .flat_map do |sym, docket|
         if sym == :legacy
           appeals = docket.appeals_tied_to_non_ssc_avljs
-          unique_appeals = legacy_rows(appeals, sym).uniq { |record| record[:veteran_file_number] }
+          unique_appeals = legacy_rows(appeals, sym).uniq { |record| record[:docket_number] }
 
           unique_appeals
         else


### PR DESCRIPTION
This addresses the issue surrounding the duplicate records in a query that occur when a single BRIEFF has multiple hearings attached to it.

This does NOT address the duplicates, it just works around them.