### PR TITLE
 APPEALS-59235 Add foreign tables for VACOLS

### DIFF
--- a/local/sql/create_foreign_tables_for_vacols.sql
+++ b/local/sql/create_foreign_tables_for_vacols.sql
@@ -1,36 +1,9 @@
--- Enable oracle_fdw extension
-CREATE EXTENSION oracle_fdw;
-
--- Print extension version
-SELECT oracle_diag ();
-
--- Create Caseflow Database
--- Skip if you aren't running this as part of an initialization script.
-CREATE DATABASE caseflow_certification_development OWNER postgres ENCODING UTF8;
-
--- #####################
--- Init foreign server
--- #####################
-
--- Create the foreign server
-CREATE SERVER vacols_sv FOREIGN DATA WRAPPER oracle_fdw OPTIONS (
-    dbserver 'localhost:1521/BVAP'
-);
-
-GRANT USAGE ON FOREIGN SERVER vacols_sv TO postgres;
-
--- Create a user mapping to the foreign server
-CREATE USER MAPPING FOR postgres SERVER vacols_sv OPTIONS (
-    USER 'VACOLS_DEV',
-    PASSWORD 'VACOLS_DEV'
-);
-
 -- #####################
 -- Create foreign tables
 -- #####################
 
--- Switch to Caseflow database
-\c caseflow_certification_development
+-- Uncomment the line below to switch to Caseflow database
+-- \c caseflow_certification_development
 
 -- BRIEFF Table
 CREATE FOREIGN

--- a/local/sql/create_foreign_tables_for_vacols.sql
+++ b/local/sql/create_foreign_tables_for_vacols.sql
@@ -334,3 +334,94 @@ TABLE IF NOT EXISTS f_vacols_issues (
     SCHEMA 'VACOLS_DEV',
     TABLE 'ISSUES'
 );
+
+-- STAFF Table
+CREATE FOREIGN
+TABLE IF NOT EXISTS f_vacols_staff (
+  STAFKEY varchar(16),
+	SUSRPW varchar(16),
+	SUSRSEC varchar(5),
+	SUSRTYP varchar(10),
+	SSALUT varchar(15),
+	SNAMEF varchar(24),
+	SNAMEMI varchar(4),
+	SNAMEL varchar(60),
+	SLOGID varchar(16),
+	STITLE varchar(60),
+	SORG varchar(60),
+	SDEPT varchar(60),
+	SADDRNUM varchar(10),
+	SADDRST1 varchar(30),
+	SADDRST2 varchar(30),
+	SADDRCTY varchar(20),
+	SADDRSTT varchar(4),
+	SADDRCNTY varchar(6),
+	SADDRZIP varchar(10),
+	STELW varchar(20),
+	STELWEX varchar(20),
+	STELFAX varchar(20),
+	STELH varchar(20),
+	STADUSER varchar(16),
+	STADTIME date,
+	STMDUSER varchar(16),
+	STMDTIME date,
+	STC1 integer,
+	STC2 integer,
+	STC3 integer,
+	STC4 integer,
+	SNOTES varchar(80),
+	SORC1 integer,
+	SORC2 integer,
+	SORC3 integer,
+	SORC4 integer,
+	SACTIVE varchar(1),
+	SSYS varchar(16),
+	SSPARE1 varchar(20),
+	SSPARE2 varchar(20),
+	SSPARE3 varchar(20),
+	SMEMGRP varchar(16),
+	SFOIASEC integer,
+	SRPTSEC integer,
+	SATTYID varchar(4),
+	SVLJ varchar(1),
+	SINVSEC varchar(1),
+	SDOMAINID varchar(20)
+) SERVER vacols_sv OPTIONS (
+  SCHEMA 'VACOLS_DEV',
+  TABLE 'STAFF'
+);
+
+-- ASSIGN Table
+CREATE FOREIGN
+TABLE IF NOT EXISTS f_vacols_assign (
+  TASKNUM varchar(12),
+	TSKTKNM varchar(12),
+	TSKSTFAS varchar(16),
+	TSKACTCD varchar(10),
+	TSKCLASS varchar(10),
+	TSKRQACT varchar(280),
+	TSKRSPN varchar(200),
+	TSKDASSN date,
+	TSKDTC integer,
+	TSKDDUE date,
+	TSKDCLS date,
+	TSKSTOWN varchar(16),
+	TSKSTAT varchar(1),
+	TSKOWNTS varchar(12),
+	TSKCLSTM date,
+	TSKADUSR varchar(16),
+	TSKADTM date,
+	TSKMDUSR varchar(16),
+	TSKMDTM date,
+	TSACTIVE varchar(1),
+	TSSPARE1 varchar(30),
+	TSSPARE2 varchar(30),
+	TSSPARE3 varchar(30),
+	TSREAD1 varchar(28),
+	TSREAD varchar(16),
+	TSKORDER varchar(15),
+	TSSYS varchar(16)
+) SERVER vacols_sv OPTIONS (
+  SCHEMA 'VACOLS_DEV',
+  TABLE 'ASSIGN'
+);


