### PR TITLE
hotfix/APPEALS-60470 - Fix enable_all: false in appeals-deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem "bgs", git: "https://github.com/department-of-veterans-affairs/ruby-bgs.git"
 gem "bootsnap", require: false
 gem "browser"
 gem "business_time", "~> 0.9.3"
-gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "9bd3635fbd8094d25160669f38d8699e2f1d7a98"
+gem "caseflow", git: "https://github.com/department-of-veterans-affairs/caseflow-commons", ref: "c21fe837fe494e408ee58d19b141f8ef777970ef"
 gem "connect_mpi", git: "https://github.com/department-of-veterans-affairs/connect-mpi.git", ref: "a3a58c64f85b980a8b5ea6347430dd73a99ea74c"
 gem "connect_vbms", git: "https://github.com/department-of-veterans-affairs/connect_vbms.git", ref: "9807d9c9f0f3e3494a60b6693dc4f455c1e3e922"
 gem "console_tree_renderer", git: "https://github.com/department-of-veterans-affairs/console-tree-renderer.git", tag: "v0.1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/department-of-veterans-affairs/caseflow-commons
-  revision: 9bd3635fbd8094d25160669f38d8699e2f1d7a98
-  ref: 9bd3635fbd8094d25160669f38d8699e2f1d7a98
+  revision: c21fe837fe494e408ee58d19b141f8ef777970ef
+  ref: c21fe837fe494e408ee58d19b141f8ef777970ef
   specs:
     caseflow (0.4.8)
       aws-sdk-s3


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-60470](https://jira.devops.va.gov/browse/APPEALS-60470)

# Description
Fix enable_all: false in appeals-deployment allowing deployments not to fail

## Acceptance Criteria
- [ ] Code compiles correctly