### PR TITLE
Add disabling of edit contention title button on the edit issues page when feature toggle enabled

### DIFF
--- a/client/app/intake/components/EditContentionTitle.jsx
+++ b/client/app/intake/components/EditContentionTitle.jsx
@@ -12,6 +12,7 @@ export const EditContentionTitle = ({
   issue,
   issueIdx,
   setEditContentionText: callback,
+  disableEditingForCompAndPen,
 }) => {
   const { text, editedDescription, notes } = issue;
   const [editing, setEditing] = useState(false);
@@ -38,6 +39,7 @@ export const EditContentionTitle = ({
           <Button
             onClick={toggleEdit}
             classNames={['cf-btn-link', 'edit-contention-issue']}
+            disabled={disableEditingForCompAndPen}
           >
             {COPY.INTAKE_EDIT_TITLE}
           </Button>
@@ -106,6 +108,7 @@ EditContentionTitle.propTypes = {
    * Callback with two arguments: issue index and new value
    */
   setEditContentionText: PropTypes.func,
+  disableEditingForCompAndPen: PropTypes.bool,
 };
 
 const mapDispatchToProps = (dispatch) =>

--- a/client/app/intake/components/IssueList.jsx
+++ b/client/app/intake/components/IssueList.jsx
@@ -209,7 +209,8 @@ export default class IssuesList extends React.Component {
               /> : null}
             {editableContentionText && <EditContentionTitle
               issue= {issue}
-              issueIdx={issue.index} />}
+              issueIdx={issue.index}
+              disableEditingForCompAndPen={disableEditingForCompAndPen} />}
           </div>;
         })}
       </div>

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require "byebug"
 
 feature "Higher Level Review Edit issues", :all_dbs do
   include IntakeHelpers
@@ -1737,7 +1738,7 @@ feature "Higher Level Review Edit issues", :all_dbs do
 
         after { FeatureToggle.disable!(:remove_comp_and_pen_intake) }
 
-        it "Add Issue, Edit claim label and Requested issues dropdown are disabled" do
+        it "Requested issues dropdown is disabled" do
           visit "higher_level_reviews/#{higher_level_review_disable.uuid}/edit"
 
           disabled_status = page.evaluate_script("document.getElementById('issue-action-0').disabled")
@@ -1746,8 +1747,24 @@ feature "Higher Level Review Edit issues", :all_dbs do
           expect(page).to have_css(".cf-select--is-disabled")
           expect(page).to have_css(".cf-select__control--is-disabled")
           expect(page).to have_content(benefit_type.capitalize)
-          expect(page).to have_button("Add issue", disabled: true)
+        end
+
+        it "Edit claim label button is disabled" do
+          visit "higher_level_reviews/#{higher_level_review_disable.uuid}/edit"
+
           expect(page).to have_button("Edit claim label", disabled: true)
+        end
+
+        it "Add Issue button is disabled" do
+          visit "higher_level_reviews/#{higher_level_review_disable.uuid}/edit"
+
+          expect(page).to have_button("Add issue", disabled: true)
+        end
+
+        it "Edit contention title button is disabled" do
+          visit "higher_level_reviews/#{higher_level_review_disable.uuid}/edit"
+
+          expect(page).to have_button("Edit contention title", disabled: true)
         end
       end
     end

--- a/spec/feature/intake/higher_level_review/edit_spec.rb
+++ b/spec/feature/intake/higher_level_review/edit_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require "byebug"
 
 feature "Higher Level Review Edit issues", :all_dbs do
   include IntakeHelpers

--- a/spec/feature/intake/supplemental_claim/edit_spec.rb
+++ b/spec/feature/intake/supplemental_claim/edit_spec.rb
@@ -987,7 +987,8 @@ feature "Supplemental Claim Edit issues", :all_dbs do
         after do
           FeatureToggle.disable!(:remove_comp_and_pen_intake)
         end
-        it "Add Issue, Edit claim label and Requested issues dropdown are disabled" do
+
+        it "Requested issues dropdown is disabled" do
           visit "supplemental_claims/#{supplemental_claim_disable.uuid}/edit"
 
           disabled_status = page.evaluate_script("document.getElementById('issue-action-0').disabled")
@@ -996,8 +997,24 @@ feature "Supplemental Claim Edit issues", :all_dbs do
           expect(page).to have_css(".cf-select--is-disabled")
           expect(page).to have_css(".cf-select__control--is-disabled")
           expect(page).to have_content(benefit_type.capitalize)
-          expect(page).to have_button("Add issue", disabled: true)
+        end
+
+        it "Edit claim label button is disabled" do
+          visit "supplemental_claims/#{supplemental_claim_disable.uuid}/edit"
+
           expect(page).to have_button("Edit claim label", disabled: true)
+        end
+
+        it "Add Issue button is disabled" do
+          visit "supplemental_claims/#{supplemental_claim_disable.uuid}/edit"
+
+          expect(page).to have_button("Add issue", disabled: true)
+        end
+
+        it "Edit contention title button is disabled" do
+          visit "supplemental_claims/#{supplemental_claim_disable.uuid}/edit"
+
+          expect(page).to have_button("Edit contention title", disabled: true)
         end
       end
     end


### PR DESCRIPTION
Resolves [Internal Defect | ability to edit contention title on the edit issues page](https://jira.devops.va.gov/browse/APPEALS-60678)

# Description
Edit contention title button on the edit issues page is now disabled when the remove_comp_and_pen feature toggle is enabled

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [X] RSpec