### PR DESCRIPTION
Resolves [Create SQL Script to Build Foreign Tables in Higher Environments](https://jira.devops.va.gov/browse/APPEALS-59235)

# Description
Adding SQL script to create foreign tables in PostGres that correspond to the VACOLS tables

## Acceptance Criteria
- [x] Code compiles correctly
- [x] A SQL script exists that creates foreign data tables in the Postgres DB to map to tables in the VACOLS DB, including:
    - BRIEFF
    - FOLDER
    - HEARSCHED
    - CORRES
    - REP
    - ISSUES
    - STAFF
    - ASSIGN
  - The created tables match the column orderings of the remote database to ensure data integrity.
- [x] Column mappings adhere to VACOLS DB's structure. 
- [x] Once the script is executed it is able to query all foreign tables. 
- [x] Foreign tables adhere to the naming convention: f_vacols_xxx
  - [x] Where "xxx" is the name of the table in VACOLS, except lowercase.
  - Ex: BRIEFF's foreign table would be named "f_vacols_brieff"

## Testing Plan
1. Go to [APPEALS-61657](https://jira.devops.va.gov/browse/APPEALS-61657)


# Backend
## Database Changes
*Only for Schema Changes*

* [ ] Add typical timestamps (`created_at`, `updated_at`) for new tables
* [ ] Update column comments; include a "PII" prefix to indicate definite or potential [PII data content](https://github.com/department-of-veterans-affairs/appeals-team/blob/main/caseflow-team/0-how-we-work/pii-handbook.md#what-is-pii)
* [ ] Have your migration classes inherit from `Caseflow::Migration`, especially when adding indexes (use `add_safe_index`) (see [Writing DB migrations](https://github.com/department-of-veterans-affairs/caseflow/wiki/Writing-DB-migrations))
* [ ] Verify that `migrate:rollback` works as desired ([`change` supported functions](https://edgeguides.rubyonrails.org/active_record_migrations.html#using-the-change-method))
* [ ] Perform query profiling (eyeball Rails log, check bullet and fasterer output)
* [ ] For queries using raw sql was an explain plan run by System Team
* [ ] Add appropriate indexes (especially for foreign keys, polymorphic columns, unique constraints, and Rails scopes)
* [ ] Run `make check-fks`; add any missing foreign keys or add to `config/initializers/immigrant.rb` (see [Record associations and Foreign Keys](https://github.com/department-of-veterans-affairs/caseflow/wiki/Record-associations-and-Foreign-Keys))
* [ ] Add `belongs_to` for associations to enable the [schema diagrams](https://department-of-veterans-affairs.github.io/caseflow/task_trees/schema/schema_diagrams) to be automatically updated
* [ ] Document any non-obvious semantics or logic useful for interpreting database data at [Caseflow Data Model and Dictionary](https://github.com/department-of-veterans-affairs/caseflow/wiki/Caseflow-Data-Model-and-Dictionary)
