### PR TITLE
Feature/appeals 49670 49667 phase ii release pt 1.1.4 -bug fixes

### DIFF
--- a/app/models/request_issue.rb
+++ b/app/models/request_issue.rb
@@ -449,7 +449,7 @@ class RequestIssue < CaseflowRecord
 
   def fetch_removed_by_user
     if removed?
-      relevant_update = request_issues_updates.find do |update|
+      relevant_update = request_issues_updates&.find do |update|
         update.removed_issues.any? { |issue| issue.id == id }
       end
 

--- a/app/models/request_issues_update_event.rb
+++ b/app/models/request_issues_update_event.rb
@@ -196,7 +196,7 @@ class RequestIssuesUpdateEvent < RequestIssuesUpdate
   end
 
   def reset_or_create_legacy_issue!(legacy_issue, request_issue)
-    if legacy_issue && optin?(@review) && request_issue.ineligible_reason.blank?
+    if legacy_issue && optin? && request_issue.ineligible_reason.blank?
       legacy_issue.legacy_issue_optin.update!(
         optin_processed_at: nil,
         rollback_processed_at: nil,
@@ -206,7 +206,7 @@ class RequestIssuesUpdateEvent < RequestIssuesUpdate
       legacy_issue = create_legacy_issue_backfill(request_issue)
 
       # LegacyIssueOptin
-      if optin?(@review) && request_issue.ineligible_reason.blank?
+      if optin? && request_issue.ineligible_reason.blank?
         create_legacy_optin_backfill(request_issue, legacy_issue)
       end
     end
@@ -323,7 +323,7 @@ class RequestIssuesUpdateEvent < RequestIssuesUpdate
         legacy_issue = create_legacy_issue_backfill(ri)
 
         # LegacyIssueOptin
-        if optin?(@review) && ri.ineligible_reason.blank?
+        if optin? && ri.ineligible_reason.blank?
           create_legacy_optin_backfill(ri, legacy_issue)
         end
       end
@@ -337,8 +337,8 @@ class RequestIssuesUpdateEvent < RequestIssuesUpdate
     request_issue.vacols_id.present? && request_issue.vacols_sequence_id.present?
   end
 
-  def optin?(decision_review)
-    decision_review.legacy_opt_in_approved?
+  def optin?
+    ActiveModel::Type::Boolean.new.cast(@parser.claim_review_legacy_opt_in_approved)
   end
 
   def create_legacy_issue_backfill(request_issue)


### PR DESCRIPTION
BUG Fixes for SOC Optin and AMA API 500 error .. 

Resolves [Internal Defect | HLRs updated by Decision Review Updated Event when a new issue is added in VBMS are being set to "Removed" in Caseflow](https://jira.devops.va.gov/browse/APPEALS-49667)

Resolves [Phase 2 Implementation: New DecisionReviewUpdated Event API](https://jira.devops.va.gov/browse/APPEALS-49670)

Description
Implementing the Event API on the Caseflow side will ensure efficient processing of Request Issues updates, enhancing system performance and reliability. This automation will reduce manual interventions and improve data accuracy.

As a development team, we need to disable the HLR and SC post-establishment editing functionality for Compensation & Pension Claim Reviews from the Caseflow UI, so we can offer an informative and more effective user interface.

Testing Plan
Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/APPEALS-49670) or list them below