### PR TITLE
APPEALS-59294: Hearings seed file is creating DistributionTasks for legacy appeals

### DIFF
--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -285,14 +285,12 @@ module Seeds
     # rubocop:disable Metrics/MethodLength
     def create_hearing_subtree(appeal, hearing)
       root_task = create(:root_task, appeal: appeal)
-      distribution_task = create(
-        :distribution_task,
-        appeal: appeal,
-        parent: root_task
-      )
+
+      distribution_task = create( :distribution_task, appeal: appeal, parent: root_task) if appeal.is_a?(Appeal)
+
       parent_hearing_task = create(
         :hearing_task,
-        parent: distribution_task,
+        parent: appeal.is_a?(Appeal) ? distribution_task : root_task,
         appeal: appeal
       )
 

--- a/db/seeds/hearings.rb
+++ b/db/seeds/hearings.rb
@@ -286,7 +286,7 @@ module Seeds
     def create_hearing_subtree(appeal, hearing)
       root_task = create(:root_task, appeal: appeal)
 
-      distribution_task = create( :distribution_task, appeal: appeal, parent: root_task) if appeal.is_a?(Appeal)
+      distribution_task = create(:distribution_task, appeal: appeal, parent: root_task) if appeal.is_a?(Appeal)
 
       parent_hearing_task = create(
         :hearing_task,


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-59294](https://jira.devops.va.gov/browse/APPEALS-59294)

# Description
Modifies the hearings seed file to not create a DistributionTask when creating a LegacyAppeal, and uses the LegacyAppeal's RootTask as the parent for the HearingTask when created. This is consistent with how LegacyAppeals are handled in production.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] Hearings seed spec file passes

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into master: Was this deployed to UAT?
