### PR TITLE
MattT/APPEALS-57189

### DIFF
--- a/app/services/hearing_time_service.rb
+++ b/app/services/hearing_time_service.rb
@@ -99,7 +99,7 @@ class HearingTimeService
   def process_legacy_scheduled_time_string(date:, time_string:)
     return nil unless date && time_string
 
-    hour, min = time_string.split(":")
+    hour, min = self.class.process_scheduled_time(time_string).split(":")
     time = date.to_datetime
     unformatted_time = Time.use_zone(VacolsHelper::VACOLS_DEFAULT_TIMEZONE) do
       Time.zone.now.change(

--- a/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
+++ b/spec/feature/hearings/virtual_hearings/daily_docket_spec.rb
@@ -209,9 +209,9 @@ RSpec.feature "Editing virtual hearing information on daily Docket", :all_dbs do
       end
 
       context "Without a pre-existing scheduled_in_timezone value" do
-        let(:hearing_time_selection_string) { "12:00 PM Central Time (US & Canada)" }
+        let(:hearing_time_selection_string) { "3:00 PM Central Time (US & Canada)" }
         let(:hearing) { initial_hearing.tap { _1.update!(scheduled_in_timezone: nil) } }
-        let(:expected_post_update_time) { "12:00 PM CST" }
+        let(:expected_post_update_time) { "3:00 PM CST" }
 
         before do
           hearing.hearing_day.update!(regional_office: "RO30", request_type: "T", scheduled_for: "2024-11-11")

--- a/spec/services/hearing_time_service_spec.rb
+++ b/spec/services/hearing_time_service_spec.rb
@@ -208,6 +208,14 @@ describe HearingTimeService, :all_dbs do
       it { is_expected.to be nil }
     end
 
+    context "When date is non-nil and time_string is non-nil" do
+      let(:test_date) { "2024-09-01" }
+      let(:test_time_string) { "2:00 PM Eastern Time (US & Canada)" }
+      let(:expected_time) { Time.use_zone("UTC") { Time.zone.parse("#{test_date} 14:00") } }
+
+      it { is_expected.to eq expected_time }
+    end
+
     describe "When the time_string is Pacific Time" do
       let(:test_time_string) { "10:00 AM Pacific Time (US & Canada)" }
       let(:expected_time) { Time.use_zone("UTC") { Time.zone.parse("#{test_date} 10:00") } }


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-57189](https://jira.devops.va.gov/browse/APPEALS-57189)

# Description
Legacy hearings without `scheduled_in_datetime` values have their updated hearing times converted to 24 hour time prior to persistence so that they appear correctly in the UI.

## Acceptance Criteria
- [ ] Legacy hearing times appear correctly post-update in all instances.