### PR TITLE
Improve CmpDocument Model Validations

### DIFF
--- a/app/controllers/api/v1/cmp_controller.rb
+++ b/app/controllers/api/v1/cmp_controller.rb
@@ -8,7 +8,7 @@ class Api::V1::CmpController < Api::ApplicationController
   end
 
   def document
-    new_document = CmpDocument.new(document_params)
+    new_document = CmpDocument.new(cmp_document_params)
 
     if new_document.save
       render json: { message: "CMP document successfully created" }, status: :ok
@@ -22,7 +22,7 @@ class Api::V1::CmpController < Api::ApplicationController
 
   private
 
-  def document_params
+  def cmp_document_params
     {
       cmp_document_id: params[:documentId],
       cmp_document_uuid: params[:documentUuid],

--- a/app/models/cmp_document.rb
+++ b/app/models/cmp_document.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CmpDocument < ApplicationRecord
+  belongs_to :cmp_mail_packet, optional: true
+
   validates :cmp_document_id,
             :cmp_document_uuid,
             :date_of_receipt,
@@ -8,13 +10,22 @@ class CmpDocument < ApplicationRecord
             :vbms_doctype_id,
             presence: true
 
-  belongs_to :cmp_mail_packet, optional: true
+  validates :vbms_doctype_id, numericality: { only_integer: true }
 
-  validate :date_of_receipt_must_be_a_date, on: [:create, :update]
+  validate :date_of_receipt_must_be_a_date
 
   def date_of_receipt_must_be_a_date
-    date_of_receipt&.to_date || errors.add(:date_of_receipt, :blank)
+    # Use the magic <attribute>_before_type_cast accessor to get the raw value
+    before_val = date_of_receipt_before_type_cast
+
+    if before_val.blank?
+      errors.add(:date_of_receipt, :blank)
+      return
+    end
+
+    # Validates dateOfReceipt is in yyyy-mm-dd (csv_date) format.
+    DateTime.strptime(before_val, Date::DATE_FORMATS[:csv_date])
   rescue Date::Error
-    errors.add(:date_of_receipt, :invalid)
+    errors.add(:date_of_receipt, "date_of_receipt must use the format yyyy-mm-dd")
   end
 end

--- a/spec/models/cmp_document_spec.rb
+++ b/spec/models/cmp_document_spec.rb
@@ -9,6 +9,10 @@ RSpec.describe CmpDocument, type: :model do
 
   it { should belong_to(:cmp_mail_packet).optional }
 
-  it { should allow_value(Time.current).for(:date_of_receipt) }
+  it { should allow_value(Time.current.strftime(Date::DATE_FORMATS[:csv_date])).for(:date_of_receipt) }
+  it { should_not allow_value("19900101").for(:date_of_receipt) }
   it { should_not allow_value("not really a date").for(:date_of_receipt) }
+
+  it { should allow_value(Faker::Number.within(range: 1..100).to_s).for(:vbms_doctype_id) }
+  it { should_not allow_value("not really an integer").for(:vbms_doctype_id) }
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Create CMP Document metadata endpoint](https://jira.devops.va.gov/browse/APPEALS-59007)

# Description
- Validate that vbms_doctype_id is an integer.
- Improve validation of date_of_receipt to be less lenient in parsing dates and require that they follow yyyy-mm-dd format.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Run specs for changed/new files:
  - `bundle exec rspec spec/models/cmp_document_spec.rb`
  - `bundle exec rspec spec/models/cmp_mail_packet_spec.rb`
  - `bundle exec rspec spec/requests/api/v1/cmp_controller_spec.rb`
