### PR TITLE
Craig/appeals 60680

### DIFF
--- a/app/models/vacols/aoj_case_docket.rb
+++ b/app/models/vacols/aoj_case_docket.rb
@@ -725,6 +725,8 @@ class VACOLS::AojCaseDocket < VACOLS::CaseDocket # rubocop:disable Metrics/Class
         next true if !ineligible_judges_sattyids.include?(appeal["vlj"])
       end
 
+      next true if appeal["prev_deciding_judge"].nil? && !ineligible_judges_sattyids.include?(appeal["vlj"])
+
       next if ineligible_or_excluded_deciding_judge?(appeal, excluded_judges_attorney_ids)
 
       if case_affinity_days_lever_value_is_selected?(lever_value)
@@ -755,6 +757,8 @@ class VACOLS::AojCaseDocket < VACOLS::CaseDocket # rubocop:disable Metrics/Class
         next if appeal["vlj"] == judge_sattyid
         next true if !ineligible_judges_sattyids.include?(appeal["vlj"])
       end
+
+      next true if appeal["prev_deciding_judge"].nil? && !ineligible_judges_sattyids.include?(appeal["vlj"])
 
       next if ineligible_or_excluded_deciding_judge?(appeal, excluded_judges_attorney_ids)
 
@@ -787,6 +791,8 @@ class VACOLS::AojCaseDocket < VACOLS::CaseDocket # rubocop:disable Metrics/Class
         next if appeal["vlj"] == judge_sattyid
         next true if !ineligible_judges_sattyids.include?(appeal["vlj"])
       end
+
+      next true if appeal["prev_deciding_judge"].nil? && !ineligible_judges_sattyids.include?(appeal["vlj"])
 
       next if ineligible_or_excluded_deciding_judge?(appeal, excluded_judges_attorney_ids)
 

--- a/app/models/vacols/case_docket.rb
+++ b/app/models/vacols/case_docket.rb
@@ -845,6 +845,8 @@ class VACOLS::CaseDocket < VACOLS::Record
         next true if !ineligible_judges_sattyids.include?(appeal["vlj"])
       end
 
+      next true if appeal["prev_deciding_judge"].nil? && !ineligible_judges_sattyids.include?(appeal["vlj"])
+
       next if ineligible_or_excluded_deciding_judge?(appeal, excluded_judges_attorney_ids)
 
       if case_affinity_days_lever_value_is_selected?(cavc_affinity_lever_value)
@@ -876,6 +878,8 @@ class VACOLS::CaseDocket < VACOLS::Record
         next if appeal["vlj"] == judge_sattyid
         next true if !ineligible_judges_sattyids.include?(appeal["vlj"])
       end
+
+      next true if appeal["prev_deciding_judge"].nil? && !ineligible_judges_sattyids.include?(appeal["vlj"])
 
       next if ineligible_or_excluded_deciding_judge?(appeal, excluded_judges_attorney_ids)
 

--- a/db/seeds/aoj_remand_return_legacy_appeals.rb
+++ b/db/seeds/aoj_remand_return_legacy_appeals.rb
@@ -34,8 +34,8 @@ module Seeds
         snamef: !options[:snamef].nil? ? options[:snamef] : Faker::Name.first_name,
         snamemi: Faker::Name.initials(number: 1),
         snamel: !options[:snamel].nil? ? options[:snamel] : Faker::Name.last_name,
-        saddrst1: Faker::Address.street_name,
-        saddrcty: Faker::Address.city,
+        saddrst1: Faker::Address.street_name.first(20),
+        saddrcty: Faker::Address.city.first(20),
         saddrstt: Faker::Address.state_abbr,
         saddrzip: Faker::Address.zip,
         staduser: "FAKEUSER",
@@ -219,9 +219,9 @@ module Seeds
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "NoAppealAffinity").ssn}S",  judge: affinity_judge, attorney: attorney, appeal_affinity: false, cavc: true)
 
         # hearing held but no previous deciding judge
-        a7 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: tied_to_judge, attorney: attorney, cavc: true)
+        a7 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVABDANIEL", snamel: "NoDecidingJudge").ssn}S", judge: tied_to_judge, attorney: attorney, cavc: true)
         VACOLS::Case.where(bfcorlid: a7.bfcorlid, bfac: "7").update(bfmemid: nil)
