### PR TITLE
APPEALS-56232 | Tasks related to an inactive appeal: Privacy act request

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2307,46 +2307,6 @@ ActiveRecord::Schema.define(version: 2024_10_12_181521) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "vbms_ext_claim", primary_key: "CLAIM_ID", id: :decimal, precision: 38, force: :cascade do |t|
-    t.string "ALLOW_POA_ACCESS", limit: 5
-    t.decimal "CLAIMANT_PERSON_ID", precision: 38
-    t.datetime "CLAIM_DATE"
-    t.string "CLAIM_SOJ", limit: 25
-    t.integer "CONTENTION_COUNT"
-    t.datetime "CREATEDDT", null: false
-    t.string "EP_CODE", limit: 25
-    t.datetime "ESTABLISHMENT_DATE"
-    t.datetime "EXPIRATIONDT"
-    t.string "INTAKE_SITE", limit: 25
-    t.datetime "LASTUPDATEDT", null: false
-    t.string "LEVEL_STATUS_CODE", limit: 25
-    t.datetime "LIFECYCLE_STATUS_CHANGE_DATE"
-    t.string "LIFECYCLE_STATUS_NAME", limit: 50
-    t.string "ORGANIZATION_NAME", limit: 100
-    t.string "ORGANIZATION_SOJ", limit: 25
-    t.string "PAYEE_CODE", limit: 25
-    t.string "POA_CODE", limit: 25
-    t.integer "PREVENT_AUDIT_TRIG", limit: 2, default: 0, null: false
-    t.string "PRE_DISCHARGE_IND", limit: 5
-    t.string "PRE_DISCHARGE_TYPE_CODE", limit: 10
-    t.string "PRIORITY", limit: 10
-    t.string "PROGRAM_TYPE_CODE", limit: 10
-    t.string "RATING_SOJ", limit: 25
-    t.string "SERVICE_TYPE_CODE", limit: 10
-    t.string "SUBMITTER_APPLICATION_CODE", limit: 25
-    t.string "SUBMITTER_ROLE_CODE", limit: 25
-    t.datetime "SUSPENSE_DATE"
-    t.string "SUSPENSE_REASON_CODE", limit: 25
-    t.string "SUSPENSE_REASON_COMMENTS", limit: 1000
-    t.decimal "SYNC_ID", precision: 38, null: false
-    t.string "TEMPORARY_CLAIM_SOJ", limit: 25
-    t.string "TYPE_CODE", limit: 25
-    t.decimal "VERSION", precision: 38, null: false
-    t.decimal "VETERAN_PERSON_ID", precision: 15
-    t.index ["CLAIM_ID"], name: "claim_id_index"
-    t.index ["LEVEL_STATUS_CODE"], name: "level_status_code_index"
-  end
-
   create_table "vbms_uploaded_documents", force: :cascade do |t|
     t.bigint "appeal_id", comment: "Appeal/LegacyAppeal ID; use as FK to appeals/legacy_appeals"
     t.string "appeal_type", comment: "'Appeal' or 'LegacyAppeal'"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Tasks related to an inactive appeal: Privacy act request](https://jira.devops.va.gov/browse/APPEALS-56232)

# Description
Please explain the changes you made here.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. These first 14 include setup steps, and the testing for this specific ticket starts on step 15.
2. Log into Caseflow as an inbound ops team user.
3. Navigate to queue/correspondence. (Note: Admins and Superusers will have access to all the correspondence already, but regular inbound ops team users may have to have a correspondence assigned to them before they will see them).
4. Select a veteran from the unassigned tab to go to the review package page
5. If necessary, add a correspondence type, and click save.
6. Scroll to the bottom and select "Create record"
7. Navigate to step 2 of the intake page
8. Find the "Tasks related to an existing Appeal" section and click the "yes" radio button
9. Note that the first six appeals should be inactive appeals. The first three will be assigned to "Mail" (cancelled), and the next three will be assigned to "Post-decision" (closed).
10. Select one of these appeals and verify that it is inactive. You can verify this by following the next three steps.
11. Click on the appeal link next to the checkbox. This should open a new tab.
12. On this new tab page, you will see the appeal information. In the address bar, change the /queue part of the address to /explain.
13. This explain page will show everything you need to know about the appeal. to verify our functionality, click the "Task Tree", and verify that the root task has a status of "cancelled" or "closed" (both of which would mean the appeal is still inactive and did not change root task state).
14. Return back to the intake tab, and make sure the checkbox is selected next to the appeal you chose. 
15. Verify the Privacy Act Request option exists in the list of available tasks for inactive appeals, as this option should be available for any appeal.
16. Choose the Privacy Act Request task and add notes into the notes section.
17. Continue to step 3 of the intake form, and confirm that the Privacy Act Request tasks is visible in the Tasks Related to and Existing Appeal section. (Note, you may want to grab the address from the address bar at this point).
18. Submit the correspondence, and confirm the submission. The record should successfully be created.
19. Next, paste the previously-copied URL into the address bar, removing the /intake portion, and go to that page
20. The linked appeal should appear in the "Existing Appeals" section, and it should be assigned to the Privacy Team