### PR TITLE
Prevent Prodtest from contacting VA Notify Staging

### DIFF
--- a/config/environments/demo.rb
+++ b/config/environments/demo.rb
@@ -85,6 +85,8 @@ Rails.application.configure do
   # eFolder Express URL for demo environment used as a mock link
   ENV["EFOLDER_EXPRESS_URL"] ||= "http://localhost:4000"
 
+  ENV["CASEFLOW_BASE_URL"] ||= "https://www.demo.appeals.va.gov"
+
   # BatchProcess ENVs
   # priority_ep_sync
   ENV["BATCH_PROCESS_JOB_DURATION"] ||= "1" # Number of hours the job will run for

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -134,6 +134,8 @@ Rails.application.configure do
   # Time in seconds before the sync lock expires
   LOCK_TIMEOUT = ENV["SYNC_LOCK_MAX_DURATION"] ||= "60"
 
+  ENV["CASEFLOW_BASE_URL"] ||= "http://localhost:3000"
+
   # Notifications page eFolder link
   ENV["CLAIM_EVIDENCE_EFOLDER_BASE_URL"] ||= "https://vefs-claimevidence-ui-uat.stage.bip.va.gov"
 

--- a/config/initializers/va_notify.rb
+++ b/config/initializers/va_notify.rb
@@ -1,1 +1,6 @@
-VANotifyService = (ApplicationController.dependencies_faked? ? Fakes::VANotifyService : ExternalApi::VANotifyService)
+case Rails.deploy_env
+when :uat, :prod
+  VANotifyService = ExternalApi::VANotifyService
+else
+  VANotifyService = Fakes::VANotifyService
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -54,6 +54,7 @@ class SeedDB
     call_and_log_seed_step Seeds::BgsServiceRecordMaker
     call_and_log_seed_step Seeds::PopulateCaseflowFromVacols
     call_and_log_seed_step Seeds::IssueModificationRequest
+    call_and_log_seed_step Seeds::ApiKey
   end
 end
 

--- a/db/seeds/va_notify_api_key.rb
+++ b/db/seeds/va_notify_api_key.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# create annotation seeds
+
+module Seeds
+  class ApiKey
+    def seed!
+      create_api_key
+    end
+
+    private
+
+    def create_api_key
+      ApiKey.create!(consumer_name: "TestApiKey", key_string: "test")
+    end
+  end
+end

--- a/lib/fakes/va_notify_service.rb
+++ b/lib/fakes/va_notify_service.rb
@@ -17,7 +17,8 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
       external_id = SecureRandom.uuid
 
       request = HTTPI::Request.new
-      request.url = "#{ENV["CASEFLOW_BASE_URL"]}#{VA_NOTIFY_ENDPOINT}?id=#{external_id}&status=delivered&to=to&notification_type=email"
+      request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
+        "?id=#{external_id}&status=delivered&to=test@example.com&notification_type=email"
       request.headers["Content-Type"] = "application/json"
       request.headers["Authorization"] = "Bearer test"
 
@@ -38,7 +39,8 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
       external_id = SecureRandom.uuid
 
       request = HTTPI::Request.new
-      request.url = "#{ENV["CASEFLOW_BASE_URL"]}#{VA_NOTIFY_ENDPOINT}?id=#{external_id}&status=delivered&to=to&notification_type=sms"
+      request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
+        "?id=#{external_id}&status=delivered&to=+15555555555&notification_type=sms"
       request.headers["Content-Type"] = "application/json"
       request.headers["Authorization"] = "Bearer test"
 

--- a/lib/fakes/va_notify_service.rb
+++ b/lib/fakes/va_notify_service.rb
@@ -16,13 +16,15 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
 
       external_id = SecureRandom.uuid
 
-      request = HTTPI::Request.new
-      request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
-        "?id=#{external_id}&status=delivered&to=test@example.com&notification_type=email"
-      request.headers["Content-Type"] = "application/json"
-      request.headers["Authorization"] = "Bearer test"
+      unless Rails.deploy_env == :test
+        request = HTTPI::Request.new
+        request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
+          "?id=#{external_id}&status=delivered&to=test@example.com&notification_type=email"
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Authorization"] = "Bearer test"
 
-      HTTPI.post(request)
+        HTTPI.post(request)
+      end
 
       fake_notification_response(email_template_id, status, external_id)
     end
@@ -38,13 +40,15 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
 
       external_id = SecureRandom.uuid
 
-      request = HTTPI::Request.new
-      request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
-        "?id=#{external_id}&status=delivered&to=+15555555555&notification_type=sms"
-      request.headers["Content-Type"] = "application/json"
-      request.headers["Authorization"] = "Bearer test"
+      unless Rails.deploy_env == :test
+        request = HTTPI::Request.new
+        request.url = "#{ENV['CASEFLOW_BASE_URL']}#{VA_NOTIFY_ENDPOINT}"\
+          "?id=#{external_id}&status=delivered&to=+15555555555&notification_type=sms"
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Authorization"] = "Bearer test"
 
-      HTTPI.post(request)
+        HTTPI.post(request)
+      end
 
       if participant_id.length.nil?
         return bad_participant_id_response

--- a/lib/fakes/va_notify_service.rb
+++ b/lib/fakes/va_notify_service.rb
@@ -124,7 +124,7 @@ class Fakes::VANotifyService < ExternalApi::VANotifyService
       )
     end
 
-    def fake_notification_response(template_id, status)
+    def fake_notification_response(template_id, status, external_id)
       HTTPI::Response.new(
         200,
         {},


### PR DESCRIPTION
Resolves [APPEALS-54918: Prevent ProdTest from contacting VA Notify](https://jira.devops.va.gov/browse/APPEALS-54918)

# Description

1. Changes in logic within the VA Notify initializer to utilize the fake service in the ProdTest environment
2. Updated the fake service to return a more realistic status for notifications

## Acceptance Criteria

- [ ] Add logic in the VA Notify initializer to utilize the fake service in the ProdTest environment
- [ ] Update the fake service to return a more realistic status for notifications
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?
