### PR TITLE
Make Further Improvements to API Validations

### DIFF
--- a/app/models/cmp_document.rb
+++ b/app/models/cmp_document.rb
@@ -5,9 +5,7 @@ class CmpDocument < ApplicationRecord
 
   validates :cmp_document_id,
             :cmp_document_uuid,
-            :date_of_receipt,
             :packet_uuid,
-            :vbms_doctype_id,
             presence: true
 
   validates :vbms_doctype_id, numericality: { only_integer: true }
@@ -23,9 +21,16 @@ class CmpDocument < ApplicationRecord
       return
     end
 
-    # Validates dateOfReceipt is in yyyy-mm-dd (csv_date) format.
+    # For yyyy-mm-dd format:
+    # Require non-zero first digit; require the exact number of digits for each.
+    if !/^[1-9]{1}\d{3}-\d{2}-\d{2}$/.match?(before_val)
+      errors.add(:date_of_receipt, "date_of_receipt must use the format yyyy-mm-dd")
+      return
+    end
+
+    # Validates dateOfReceipt is in yyyy-mm-dd (csv_date) format and is parsable to a valid date
     DateTime.strptime(before_val, Date::DATE_FORMATS[:csv_date])
   rescue Date::Error
-    errors.add(:date_of_receipt, "date_of_receipt must use the format yyyy-mm-dd")
+    errors.add(:date_of_receipt, "date_of_receipt must be a valid date")
   end
 end

--- a/spec/models/cmp_document_spec.rb
+++ b/spec/models/cmp_document_spec.rb
@@ -3,16 +3,20 @@
 RSpec.describe CmpDocument, type: :model do
   it { should validate_presence_of(:cmp_document_id) }
   it { should validate_presence_of(:cmp_document_uuid) }
-  it { should validate_presence_of(:date_of_receipt) }
   it { should validate_presence_of(:packet_uuid) }
-  it { should validate_presence_of(:vbms_doctype_id) }
-
-  it { should belong_to(:cmp_mail_packet).optional }
 
   it { should allow_value(Time.current.strftime(Date::DATE_FORMATS[:csv_date])).for(:date_of_receipt) }
+  it { should_not allow_value(nil).for(:date_of_receipt) }
   it { should_not allow_value("19900101").for(:date_of_receipt) }
+  it { should_not allow_value("0199-01-01").for(:date_of_receipt) }
+  it { should_not allow_value("1999-122-31").for(:date_of_receipt) }
+  it { should_not allow_value("1999-12-311").for(:date_of_receipt) }
+  it { should_not allow_value("1999-12-32").for(:date_of_receipt) }
   it { should_not allow_value("not really a date").for(:date_of_receipt) }
 
   it { should allow_value(Faker::Number.within(range: 1..100).to_s).for(:vbms_doctype_id) }
+  it { should_not allow_value(nil).for(:vbms_doctype_id) }
   it { should_not allow_value("not really an integer").for(:vbms_doctype_id) }
+
+  it { should belong_to(:cmp_mail_packet).optional }
 end

--- a/spec/requests/api/v1/cmp_controller_spec.rb
+++ b/spec/requests/api/v1/cmp_controller_spec.rb
@@ -11,7 +11,7 @@ shared_examples "a validates required params are not null #document endpoint" do
 
   let(:post_data) do
     {
-      dateOfReceipt: 1.day.ago,
+      dateOfReceipt: 1.day.ago.strftime(Date::DATE_FORMATS[:csv_date]),
       documentId: SecureRandom.uuid,
       documentUuid: SecureRandom.uuid,
       nonVbmsDocTypeName: Faker::Internet.username(specifier: 8),
@@ -48,7 +48,7 @@ describe Api::V1::CmpController, type: :request do
   describe "#document" do
     let!(:cmp_document_id) { SecureRandom.uuid }
     let!(:cmp_document_uuid) { SecureRandom.uuid }
-    let!(:date_of_receipt) { 1.day.ago }
+    let!(:date_of_receipt) { 1.day.ago.strftime(Date::DATE_FORMATS[:csv_date]) }
     let!(:packet_uuid) { SecureRandom.uuid }
     let!(:doctype_name) { Faker::Internet.username(specifier: 8) }
     let!(:vbms_doctype_id) { Faker::Number.within(range: 1..10) }
@@ -81,11 +81,7 @@ describe Api::V1::CmpController, type: :request do
         expect(cmp_document.cmp_document_id).to eq(cmp_document_id)
         expect(cmp_document.cmp_document_uuid).to eq(cmp_document_uuid)
         expect(cmp_document.packet_uuid).to eq(packet_uuid)
-        # Ruby Time object maintains greater precision than the database does.
-        # When the value is read back from the database, it’s only preserved to microsecond precision,
-        # while the in-memory representation is precise to nanoseconds.
-        # https://stackoverflow.com/a/20403290
-        expect(cmp_document.date_of_receipt).to be_within(1.second).of date_of_receipt
+        expect(cmp_document.date_of_receipt.strftime(Date::DATE_FORMATS[:csv_date])).to eq date_of_receipt
         expect(cmp_document.doctype_name).to eq(doctype_name)
         expect(cmp_document.vbms_doctype_id).to eq(vbms_doctype_id)
       end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Create CMP Document metadata endpoint](https://jira.devops.va.gov/browse/APPEALS-59007)

# Description
- Required that dates have 4 digits in order to prevent dates too far in the past or future from being accepted.
- Remove some presence validations to prevent duplicate validation errors for vbms_doctype_id and date_of_receipt.

## Acceptance Criteria
- [ ] All specs passing

## Testing Plan
1. Run specs for changed/new files:
  - `bundle exec rspec spec/models/cmp_document_spec.rb`
  - `bundle exec rspec spec/models/cmp_mail_packet_spec.rb`
  - `bundle exec rspec spec/requests/api/v1/cmp_controller_spec.rb`
