### PR TITLE
Khalin/appeals 42561 success banner fix v2

### DIFF
--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -123,12 +123,12 @@ const CorrespondenceDetails = (props) => {
     // Data for the PATCH request to remove unchecked relations
     const patchData = {
       correspondence_uuid: correspondence.uuid,
-      correspondence_relations: uncheckedCheckboxes,
+      correspondence_relations: uncheckedCheckboxes
     };
 
     // Data for the POST request to add checked relations
     const postData = {
-      priorMailIds: checkedCheckboxes,
+      priorMailIds: checkedCheckboxes
     };
 
     try {

--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -133,51 +133,71 @@ const CorrespondenceDetails = (props) => {
 
     try {
     // Send PATCH request to remove unchecked relations
-      const patchResponse = await ApiUtil.patch(`/queue/correspondence/${correspondence.uuid}/update_correspondence`, {
-        data: patchData
-      });
+      let patchSuccess = false;
 
-      if (patchResponse.status === 201) {
-      // If successful, proceed with POST request for checked relations
-        if (checkedCheckboxes.length > 0) {
-          // eslint-disable-next-line max-len
-          const postResponse = await ApiUtil.post(`/queue/correspondence/${correspondence.uuid}/create_correspondence_relations`, {
-            data: postData
-          });
-
-          if (postResponse.status === 201) {
-            setShowSuccessBanner(true);
-            // eslint-disable-next-line max-len
-            console.log('Correspondence relations updated successfully.', postResponse.status); // eslint-disable-line no-console
-          }
-        }
-
-        // Sort the prior mail into linked (checked) and unlinked (unchecked) groups
-        const updatedSortedPriorMail = [...priorMail].sort((first, second) => {
-          const firstInState = checkboxStates[first.id];
-          const secondInState = checkboxStates[second.id];
-
-          // If both are linked or both are unlinked, sort by vaDateOfReceipt
-          if (firstInState && secondInState) {
-            // Sort linked mail from most recent to oldest
-            return new Date(second.vaDateOfReceipt) - new Date(first.vaDateOfReceipt);
-          } else if (!firstInState && !secondInState) {
-            // Sort unlinked mail from oldest to most recent
-            return new Date(first.vaDateOfReceipt) - new Date(second.vaDateOfReceipt);
-          } else if (firstInState) {
-            // Ensure linked items come before unlinked items
-            return -1;
-          } else if (secondInState) {
-            return 1;
-          }
-          // Maintain original order otherwise
-
-          return 0;
+      if (uncheckedCheckboxes.length > 0) {
+        // eslint-disable-next-line max-len
+        const patchResponse = await ApiUtil.patch(`/queue/correspondence/${correspondence.uuid}/update_correspondence`, {
+          data: patchData
         });
 
-        // Update the state with the sorted list after saving changes
-        setSortedPriorMail(updatedSortedPriorMail);
+        // Check for general success status (any 2xx status)
+        if (patchResponse.ok) {
+          patchSuccess = true;
+          console.log('PATCH successful:', patchResponse.status); // eslint-disable-line no-console
+        }
+      } else {
+        patchSuccess = true;
       }
+
+      // Send POST request to add checked relations if necessary
+      let postSuccess = false;
+
+      if (checkedCheckboxes.length > 0) {
+        // eslint-disable-next-line max-len
+        const postResponse = await ApiUtil.post(`/queue/correspondence/${correspondence.uuid}/create_correspondence_relations`, {
+          data: postData
+        });
+
+        // Check for general success status (any 2xx status)
+        if (postResponse.ok) {
+          postSuccess = true;
+          console.log('POST successful:', postResponse.status); // eslint-disable-line no-console
+        }
+      } else {
+        postSuccess = true;
+      }
+
+      // Only show success banner if both PATCH and POST requests succeeded
+      if (patchSuccess && postSuccess) {
+        setShowSuccessBanner(true);
+      }
+
+      // Sort the prior mail into linked (checked) and unlinked (unchecked) groups
+      const updatedSortedPriorMail = [...priorMail].sort((first, second) => {
+        const firstInState = checkboxStates[first.id];
+        const secondInState = checkboxStates[second.id];
+
+        // If both are linked or both are unlinked, sort by vaDateOfReceipt
+        if (firstInState && secondInState) {
+          // Sort linked mail from most recent to oldest
+          return new Date(second.vaDateOfReceipt) - new Date(first.vaDateOfReceipt);
+        } else if (!firstInState && !secondInState) {
+          // Sort unlinked mail from oldest to most recent
+          return new Date(first.vaDateOfReceipt) - new Date(second.vaDateOfReceipt);
+        } else if (firstInState) {
+          // Ensure linked items come before unlinked items
+          return -1;
+        } else if (secondInState) {
+          return 1;
+        }
+        // Maintain original order otherwise
+
+        return 0;
+      });
+
+      // Update the state with the sorted list after saving changes
+      setSortedPriorMail(updatedSortedPriorMail);
     } catch (error) {
       console.error('Error during PATCH/POST request:', error.message);
     } finally {

--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -123,49 +123,48 @@ const CorrespondenceDetails = (props) => {
     // Data for the PATCH request to remove unchecked relations
     const patchData = {
       correspondence_uuid: correspondence.uuid,
-      correspondence_relations: uncheckedCheckboxes
+      correspondence_relations: uncheckedCheckboxes,
     };
 
     // Data for the POST request to add checked relations
     const postData = {
-      priorMailIds: checkedCheckboxes
+      priorMailIds: checkedCheckboxes,
     };
 
     try {
-    // Send PATCH request to remove unchecked relations
-      let patchSuccess = false;
+    // Helper function to check for success response
+      const isSuccess = (response) => response.ok;
+
+      // Send PATCH request to remove unchecked relations if necessary
+      // If no unchecked items, PATCH is already successful
+      let patchSuccess = uncheckedCheckboxes.length === 0;
 
       if (uncheckedCheckboxes.length > 0) {
-        // eslint-disable-next-line max-len
-        const patchResponse = await ApiUtil.patch(`/queue/correspondence/${correspondence.uuid}/update_correspondence`, {
-          data: patchData
-        });
+      // Send PATCH request to update the backend
+        const patchResponse = await ApiUtil.patch(
+        `/queue/correspondence/${correspondence.uuid}/update_correspondence`,
+        { data: patchData }
+        );
 
         // Check for general success status (any 2xx status)
-        if (patchResponse.ok) {
-          patchSuccess = true;
-          console.log('PATCH successful:', patchResponse.status); // eslint-disable-line no-console
-        }
-      } else {
-        patchSuccess = true;
+        patchSuccess = isSuccess(patchResponse);
+        console.log('PATCH successful:', patchResponse.status); // eslint-disable-line no-console
       }
 
       // Send POST request to add checked relations if necessary
-      let postSuccess = false;
+      // If no checked items, POST is already successful
+      let postSuccess = checkedCheckboxes.length === 0;
 
       if (checkedCheckboxes.length > 0) {
-        // eslint-disable-next-line max-len
-        const postResponse = await ApiUtil.post(`/queue/correspondence/${correspondence.uuid}/create_correspondence_relations`, {
-          data: postData
-        });
+      // Send POST request to create relations
+        const postResponse = await ApiUtil.post(
+        `/queue/correspondence/${correspondence.uuid}/create_correspondence_relations`,
+        { data: postData }
+        );
 
         // Check for general success status (any 2xx status)
-        if (postResponse.ok) {
-          postSuccess = true;
-          console.log('POST successful:', postResponse.status); // eslint-disable-line no-console
-        }
-      } else {
-        postSuccess = true;
+        postSuccess = isSuccess(postResponse);
+        console.log('POST successful:', postResponse.status); // eslint-disable-line no-console
       }
 
       // Only show success banner if both PATCH and POST requests succeeded
@@ -178,29 +177,32 @@ const CorrespondenceDetails = (props) => {
         const firstInState = checkboxStates[first.id];
         const secondInState = checkboxStates[second.id];
 
-        // If both are linked or both are unlinked, sort by vaDateOfReceipt
-        if (firstInState && secondInState) {
-          // Sort linked mail from most recent to oldest
-          return new Date(second.vaDateOfReceipt) - new Date(first.vaDateOfReceipt);
-        } else if (!firstInState && !secondInState) {
-          // Sort unlinked mail from oldest to most recent
-          return new Date(first.vaDateOfReceipt) - new Date(second.vaDateOfReceipt);
-        } else if (firstInState) {
-          // Ensure linked items come before unlinked items
-          return -1;
-        } else if (secondInState) {
-          return 1;
-        }
-        // Maintain original order otherwise
+        // Default sorting order
+        let sortOrder = 0;
 
-        return 0;
+        if (firstInState && secondInState) {
+        // Sort linked mail from most recent to oldest
+          sortOrder = new Date(second.vaDateOfReceipt) - new Date(first.vaDateOfReceipt);
+        } else if (!firstInState && !secondInState) {
+        // Sort unlinked mail from oldest to most recent
+          sortOrder = new Date(first.vaDateOfReceipt) - new Date(second.vaDateOfReceipt);
+        } else if (firstInState) {
+        // Ensure linked items come before unlinked items
+          sortOrder = -1;
+        } else if (secondInState) {
+          sortOrder = 1;
+        }
+
+        // Single return for sorting
+        return sortOrder;
       });
 
       // Update the state with the sorted list after saving changes
       setSortedPriorMail(updatedSortedPriorMail);
     } catch (error) {
-      console.error('Error during PATCH/POST request:', error.message);
+      console.error('Error during PATCH/POST request:', error.message); // eslint-disable-line no-console
     } finally {
+      // Re-enable the button
       setDisableSubmitButton(true);
     }
 


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/APPEALS-42561)

# Description
A success banner now populates when checkbox relationship is added and removed. 

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan

1. Log into Caseflow as an Inbound Ops Supervisor user
2. Go to "Your Queue"
3. Click "Correspondence Cases" in the "Switch Views" drop down
4. Click any veteran in the "Veteran Details" column(That does NOT have a pending request)
5. Select any Correspondence Type and click Save Changes
6. Scroll to the bottom and click "Create Record"
7. Under the "Associate with prior Mail" section Click "Yes"
8. Add 2-3 of the prior mail options via the checkbox
9. Click Continue to go to the second step
10. Under the "Tasks not related to an Appeal" Click "+Add Task"
11. In the New Task modal that renders add and "Other Motion" task and add any test text in the instructions
12. Scroll to the bottom and click "Continue"
13. Scroll to the bottom and click "Submit" then "Confirm" in the pop-up modal
14. Copy the name that shows up in the support banner on the next redirected page(/correspondence/team)
15. Go to the "Pending" tab
16. Paste the name that you copied from the success banner
17. Click the result with "Other motion" under the "Tasks" section(You may need to navigate through the pages until you see "Other Motion")
18. On the Correspondence Details Page, Click the "Associated Prior Mail" Tab
19. Uncheck one of the prior mail checkboxes and click "Save changes" at the bottom
20. Refresh the page
21. On the Correspondence Details Page, Click the "Associated Prior Mail" Tab
22. Confirm the checkbox has remained unchecked
23. Repeat steps 1-22 as an Inbound Ops Superuser
