### PR TITLE
update backend routes for task movement

### DIFF
--- a/app/controllers/concerns/errors.rb
+++ b/app/controllers/concerns/errors.rb
@@ -10,4 +10,13 @@ module Errors
       ]
     }, status: :bad_request
   end
+
+  def invalid_task_movement_error
+    render json: {
+      "errors": [
+        "title": "Blocked Legacy Appeal Case Movement is Invalid",
+        "detail": "LegacyAppealAssignmentTrackingTask was not created"
+      ]
+    }, status: :bad_request
+  end
 end

--- a/app/controllers/concerns/errors.rb
+++ b/app/controllers/concerns/errors.rb
@@ -17,6 +17,6 @@ module Errors
         "title": "Blocked Legacy Appeal Case Movement is Invalid",
         "detail": "LegacyAppealAssignmentTrackingTask was not created"
       ]
-    }, status: :bad_request
+    }, status: :internal_server_error
   end
 end

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -99,7 +99,6 @@ class LegacyTasksController < ApplicationController
       assigned_to: assigned_to,
       assigned_by_id: current_user.id,
       instructions: params[:tasks][:instructions],
-      completed_by_id: current_user.id,
       status: Constants.TASK_STATUSES.completed
     )
 

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -100,7 +100,7 @@ class LegacyTasksController < ApplicationController
       assigned_by_id: current_user.id,
       instructions: params[:tasks][:instructions],
       completed_by_id: current_user.id,
-      status: "completed"
+      status: Constants.TASK_STATUSES.completed
     )
 
     return invalid_task_movement_error if tracking_task.blank?

--- a/app/controllers/legacy_tasks_controller.rb
+++ b/app/controllers/legacy_tasks_controller.rb
@@ -92,9 +92,9 @@ class LegacyTasksController < ApplicationController
   end
 
   def blocked_assign_to_judge
