### PR TITLE
APPEALS-53923

### DIFF
--- a/app/services/events/decision_review_updated/update_informal_conference.rb
+++ b/app/services/events/decision_review_updated/update_informal_conference.rb
@@ -9,12 +9,13 @@ class Events::DecisionReviewUpdated::UpdateInformalConference
       parser = params[:parser]
       if parser.detail_type == "HigherLevelReview"
         # fetch the EPE and use it to get the source (i.e. HLR)
-        hlr = EndProductEstablishment.find_by(reference_id: parser.end_product_establishments_reference_id).source
+        hlr = EndProductEstablishment.find_by(reference_id: parser.end_product_establishments_reference_id)&.source
         hlr.update!(
           informal_conference: parser.claim_review_informal_conference,
           same_office: parser.claim_review_same_office
         )
         EventRecord.create!(event: event, evented_record: hlr)
+        hlr
       end
     rescue StandardError => error
       raise Caseflow::Error::DecisionReviewUpdatedInformalConferenceError, error.message

--- a/app/services/events/decision_review_updated/update_informal_conference.rb
+++ b/app/services/events/decision_review_updated/update_informal_conference.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Service class to handle changes to the informal_conference and/or same_office values on a HLR that
+# was previously created through DecisionReviewCreated
+class Events::DecisionReviewUpdated::UpdateInformalConference
+  class << self
+    def process!(params)
+      event = params[:event]
+      parser = params[:parser]
+      if parser.detail_type == "HigherLevelReview"
+        # fetch the EPE and use it to get the source (i.e. HLR)
+        hlr = EndProductEstablishment.find_by(reference_id: parser.end_product_establishments_reference_id).source
+        hlr.update!(
+          informal_conference: parser.claim_review_informal_conference,
+          same_office: parser.claim_review_same_office
+        )
+        EventRecord.create!(event: event, evented_record: hlr)
+      end
+    rescue StandardError => error
+      raise Caseflow::Error::DecisionReviewUpdatedInformalConferenceError, error.message
+    end
+  end
+end

--- a/lib/caseflow/error.rb
+++ b/lib/caseflow/error.rb
@@ -505,6 +505,7 @@ module Caseflow::Error
   class DecisionReviewCreatedEpEstablishmentError < StandardError; end
   class DecisionReviewCreatedRequestIssuesError < StandardError; end
   class DecisionReviewUpdatedRequestIssuesError < StandardError; end
+  class DecisionReviewUpdatedInformalConferenceError < StandardError; end
   class MaximumBatchSizeViolationError < StandardError
     def initialize(msg = "The batch size of jobs must not exceed 10")
       super(msg)

--- a/spec/services/events/decision_review_updated/update_informal_conference_spec.rb
+++ b/spec/services/events/decision_review_updated/update_informal_conference_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+RSpec.describe Events::DecisionReviewUpdated::UpdateInformalConference do
+  let!(:event) { DecisionReviewUpdatedEvent.create!(reference_id: "1") }
+  let!(:epe) { create(:end_product_establishment, :active_hlr) }
+  let!(:hlr) { epe.source }
+  let!(:payload) { Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.example_response }
+  # let(:parser) { Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.load_example }
+
+  describe ".process" do
+    context "informal_conference true to false" do
+      before do
+        hlr.update!(informal_conference: true)
+      end
+
+      it "updates the value to false" do
+        hash = JSON.parse(payload)
+        hash["detail_type"] = "HigherLevelReview"
+        hash["end_product_establishments"]["reference_id"] = epe.reference_id.to_s
+        hash["claim_review"]["informal_conference"] = false
+        parser = Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.new({}, hash)
+        expect do
+          described_class.process!(event: event, parser: parser)
+        end.to change { EventRecord.count }.by(1)
+
+        hlr.reload
+        expect(hlr.informal_conference).to eq(false)
+      end
+    end
+    context "informal_conference false to true" do
+      before do
+        hlr.update!(informal_conference: false)
+      end
+
+      it "updates the value to true" do
+        hash = JSON.parse(payload)
+        hash["detail_type"] = "HigherLevelReview"
+        hash["end_product_establishments"]["reference_id"] = epe.reference_id.to_s
+        hash["claim_review"]["informal_conference"] = true
+        parser = Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.new({}, hash)
+        expect do
+          described_class.process!(event: event, parser: parser)
+        end.to change { EventRecord.count }.by(1)
+
+        hlr.reload
+        expect(hlr.informal_conference).to eq(true)
+      end
+    end
+
+    context "same_office true to false" do
+      before do
+        hlr.update!(same_office: true)
+      end
+
+      it "updates the value to false" do
+        hash = JSON.parse(payload)
+        hash["detail_type"] = "HigherLevelReview"
+        hash["end_product_establishments"]["reference_id"] = epe.reference_id.to_s
+        hash["claim_review"]["same_office"] = false
+        parser = Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.new({}, hash)
+        expect do
+          described_class.process!(event: event, parser: parser)
+        end.to change { EventRecord.count }.by(1)
+
+        hlr.reload
+        expect(hlr.same_office).to eq(false)
+      end
+    end
+    context "same_office false to true" do
+      before do
+        hlr.update!(same_office: false)
+      end
+
+      it "updates the value to true" do
+        hash = JSON.parse(payload)
+        hash["detail_type"] = "HigherLevelReview"
+        hash["end_product_establishments"]["reference_id"] = epe.reference_id.to_s
+        hash["claim_review"]["same_office"] = true
+        parser = Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.new({}, hash)
+        expect do
+          described_class.process!(event: event, parser: parser)
+        end.to change { EventRecord.count }.by(1)
+
+        hlr.reload
+        expect(hlr.same_office).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/services/events/decision_review_updated/update_informal_conference_spec.rb
+++ b/spec/services/events/decision_review_updated/update_informal_conference_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Events::DecisionReviewUpdated::UpdateInformalConference do
   let!(:epe) { create(:end_product_establishment, :active_hlr) }
   let!(:hlr) { epe.source }
   let!(:payload) { Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.example_response }
-  # let(:parser) { Events::DecisionReviewUpdated::DecisionReviewUpdatedParser.load_example }
 
   describe ".process" do
     context "informal_conference true to false" do


### PR DESCRIPTION

Resolves [APPEALS-53923](https://jira.devops.va.gov/browse/APPEALS-53923)

# Description
Created new service class to handle changes to the informal_conference & same_office values coming from a DecisionReviewUpdatedEvent. This will only affect HLRs.




