### PR TITLE
Add FindDocumentSeriesReference Sensitivity Checks

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,15 @@ class ApplicationController < ApplicationBaseController
     end
   end
 
+  rescue_from BGS::SensitivityLevelCheckFailure do |e|
+    render json: {
+      status: e.message,
+      featureToggles: {
+        checkUserSensitivity: FeatureToggle.enabled?(:check_user_sensitivity)
+      }
+    }, status: :forbidden
+  end
+
   private
 
   def deny_non_bva_admins

--- a/app/exceptions/bgs/sensitivity_level_check_failure.rb
+++ b/app/exceptions/bgs/sensitivity_level_check_failure.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Class for various errors that can be received from the BGS service
+# Error class for when user/veteran sensitivity levels are not compatible
 module BGS
   class SensitivityLevelCheckFailure < StandardError; end
 end

--- a/app/exceptions/bgs/sensitivity_level_check_failure.rb
+++ b/app/exceptions/bgs/sensitivity_level_check_failure.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Class for various errors that can be received from the BGS service
+module BGS
+  class SensitivityLevelCheckFailure < StandardError; end
+end

--- a/app/services/external_api/vbms_document_series_for_appeal.rb
+++ b/app/services/external_api/vbms_document_series_for_appeal.rb
@@ -8,6 +8,8 @@ class ExternalApi::VbmsDocumentSeriesForAppeal < ExternalApi::VbmsRequestWithFil
   protected
 
   def do_request(ssn_or_claim_number)
+    verify_current_user_veteran_access(Veteran.find_by_file_number_or_ssn(ssn_or_claim_number))
+
     if FeatureToggle.enabled?(:vbms_pagination, user: RequestStore[:current_user])
       service = VBMS::Service::PagedDocuments.new(client: vbms_client)
 

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -64,7 +64,7 @@ class ExternalApi::VbmsRequestWithFileNumber
 
     current_user = RequestStore[:current_user]
 