-    # If the user being assigned to is a judge, do not create a DECASS record, just
-    # update the location to the assigned judge.
-    LegacyAppealAssignmentTrackingTask.create!(
+    return unless FeatureToggle.enabled?(:legacy_case_movement_scm_to_vlj_for_blockhtask)
+
+    tracking_task = LegacyAppealAssignmentTrackingTask.create!(
       appeal: appeal,
       assigned_to: assigned_to,
       assigned_by_id: current_user.id,
@@ -102,6 +102,8 @@ class LegacyTasksController < ApplicationController
       completed_by_id: current_user.id,
       status: "completed"
     )
+
+    return invalid_task_movement_error if tracking_task.blank?
 
     QueueRepository.update_location_to_judge(appeal.vacols_id, assigned_to)
 

--- a/app/models/legacy_appeal.rb
+++ b/app/models/legacy_appeal.rb
@@ -930,7 +930,7 @@ class LegacyAppeal < CaseflowRecord
     # In case an attorney case review does not exist in caseflow or if this acting judge was neither the judge or
     # attorney listed in the review, check to see if a decision has already been written for the appeal. If so, assume
     # this appeal is assigned to the acting judge as a judge task as a best guess
-    vacols_case_review.valid_document_id?
+    vacols_case_review.valid_document_id? || vacols_case_review&.created_at.nil?
   end
 
   def claimant_participant_id

--- a/app/models/legacy_tasks/judge_legacy_assign_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_assign_task.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class JudgeLegacyAssignTask < JudgeLegacyTask
-  def available_actions(user, role)
-    if assigned_to == user && role == "judge"
+  def available_actions(user, _role)
+    if assigned_to == user && (user.pure_judge_in_vacols? || user.acting_judge_in_vacols?)
       [
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
         Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,

--- a/app/models/legacy_tasks/judge_legacy_assign_task.rb
+++ b/app/models/legacy_tasks/judge_legacy_assign_task.rb
@@ -2,7 +2,7 @@
 
 class JudgeLegacyAssignTask < JudgeLegacyTask
   def available_actions(user, _role)
-    if assigned_to == user && (user.pure_judge_in_vacols? || user.acting_judge_in_vacols?)
+    if assigned_to == user && user.judge_in_vacols?
       [
         Constants.TASK_ACTIONS.ADD_ADMIN_ACTION.to_h,
         Constants.TASK_ACTIONS.ASSIGN_TO_ATTORNEY.to_h,

--- a/app/models/tasks/legacy_appeal_assignment_tracking_task.rb
+++ b/app/models/tasks/legacy_appeal_assignment_tracking_task.rb
@@ -29,8 +29,9 @@ class LegacyAppealAssignmentTrackingTask < Task
   end
 
   def blocked_legacy_appeal?
-    FeatureToggle.enabled?(:legacy_case_movement_scm_to_vlj_for_blockhtask, user: user) &&
-      HearingTask.find_by(appeal_id: appeal.id, status: Constants.TASK_STATUSES.on_hold).exists?
+    FeatureToggle.enabled?(:legacy_case_movement_scm_to_vlj_for_blockhtask) &&
+      HearingTask.find_by(appeal_id: appeal.id, status: Constants.TASK_STATUSES.on_hold).present? &&
+      appeal.is_a?(LegacyAppeal)
   end
 
   def cancel_blocking_tasks

--- a/app/models/tasks/legacy_appeal_assignment_tracking_task.rb
+++ b/app/models/tasks/legacy_appeal_assignment_tracking_task.rb
@@ -2,6 +2,7 @@
 
 class LegacyAppealAssignmentTrackingTask < Task
   validate :appeal_is_legacy_appeal, on: :create
+  before_create :cancel_blocking_tasks, if: :blocked_legacy_appeal?
 
   def self.hide_from_queue_table_view
     true
@@ -25,5 +26,15 @@ class LegacyAppealAssignmentTrackingTask < Task
            task_type: type,
            message: "Task status has to be '#{Constants.TASK_STATUSES.completed}' on create for #{type}")
     end
+  end
+
+  def blocked_legacy_appeal?
+    FeatureToggle.enabled?(:legacy_case_movement_scm_to_vlj_for_blockhtask, user: user) &&
+      HearingTask.find_by(appeal_id: appeal.id, status: Constants.TASK_STATUSES.on_hold).exists?
+  end
+
+  def cancel_blocking_tasks
+    HearingTask.find_by(appeal_id: appeal.id, status: Constants.TASK_STATUSES.on_hold)
+      .cancel_descendants(instructions: instructions[1])
   end
 end

--- a/app/repositories/task_action_repository.rb
+++ b/app/repositories/task_action_repository.rb
@@ -186,7 +186,7 @@ class TaskActionRepository # rubocop:disable Metrics/ClassLength
     def assign_to_attorney_data(task, user)
       {
         selected: nil,
-        options: user.can_act_on_behalf_of_judges? ? users_to_options(Attorney.list_all) : nil,
+        options: (user.can_act_on_behalf_of_judges? || user.acting_judge_in_vacols?) ? users_to_options(Attorney.list_all) : nil, # rubocop:disable Layout/LineLength
         type: task.is_a?(LegacyTask) ? AttorneyLegacyTask.name : AttorneyTask.name
       }
     end

--- a/client/app/components/FlowModal.jsx
+++ b/client/app/components/FlowModal.jsx
@@ -53,7 +53,7 @@ export default class FlowModal extends React.PureComponent {
   };
 
   render = () => {
-    const { title, button, children, error, success, submitDisabled, submitButtonClassNames } = this.props;
+    const { title, button, children, error, success, submitDisabled, submitButtonClassNames, icon } = this.props;
 
     return (
       <Modal
@@ -73,6 +73,7 @@ export default class FlowModal extends React.PureComponent {
           }
         ]}
         closeHandler={this.cancelHandler}
+        icon={icon}
       >
         {error && <Alert title={error.title} type="error">{error.detail}</Alert>}
         {success && <Alert title={success.title} type="success">{success.detail}</Alert>}
@@ -96,6 +97,7 @@ FlowModal.propTypes = {
   history: PropTypes.object,
   title: PropTypes.string,
   button: PropTypes.string,
+  icon: PropTypes.string,
   onCancel: PropTypes.func,
   pathAfterSubmit: PropTypes.string,
   // submit should return a promise on which .then() can be called

--- a/client/app/components/FlowModal.jsx
+++ b/client/app/components/FlowModal.jsx
@@ -53,7 +53,17 @@ export default class FlowModal extends React.PureComponent {
   };
 
   render = () => {
-    const { title, button, children, error, success, submitDisabled, submitButtonClassNames, icon, closeButton } = this.props;
+    const {
+      title,
+      button,
+      children,
+      error,
+      success,
+      submitDisabled,
+      submitButtonClassNames,
+      icon,
+      closeButton
+    } = this.props;
 
     return (
       <Modal

--- a/client/app/components/FlowModal.jsx
+++ b/client/app/components/FlowModal.jsx
@@ -53,7 +53,7 @@ export default class FlowModal extends React.PureComponent {
   };
 
   render = () => {
-    const { title, button, children, error, success, submitDisabled, submitButtonClassNames, icon } = this.props;
+    const { title, button, children, error, success, submitDisabled, submitButtonClassNames, icon, closeButton } = this.props;
 
     return (
       <Modal
@@ -61,7 +61,7 @@ export default class FlowModal extends React.PureComponent {
         buttons={[
           {
             classNames: ['usa-button', 'cf-btn-link'],
-            name: COPY.MODAL_CANCEL_BUTTON,
+            name: closeButton ? COPY.MODAL_CLOSE_BUTTON : COPY.MODAL_CANCEL_BUTTON,
             onClick: this.cancelHandler
           },
           {
@@ -97,6 +97,7 @@ FlowModal.propTypes = {
   history: PropTypes.object,
   title: PropTypes.string,
   button: PropTypes.string,
+  closeButton: PropTypes.bool,
   icon: PropTypes.string,
   onCancel: PropTypes.func,
   pathAfterSubmit: PropTypes.string,

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -188,7 +188,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
     return <div className="cf-modal-scroll">
       <QueueFlowModal
         {...modalProps}
-        onCancel={() => this.setState({ showModal: false, selectedAssignee: null, instructions: null })}
+        onCancel={() => this.setState({ showModal: false, selectedAssignee: null, instructions: '' })}
         icon="warning"
       >
         {this.modalAlert()}

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -180,6 +180,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
       title: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_TITLE,
       pathAfterSubmit: (actionData && actionData.redirect_after) || `/queue/appeals/${appeal.externalId}`,
       button: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_SUBMIT,
+      closeButton: true,
       submit: this.submit,
       validateForm: this.validateModal
     };

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -103,10 +103,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
         cancelledTasks: this.actionData().blocking_tasks,
         cancellationReason: this.state.selectedReason,
         cancellationInstructions: this.state.cancellationInstructions,
-      }, successMessage).
-        then(() => {
-          this.props.history.replace(`/queue/appeals/${appeal.externalId}`);
-        });
+      }, successMessage);
     }
 
     const payload = {

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 import { withRouter } from 'react-router-dom';
 import { sprintf } from 'sprintf-js';
 import { css } from 'glamor';
+import QueueFlowModal from './components/QueueFlowModal';
 
 import COPY from '../../COPY';
 
@@ -17,7 +18,6 @@ import QueueFlowPage from './components/QueueFlowPage';
 import SearchableDropdown from '../components/SearchableDropdown';
 import TextareaField from '../components/TextareaField';
 import RadioField from '../components/RadioField';
-import Modal from '../components/Modal';
 import Alert from '../components/Alert';
 
 const ADVANCEMENT_REASONS = [
@@ -175,22 +175,22 @@ class BlockedAdvanceToJudgeView extends React.Component {
 
     const { highlightFormItems } = this.props;
 
+    const actionData = this.actionData()
     const options = this.actionData().options;
     const selectedJudgeName = this.getAssigneeLabel() || 'judge';
 
+    const modalProps = {
+      title: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_TITLE,
+      pathAfterSubmit: (actionData && actionData.redirect_after) || '/queue',
+      button: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_SUBMIT,
+      submit: this.submit,
+      validateForm: this.validateForm
+    };
+
     return <div className="cf-modal-scroll">
-      <Modal
-        title={COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_TITLE}
-        buttons={[{
-          classNames: ['usa-button', 'cf-btn-link'],
-          name: 'Close',
-          onClick: () => this.setState({ showModal: false })
-        }, {
-          classNames: ['usa-button-secondary', 'usa-button-hover', 'usa-button-warning'],
-          name: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_SUBMIT,
-          onClick: this.submit
-        }]}
-        closeHandler={() => this.setState({ showModal: false })}
+      <QueueFlowModal
+        {...modalProps}
+        onCancel={() => this.setState({ showModal: false })}
         icon="warning"
       >
         {this.modalAlert()}
@@ -216,7 +216,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
           onChange={(value) => this.setState({ instructions: value })}
           value={this.state.instructions}
         />
-      </Modal>
+      </QueueFlowModal>
     </div>;
   }
 

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -187,7 +187,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
     return <div className="cf-modal-scroll">
       <QueueFlowModal
         {...modalProps}
-        onCancel={() => this.setState({ showModal: false })}
+        onCancel={() => this.setState({ showModal: false, selectedAssignee: null, instructions: null })}
         icon="warning"
       >
         {this.modalAlert()}

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -170,7 +170,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
       return;
     }
 
-    const { highlightFormItems } = this.props;
+    const { highlightFormItems, appeal } = this.props;
 
     const actionData = this.actionData();
     const options = this.actionData().options;
@@ -178,7 +178,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
 
     const modalProps = {
       title: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_TITLE,
-      pathAfterSubmit: (actionData && actionData.redirect_after) || '/queue',
+      pathAfterSubmit: (actionData && actionData.redirect_after) || `/queue/appeals/${appeal.externalId}`,
       button: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_SUBMIT,
       submit: this.submit,
       validateForm: this.validateModal

--- a/client/app/queue/BlockedAdvanceToJudgeView.jsx
+++ b/client/app/queue/BlockedAdvanceToJudgeView.jsx
@@ -172,7 +172,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
 
     const { highlightFormItems } = this.props;
 
-    const actionData = this.actionData()
+    const actionData = this.actionData();
     const options = this.actionData().options;
     const selectedJudgeName = this.getAssigneeLabel() || 'judge';
 
@@ -181,7 +181,7 @@ class BlockedAdvanceToJudgeView extends React.Component {
       pathAfterSubmit: (actionData && actionData.redirect_after) || '/queue',
       button: COPY.BLOCKED_SPECIAL_CASE_MOVEMENT_MODAL_SUBMIT,
       submit: this.submit,
-      validateForm: this.validateForm
+      validateForm: this.validateModal
     };
 
     return <div className="cf-modal-scroll">

--- a/client/app/queue/selectors.js
+++ b/client/app/queue/selectors.js
@@ -202,7 +202,6 @@ const taskIsLegacyAttorneyJudgeTask = (task) => {
   const legacyAttorneyJudgeTaskTypes = [
     'AttorneyLegacyTask',
     'JudgeLegacyTask',
-    'JudgeLegacyAssignTask',
     'JudgeLegacyDecisionReviewTask'
   ];
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -385,6 +385,7 @@ Rails.application.routes.draw do
 
   resources :legacy_tasks, only: [:create, :update]
   post '/legacy_tasks/assign_to_judge', to: 'legacy_tasks#assign_to_judge'
+  post '/legacy_tasks/blocked_assign_to_judge', to: 'legacy_tasks#blocked_assign_to_judge'
   resources :tasks, only: [:index, :create, :update] do
     member do
       post :reschedule

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -497,4 +497,63 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       end
     end
   end
+
+  describe "POST legacy_tasks/blocked_assign_to_judge" do
+    let(:assigning_judge) { create(:user) }
+    let(:assignee_judge) { create(:user) }
+    let(:assigning_judge_staff) { create(:staff, :judge_role, user: assigning_judge) }
+    let!(:assignee_judge_staff) { create(:staff, :judge_role, user: assignee_judge) }
+    let(:blocked_appeal) do
+      create(:legacy_appeal,
+             :with_schedule_hearing_tasks,
+             vacols_case: create(:case_with_form_9, staff: assigning_judge_staff))
+    end
+    let(:params) do
+      {
+        "appeal_id": blocked_appeal.id,
+        "assigned_to_id": assignee_judge.id,
+        "instructions": ["just testing this out", "here are the instructions", "last one"]
+      }
+    end
+
+    before do
+      User.stub = create(:user).tap { |scm_user| SpecialCaseMovementTeam.singleton.add_user(scm_user) }
+      FeatureToggle.enable!(:legacy_case_movement_scm_to_vlj_for_blockhtask)
+    end
+
+    shared_examples "scm user reassigns case" do
+      it "should be successful" do
+        expect(VACOLS::Case.find_by(bfkey: blocked_appeal.vacols_id).bfcurloc).to eq assigning_judge.vacols_uniq_id
+        patch :blocked_assign_to_judge, params: { tasks: params }
+        expect(response.status).to eq 200
+        expect(VACOLS::Case.find_by(bfkey: blocked_appeal.vacols_id).bfcurloc).to eq assignee_judge.vacols_uniq_id
+      end
+
+      it "should cancel all blocking tasks" do
+        expect(HearingTask.find_by(appeal_id: blocked_appeal.id).present?).to be true
+        expect(HearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.on_hold)
+        expect(ScheduleHearingTask.find_by(appeal_id: blocked_appeal.id).present?).to be true
+        expect(ScheduleHearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.assigned)
+        patch :blocked_assign_to_judge, params: { tasks: params }
+        expect(response.status).to eq 200
+        expect(HearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.cancelled)
+        expect(ScheduleHearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.cancelled)
+      end
+
+      it "should create a LegacyAppealAssignmentTrackingTask" do
+        expect(LegacyAppealAssignmentTrackingTask.find_by(appeal_id: blocked_appeal.id).present?).to be false
+        patch :blocked_assign_to_judge, params: { tasks: params }
+        expect(response.status).to eq 200
+        expect(LegacyAppealAssignmentTrackingTask.find_by(appeal_id: blocked_appeal.id).present?).to be true
+        expect(LegacyAppealAssignmentTrackingTask.find_by(appeal_id: blocked_appeal.id).status)
+          .to eq(Constants.TASK_STATUSES.completed)
+        expect(LegacyAppealAssignmentTrackingTask.find_by(appeal_id: blocked_appeal.id).instructions)
+          .to eq(params[:instructions])
+        expect(LegacyAppealAssignmentTrackingTask.find_by(appeal_id: blocked_appeal.id).assigned_to)
+          .to eq(assignee_judge)
+      end
+    end
+
+    it_behaves_like "scm user reassigns case"
+  end
 end

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -537,7 +537,8 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
         patch :blocked_assign_to_judge, params: { tasks: params }
         expect(response.status).to eq 200
         expect(HearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.cancelled)
-        expect(ScheduleHearingTask.find_by(appeal_id: blocked_appeal.id).status).to eq(Constants.TASK_STATUSES.cancelled)
+        expect(ScheduleHearingTask.find_by(appeal_id: blocked_appeal.id).status)
+          .to eq(Constants.TASK_STATUSES.cancelled)
       end
 
       it "should create a LegacyAppealAssignmentTrackingTask" do

--- a/spec/controllers/legacy_tasks_controller_spec.rb
+++ b/spec/controllers/legacy_tasks_controller_spec.rb
@@ -521,6 +521,10 @@ RSpec.describe LegacyTasksController, :all_dbs, type: :controller do
       FeatureToggle.enable!(:legacy_case_movement_scm_to_vlj_for_blockhtask)
     end
 
+    after do
+      FeatureToggle.disable!(:legacy_case_movement_scm_to_vlj_for_blockhtask)
+    end
+
     shared_examples "scm user reassigns case" do
       it "should be successful" do
         expect(VACOLS::Case.find_by(bfkey: blocked_appeal.vacols_id).bfcurloc).to eq assigning_judge.vacols_uniq_id


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-62472](https://jira.devops.va.gov/browse/APPEALS-62472)

# Description
Added a new blocked_assign_to_judge method to the legacy_tasks_controller.rb to handle the cancelling of blocking tasks and Case Movement to a judge.

Added cancel_blocking_tasks method to LegacyAppealAssignmentTrackingTask 

Added Error handling to new task action workflow + put work behind the FeatureToggle :legacy_case_movement_scm_to_vlj_for_blockhtask

Added rspec tests to legacy_tasks_controller_spec.rb to handle the new task action.

Changed BlockedAdvanceToJudgeView.jsx to now use QueueFlowModal.jsx instead of Modal.jsx (better prop handling)

Adds the ability for AVLJ's to view and select Task Actions on JudgeLegacyAssignTask's that are assigned to them

Updates assign_to_attorney_data in the task_action_repository to now allow AVLJ's to see a list of Attorneys when completing the task action Assign To Attorney

Removes JudgeLegacyAssignTasks from an Attorney's Queue List, so that AVLJ's don't see these cases in both their Queue and Assign Cases page.

## Acceptance Criteria
- [ ] Code compiles correctly
- [ ] When the user clicks the Cancel Task and Reassign button, the following updates are made:
- Blocking Hearing tasks are cancelled
- VACOLS BRIEFF and PRIORLOC records are updated upon case reassignment
- Appeal's current task is Assign.
- Appeal is Assigned To the the judge selected in the Confirm Cancellation and Reassign modal.

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Run seed data, `bundle exec rake db:seed:legacy_appeals_for_vlj_movement_testing`
2. Enable feature toggle, `FeatureToggle.enable!(:legacy_case_movement_scm_to_vlj_for_blockhtask)`
3. Switch to User "TEAM_ADMIN"
4. Go to their queue, switch views to the Board Of Veteran's Appeals Cases
5. Filter by Legacy Appeal to find the specific seeds with their Veteran Name
6. Open all appeals, then verify no task action is available on the active blocking hearing task.
7. With the appeals open, in another tab switch users to "BVARDUNKLE" who is an SCM User.
8. Refresh the appeal case details pages
9. Verify that there is a Task Action dropdown next to the HearingTask that allows the SCM User to Cancel Blocking Tasks and Advance To Judge
10. Click the Task Action and Advance through the workflow all the way to the Confirm Cancellation Modal.
11. Select Cancel and Advance To Judge button.
12. Confirm Case Movement + cancellation of blocking hearing tasks

