### PR TITLE
APPEALS-61666: Modify Direct Review and Evidence Submission dockets to return only non genpop appeals when non genpop is specified

### DIFF
--- a/app/models/concerns/distribution_scopes.rb
+++ b/app/models/concerns/distribution_scopes.rb
@@ -138,14 +138,14 @@ module DistributionScopes # rubocop:disable Metrics/ModuleLength
   def generate_non_genpop_cavc_aod_affinity_days_lever_query(judge)
     if case_affinity_days_lever_value_is_selected?(CaseDistributionLever.cavc_aod_affinity_days)
       non_genpop_for_judge(judge, CaseDistributionLever.cavc_aod_affinity_days)
-        .ama_non_aod_appeals
+        .ama_aod_appeals
     elsif CaseDistributionLever.cavc_aod_affinity_days == Constants.ACD_LEVERS.infinite
       genpop_base_query
-        .ama_non_aod_appeals
+        .ama_aod_appeals
         .where(original_judge_task: { assigned_to_id: judge&.id },
                appeals: { stream_type: Constants.AMA_STREAM_TYPES.court_remand })
     elsif CaseDistributionLever.cavc_aod_affinity_days == Constants.ACD_LEVERS.omit
-      genpop_base_query.ama_non_aod_appeals.none
+      genpop_base_query.ama_aod_appeals.none
     end
   end
 

--- a/app/models/dockets/hearing_request_docket.rb
+++ b/app/models/dockets/hearing_request_docket.rb
@@ -46,11 +46,11 @@ class HearingRequestDocket < Docket
 
   # rubocop:disable Lint/UnusedMethodArgument
   def distribute_appeals(distribution, priority: false, genpop: "any", limit: 1, style: "push")
-    query_args = { priority: priority, ready: true, judge: distribution.judge }
-    base_relation = ready_priority_nonpriority_appeals(query_args).limit(limit)
-
     # setting genpop to "only_genpop" behind feature toggle as this module only processes AMA.
     genpop = "only_genpop" if use_by_docket_date?
+
+    query_args = { priority: priority, genpop: genpop, ready: true, judge: distribution.judge }
+    base_relation = ready_priority_nonpriority_appeals(query_args).limit(limit)
 
     sct_appeals = extract_sct_appeals(query_args, limit)
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -55,6 +55,8 @@ class SeedDB
     call_and_log_seed_step Seeds::BgsServiceRecordMaker
     call_and_log_seed_step Seeds::PopulateCaseflowFromVacols
     call_and_log_seed_step Seeds::IssueModificationRequest
+    # TODO: Remove the below seed from this file prior to production release
+    call_and_log_seed_step Seeds::AppealsForPushPriorityJobDistribution
   end
 end
 

--- a/db/seeds/appeals_for_push_priority_job_distribution.rb
+++ b/db/seeds/appeals_for_push_priority_job_distribution.rb
@@ -7,13 +7,16 @@ module Seeds
     def seed!
       RequestStore[:current_user] = User.system_user
 
-      instantiate_judges
-      create_direct_review_cases
-      create_evidence_submission_cases
-      create_hearing_cases
-      create_legacy_cases
-      create_aoj_legacy_cases
-      create_previous_distribtions
+      # TODO: take the transaction block out after testing
+      ApplicationRecord.multi_transaction do
+        instantiate_judges
+        create_direct_review_cases
+        create_evidence_submission_cases
+        create_hearing_cases
+        create_legacy_cases
+        create_aoj_legacy_cases
+        create_previous_distribtions
+      end
     end
 
     private
@@ -107,41 +110,41 @@ module Seeds
       create_direct_review_priority_not_genpop_cases
       create_direct_review_priority_genpop_cases
       create_direct_review_priority_not_ready_cases
-      create_direct_review_nonpriority_cases
+      create_direct_review_nonpriority_ready_cases
     end
 
     def create_evidence_submission_cases
       create_evidence_submission_priority_not_genpop_cases
       create_evidence_submission_priority_genpop_cases
       create_evidence_submission_priority_not_ready_cases
-      create_evidence_submission_nonpriority_cases
+      create_evidence_submission_nonpriority_ready_cases
     end
 
     def create_hearing_cases
       create_hearing_priority_not_genpop_cases
       create_hearing_priority_genpop_cases
       create_hearing_priority_not_ready_cases
