### PR TITLE
Khalin/appeals 42561 Checkbox Sorting Fix

### DIFF
--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -147,7 +147,7 @@ const CorrespondenceDetails = (props) => {
     } catch (error) {
       console.error('Error during PATCH request:', error.message);
     } finally {
-      setDisableSubmitButton(false);
+      setDisableSubmitButton(true);
     }
 
     // Reset checkboxes to the new state


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/APPEALS-42561)

# Description
As an Inbound Ops Team Superuser and Inbound Ops Team Supervisor, I will now see that checkboxes sorting as intended onSave when the prior mail association is removed. 

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan

1. Log into Caseflow as an Inbound Ops Supervisor user
2. Go to "Your Queue"
3. Click "Correspondence Cases" in the "Switch Views" drop down
4. Click any veteran in the "Veteran Details" column(That does NOT have a pending request)
5. Select any Correspondence Type and click Save Changes
6. Scroll to the bottom and click "Create Record"
7. Under the "Associate with prior Mail" section Click "Yes"
8. Add 2-3 of the prior mail options via the checkbox
9. Click Continue to go to the second step
10. Under the "Tasks not related to an Appeal" Click "+Add Task"
11. In the New Task modal that renders add and "Other Motion" task and add any test text in the instructions
12. Scroll to the bottom and click "Continue"
13. Scroll to the bottom and click "Submit" then "Confirm" in the pop-up modal
14. Copy the name that shows up in the support banner on the next redirected page(/correspondence/team)
15. Go to the "Pending" tab
16. Paste the name that you copied from the success banner
17. Click the result with "Other motion" under the "Tasks" section(You may need to navigate through the pages until you see "Other Motion")
18. On the Correspondence Details Page, Click the "Associated Prior Mail" Tab
19. Uncheck one of the prior mail checkboxes and click "Save changes" at the bottom
20. Refresh the page
21. On the Correspondence Details Page, Click the "Associated Prior Mail" Tab
22. Confirm the checkbox has remained unchecked
23. Repeat steps 1-22 as an Inbound Ops Superuser