-        a8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney, cavc: true)
+        a8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAEEMARD", snamel: "NoDecidingJudge").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney, cavc: true)
         VACOLS::Case.where(bfcorlid: a8.bfcorlid, bfac: "7").update(bfmemid: nil)
 
         # no hearing held, no previous deciding judge
@@ -339,7 +339,7 @@ module Seeds
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "3DaysAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  affinity_start_date: 3.days.ago, cavc: true)
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoAppealAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  appeal_affinity: false, cavc: true)
         # hearing held but no previous deciding judge
-        a17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: ineligible_judge, attorney: attorney, cavc: true)
+        a17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoDecidingJudge").ssn}S", judge: ineligible_judge, attorney: attorney, cavc: true)
         VACOLS::Case.where(bfcorlid: a17.bfcorlid, bfac: "7").update(bfmemid: nil)
     end
 
@@ -474,10 +474,10 @@ module Seeds
         create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "3DaysAffinity").ssn}S",  judge: affinity_judge, attorney: attorney, affinity_start_date: 3.days.ago)
         create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "NoAppealAffinity").ssn}S",  judge: affinity_judge, attorney: attorney, appeal_affinity: false)
         # hearing held but no previous deciding judge
-        ca7 = create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: tied_to_judge, attorney: attorney)
+        ca7 = create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToBVABDANIEL", snamel: "NoDecidingJudge").ssn}S", judge: tied_to_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca7.bfcorlid, bfac: "1").update(bfmemid: nil)
 
-        ca8 = create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney)
+        ca8 = create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAEEMARD", snamel: "NoDecidingJudge").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca8.bfcorlid, bfac: "1").update(bfmemid: nil)
 
         # no hearing held, no previous deciding judge
@@ -597,7 +597,7 @@ module Seeds
         create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "3DaysAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  affinity_start_date: 3.days.ago)
         create(:legacy_aoj_appeal, :aod, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoAppealAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  appeal_affinity: false)
         # hearing held but no previous deciding judge
-        ca17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: ineligible_judge, attorney: attorney)
+        ca17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoDecidingJudge").ssn}S", judge: ineligible_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca17.bfcorlid, bfac: "1").update(bfmemid: nil)
     end
 
@@ -743,13 +743,13 @@ module Seeds
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "3DaysAffinity").ssn}S",  judge: affinity_judge, attorney: attorney, affinity_start_date: 3.days.ago)
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "NoAppealAffinity").ssn}S",  judge: affinity_judge, attorney: attorney, appeal_affinity: false)
         # hearing held but no previous deciding judge
-        ca7 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: tied_to_judge, attorney: attorney)
+        ca7 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVABDANIEL", snamel: "NoDecidingJudge").ssn}S", judge: tied_to_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca7.bfcorlid, bfac: "1").update(bfmemid: nil)
 
-        ca8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney)
+        ca8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAEEMARD", snamel: "NoDecidingJudge").ssn}S",  judge: affinity_and_tied_to_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca8.bfcorlid, bfac: "1").update(bfmemid: nil)
 
-        caa8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S",  judge: affinity_judge, attorney: attorney)
+        caa8 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToBVAGSPORER", snamel: "NoDecidingJudge").ssn}S",  judge: affinity_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: caa8.bfcorlid, bfac: "1").update(bfmemid: nil)
 
         # no hearing held, no previous deciding judge
@@ -869,7 +869,7 @@ module Seeds
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "3DaysAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  affinity_start_date: 3.days.ago)
         create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoAppealAffinity").ssn}S", judge: ineligible_judge, attorney: attorney,  appeal_affinity: false)
         # hearing held but no previous deciding judge
-        ca17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "Genpop60Days", snamel: "AffinityStartDate").ssn}S", judge: ineligible_judge, attorney: attorney)
+        ca17 = create(:legacy_aoj_appeal, bfcorlid: "#{create_correspondent(snamef: "TiedToIneligibleJudge", snamel: "NoDecidingJudge").ssn}S", judge: ineligible_judge, attorney: attorney)
         VACOLS::Case.where(bfcorlid: ca17.bfcorlid, bfac: "1").update(bfmemid: nil)
     end
 