-    fail "User does not have permission to access this information" unless
+    fail BGS::SensitivityLevelCheckFailure, "User does not have permission to access this information" unless
       SensitivityChecker.new(current_user).sensitivity_levels_compatible?(
         user: current_user,
         veteran: veteran

--- a/app/services/external_api/vbms_request_with_file_number.rb
+++ b/app/services/external_api/vbms_request_with_file_number.rb
@@ -58,4 +58,16 @@ class ExternalApi::VbmsRequestWithFileNumber
   def bgs_claim_number
     @bgs_claim_number ||= bgs_client.fetch_veteran_info(file_number)[:claim_number]
   end
+
+  def verify_current_user_veteran_access(veteran)
+    return if !FeatureToggle.enabled?(:check_user_sensitivity)
+
+    current_user = RequestStore[:current_user]
+
+    fail "User does not have permission to access this information" unless
+      SensitivityChecker.new(current_user).sensitivity_levels_compatible?(
+        user: current_user,
+        veteran: veteran
+      )
+  end
 end

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -53,6 +53,8 @@ class ExternalApi::VBMSService
   end
 
   def self.fetch_document_series_for(appeal)
+    verify_current_user_veteran_access(appeal.veteran)
+
     if FeatureToggle.enabled?(:use_ce_api)
       response = VeteranFileFetcher.fetch_veteran_file_list(veteran_file_number: appeal.veteran_file_number)
       JsonApiResponseAdapter.new.adapt_fetch_document_series_for(response)

--- a/app/services/external_api/vbms_service.rb
+++ b/app/services/external_api/vbms_service.rb
@@ -337,7 +337,7 @@ class ExternalApi::VBMSService
 
     current_user = RequestStore[:current_user]
 
-    fail "User does not have permission to access this information" unless
+    fail BGS::SensitivityLevelCheckFailure, "User does not have permission to access this information" unless
       SensitivityChecker.new(current_user).sensitivity_levels_compatible?(
         user: current_user,
         veteran: veteran

--- a/app/services/sensitivity_checker.rb
+++ b/app/services/sensitivity_checker.rb
@@ -6,27 +6,25 @@ class SensitivityChecker
   end
 
   def sensitivity_levels_compatible?(user:, veteran:)
-    begin
-      sensitivity_checker.sensitivity_level_for_user(user) >=
-        sensitivity_checker.sensitivity_level_for_veteran(veteran)
-    rescue StandardError => error
-      error_uuid = SecureRandom.uuid
-      Raven.capture_exception(error, extra: { error_uuid: error_uuid })
+    bgs_service.sensitivity_level_for_user(user) >=
+      bgs_service.sensitivity_level_for_veteran(veteran)
+  rescue StandardError => error
+    error_uuid = SecureRandom.uuid
+    Raven.capture_exception(error, extra: { error_uuid: error_uuid })
 
-      false
-    end
+    false
   end
 
   private
 
   attr_accessor :current_user
 
-  def sensitivity_checker
-    return @sensitivity_checker if @sensitivity_checker.present?
+  def bgs_service
+    return @bgs_service if @bgs_service.present?
 
     # Set for use by BGSService
     RequestStore.store[:current_user] ||= current_user
 
-    @sensitivity_checker = BGSService.new
+    @bgs_service = BGSService.new
   end
 end

--- a/app/services/sensitivity_checker.rb
+++ b/app/services/sensitivity_checker.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# Uses the BGSService to check a user's sensitivity level,
+# which is used to control access to a veteran's information
 class SensitivityChecker
   def initialize(current_user)
     self.current_user = current_user

--- a/client/app/components/LoadingDataDisplay.jsx
+++ b/client/app/components/LoadingDataDisplay.jsx
@@ -35,7 +35,7 @@ const accessDeniedMsg = <div>
   <br />
   If you have any questions or need assistance with the request form linked above,
   please contact the Restricted Portfolio Management team at
-  <a href="mailto:VBA.RPM@va.gov">VBA.RPM@va.gov</a>.
+  &nbsp;<a href="mailto:VBA.RPM@va.gov">VBA.RPM@va.gov</a>.
 </div>;
 
 const duplicateNumberTitle = { title: COPY.DUPLICATE_PHONE_NUMBER_TITLE };

--- a/lib/fakes/vbms_service.rb
+++ b/lib/fakes/vbms_service.rb
@@ -95,6 +95,8 @@ class Fakes::VBMSService
   end
 
   def self.fetch_document_series_for(appeal)
+    verify_current_user_veteran_access(appeal.veteran)
+
     Document.where(file_number: appeal.veteran_file_number).flat_map do |document|
       (0..document.id % 3).map do |index|
         OpenStruct.new(
@@ -254,5 +256,9 @@ class Fakes::VBMSService
     self.manifest_vbms_fetched_at = nil
     self.manifest_vva_fetched_at = nil
     self.end_product_claim_ids_by_file_number = nil
+  end
+
+  def self.verify_current_user_veteran_access(veteran)
+    # fail BGS::SensitivityLevelCheckFailure, "User does not have permission to access this information"
   end
 end

--- a/spec/services/external_api/vbms_document_series_for_appeal_spec.rb
+++ b/spec/services/external_api/vbms_document_series_for_appeal_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+describe ExternalApi::VbmsDocumentSeriesForAppeal do
+  let(:appeal) { create(:appeal) }
+  let(:mock_sensitivity_checker) { instance_double(SensitivityChecker, sensitivity_levels_compatible?: true) }
+
+  before do
+    allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
+  end
+
+  describe "#fetch" do
+    context "with check_user_sensitivity feature toggle enabled" do
+      let!(:user) do
+        user = create(:user)
+        RequestStore.store[:current_user] = user
+      end
+
+      before do
+        expect(VBMS::Client).to receive(:from_env_vars).and_return(true)
+        expect(ExternalApi::VBMSService).to receive(:send_and_log_request).and_return(true)
+        FeatureToggle.enable!(:check_user_sensitivity)
+      end
+
+      after { FeatureToggle.disable!(:check_user_sensitivity) }
+
+      it "check user sensitivity compatibility before calling any APIs" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran: appeal.veteran).and_return(true)
+
+        described_class.new(file_number: appeal.veteran_file_number).fetch
+      end
+    end
+  end
+end

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails_helper"
+
 describe ExternalApi::VBMSService do
   subject(:described) { described_class }
   let(:mock_json_adapter) { instance_double(JsonApiResponseAdapter) }
@@ -34,7 +36,7 @@ describe ExternalApi::VBMSService do
           .with(user: user, veteran: appeal.veteran).and_return(false)
 
         expect { described.verify_current_user_veteran_access(appeal.veteran) }
-          .to raise_error(RuntimeError, "User does not have permission to access this information")
+          .to raise_error(BGS::SensitivityLevelCheckFailure, "User does not have permission to access this information")
       end
     end
   end

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -3,13 +3,44 @@
 describe ExternalApi::VBMSService do
   subject(:described) { described_class }
   let(:mock_json_adapter) { instance_double(JsonApiResponseAdapter) }
+  let(:mock_sensitivity_checker) { instance_double(SensitivityChecker, sensitivity_levels_compatible?: true) }
+
   before do
     allow(JsonApiResponseAdapter).to receive(:new).and_return(mock_json_adapter)
+    allow(SensitivityChecker).to receive(:new).and_return(mock_sensitivity_checker)
+  end
+
+  describe ".verify_current_user_veteran_access" do
+    let!(:appeal) { create(:appeal) }
+
+    context "with check_user_sensitivity feature flag enabled" do
+      before { FeatureToggle.enable!(:check_user_sensitivity) }
+      after { FeatureToggle.disable!(:check_user_sensitivity) }
+
+      let!(:user) do
+        user = create(:user)
+        RequestStore.store[:current_user] = user
+      end
+
+      it "checks the user's sensitivity" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran: appeal.veteran).and_return(true)
+
+        described.verify_current_user_veteran_access(appeal.veteran)
+      end
+
+      it "raises an exception when the sensitivity level is not compatible" do
+        expect(mock_sensitivity_checker).to receive(:sensitivity_levels_compatible?)
+          .with(user: user, veteran: appeal.veteran).and_return(false)
+
+        expect { described.verify_current_user_veteran_access(appeal.veteran) }
+          .to raise_error(RuntimeError, "User does not have permission to access this information")
+      end
+    end
   end
 
   describe ".fetch_document_series_for" do
     let(:mock_vbms_document_series_for_appeal) { instance_double(ExternalApi::VbmsDocumentSeriesForAppeal) }
-
     let!(:appeal) { create(:appeal) }
 
     before do
@@ -29,8 +60,9 @@ describe ExternalApi::VBMSService do
       end
     end
 
-    context "with no feature toggles enabled" do
+    context "with use_ce_api feature toggle disabled" do
       it "calls the VbmsDocumentSeriesForAppeal service" do
+        expect(FeatureToggle).to receive(:enabled?).with(:check_user_sensitivity).and_return(false)
         expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
         expect(ExternalApi::VbmsDocumentSeriesForAppeal).to receive(:new).with(file_number: appeal.veteran_file_number)
         expect(mock_vbms_document_series_for_appeal).to receive(:fetch)
@@ -40,7 +72,7 @@ describe ExternalApi::VBMSService do
     end
   end
 
-  describe ".fetch_document_for" do
+  describe ".fetch_document_series_for" do
     let(:mock_json_adapter) { instance_double(JsonApiResponseAdapter) }
     let!(:appeal) { create(:appeal) }
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Caseflow: Include current user information to FindDocumentSeriesReference Service](https://jira.devops.va.gov/browse/APPEALS-53840)

# Description
Verify user/veteran sensitivity levels are compatible when calling `ExternalApi::VBMSService.fetch_document_series_for` and when calling `ExternalApi::VbmsDocumentSeriesForAppeal.fetch`.

## Acceptance Criteria
- [ ] All specs passing.

## Testing Plan
See Confluence page: https://confluence.devops.va.gov/display/VAExternal/FindDocumentSeriesReference%3A+SOAP+to+REST+API+Migration

# Best practices
## Code Documentation Updates
- [x] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
