### PR TITLE
akonhilas/APPEALS-59152

### DIFF
--- a/client/app/hearings/components/VirtualHearingLink.jsx
+++ b/client/app/hearings/components/VirtualHearingLink.jsx
@@ -11,8 +11,7 @@ const ICON_POSITION_FIX = css({ position: 'relative', top: 1 });
 const VirtualHearingLink = ({
   newWindow,
   link,
-  label,
-  hearing
+  label
 }) => {
   return (
     <Link
@@ -22,7 +21,7 @@ const VirtualHearingLink = ({
       <strong>{label}</strong>
       <span {...ICON_POSITION_FIX}>
         &nbsp;
-        <ExternalLinkIcon color={hearing?.scheduledForIsPast ? COLORS.PRIMARY : COLORS.GREY_MEDIUM} />
+        <ExternalLinkIcon color={COLORS.PRIMARY} />
       </span>
     </Link>
   );

--- a/client/test/app/hearings/components/dailyDocket/__snapshots__/StaticVirtualHearing.test.js.snap
+++ b/client/test/app/hearings/components/dailyDocket/__snapshots__/StaticVirtualHearing.test.js.snap
@@ -31,7 +31,7 @@ Object {
                 stroke-width="1"
               >
                 <g
-                  fill="#757575"
+                  fill="#0071bc"
                   fill-rule="nonzero"
                 >
                   <g
@@ -81,7 +81,7 @@ Object {
               stroke-width="1"
             >
               <g
-                fill="#757575"
+                fill="#0071bc"
                 fill-rule="nonzero"
               >
                 <g
@@ -188,7 +188,7 @@ Object {
                 stroke-width="1"
               >
                 <g
-                  fill="#757575"
+                  fill="#0071bc"
                   fill-rule="nonzero"
                 >
                   <g
@@ -238,7 +238,7 @@ Object {
               stroke-width="1"
             >
               <g
-                fill="#757575"
+                fill="#0071bc"
                 fill-rule="nonzero"
               >
                 <g
@@ -342,7 +342,7 @@ exports[`StaticVirtualHearing renders correctly 1`] = `
             stroke-width="1"
           >
             <g
-              fill="#757575"
+              fill="#0071bc"
               fill-rule="nonzero"
             >
               <g

--- a/client/test/app/hearings/components/details/__snapshots__/HearingLinks.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/HearingLinks.test.js.snap
@@ -181,7 +181,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -198,7 +198,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -552,7 +552,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -569,7 +569,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -923,7 +923,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -940,7 +940,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, pexip, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -1321,7 +1321,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -1338,7 +1338,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -1672,7 +1672,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -1689,7 +1689,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -2023,7 +2023,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -2040,7 +2040,7 @@ exports[`HearingLinks Matches snapshot when hearing is non-virtual, webex, and i
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -2443,7 +2443,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -2460,7 +2460,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -2829,7 +2829,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -2846,7 +2846,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -3215,7 +3215,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -3232,7 +3232,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, pexip, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -3655,7 +3655,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -3672,7 +3672,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -4039,7 +4039,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -4056,7 +4056,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -4423,7 +4423,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -4440,7 +4440,7 @@ exports[`HearingLinks Matches snapshot when hearing is virtual, webex, and in pr
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g
@@ -6183,7 +6183,7 @@ exports[`HearingLinks Only displays Guest Link when user is not a host 1`] = `
                    
                   <ExternalLinkIcon
                     className=""
-                    color="#757575"
+                    color="#0071bc"
                     size={20}
                   >
                     <svg
@@ -6200,7 +6200,7 @@ exports[`HearingLinks Only displays Guest Link when user is not a host 1`] = `
                         strokeWidth="1"
                       >
                         <g
-                          fill="#757575"
+                          fill="#0071bc"
                           fillRule="nonzero"
                         >
                           <g

--- a/client/test/app/hearings/components/details/__snapshots__/VirtualHearingFields.test.js.snap
+++ b/client/test/app/hearings/components/details/__snapshots__/VirtualHearingFields.test.js.snap
@@ -1490,7 +1490,7 @@ exports[`VirtualHearingFields Renders pexip conference when conference provider 
                            
                           <ExternalLinkIcon
                             className=""
-                            color="#757575"
+                            color="#0071bc"
                             size={20}
                           >
                             <svg
@@ -1507,7 +1507,7 @@ exports[`VirtualHearingFields Renders pexip conference when conference provider 
                                 strokeWidth="1"
                               >
                                 <g
-                                  fill="#757575"
+                                  fill="#0071bc"
                                   fillRule="nonzero"
                                 >
                                   <g
@@ -2561,7 +2561,7 @@ exports[`VirtualHearingFields Renders webex conference when conference provider 
                            
                           <ExternalLinkIcon
                             className=""
-                            color="#757575"
+                            color="#0071bc"
                             size={20}
                           >
                             <svg
@@ -2578,7 +2578,7 @@ exports[`VirtualHearingFields Renders webex conference when conference provider 
                                 strokeWidth="1"
                               >
                                 <g
-                                  fill="#757575"
+                                  fill="#0071bc"
                                   fillRule="nonzero"
                                 >
                                   <g
@@ -3622,7 +3622,7 @@ exports[`VirtualHearingFields Shows hearing details with virtualHearing 1`] = `
                            
                           <ExternalLinkIcon
                             className=""
-                            color="#757575"
+                            color="#0071bc"
                             size={20}
                           >
                             <svg
@@ -3639,7 +3639,7 @@ exports[`VirtualHearingFields Shows hearing details with virtualHearing 1`] = `
                                 strokeWidth="1"
                               >
                                 <g
-                                  fill="#757575"
+                                  fill="#0071bc"
                                   fillRule="nonzero"
                                 >
                                   <g
@@ -4693,7 +4693,7 @@ exports[`VirtualHearingFields Shows only hearing links with no virtualHearing 1`
                            
                           <ExternalLinkIcon
                             className=""
-                            color="#757575"
+                            color="#0071bc"
                             size={20}
                           >
                             <svg
@@ -4710,7 +4710,7 @@ exports[`VirtualHearingFields Shows only hearing links with no virtualHearing 1`
                                 strokeWidth="1"
                               >
                                 <g
-                                  fill="#757575"
+                                  fill="#0071bc"
                                   fillRule="nonzero"
                                 >
                                   <g


### PR DESCRIPTION
## Resolves Change color of the new window Icon in Hearing Details page
https://jira.devops.va.gov/browse/APPEALS-59152

# Description
New window icon next to hearing links is updated from gray to blue

## Acceptance Criteria
- [x] Code compiles correctly
- [x] New window icon next to hearing links is blue

## Testing Plan
1. Go to https://jira.devops.va.gov/browse/APPEALS-59220

# Frontend
## User Facing Changes
 - [x] Screenshots of UI changes added to PR & Original Issue

| BEFORE | AFTER |
|----|----|
|<img width="1348" alt="Screenshot 2024-09-25 at 2 55 19 PM" src="https://github.com/user-attachments/assets/cd957b58-38f5-419e-9c75-6bc7cfd3a25a">|<img width="1354" alt="Screenshot 2024-09-25 at 2 54 59 PM" src="https://github.com/user-attachments/assets/9ff3e5b9-3231-4603-9a6b-6e62558c7103">|

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [ ] RSpec
- [x] Jest
- [ ] Other