--- a/db/seeds/cavc_affinity_levers_test_data.rb
+++ b/db/seeds/cavc_affinity_levers_test_data.rb
@@ -507,8 +507,8 @@ module Seeds
       # no original hearing, decided by BVADCREMIN, no new hearing => affintiy to BVADCREMIN
       create(:legacy_cavc_appeal, bfd19: 5.years.ago, bfcorlid: "#{create_veteran_for_bvadcremin_judge("AffinityToCremin").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvadcremin.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), tied_to: false, affinity_start_date: 3.days.ago)
 
-      # original hearing held by SPORER, no original deciding judge, no new hearing => genpop
-      c9 = create(:legacy_cavc_appeal, bfd19: 5.years.ago, bfcorlid: "#{create_veteran_for_genpop("Genpop").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvagsporer.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), tied_to: true)
+      # original hearing held by SPORER, no original deciding judge, no new hearing => tied to SPORER
+      c9 = create(:legacy_cavc_appeal, bfd19: 5.years.ago, bfcorlid: "#{create_veteran_for_bvagsporer_judge("TiedToSporer").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvagsporer.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), tied_to: true)
       c9.update!(bfmemid: nil)
 
       # no original hearing, no original deciding judge, no new hearing => genpop
@@ -843,9 +843,9 @@ module Seeds
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvaeemard_judge("TiedToEmard").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), appeal_affinity: false)
 
         # hearing held but no previous deciding judge
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvabdaniel.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id))
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvabdaniel_judge("TiedToDaniel").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvabdaniel.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id))
         .update!(bfmemid: nil)
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id))
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvaeemard_judge("TiedToEmard").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id))
         .update!(bfmemid: nil)
 
         # no hearing held, no previous deciding judge
@@ -901,7 +901,7 @@ module Seeds
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id),  affinity_start_date: 3.days.ago)
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id),  appeal_affinity: false)
         # hearing held but no previous deciding judge
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id)).update!(bfmemid: nil)
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id)).update!(bfmemid: nil)
     end
 
     def create_cases_for_cavc_aod_affinty_days_lever
@@ -935,9 +935,9 @@ module Seeds
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvaeemard_judge("TiedToEmard").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true, affinity_start_date: 3.days.ago)
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvaeemard_judge("TiedToEmard").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true, appeal_affinity: false)
         # hearing held but no previous deciding judge
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvabdaniel.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvabdaniel_judge("TiedToDaniel").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvabdaniel.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
         .update!(bfmemid: nil)
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_bvaeemard_judge("TiedToEmard").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvaeemard.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
         .update!(bfmemid: nil)
         # no hearing held, no previous deciding judge
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_bvagsporer.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true, tied_to: false)
@@ -983,7 +983,7 @@ module Seeds
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true, affinity_start_date: 3.days.ago)
         create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true, appeal_affinity: false)
         # hearing held but no previous deciding judge
-        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_genpop().file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
+        create(:legacy_cavc_appeal, bfcorlid: "#{create_veteran_for_inactivejudge_judge("TiedToInactiveJudge").file_number}S", judge: VACOLS::Staff.find_by(sdomainid: judge_inactivejudge.css_id), attorney: VACOLS::Staff.find_by(sdomainid: attorney.css_id), aod: true)
           .update!(bfmemid: nil)
     end
   end

--- a/spec/models/vacols/aoj_case_docket_spec.rb
+++ b/spec/models/vacols/aoj_case_docket_spec.rb
@@ -864,7 +864,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         expect(
           VACOLS::AojCaseDocket.age_of_n_oldest_nonpriority_appeals_available_to_judge(judge, 100).count
         )
