### PR TITLE
APPEALS-55521: Spelling Error in description of CAVC AOD Affinity Days lever

### DIFF
--- a/client/test/data/formattedCaseDistributionData.js
+++ b/client/test/data/formattedCaseDistributionData.js
@@ -269,7 +269,7 @@ export const formattedLevers = [
     id: 10,
     item: 'lever_11',
     title: 'CAVC AOD Affinity Days',
-    description: 'Sets the number of days appeals returned from CAVC that are also AOD respect the affinity to the deciding judge. This is not applicable for legacy apeals for which the deciding judge conducted the most recent hearing.',
+    description: 'Sets the number of days appeals returned from CAVC that are also AOD respect the affinity to the deciding judge. This is not applicable for legacy appeals for which the deciding judge conducted the most recent hearing.',
     data_type: ACD_LEVERS.data_types.radio,
     value: ACD_LEVERS.value,
     unit: ACD_LEVERS.days,

--- a/db/seeds/case_distribution_levers.rb
+++ b/db/seeds/case_distribution_levers.rb
@@ -314,7 +314,7 @@ module Seeds
           {
             item: Constants.DISTRIBUTION.cavc_aod_affinity_days,
             title: Constants.DISTRIBUTION.cavc_aod_affinity_days_title,
-            description: "Sets the number of days appeals returned from CAVC that are also AOD respect the affinity to the deciding judge. This is not applicable for legacy apeals for which the deciding judge conducted the most recent hearing.",
+            description: "Sets the number of days appeals returned from CAVC that are also AOD respect the affinity to the deciding judge. This is not applicable for legacy appeals for which the deciding judge conducted the most recent hearing.",
             data_type: Constants.ACD_LEVERS.data_types.radio,
             value: "14",
             unit: Constants.ACD_LEVERS.days,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-55521](https://jira.devops.va.gov/browse/APPEALS-55521): Spelling Error in description of CAVC AOD Affinity Days lever

# Description
Updates the test data and case distribution lever seed files to correct the spelling of the word "apeals" in the CAVC AOD Affinity Days Lever.

The text string with the spelling error is contained in the `case_distribution_levers` database table. To update the table in higher environments, run the following SQL on the Caseflow DB:
```
update case_distribution_levers
set description = 'Sets the number of days appeals returned from CAVC that are also AOD respect the affinity to the deciding judge. This is not applicable for legacy appeals for which the deciding judge conducted the most recent hearing.'
where item = 'cavc_aod_affinity_days'
```

## Acceptance Criteria
- [X] Code compiles correctly
- [X] On the `/case-distribution-controls` page, the description for the CAVC AOD Affinity Days lever does not have the misspelling "apeals"

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Login to Caseflow as an admin user for the `CdaControlGroup` (CDAADMINLEO in demo)
2. Go to the `/case-distribution-controls` page
3. Verify the above spelling error is not present

# Frontend
## User Facing Changes

<img width="683" alt="image" src="https://github.com/user-attachments/assets/a547acf5-79eb-4293-bfa6-e2fbb9240f04">
