### PR TITLE
Ki/APPEALS-65572 - Resolve jest failures in TestCorrespondence.test.js

### DIFF
--- a/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
+++ b/client/app/queue/correspondence/details/CorrespondenceDetails.jsx
@@ -633,7 +633,7 @@ const CorrespondenceDetails = (props) => {
               '' :
               <Button
                 onClick={handleEditGeneralInformationModal}
-                classNames={['button-style']}
+                classNames={['cf-left-side']}
               >Edit</Button> }
           </div>
           <table className="corr-table-borderless-no-background gray-border">

--- a/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
+++ b/client/test/app/queue/correspondences/CorrespondenceChangeTaskTypeModal.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import { Provider } from 'react-redux';
 import { applyMiddleware, compose, createStore } from 'redux';
 import rootReducer from 'app/queue/reducers';
@@ -70,7 +70,7 @@ describe('CorrespondenceChangeTaskTypeModal', () => {
     renderComponent();
 
     expect(screen.getByText('Select an action type...')).toBeInTheDocument();
-    expect(screen.getByLabelText(COPY.CHANGE_TASK_TYPE_INSTRUCTIONS_LABEL)).toBeInTheDocument();
+    expect(screen.getByLabelText(COPY.PLEASE_PROVIDE_CONTEXT_AND_INSTRUCTIONS_LABEL)).toBeInTheDocument();
   });
 
   it('disables the submit button if the form is not valid', () => {
@@ -86,7 +86,7 @@ describe('CorrespondenceChangeTaskTypeModal', () => {
     renderComponent();
 
     userEvent.type(screen.getByRole('combobox'), 'CAVC{enter}');
-    userEvent.type(screen.getByLabelText(COPY.CHANGE_TASK_TYPE_INSTRUCTIONS_LABEL), 'test instructions');
+    userEvent.type(screen.getByLabelText(COPY.PLEASE_PROVIDE_CONTEXT_AND_INSTRUCTIONS_LABEL), 'test instructions');
 
     const submitButton = screen.getByRole('button', { name: COPY.CHANGE_TASK_TYPE_SUBHEAD });
 
@@ -96,9 +96,10 @@ describe('CorrespondenceChangeTaskTypeModal', () => {
   it('renders dropdown with correct options', () => {
     renderComponent();
 
-    const dropdown = screen.getByRole('combobox');
+    const dropdown = screen.getByRole('combobox',
+      { name: 'Select another task type from the list of available options:' });
 
-    fireEvent.mouseDown(dropdown);
+    fireEvent.keyDown(dropdown, { key: 'ArrowDown' });
 
     // Ensure each option is rendered
     INTAKE_FORM_TASK_TYPES.unrelatedToAppeal.forEach((option) => {

--- a/client/test/app/test/TestCorrespondence.test.js
+++ b/client/test/app/test/TestCorrespondence.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom';
 import ApiUtil from 'app/util/ApiUtil';
 import COPY from '../../../COPY';
 import TestCorrespondence from 'app/test/TestCorrespondence';


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-65572 - Resolve jest failures in TestCorrespondence.test.js](https://jira.devops.va.gov/browse/APPEALS-65572)
Resolves [APPEALS-65571 - Resolve jest failures in CorrespondenceChangeTaskTypeModal.test.js](https://jira.devops.va.gov/browse/APPEALS-65571)

# Description

1. Updated extend-expect designation to match updates from jest-dom testing updates:
    1. https://github.com/testing-library/jest-dom/releases/tag/v6.0.0
2. Updated tests for CorrespondenceChangeTaskTypeModal to match correct labels and for tests cases to work correctly
3. Additional styling fix for Edit button on Correspondence Details page.

## Acceptance Criteria
- [X] Code compiles correctly

## Testing Plan
<!-- Change JIRA-12345 to reflect the URL of the location of the test plan(s) for this PR -->
1. Validate jest tests for TestCorrespondence.test.js pass.
5. Validate jest tests for CorrespondenceChangeTaskTypeModal.test.js pass.


# Best practices
## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [X] Jest