### PR TITLE
Pass in temporary linked appealUuid signifier which is mapped to externalId

### DIFF
--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -551,7 +551,7 @@ const CorrespondenceDetails = (props) => {
                   correspondence={props.correspondence}
                   organizations={props.organizations}
                   userCssId={props.userCssId}
-                  appealUuid={taskAdded.appealUuid}
+                  appealUuid={taskAdded.appealUuid || taskAdded.externalId}
                   waivableUser={props.isInboundOpsSuperuser || props.isInboundOpsSupervisor}
                   correspondence_uuid={props.correspondence_uuid}
                 />
@@ -905,15 +905,6 @@ const CorrespondenceDetails = (props) => {
           const appealIds = resp.body.related_appeals;
           const correspondenceAppeals = resp.body.correspondence_appeals;
 
-          setSelectedAppeals(appealIds);
-          setInitialSelectedAppeals(appealIds);
-          setAppealTableKey((key) => key + 1);
-          props.updateCorrespondenceInfo(tempCor);
-          setRelatedCorrespondenceIds([...relatedCorrespondenceIds, ...priorMailIds]);
-          setShowSuccessBanner(true);
-          setSelectedPriorMail([]);
-          setDisableSubmitButton(true);
-
           // Removes all entries in the queue.appeals redux store
           Object.entries(props.appealsFromStore).forEach(
             ([, value]) => dispatch(deleteAppeal((value.externalId)))
@@ -926,6 +917,15 @@ const CorrespondenceDetails = (props) => {
           });
 
           dispatch(fetchCorrespondencesAppealsTasks(correspondence.uuid));
+
+          props.updateCorrespondenceInfo(tempCor);
+          setSelectedAppeals(appealIds);
+          setInitialSelectedAppeals(appealIds);
+          setAppealTableKey((key) => key + 1);
+          setRelatedCorrespondenceIds([...relatedCorrespondenceIds, ...priorMailIds]);
+          setShowSuccessBanner(true);
+          setSelectedPriorMail([]);
+          setDisableSubmitButton(true);
 
           sortAppeals(appealIds);
           window.scrollTo({


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Currently affects:
[APPEALS-63124](https://jira.devops.va.gov/browse/APPEALS-63124)
[APPEALS-54280](https://jira.devops.va.gov/browse/APPEALS-54280)
[APPEALS-58114](https://jira.devops.va.gov/browse/APPEALS-58114)
[APPEALS-59817](https://jira.devops.va.gov/browse/APPEALS-59817)


# Description
Updates the appealUuid pass-in value for the CorrespondenceAppealTasks to be either the appealUuid (for already serialized and existing appeals), or the externalId(for temporary linked appeals).

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [64280 Pull Request](https://github.com/department-of-veterans-affairs/caseflow/pull/23274)
or [63124 Pull Request](https://github.com/department-of-veterans-affairs/caseflow/pull/23381)