-          .to eq(18)
+          .to eq(17)
 
         # ensure that excluded judge recieves their tied cases which would not go to default judge
         expect(VACOLS::AojCaseDocket.distribute_nonpriority_appeals(excl_judge_caseflow, "any", 100, nil, false, true)
@@ -1394,7 +1394,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
 
         expect(new_hearing_judge_cases.map { |c| c["bfkey"] }.sort)
           .to match_array([
-            case_1, case_2, case_3, case_4, case_5, case_9, case_10, case_12, case_13
+            case_1, case_2, case_3, case_4, case_5, case_10, case_12, case_13
           ].map { |c| c["bfkey"].to_i.to_s }.sort)
 
         expect(tied_judge_cases.map { |c| c["bfkey"] }.sort)
@@ -1404,7 +1404,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
 
         expect(other_judge_cases.map { |c| c["bfkey"] }.sort)
           .to match_array([
-            case_7, case_8, case_9, case_10, case_12, case_13
+            case_7, case_8, case_10, case_12, case_13
           ].map { |c| c["bfkey"].to_i.to_s }.sort)
 
         # For case distribution levers set to infinite
@@ -1444,7 +1444,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
 
         expect(new_hearing_judge_omit.map { |c| c["bfkey"] }.sort)
           .to match_array([
-            case_1, case_2, case_3, case_4, case_5, case_7, case_8, case_9, case_10, case_11, case_12, case_13
+            case_1, case_2, case_3, case_4, case_5, case_7, case_8, case_10, case_11, case_12, case_13
           ].map { |c| c["bfkey"].to_i.to_s }.sort)
 
         expect(tied_judge_omit.map { |c| c["bfkey"] }.sort)
@@ -1454,7 +1454,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
 
         expect(other_judge_omit.map { |c| c["bfkey"] }.sort)
           .to match_array([
-            case_7, case_8, case_9, case_10, case_11, case_12, case_13
+            case_7, case_8, case_10, case_11, case_12, case_13
           ].map { |c| c["bfkey"].to_i.to_s }.sort)
       end
     end

--- a/spec/models/vacols/aoj_case_docket_spec.rb
+++ b/spec/models/vacols/aoj_case_docket_spec.rb
@@ -836,6 +836,12 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         VACOLS::Case.where(bfcorlid: c33.bfcorlid, bfkey: (c33.bfkey.to_i + 1).to_s).update(bfmemid: other_judge.sattyid)
         c33
       end
+      # hearing held by excluded judge with no previous decision (tied to excl judge)
+      let!(:c34) do
+        c34 = create(:legacy_aoj_appeal, judge: excl_judge, attorney: attorney)
+        VACOLS::Case.where(bfcorlid: c34.bfcorlid, bfkey: (c34.bfkey.to_i + 1).to_s).update(bfmemid: nil)
+        c34
+      end
 
       it "distributes aoj cases correctly based on lever value", :aggregate_failures do
         IneligibleJudgesJob.new.perform_now
@@ -845,7 +851,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         aoj_lever.update!(value: 14)
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_nonpriority_appeals(judge, "any", 100, nil, false, true).map { |c| c["bfkey"] }.sort)
-          .to match_array([c1, c4, c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31]
+          .to match_array([c1, c4, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31]
           .map { |c| c["bfkey"].to_i.to_s }.sort)
         # {FOR LEVER BEING INFINITE:}
         aoj_lever.update!(value: "infinite")
@@ -853,18 +859,26 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         expect(
           VACOLS::AojCaseDocket.distribute_nonpriority_appeals(judge, "any", 100, nil, false, true).map { |c| c["bfkey"] }.sort
         )
-          .to match_array([c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30]
+          .to match_array([c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30]
             .map { |c| c["bfkey"].to_i.to_s }.sort)
         expect(
           VACOLS::AojCaseDocket.age_of_n_oldest_nonpriority_appeals_available_to_judge(judge, 100).count
         )
           .to eq(18)
+
+        # ensure that excluded judge recieves their tied cases which would not go to default judge
+        expect(VACOLS::AojCaseDocket.distribute_nonpriority_appeals(excl_judge_caseflow, "any", 100, nil, false, true)
+          .map { |c| c["bfkey"] }.sort)
+          .to match_array([
+            c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c34
+          ].map { |c| c["bfkey"].to_i.to_s }.sort)
+
         # {FOR LEVER BEING OMIT:}
         aoj_lever.update!(value: "omit")
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_nonpriority_appeals(judge, "any", 100, nil, false, true).map { |c| c["bfkey"] }.sort)
           .to match_array([
-            c1, c2, c3, c4, c5, c6, c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33
+            c1, c2, c3, c4, c5, c6, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33
           ]
           .map { |c| c["bfkey"].to_i.to_s }.sort)
       end
@@ -1014,6 +1028,12 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         VACOLS::Case.where(bfcorlid: c33.bfcorlid, bfkey: (c33.bfkey.to_i + 1).to_s).update(bfmemid: other_judge.sattyid)
         c33
       end
+      # hearing held by excluded judge with no previous decision (tied to excl judge)
+      let!(:c34) do
+        c34 = create(:legacy_aoj_appeal, judge: excl_judge, attorney: attorney, cavc: true)
+        VACOLS::Case.where(bfcorlid: c34.bfcorlid, bfkey: (c34.bfkey.to_i + 1).to_s).update(bfmemid: nil)
+        c34
+      end
 
       it "distributes CAVC cases correctly based on lever value", :aggregate_failures do
         IneligibleJudgesJob.new.perform_now
@@ -1023,7 +1043,7 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         aoj_cavc_lever.update!(value: 14)
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort)
-          .to match_array([c1, c4, c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31]
+          .to match_array([c1, c4, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31]
           .map { |c| c["bfkey"].to_i.to_s }.sort)
         # {FOR LEVER BEING INFINITE:}
         aoj_cavc_lever.update!(value: "infinite")
@@ -1031,14 +1051,22 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         expect(
           VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort
         )
-          .to match_array([c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30]
+          .to match_array([c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30]
             .map { |c| c["bfkey"].to_i.to_s }.sort)
+
+        # ensure that excluded judge recieves their tied cases which would not go to default judge
+        expect(VACOLS::AojCaseDocket.distribute_priority_appeals(excl_judge_caseflow, "any", 100, true)
+          .map { |c| c["bfkey"] }.sort)
+          .to match_array([
+            c11, c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c34
+          ].map { |c| c["bfkey"].to_i.to_s }.sort)
+
         # {FOR LEVER BEING OMIT:}
         aoj_cavc_lever.update!(value: "omit")
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort)
           .to match_array([
-            c1, c2, c3, c4, c5, c6, c10, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33
+            c1, c2, c3, c4, c5, c6, c11, c12, c13, c14, c15, c16, c17, c21, c22, c23, c24, c25, c26, c27, c28, c29, c30, c31, c32, c33
           ]
           .map { |c| c["bfkey"].to_i.to_s }.sort)
       end
@@ -1154,6 +1182,12 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         VACOLS::Case.where(bfcorlid: ca33.bfcorlid, bfkey: (ca33.bfkey.to_i + 1).to_s).update(bfmemid: other_judge.sattyid)
         ca33
       end
+      # hearing held by excluded judge with no previous decision (tied to excl judge)
+      let!(:ca34) do
+        ca34 = create(:legacy_aoj_appeal, :aod, judge: excl_judge, attorney: attorney)
+        VACOLS::Case.where(bfcorlid: ca34.bfcorlid, bfkey: (ca34.bfkey.to_i + 1).to_s).update(bfmemid: nil)
+        ca34
+      end
 
       it "distributes AOJ AOD cases correctly based on lever value", :aggregate_failures do
         IneligibleJudgesJob.new.perform_now
@@ -1164,22 +1198,31 @@ describe VACOLS::AojCaseDocket, :all_dbs do
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort)
           .to match_array([
-            ca1, ca4, ca10, ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22, ca23, ca24, ca25,
+            ca1, ca4, ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22, ca23, ca24, ca25,
             ca26, ca27, ca28, ca29, ca30, ca31
           ]
             .map { |c| c["bfkey"].to_i.to_s }.sort)
