### PR TITLE
APPEALS-63535: AOJ Legacy nonpriority appeals can be distributed in place of priority appeals

### DIFF
--- a/app/models/vacols/aoj_case_docket.rb
+++ b/app/models/vacols/aoj_case_docket.rb
@@ -555,7 +555,7 @@ class VACOLS::AojCaseDocket < VACOLS::CaseDocket # rubocop:disable Metrics/Class
                aoj_aod_affinity_lever_value == Constants.ACD_LEVERS.infinite
               <<-SQL
                 #{SELECT_PRIORITY_APPEALS_ORDER_BY_BFD19}
-                where (((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?)
+                where ((((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?))
                 and (PREV_TYPE_ACTION = '7' or AOD = '1')
                 or ((PREV_DECIDING_JUDGE = ? or #{ineligible_judges_sattyid_cache(true)}
                 or #{vacols_judges_with_exclude_appeals_from_affinity(excluded_judges_attorney_ids)})
@@ -564,14 +564,14 @@ class VACOLS::AojCaseDocket < VACOLS::CaseDocket # rubocop:disable Metrics/Class
             elsif use_by_docket_date?
               <<-SQL
                 #{SELECT_PRIORITY_APPEALS_ORDER_BY_BFD19}
-                where ((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?)
+                where (((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?))
                 and (PREV_TYPE_ACTION = '7' or AOD = '1')
                 or #{priority_aoj_cdl_query} or #{priority_cdl_aoj_aod_query}
               SQL
             else
               <<-SQL
                 #{SELECT_PRIORITY_APPEALS}
-                where ((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?)
+                where (((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?))
                 and (PREV_TYPE_ACTION = '7' or AOD = '1')
                 or #{priority_aoj_cdl_query} or #{priority_cdl_aoj_aod_query}
               SQL


### PR DESCRIPTION
Resolves [APPEALS-63535](https://jira.devops.va.gov/browse/APPEALS-63535)

# Description
- Add parenthesis to the distribute priority appeals query in the AOJ Case Docket file. The existing code is
```
where ((VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?)
and (PREV_TYPE_ACTION = '7' or AOD = '1')
```
Which logically equates to:
- VLJ is the requesting judge and 1=1 or the VLJ is in ineligible list and 1=1
- OR vlj is null and 1=1 and previous type action is 7 or aod is 1

The first bullet above was causing nonpriority appeals which met the criteria VLJ = requesting judge to be included in the query results

The update adds a set of parenthesis around `(VLJ = ? or #{ineligible_judges_sattyid_cache}) and 1 = ?) or (VLJ is null and 1 = ?)` to update the logic to:
- VLJ is the requesting judge and 1=1 and previous type action is 7 or aod is 1
- OR the VLJ is in ineligible list and 1=1 and previous type action is 7 or aod is 1

This will correctly apply the priority requirements `(PREV_TYPE_ACTION = '7' or AOD = '1')` to all appeals in the query

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into main: Was this deployed to UAT?
