### PR TITLE
Create Bruno Collection for Testing CMP Document Endpoint

### DIFF
--- a/api_collections/bruno/cmp/api-v1-cmp-document/200 API Token.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/200 API Token.bru
@@ -1,0 +1,21 @@
+meta {
+  name: 200 API Token
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{BASE_URL}}/api/v1/token?consumer_name=test-consumer
+  body: none
+  auth: none
+}
+
+params:query {
+  consumer_name: test-consumer
+}
+
+tests {
+  test("Successful API Token POST", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/200 Cmp Document.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/200 Cmp Document.bru
@@ -1,0 +1,29 @@
+meta {
+  name: 200 Cmp Document
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{BASE_URL}}/api/v1/cmp/document
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "packetUuid": "cffd1510-60b5-47ea-a2b2-89459b92f14e",
+    "documentId": "ad5bf647ae687g",
+    "documentUuid": "a0872b22-f743-4ad1-b510-dad98037ad26",
+    "dateOfReceipt": "2024-11-07",
+    "nonVbmsDocTypeName": "example-vbms-name",
+    "packetUuid": "77b12f7a-8529-4315-8194-dcd70c34f8f9",
+    "vbmsDocTypeId": 84
+  }
+}
+
+tests {
+  test("Successful CMP Document POST", function() {
+    expect(res.status).to.equal(200);
+  });
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/400 Cmp Document.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/400 Cmp Document.bru
@@ -1,0 +1,29 @@
+meta {
+  name: 400 Cmp Document
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{BASE_URL}}/api/v1/cmp/document
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "packetUuid": "cffd1510-60b5-47ea-a2b2-89459b92f14e",
+    "documentId": "ad5bf647ae687g",
+    "documentUuid": "a0872b22-f743-4ad1-b510-dad98037ad26",
+    "dateOfReceipt": "",
+    "nonVbmsDocTypeName": "example-vbms-name",
+    "packetUuid": "77b12f7a-8529-4315-8194-dcd70c34f8f9",
+    "vbmsDocTypeId": 84
+  }
+}
+
+tests {
+  test("Failed CMP Document POST", function() {
+    expect(res.status).to.equal(422);
+  });
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/500 API Token.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/500 API Token.bru
@@ -1,0 +1,17 @@
+meta {
+  name: 500 API Token
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{BASE_URL}}/api/v1/token
+  body: none
+  auth: none
+}
+
+tests {
+  test("Failed API Token POST", function() {
+    expect(res.status).to.equal(500);
+  });
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/bruno.json
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "/api/v1/cmp/document",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/collection.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/collection.bru
@@ -1,0 +1,11 @@
+headers {
+  Accept: application/json
+}
+
+auth {
+  mode: bearer
+}
+
+auth:bearer {
+  token: get-from-200-api-token
+}

--- a/api_collections/bruno/cmp/api-v1-cmp-document/environments/dev.bru
+++ b/api_collections/bruno/cmp/api-v1-cmp-document/environments/dev.bru
@@ -1,0 +1,3 @@
+vars {
+  BASE_URL: http://localhost:3000
+}


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Setup Bruno Test suite](https://jira.devops.va.gov/browse/APPEALS-63474)

# Description
Create new Bruno test suite for the CMP document endpoint.

## Acceptance Criteria
See Jira ticket.

## Testing Plan
1. Open the collection in Bruno (located at `api_collections/bruno/cmp/api-v1-cmp-document`).
2. Use the "200 API Token" endpoint to obtain an API token.
3. Enter the token in the "Auth" tab in the collection settings.
4. Verify the other endpoints (should be passing under the "tests" tab in the right-hand panel).
