### PR TITLE
Update VACOLS case factory sequence to remove leading zeroes

### DIFF
--- a/spec/factories/sequences.rb
+++ b/spec/factories/sequences.rb
@@ -3,12 +3,18 @@
 FactoryBot.define do
   # returns digits 4-8 of epoch time to be used for unique id sequencing
   def time
-    Time.now.to_i.to_s.split("")[3..7].join
+    t = Time.now.to_i.to_s.split("")
+    # if t[3] is 0, a leading zero is maintained which affects some tests, so "decrement" that zero
+    t[3] = "9" if t[3] == "0"
+    t[3..7].join
   end
 
   # returns digits 7-10 of epoch time for use in CSS_ID sequencing
   def shortened_time
-    Time.now.to_i.to_s.split("")[6..9].join
+    t = Time.now.to_i.to_s.split("")
+    # if t[6] is 0, a leading zero is maintained which affects some tests, so "decrement" that zero
+    t[6] = "9" if t[6] == "0"
+    t[6..9].join
   end
 
   # BRIEFF.BFCORLID in VACOLS, file_number/veteran_file_number in Caseflow


### PR DESCRIPTION
# Description
Updates the global sequence values which use the current time to remove leading zeroes from the results, as they were causing some tests to fail. Affected sequences: 
- veteran_file_number
- vacols_correspondent_key
- vacols_case_key
- participant_id
- css_id

## Acceptance Criteria
- [ ] Code compiles correctly