+
         # {FOR LEVER BEING INFINITE:}
         aoj_aod_lever.update!(value: "infinite")
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort)
-          .to match_array([ca10, ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22, ca23, ca24, ca25, ca26, ca27, ca28, ca29, ca30]
+          .to match_array([ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22, ca23, ca24, ca25, ca26, ca27, ca28, ca29, ca30]
             .map { |c| c["bfkey"].to_i.to_s }.sort)
+
+        # ensure that excluded judge recieves their tied cases which would not go to default judge
+        expect(VACOLS::AojCaseDocket.distribute_priority_appeals(excl_judge_caseflow, "any", 100, true)
+          .map { |c| c["bfkey"] }.sort)
+          .to match_array([
+            ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca18, ca19, ca20, ca21, ca22, ca23, ca24, ca25, ca26, ca27, ca28, ca29, ca30, ca34
+          ].map { |c| c["bfkey"].to_i.to_s }.sort)
+
         # {FOR LEVER BEING OMIT:}
         aoj_aod_lever.update!(value: "omit")
         CaseDistributionLever.clear_distribution_lever_cache
         expect(VACOLS::AojCaseDocket.distribute_priority_appeals(judge, "any", 100, true).map { |c| c["bfkey"] }.sort)
           .to match_array([
-            ca1, ca2, ca3, ca4, ca5, ca6, ca10, ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22,
+            ca1, ca2, ca3, ca4, ca5, ca6, ca11, ca12, ca13, ca14, ca15, ca16, ca17, ca21, ca22,
             ca23, ca24, ca25, ca26, ca27, ca28, ca29, ca30, ca31, ca32, ca33
           ]
             .map { |c| c["bfkey"].to_i.to_s }.sort)

--- a/spec/models/vacols/case_docket_spec.rb
+++ b/spec/models/vacols/case_docket_spec.rb
@@ -1230,7 +1230,7 @@ describe VACOLS::CaseDocket, :all_dbs do
 
           expect(new_hearing_judge_cases.map { |c| c["bfkey"] }.sort)
             .to match_array([
-              case_1, case_2, case_3, case_4, case_5, case_9, case_10, case_12, case_13
+              case_1, case_2, case_3, case_4, case_5, case_10, case_12, case_13
             ].map { |c| (c["bfkey"].to_i + 1).to_s }.sort)
 
           expect(tied_judge_cases.map { |c| c["bfkey"] }.sort)
@@ -1240,7 +1240,7 @@ describe VACOLS::CaseDocket, :all_dbs do
 
           expect(other_judge_cases.map { |c| c["bfkey"] }.sort)
             .to match_array([
-              case_7, case_8, case_9, case_10, case_12, case_13
+              case_7, case_8, case_10, case_12, case_13
             ].map { |c| (c["bfkey"].to_i + 1).to_s }.sort)
 
           # For case distribution levers set to infinite
@@ -1278,7 +1278,7 @@ describe VACOLS::CaseDocket, :all_dbs do
 
           expect(new_hearing_judge_omit.map { |c| c["bfkey"] }.sort)
             .to match_array([
-              case_1, case_2, case_3, case_4, case_5, case_7, case_8, case_9, case_10, case_11, case_12, case_13
+              case_1, case_2, case_3, case_4, case_5, case_7, case_8, case_10, case_11, case_12, case_13
             ].map { |c| (c["bfkey"].to_i + 1).to_s }.sort)
 
           expect(tied_judge_omit.map { |c| c["bfkey"] }.sort)
@@ -1288,7 +1288,7 @@ describe VACOLS::CaseDocket, :all_dbs do
 
           expect(other_judge_omit.map { |c| c["bfkey"] }.sort)
             .to match_array([
-              case_7, case_8, case_9, case_10, case_11, case_12, case_13
+              case_7, case_8, case_10, case_11, case_12, case_13
             ].map { |c| (c["bfkey"].to_i + 1).to_s }.sort)
         end
       end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60680](https://jira.devops.va.gov/browse/APPEALS-60680)

# Description
Adds a check which will reject appeals from being counted/distributed in the CAVC, CAVC AOD, AOJ, AOJ AOD, and AOJ CAVC filter methods in case_docket.rb and aoj_case_docket.rb. This check rejects appeals if:
- The previous appeal's deciding judge field `BFMEMID` is null AND
- The most recently held hearing was by a judge who is NOT inactive

Note: doing `!ineligible_judges_sattyids.include?(appeal["vlj"])` seemed quite ugly to me as it's kind of a double negative, but the filter is used by skipping appeals which are explicitly allowed to be distributed to the requesting judge. This check is the opposite and is explicitly rejecting the appeal before checking for affinity. At this point it is becoming difficult to understand and definitely should be refactored in the future, but the tradeoff is that we need to release this sooner than we could doing a full refactor. 

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into main: Was this deployed to UAT?
