### PR TITLE
Deepak/appeals 65021

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -113,7 +113,7 @@ class Document < CaseflowRecord
       file_number: file_number
     )
 
-    if FeatureToggle.enabled?(:use_ce_api)
+    if FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
       document.assign_attributes(series_id: vbms_document.series_id)
     end
 

--- a/app/services/error_handlers/claim_evidence_api_error_handler.rb
+++ b/app/services/error_handlers/claim_evidence_api_error_handler.rb
@@ -26,6 +26,6 @@ class ErrorHandlers::ClaimEvidenceApiErrorHandler
   end
 
   def use_ce_api?
-    FeatureToggle.enabled?(:use_ce_api)
+    FeatureToggle.enabled?(:use_ce_api, user: RequestStore[:current_user])
   end
 end

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -71,7 +71,7 @@ describe ExternalApi::VBMSService do
 
     context "with use_ce_api feature toggle disabled" do
       it "calls the VbmsDocumentSeriesForAppeal service" do
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api,user: user).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(ExternalApi::VbmsDocumentSeriesForAppeal).to receive(:new).with(file_number: appeal.veteran_file_number)
         expect(mock_vbms_document_series_for_appeal).to receive(:fetch)
 

--- a/spec/services/external_api/vbms_service_spec.rb
+++ b/spec/services/external_api/vbms_service_spec.rb
@@ -71,7 +71,7 @@ describe ExternalApi::VBMSService do
 
     context "with use_ce_api feature toggle disabled" do
       it "calls the VbmsDocumentSeriesForAppeal service" do
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api,user: user).and_return(false)
         expect(ExternalApi::VbmsDocumentSeriesForAppeal).to receive(:new).with(file_number: appeal.veteran_file_number)
         expect(mock_vbms_document_series_for_appeal).to receive(:fetch)
 
@@ -108,7 +108,7 @@ describe ExternalApi::VBMSService do
 
     context "with use_ce_api feature toggle disabled" do
       it "calls the VbmsDocumentsForAppeal service" do
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(ExternalApi::VbmsDocumentsForAppeal).to receive(:new).with(file_number: appeal.veteran_file_number)
         expect(mock_vbms_document_series_for_appeal).to receive(:fetch)
 
@@ -179,7 +179,7 @@ describe ExternalApi::VBMSService do
       let(:mock_init_update_response) { double(updated_document_token: "document-token") }
 
       it "calls the SOAP API implementation" do
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(described).to receive(:init_vbms_client)
         expect(described).to receive(:initialize_update).and_return(mock_init_update_response)
         expect(described).to receive(:send_and_log_request)
@@ -229,7 +229,7 @@ describe ExternalApi::VBMSService do
       let(:mock_init_update_response) { double(updated_document_token: "document-token") }
 
       it "calls the SOAP API implementation" do
-        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api).and_return(false)
+        expect(FeatureToggle).to receive(:enabled?).with(:use_ce_api, user: user).and_return(false)
         expect(described).to receive(:init_vbms_client)
         expect(described).to receive(:initialize_update).with(appeal, fake_document)
           .and_return(mock_init_update_response)
@@ -249,8 +249,7 @@ describe ExternalApi::VBMSService do
         source: "my_source",
         document_type_id: 1,
         document_type: "test",
-        document_subject: "testing1",
-        new_mail: true
+        document_subject: "testing1"
       )
     end
     let(:veteran_file_number) { "123456789" }
@@ -315,8 +314,7 @@ describe ExternalApi::VBMSService do
         source: "my_source",
         document_type_id: 1,
         document_type: "test",
-        document_subject: "testing1",
-        new_mail: true
+        document_subject: "testing1"
       )
     end
     let(:appeal) { create(:appeal) }


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves - https://jira.devops.va.gov/browse/APPEALS-65021

# Description
Update the use_ce_api feature flag for the user-specific

You'll need to specify the scope at which you're checking the feature state: if you check enabled? without specifying a user, the result will be false if the feature is only enabled for specific user.
FeatureToggle.enabled?(:bar, user: current_user)

State checking methods receive User objects, not Arrays

Example of config_file - [features-config.yml] for higher Envs
```

[
   {
     feature: "use_ce_api",
     enable_all: true
   },
   {
     feature: "use_ce_api",
     users: ["VHAISADJURIN", "VHAISAPROKOA", "VHAISWSTEWAA"]
   }
 ]

```

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
- For backend console
FeatureToggle.enable!(:use_ce_api, users: ["CSS_ID_1", "CSS_ID_2"])
FeatureToggle.disable!(:use_ce_api, users: ["CSS_ID_1", "CSS_ID_2"])
