### PR TITLE
APPEALS-65174: Refactor ineligible judge list to not call to VACOLS on app startup

### DIFF
--- a/app/queries/ineligible_judge_list.rb
+++ b/app/queries/ineligible_judge_list.rb
@@ -12,8 +12,6 @@ class IneligibleJudgeList
   }.freeze
 
   EMPTY_KEY_VALUE = "No Key Present"
-  INACTIVE_VACOLS = CaseDistributionIneligibleJudges.ineligible_vacols_judges
-  INACTIVE_CASEFLOW = CaseDistributionIneligibleJudges.ineligible_caseflow_judges
 
   def self.generate_rows(record)
     HEADERS.keys.map { |key| record[key] }
@@ -47,9 +45,17 @@ class IneligibleJudgeList
     }
   end
 
+  def self.inactive_caseflow
+    @inactive_caseflow ||= CaseDistributionIneligibleJudges.ineligible_caseflow_judges
+  end
+
+  def self.inactive_vacols
+    @inactive_vacols ||= CaseDistributionIneligibleJudges.ineligible_vacols_judges
+  end
+
   def self.get_reason_for_ineligibility(css_id_value, sdomainid_value)
-    inactive_caseflow_user = INACTIVE_CASEFLOW.find { |caseflow_user| caseflow_user[:css_id] == css_id_value }
-    inactive_vacols_user = INACTIVE_VACOLS.find { |vacols_user| vacols_user[:sdomainid] == sdomainid_value }
+    inactive_caseflow_user = inactive_caseflow.find { |caseflow_user| caseflow_user[:css_id] == css_id_value }
+    inactive_vacols_user = inactive_vacols.find { |vacols_user| vacols_user[:sdomainid] == sdomainid_value }
 
     @reason = if inactive_caseflow_user && inactive_vacols_user
                 "BOTH"


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-65174](https://jira.devops.va.gov/browse/APPEALS-65174)

# Description
Changes calls made to the Caseflow and VACOLS databases to retrieve ineligible/inactive judge information in the query file IneligibleJudgeList to be memoized class methods instead of class constants.

## Acceptance Criteria
- [ ] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Go to [Jira Issue/Test Plan Link](https://jira.devops.va.gov/browse/JIRA-12345) or list them below

- [ ] For feature branches merging into main: Was this deployed to UAT?