### PR TITLE
Add Base Sensitivity Methods and Services

### DIFF
--- a/app/services/external_api/bgs_service.rb
+++ b/app/services/external_api/bgs_service.rb
@@ -24,6 +24,57 @@ class ExternalApi::BGSService
     @people_by_ssn = {}
   end
 
+  def sensitivity_level_for_user(user)
+    fail "Invalid user" if !user.instance_of?(User)
+
+    participant_id = get_participant_id_for_user(user)
+
+    Rails.cache.fetch("sensitivity_level_for_user_id_#{user.id}", expires_in: 1.hour) do
+      DBService.release_db_connections
+
+      MetricsService.record(
+        "BGS: sensitivity level for user #{user.id}",
+        service: :bgs,
+        name: "security.find_person_scrty_log_by_ptcpnt_id"
+      ) do
+        response = client.security.find_person_scrty_log_by_ptcpnt_id(participant_id)
+
+        # guard clause for no response
+        return 0 if response.blank?
+
+        response.key?(:scrty_level_type_cd) ? Integer(response[:scrty_level_type_cd]) : 0
+      rescue BGS::ShareError
+        0
+      end
+    end
+  end
+
+  # :reek:FeatureEnvy
+  def sensitivity_level_for_veteran(veteran)
+    fail "Invalid veteran" if !veteran.instance_of?(Veteran)
+
+    participant_id = veteran.participant_id
+
+    Rails.cache.fetch("sensitivity_level_for_veteran_id_#{veteran.id}", expires_in: 1.hour) do
+      DBService.release_db_connections
+
+      MetricsService.record(
+        "BGS: sensitivity level for veteran #{veteran.id}",
+        service: :bgs,
+        name: "security.find_sensitivity_level_by_participant_id"
+      ) do
+        response = client.security.find_sensitivity_level_by_participant_id(participant_id)
+
+        # guard clause for no response
+        return 0 if response.blank?
+
+        response.key?(:scrty_level_type_cd) ? Integer(response[:scrty_level_type_cd]) : 0
+      rescue BGS::ShareError
+        0
+      end
+    end
+  end
+
   # :nocov:
 
   def get_end_products(vbms_id)

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -329,4 +329,16 @@ class ExternalApi::VBMSService
       service.call(file_number: vbms_id)
     end
   end
+
+  def self.verify_current_user_veteran_access(veteran)
+    return if !FeatureToggle.enabled?(:check_user_sensitivity)
+
+    current_user = RequestStore[:current_user]
+
+    fail "User does not have permission to access this information" unless
+      SensitivityChecker.new(current_user).sensitivity_levels_compatible?(
+        user: current_user,
+        veteran: veteran
+      )
+  end
 end

--- a/app/services/sensitivity_checker.rb
+++ b/app/services/sensitivity_checker.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class SensitivityChecker
+  def initialize(current_user)
+    self.current_user = current_user
+  end
+
+  def sensitivity_levels_compatible?(user:, veteran:)
+    begin
+      sensitivity_checker.sensitivity_level_for_user(user) >=
+        sensitivity_checker.sensitivity_level_for_veteran(veteran)
+    rescue StandardError => error
+      error_uuid = SecureRandom.uuid
+      Raven.capture_exception(error, extra: { error_uuid: error_uuid })
+
+      false
+    end
+  end
+
+  private
+
+  attr_accessor :current_user
+
+  def sensitivity_checker
+    return @sensitivity_checker if @sensitivity_checker.present?
+
+    # Set for use by BGSService
+    RequestStore.store[:current_user] ||= current_user
+
+    @sensitivity_checker = BGSService.new
+  end
+end

--- a/lib/fakes/bgs_service.rb
+++ b/lib/fakes/bgs_service.rb
@@ -120,6 +120,18 @@ class Fakes::BGSService
     end
   end
 
+  def sensitivity_level_for_user(user)
+    fail "Invalid user" if !user.instance_of?(User)
+
+    Random.new.rand(4..9)
+  end
+
+  def sensitivity_level_for_veteran(veteran)
+    fail "Invalid veteran" if !veteran.instance_of?(Veteran)
+
+    Random.new.rand(1..4)
+  end
+
   def get_end_products(file_number)
     store = self.class.end_product_store
     records = store.fetch_and_inflate(file_number) || store.fetch_and_inflate(:default) || {}

--- a/spec/services/sensitivity_checker_spec.rb
+++ b/spec/services/sensitivity_checker_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+describe SensitivityChecker do
+  let!(:current_user) { create(:user) }
+  subject(:described) { described_class.new(current_user) }
+
+  let(:user) { create(:user) }
+  let(:veteran) { create(:veteran) }
+
+  let!(:bgs) { BGSService.new }
+  let(:mock_sensitivity_checker) { instance_double(BGSService) }
+
+  before do
+    allow(BGSService).to receive(:new).and_return(mock_sensitivity_checker)
+
+    allow(mock_sensitivity_checker).to receive(:fetch_person_info) do |vbms_id|
+      bgs.fetch_person_info(vbms_id)
+    end
+
+    allow(mock_sensitivity_checker).to receive(:fetch_veteran_info) do |vbms_id|
+      bgs.fetch_veteran_info(vbms_id)
+    end
+  end
+
+  describe "#sensitivity_levels_compatible?" do
+    context "when the sensitivity levels are compatible" do
+      it "returns true" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+          .with(user).and_return(Random.new.rand(4..9))
+        expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_veteran)
+          .with(veteran).and_return(Random.new.rand(1..4))
+
+        expect(described.sensitivity_levels_compatible?(user: user, veteran: veteran)).to eq true
+      end
+    end
+
+    context "when the sensitivity levels are NOT compatible" do
+      it "returns false" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+          .with(user).and_return(Random.new.rand(1..4))
+        expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_veteran)
+          .with(veteran).and_return(Random.new.rand(4..9))
+
+        expect(described.sensitivity_levels_compatible?(user: user, veteran: veteran)).to eq false
+      end
+    end
+
+    context "when the BGS call raises an exception" do
+      it "returns false" do
+        error = StandardError.new
+
+        expect(mock_sensitivity_checker).to receive(:sensitivity_level_for_user)
+          .with(user).and_raise(error)
+        expect(SecureRandom).to receive(:uuid).and_return("1234")
+        expect(Raven).to receive(:capture_exception).with(error, extra: { error_uuid: "1234" })
+
+        expect(described.sensitivity_levels_compatible?(user: user, veteran: veteran)).to eq false
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Caseflow: Include current user information to FindDocumentSeriesReference Service](https://jira.devops.va.gov/browse/APPEALS-53840)

# Description
- Add user/veteran sensitivity methods to BGSService, borrowed from work done for correspondence auto assignment.

- Create new service for checking the compatibility of user/veteran sensitivity.

## Acceptance Criteria
- [ ] All specs passing.

## Testing Plan
1. Run specs for changed files:
  - `bundle exec rspec spec/services/sensitivity_checker_spec.rb`
  - `bundle exec rspec spec/services/external_api/bgs_service_spec.rb`