-      create_hearing_nonpriority_cases
+      create_hearing_nonpriority_ready_cases
     end
 
     def create_legacy_cases
       create_legacy_priority_not_genpop_cases
       create_legacy_priority_genpop_cases
       create_legacy_priority_not_ready_cases
-      create_legacy_nonpriority_cases
+      create_legacy_nonpriority_ready_cases
     end
 
     def create_aoj_legacy_cases
       create_aoj_legacy_priority_not_genpop_cases
       create_aoj_legacy_priority_genpop_cases
       create_aoj_legacy_priority_not_ready_cases
-      create_aoj_legacy_nonpriority_cases
+      create_aoj_legacy_nonpriority_ready_cases
     end
 
     # these distributions will cause the associated judges to not recieve as many (or any) cases in the push job
     def create_previous_distribtions
       statistics = { batch_size: 10, info: "See related row in distribution_stats for additional stats" }
-      (1..4).times do |n|
+      4.times do |n|
         create(:distribution, :completed, :priority,
                judge: judge_many_previous_distributions, completed_at: n.weeks.ago, statistics: statistics)
       end

--- a/db/seeds/appeals_for_push_priority_job_distribution.rb
+++ b/db/seeds/appeals_for_push_priority_job_distribution.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+# This seed file creates ready appeals for testing the function of the PushPriorityAppealsToJudgesJob
+
+module Seeds
+  class AppealsForPushPriorityJobDistribution < Base
+    def seed!
+      RequestStore[:current_user] = User.system_user
+
+      instantiate_judges
+      create_direct_review_cases
+      create_evidence_submission_cases
+      create_hearing_cases
+      create_legacy_cases
+      create_aoj_legacy_cases
+      create_previous_distribtions
+    end
+
+    private
+
+    # no appeals should be created as tied to or with affinity to these judges so they receive only genpop appeals
+    # create them first so that they are distributed to first when the push job runs
+    def judge_no_tied_affinity_cases_1
+      @judge_no_tied_affinity_cases_1 ||= User.find_by(css_id: "GENPOPJUDGE1") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "GENPOPJUDGE1", full_name: "GenpopJudge NoAffinityTiedCasesOne")
+    end
+
+    def judge_no_tied_affinity_cases_2
+      @judge_no_tied_affinity_cases_2 ||= User.find_by(css_id: "GENPOPJUDGE2") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "GENPOPJUDGE2", full_name: "GenpopJudge NoAffinityTiedCasesTwo")
+    end
+
+    # this judge's JudgeTeam should not receive any cases during the push priority job run
+    def judge_does_not_accept_priority_push_cases
+      @judge_does_not_accept_priority_push_cases ||= (
+        user = User.find_by(css_id: "NOPUSHJUDGE1") ||
+          create(:user, :judge, :with_vacols_judge_record,
+            css_id: "NOPUSHJUDGE1", full_name: "PushJudge NotAcceptingCases")
+
+        JudgeTeam.for_judge(user).update!(accepts_priority_pushed_cases: false)
+        user
+      )
+    end
+
+    # this judge will have several prior distribution created to set their monthly appeals distributed count
+    # too high to be included in the eligible judges after a priority target is calculated
+    def judge_many_previous_distributions
+      @judge_many_previous_distributions ||= User.find_by(css_id: "NOPUSHJUDGE2") ||
+        create(:user, :judge, :with_vacols_judge_record,
+               css_id: "NOPUSHJUDGE2", full_name: "PushJudge ManyPrevCases")
+    end
+
+    # this judge will have a single prior distribution created to set their monthly appeals distributed count
+    # too high to be included in the eligible judges after a priority target is calculated
+    def judge_one_large_previous_distribution
+      @judge_one_large_previous_distributions ||= User.find_by(css_id: "NOPUSHJUDGE3") ||
+        create(:user, :judge, :with_vacols_judge_record,
+               css_id: "NOPUSHJUDGE3", full_name: "PushJudge OneLargePrevDist")
+    end
+
+    # a balanced number of appeals should be created which have an affinity to or are tied to these judges
+    def judge_1
+      @judge_1 ||= User.find_by(css_id: "PUSHJUDGE1") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "PUSHJUDGE1", full_name: "PushJudge One")
+    end
+
+    def judge_2
+      @judge_2 ||=  User.find_by(css_id: "PUSHJUDGE2") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "PUSHJUDGE2", full_name: "PushJudge Two")
+    end
+
+    def judge_3
+      @judge_3 ||=  User.find_by(css_id: "PUSHJUDGE3") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "PUSHJUDGE3", full_name: "PushJudge Three")
+    end
+
+    def judge_4
+      @judge_4 ||=  User.find_by(css_id: "PUSHJUDGE4") ||
+        create(:user, :judge, :with_vacols_judge_record, css_id: "PUSHJUDGE4", full_name: "PushJudge Four")
+    end
+
+    # many appeals should be created which are tied to this judge so that a single run of the job will distribute
+    # enough appeals to them where they will receieve no genpop appeals during the job run
+    def judge_many_tied_cases
+      @judge_many_tied_cases ||= User.find_by(css_id: "PUSHJUDGE5") ||
+        create(:user, :judge, :with_vacols_judge_record,
+               css_id: "PUSHJUDGE5", full_name: "PushJudge ManyTiedCases")
+    end
+
+    def instantiate_judges
+      judge_1
+      judge_2
+      judge_3
+      judge_4
+      judge_no_tied_affinity_cases_1
+      judge_no_tied_affinity_cases_2
+      judge_does_not_accept_priority_push_cases
+      judge_many_previous_distributions
+      judge_one_large_previous_distribution
+    end
+
+    def tied_or_affinity_judges
+      [judge_1, judge_2, judge_3, judge_4]
+    end
+
+    def create_direct_review_cases
+      create_direct_review_priority_not_genpop_cases
+      create_direct_review_priority_genpop_cases
+      create_direct_review_priority_not_ready_cases
+      create_direct_review_nonpriority_cases
+    end
+
+    def create_evidence_submission_cases
+      create_evidence_submission_priority_not_genpop_cases
+      create_evidence_submission_priority_genpop_cases
+      create_evidence_submission_priority_not_ready_cases
+      create_evidence_submission_nonpriority_cases
+    end
+
+    def create_hearing_cases
+      create_hearing_priority_not_genpop_cases
+      create_hearing_priority_genpop_cases
+      create_hearing_priority_not_ready_cases
+      create_hearing_nonpriority_cases
+    end
+
+    def create_legacy_cases
+      create_legacy_priority_not_genpop_cases
+      create_legacy_priority_genpop_cases
+      create_legacy_priority_not_ready_cases
+      create_legacy_nonpriority_cases
+    end
+
+    def create_aoj_legacy_cases
+      create_aoj_legacy_priority_not_genpop_cases
+      create_aoj_legacy_priority_genpop_cases
+      create_aoj_legacy_priority_not_ready_cases
+      create_aoj_legacy_nonpriority_cases
+    end
+
+    # these distributions will cause the associated judges to not recieve as many (or any) cases in the push job
+    def create_previous_distribtions
+      statistics = { batch_size: 10, info: "See related row in distribution_stats for additional stats" }
+      (1..4).times do |n|
+        create(:distribution, :completed, :priority,
+               judge: judge_many_previous_distributions, completed_at: n.weeks.ago, statistics: statistics)
+      end
+
+      statistics = { batch_size: 100, info: "See related row in distribution_stats for additional stats" }
+      create(:distribution, :completed, :priority, :this_month,
+             judge: judge_one_large_previous_distribution, statistics: statistics)
+    end
+
+    def create_direct_review_priority_not_genpop_cases
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :direct_review_docket, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+      end
+    end
+
+    def create_direct_review_priority_genpop_cases
+      create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_age, :ready_for_distribution)
+      create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_motion, :ready_for_distribution)
+
+      # appeals which had affinity but are outside the window and can be distributed to other judges
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :direct_review_docket, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+      end
+    end
+
+    def create_direct_review_priority_not_ready_cases
+      # CAVC remands which are tied to a judge but not ready to distribute
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :direct_review_docket, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+        create(:appeal, :direct_review_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+      end
+
+      # genpop appeals with a blocking mail task that are not ready to distribute
+      appeal_1 = create(:appeal, :direct_review_docket,
+                        :advanced_on_docket_due_to_age, :ready_for_distribution)
+      dist_task_1 = DistributionTask.find_by(appeal_id: appeal_1.id, appeal_type: 'Appeal')
+      create(:congressional_interest_mail_task, parent: dist_task_1)
+
+      appeal_2 = create(:appeal, :direct_review_docket,
+                        :advanced_on_docket_due_to_motion, :ready_for_distribution)
+      dist_task_2 = DistributionTask.find_by(appeal_id: appeal_2.id, appeal_type: 'Appeal')
+      create(:congressional_interest_mail_task, parent: dist_task_2)
+    end
+
+    def create_direct_review_nonpriority_ready_cases
+      create(:appeal, :direct_review_docket, :ready_for_distribution)
+    end
+
+    def create_evidence_submission_priority_not_genpop_cases
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :evidence_submission_docket, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_ready_for_distribution, judge: judge)
+      end
+    end
+
+    def create_evidence_submission_priority_genpop_cases
+      create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_age, :ready_for_distribution)
+      create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_motion, :ready_for_distribution)
+
+      # appeals which had affinity but are outside the window and can be distributed to other judges
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :evidence_submission_docket, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_ready_for_distribution, :with_appeal_affinity, judge: judge, affinity_start_date: 3.months.ago)
+      end
+    end
+
+    def create_evidence_submission_priority_not_ready_cases
+      # CAVC remands which are tied to a judge but not ready to distribute
+      tied_or_affinity_judges.each do |judge|
+        create(:appeal, :evidence_submission_docket, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_age, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+        create(:appeal, :evidence_submission_docket, :advanced_on_docket_due_to_motion, :type_cavc_remand, :cavc_response_window_open, judge: judge)
+      end
+
+      # genpop appeals with a blocking mail task that are not ready to distribute
+      appeal_1 = create(:appeal, :evidence_submission_docket,
+                        :advanced_on_docket_due_to_age, :ready_for_distribution)
+      dist_task_1 = DistributionTask.find_by(appeal_id: appeal_1.id, appeal_type: 'Appeal')
+      create(:congressional_interest_mail_task, parent: dist_task_1)
+
+      appeal_2 = create(:appeal, :evidence_submission_docket,
+                        :advanced_on_docket_due_to_motion, :ready_for_distribution)
+      dist_task_2 = DistributionTask.find_by(appeal_id: appeal_2.id, appeal_type: 'Appeal')
+      create(:congressional_interest_mail_task, parent: dist_task_2)
+    end
+
+    def create_evidence_submission_nonpriority_ready_cases
+      create(:appeal, :evidence_submission_docket, :ready_for_distribution)
+    end
+
+    def create_hearing_priority_not_genpop_cases; end
+    def create_hearing_priority_genpop_cases; end
+    def create_hearing_priority_not_ready_cases; end
+    def create_hearing_nonpriority_ready_cases; end
+
+    def create_legacy_priority_not_genpop_cases; end
+    def create_legacy_priority_genpop_cases; end
+    def create_legacy_priority_not_ready_cases; end
+    def create_legacy_nonpriority_ready_cases; end
+
+    def create_aoj_legacy_priority_not_genpop_cases; end
+    def create_aoj_legacy_priority_genpop_cases; end
+    def create_aoj_legacy_priority_not_ready_cases; end
+    def create_aoj_legacy_nonpriority_ready_cases; end
+  end
+end

--- a/db/seeds/users.rb
+++ b/db/seeds/users.rb
@@ -234,6 +234,7 @@ module Seeds
         judge = User.find_or_create_by(css_id: judge_css_id, station_id: 101)
         judge.roles = judge.roles << "Hearing Prep" unless judge.roles.include?("Hearing Prep")
         judge.save!
+        create(:staff, :judge_role) if judge.vacols_staff.nil?
         judge_team = JudgeTeam.for_judge(judge) || JudgeTeam.create_for_judge(judge)
         h[:attorneys].each do |css_id|
           judge_team.add_user(User.find_or_create_by(css_id: css_id, station_id: 101))

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -143,7 +143,7 @@ FactoryBot.define do
       stream_type { Constants.AMA_STREAM_TYPES.court_remand }
       transient do
         remand_subtype { Constants.CAVC_REMAND_SUBTYPES.jmpr }
-        judge { JudgeTeam.first&.judge || create(:user, :judge, :with_vacols_judge_record) }
+        judge { JudgeTeam.first&.judge || create(:user, :with_vacols_judge_record) }
       end
       initialize_with do
         cavc_remand = create(:cavc_remand,

--- a/spec/factories/appeal.rb
+++ b/spec/factories/appeal.rb
@@ -143,13 +143,15 @@ FactoryBot.define do
       stream_type { Constants.AMA_STREAM_TYPES.court_remand }
       transient do
         remand_subtype { Constants.CAVC_REMAND_SUBTYPES.jmpr }
+        judge { JudgeTeam.first&.judge || create(:user, :judge, :with_vacols_judge_record) }
       end
       initialize_with do
         cavc_remand = create(:cavc_remand,
                              remand_subtype: remand_subtype,
                              veteran: veteran,
                              # pass docket type so that the created source appeal is the same docket type
-                             docket_type: attributes[:docket_type])
+                             docket_type: attributes[:docket_type],
+                             judge: judge)
         # cavc_remand creation triggers creation of a remand_appeal having appropriate tasks depending on remand_subtype
         cavc_remand.remand_appeal
       end

--- a/spec/models/docket_spec.rb
+++ b/spec/models/docket_spec.rb
@@ -126,20 +126,6 @@ describe Docket, :all_dbs do
             expect(subject).to match_array([cavc_appeal])
           end
         end
-
-        context "when acd_exclude_from_affinity flag is enabled" do
-          before { FeatureToggle.enable!(:acd_exclude_from_affinity) }
-
-          context "when called for ready is true and judge is passed" do
-            let(:judge) { judge_decision_review_task.assigned_to }
-
-            subject { DirectReviewDocket.new.appeals(ready: true, priority: false, judge: judge) }
-
-            it "returns non priority appeals" do
-              expect(subject).to match_array([appeal, denied_aod_motion_appeal, inapplicable_aod_motion_appeal])
-            end
-          end
-        end
       end
 
       context "when ready is false" do


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-61666](https://jira.devops.va.gov/browse/APPEALS-61666)

# Description
- Modifies docket.rb to return **only** non genpop appeals if passed the genpop value `not_genpop`
- Modifies the hearing_request_docket.rb file to pass the value of the genpop argument through to the `base_relation` if one is passed (necessary to fix tests in the hearing_request_docket_spec.rb file)
- Adds seed file to default seeds which can be used in future story work for this epic. It currently:
  - Creates several judges who will have tied/affinity appeals distribute to them
  - Creates several judge who do not have any tied/affinity cases
  - Creates several judges who should not receive cases when the push job is run
  - Creates Direct Review and Evidence Submission docket cases which are priority non-genpop, priority genpop, priority not ready, and nonpriority ready

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
If you do not want to reset your local environment, run the seed file below:
1. `bundle exec rake db:seed:appeals_for_push_priority_job_distribution

If you want to/don't care if you reset your local environment:
1. Run `make reset`
2. Open a rails console `make c`
3. Get a push priority judge from the seed file `judge = User.find_by_css_id 'PUSHJUDGE1'`
4. Create a Direct Review Docket object `drd = DirectReviewDocket.new`
5. See how many appeals are available to the judge `drd.appeals(priority: true, ready: true, judge: judge).to_a.count` => should return 17; 14 genpop, 3 non genpop
6. See how many appeals are available when getting only non-genpop: `drd.appeals(priority: true, ready: true, judge: judge, genpop: 'not_genpop').to_a.count` => should return 3
7. Create a distribution for the judge `distribution = Distribution.create!(judge: judge)`
8. Use the distribution and docket object to distribute non-genpop appeals to the judge with no limit (as they would be distributed in a push priority job): `drd.distribute_appeals(distribution, priority: true, genpop: 'not_genpop', limit: nil, style: 'push')`
9. Check the number of cases distributed `distribution.reload.distributed_cases.count` => should return 3
10. Check the number of appeals that are available when getting only non-genpop: `drd.appeals(priority: true, ready: true, judge: judge, genpop: 'not_genpop').to_a.count` => should return 0
11. See how many appeals are available to the judge `drd.appeals(priority: true, ready: true, judge: judge).to_a.count` => should return 14; 14 genpop, 0 non genpop

