### PR TITLE
Ki/APPEALS-42563 - User Access Fix

### DIFF
--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -513,10 +513,12 @@ const CorrespondenceDetails = (props) => {
         <div className="correspondence-package-details">
           <div className="corr-title-with-button">
             <h2 className="correspondence-h2">General Information</h2>
-            <Button
-              onClick={handleEditGeneralInformationModal}
-              classNames={['button-style']}
-            >Edit</Button>
+            {isAdminNotLoggedIn() ?
+              '' :
+              <Button
+                onClick={handleEditGeneralInformationModal}
+                classNames={['button-style']}
+              >Edit</Button> }
           </div>
           <table className="corr-table-borderless-no-background gray-border">
             <tbody>

--- a/spec/feature/queue/correspondence/correspondence_details_spec.rb
+++ b/spec/feature/queue/correspondence/correspondence_details_spec.rb
@@ -197,7 +197,7 @@ RSpec.feature("The Correspondence Details page") do
 
   context "correspondence package details tab" do
     before do
-      correspondence_spec_user_access
+      correspondence_spec_super_access
       FeatureToggle.enable!(:correspondence_queue)
       @correspondence = create(
         :correspondence,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-42563 - Package Details: Inbound Ops Team Superuser/visor: Edit Information - Part 2, User fix](https://jira.devops.va.gov/browse/APPEALS-42563)

# Description
Uses the boolean from isAdminNotLoggedIn function to check user access and limits the Edit button display.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Original PR ticket](https://github.com/department-of-veterans-affairs/caseflow/pull/22944)

### Admin
![Screenshot 2024-10-03 at 2 06 08 PM](https://github.com/user-attachments/assets/2bb133d6-799c-4e67-8079-7545b6e1cb01)

### Not Admin
![Screenshot 2024-10-03 at 2 08 26 PM](https://github.com/user-attachments/assets/72acfe9c-0534-4879-a5fd-227ea8646c77)