### PR TITLE
Ki/APPEALS-64500 - Correspondence Details: Add Task Modal Error Handling

### DIFF
--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddRelatedTaskModalCorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddRelatedTaskModalCorrespondenceDetails.jsx
@@ -61,7 +61,9 @@ const AddRelatedTaskModalCorrespondenceDetails = ({
   // or task content and additional are not filled out
   // const isSubmitDisabled = !(taskContent || additionalContent) || !selectedTaskType || isLoading;
 
-  const isSubmitDisabled = !(taskContent) || !selectedTaskType || isLoading;
+  const isSubmitDisabled = !taskContent || !selectedTaskType || isLoading;
+
+  const isNextDisabled = !selectedTaskType;
 
   // Handle task type selection, stores the selected task type
   const updateTaskType = (newType) => setSelectedTaskType(newType.value);
@@ -154,7 +156,7 @@ const AddRelatedTaskModalCorrespondenceDetails = ({
           // onClick={isSecondPage ? handleSubmit : handleNext}
           // disabled={isSecondPage ? isSubmitDisabled : false}
           onClick={handleSubmit}
-          disabled={isSubmitDisabled ? isSubmitDisabled : false}
+          disabled={isSubmitDisabled ? isSubmitDisabled : isNextDisabled}
         >
           {isLoading ? 'Loading...' : 'Next'}
         </Button>

--- a/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskModalCorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/intake/components/TasksAppeals/AddTaskModalCorrespondenceDetails.jsx
@@ -47,6 +47,7 @@ const AddTaskModalCorrespondenceDetails = ({
   // Filters task type options based on unrelated tasks, excluding already selected tasks
   const getFilteredTaskTypeOptions = () => {
     const safeUnrelatedTaskList = Array.isArray(unrelatedTaskList) ? unrelatedTaskList : [];
+
     return INTAKE_FORM_TASK_TYPES.unrelatedToAppeal.
       filter((option) =>
         !safeUnrelatedTaskList.some(
@@ -64,6 +65,8 @@ const AddTaskModalCorrespondenceDetails = ({
   // Submit disabled if task type is not selected,
   // the page is loading, or task content and additional are not filled out
   const isSubmitDisabled = !(taskContent || additionalContent) || !selectedTaskType || isLoading;
+
+  const isNextDisabled = !selectedTaskType;
 
   // Handle task type selection, stores the selected task type
   const updateTaskType = (newType) => setSelectedTaskType(newType.value);
@@ -155,7 +158,7 @@ const AddTaskModalCorrespondenceDetails = ({
         <Button
           // "Submit" on second page, "Next" on first page
           onClick={isSecondPage ? handleSubmit : handleNext}
-          disabled={isSecondPage ? isSubmitDisabled : false}
+          disabled={isSecondPage ? isSubmitDisabled : isNextDisabled}
         >
           {getButtonText()}
         </Button>

--- a/spec/feature/queue/correspondence/correspondence_details_existing_appeals_spec.rb
+++ b/spec/feature/queue/correspondence/correspondence_details_existing_appeals_spec.rb
@@ -113,9 +113,11 @@ RSpec.feature("Tasks related to an existing Appeal - In Correspondence Details P
       expect(page).to have_content("Add task to appeal")
       expect(page).to have_selector(".add-task-modal-container")
       expect(page).to have_field("content")
+      fill_in "content", with: "Test"
+      expect(page).to have_button("Next", disabled: true)
       find(".add-task-dropdown-style").click
       find(".react-select__option", text: "Congressional Interest").click
-      fill_in "content", with: "Test"
+      expect(page).to have_button("Next", disabled: false)
       click_button "Next"
       using_wait_time(10) do
         expect(page).to have_content("Congressional Interest")

--- a/spec/feature/queue/correspondence/correspondence_details_spec.rb
+++ b/spec/feature/queue/correspondence/correspondence_details_spec.rb
@@ -317,9 +317,11 @@ RSpec.feature("The Correspondence Details page") do
         expect(page).to have_selector("h1", text: "Add task to correspondence")
         expect(page).to have_selector(".add-task-modal-container")
         expect(page).to have_field("content")
+        fill_in "content", with: "Test"
+        expect(page).to have_button("Next", disabled: true)
         find(".add-task-dropdown-style").click
         find(".react-select__option", text: "Congressional Interest").click
-        fill_in "content", with: "Test"
+        expect(page).to have_button("Next", disabled: false)
         click_button "Next"
 
         # Test textarea autotext based on radio selection
@@ -327,7 +329,7 @@ RSpec.feature("The Correspondence Details page") do
         find("label", text: "C&P exam report").click
         expect(page).to have_content("Address updated in VACOLS, \nC&P exam report")
 
-        click_button "Submit"
+        click_button "Add task"
         using_wait_time(10) do
           expect(page).to have_content("Congressional Interest")
         end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-64500 - Correspondence Details: Add Task Modal Error Handling](https://jira.devops.va.gov/browse/APPEALS-64500)

# Description
Added an isNextDisabled boolean check to the Add Tasks for Related Appeals and the Add Tasks for Not Related Correspondences modals.  This prevents the Next button from being enabled until a Task is selected from the dropdown.
Note: The AddRelatedTaskModalCorrespondenceDetails modal still requires the text box to be filled out until the AutoText ticket is completed.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Navigate to a Correspondence Details page under Superuser/Supervisor.
2. Click "Add Task" under **Task not related to an Appeal** and check that the Next button does not activate until a selection is made from the Task dropdown.
3. Click "Add Task" on a **Linked Appeal** (either from one that's already on there, or after adding one from Existing Appeals and saving).
4. Validate that the Next button is not available unless selection is made from the Task dropdown. (Note: Currently also requires text box to be filled out, so you can check by filling out the text box first).


# Best practices
## Code Documentation Updates
- [X] Add or update code comments at the top of the class, module, and/or component.

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [X] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [X] No new code climate issues added