### PR TITLE
Sivakesh/appeals 49703 update tasks list

### DIFF
--- a/client/app/queue/components/CorrespondenceChangeTaskTypeModal.jsx
+++ b/client/app/queue/components/CorrespondenceChangeTaskTypeModal.jsx
@@ -4,8 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { requestPatch } from '../uiReducer/uiActions';
-import { marginTop } from '../constants';
-import { taskActionData } from '../utils';
+import { INTAKE_FORM_TASK_TYPES, marginTop } from '../constants';
 import QueueFlowModal from '../components/QueueFlowModal';
 import TextareaField from 'app/components/TextareaField';
 import SearchableDropdown from 'app/components/SearchableDropdown';
@@ -18,7 +17,6 @@ import {
 
 const CorrespondenceChangeTaskTypeModal = (props) => {
   const { error } = props;
-  const taskData = taskActionData(props);
   const [typeOption, setTypeOption] = useState(null);
   const [instructions, setInstructions] = useState('');
 
@@ -28,7 +26,7 @@ const CorrespondenceChangeTaskTypeModal = (props) => {
     const payload = {
       data: {
         task: {
-          type: typeOption.value,
+          type: typeOption.value.klass,
           instructions
         }
       }
@@ -62,9 +60,9 @@ const CorrespondenceChangeTaskTypeModal = (props) => {
           <SearchableDropdown
             name={COPY.CHANGE_TASK_TYPE_ACTION_LABEL}
             placeholder="Select an action type..."
-            options={taskData.options}
+            options={INTAKE_FORM_TASK_TYPES.unrelatedToAppeal}
             onChange={(option) => option && setTypeOption(option)}
-            value={typeOption?.value}
+            value={typeOption?.value.klass}
           />
         </div>
         <div {...marginTop(4)}>

--- a/client/app/queue/correspondence/correspondenceDetailsReducer/correspondenceDetailsActions.js
+++ b/client/app/queue/correspondence/correspondenceDetailsReducer/correspondenceDetailsActions.js
@@ -77,7 +77,7 @@ export const changeTaskTypeNotRelatedToAppeal = (taskID, payload, taskNames, cor
         payload: {
           bannerAlert: {
             title: 'Warning',
-            message: error,
+            message: error.message,
             type: 'warning'
           }
         }

--- a/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
+++ b/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
 import { Provider } from 'react-redux';
 import { applyMiddleware, compose, createStore } from 'redux';
@@ -9,16 +9,7 @@ import COPY from '../../../../COPY';
 import CorrespondenceChangeTaskTypeModal from 'app/queue/components/CorrespondenceChangeTaskTypeModal';
 import userEvent from '@testing-library/user-event';
 import thunk from 'redux-thunk';
-
-jest.mock('app/queue/utils', () => ({
-  taskActionData: jest.fn().mockReturnValue({
-    options: [
-      { label: 'Option 1', value: 'option_1' },
-      { label: 'Option 2', value: 'option_2' },
-      { label: 'IHP', value: 'IHP' }
-    ]
-  })
-}));
+import { INTAKE_FORM_TASK_TYPES } from 'app/queue/constants';
 
 describe('CorrespondenceChangeTaskTypeModal', () => {
   const mockProps = {
@@ -96,11 +87,26 @@ describe('CorrespondenceChangeTaskTypeModal', () => {
   it('enables the submit button when both the dropdown and instructions are filled', () => {
     renderComponent();
 
-    userEvent.type(screen.getByRole('combobox'), 'IHP{enter}');
+    userEvent.type(screen.getByRole('combobox'), 'CAVC{enter}');
     userEvent.type(screen.getByLabelText(COPY.CHANGE_TASK_TYPE_INSTRUCTIONS_LABEL), 'test instructions');
 
     const submitButton = screen.getByRole('button', { name: COPY.CHANGE_TASK_TYPE_SUBHEAD });
 
     expect(submitButton).not.toBeDisabled();
+  });
+
+  it('renders dropdown with correct options', () => {
+    renderComponent();
+
+    // Verify dropdown options
+    // const dropdown = screen.getByPlaceholderText('Select an action type');
+    const dropdown = screen.getByRole('combobox');
+
+    fireEvent.mouseDown(dropdown);
+
+    // Ensure each option is rendered
+    INTAKE_FORM_TASK_TYPES.unrelatedToAppeal.forEach((option) => {
+      expect(screen.getByText(option.label)).toBeInTheDocument();
+    });
   });
 });

--- a/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
+++ b/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
@@ -98,8 +98,6 @@ describe('CorrespondenceChangeTaskTypeModal', () => {
   it('renders dropdown with correct options', () => {
     renderComponent();
 
-    // Verify dropdown options
-    // const dropdown = screen.getByPlaceholderText('Select an action type');
     const dropdown = screen.getByRole('combobox');
 
     fireEvent.mouseDown(dropdown);


### PR DESCRIPTION
- This is a follow up change for the [PR](https://github.com/department-of-veterans-affairs/caseflow/pull/22632)
- These changes here updates the list of options in the Task Type dropdown as mentioned in AC 1.1.2.2 in [Task Actions: Other motion: Change Task Type](https://jira.devops.va.gov/browse/APPEALS-49703) story.
- Added another Jest Test to validate the options list

Note: For test steps and all other details please refer to previous [PR](https://github.com/department-of-veterans-affairs/caseflow/pull/22632) and the [story](https://jira.devops.va.gov/browse/APPEALS-49703)

![image](https://github.com/user-attachments/assets/7c3ae2fb-7292-4bb8-b974-7a66ac02d3f5)
