### PR TITLE
Submit action for 'No Errors Found' modal

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -187,10 +187,10 @@ class TasksController < ApplicationController
   end
 
   def upload_transcription_to_vbms
-    file_paths = ReviewTranscriptTask.find_by(id: task.id).appeal.hearings.first.transcription_files
+    file_paths = task.appeal.hearings.first.transcription_files
       .where(file_type: "pdf").map(&:fetch_file_from_s3!)
 
-    appeal = ReviewTranscriptTask.find_by(id: task.id).appeal
+    appeal = task.appeal
     file_paths.each do |current_file_path|
       file_name = current_file_path.split("/").last
       document_params = create_document_params(appeal, file_name, current_file_path)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -193,7 +193,15 @@ class TasksController < ApplicationController
     appeal = task.appeal
     file_paths.each do |current_file_path|
       file_name = current_file_path.split("/").last
-      document_params = create_document_params(appeal, file_name, current_file_path)
+      document_params =
+      {
+        veteran_file_number: appeal.veteran_file_number,
+        document_type: "Hearing Transcript",
+        document_subject: "notifications",
+        document_name: file_name,
+        application: "notification-report",
+        file: current_file_path
+      }
       response = PrepareDocumentUploadToVbms.new(document_params, User.system_user, appeal).call
       if response.success?
         # change status of ReviewTranscriptTask
@@ -205,17 +213,6 @@ class TasksController < ApplicationController
   def error_found_upload_transcription_to_vbms; end
 
   private
-
-  def create_document_params(appeal, file_name, current_file_path)
-    {
-      veteran_file_number: appeal.veteran_file_number,
-      document_type: "Hearing Transcript",
-      document_subject: "notifications",
-      document_name: file_name,
-      application: "notification-report",
-      file: current_file_path
-    }
-  end
 
   def complete_transcript_review
     return unless task.type == "ReviewTranscriptTask" && task.status == "in_progress"

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -187,12 +187,12 @@ class TasksController < ApplicationController
   end
 
   def upload_transcription_to_vbms
-    file_paths = ReviewTranscriptTask.find_by(id: task.id).appeal.hearings.first.transcription_files.
-      where(file_type: "pdf").map(&:fetch_file_from_s3!)
+    file_paths = ReviewTranscriptTask.find_by(id: task.id).appeal.hearings.first.transcription_files
+      .where(file_type: "pdf").map(&:fetch_file_from_s3!)
 
     appeal = ReviewTranscriptTask.find_by(id: task.id).appeal
     file_paths.each do |current_file_path|
-      file_name = current_file_path.split('/').last
+      file_name = current_file_path.split("/").last
       document_params = create_document_params(appeal, file_name, current_file_path)
       response = PrepareDocumentUploadToVbms.new(document_params, User.system_user, appeal).call
       if response.success?
@@ -200,7 +200,6 @@ class TasksController < ApplicationController
         complete_transcript_review
       end
     end
-
   end
 
   def error_found_upload_transcription_to_vbms; end
@@ -208,7 +207,7 @@ class TasksController < ApplicationController
   private
 
   def create_document_params(appeal, file_name, current_file_path)
-    return {
+    {
       veteran_file_number: appeal.veteran_file_number,
       document_type: "Hearing Transcript",
       document_subject: "notifications",

--- a/app/workflows/transcription_file_upload.rb
+++ b/app/workflows/transcription_file_upload.rb
@@ -13,7 +13,8 @@ class TranscriptionFileUpload
     xls: "transcript_text",
     csv: "transcript_text",
     zip: "transcript_text",
-    json: "transcript_text"
+    json: "transcript_text",
+    pdf: "transcript_pdf"
   }.freeze
 
   class FileUploadError < StandardError; end

--- a/spec/controllers/tasks_controller_spec.rb
+++ b/spec/controllers/tasks_controller_spec.rb
@@ -1667,4 +1667,57 @@ RSpec.describe TasksController, :all_dbs, type: :controller do
       end
     end
   end
+
+  describe "PATH tasks/:id/modal/upload_transcription_vbms" do
+    let(:file_type) { "pdf" }
+    let(:hearing) { create(:hearing) }
+    let(:docket_number) { hearing.docket_number }
+    let(:appeal_id) { hearing.appeal.uuid }
+    let(:file_name) { "#{docket_number}_#{hearing.id}_#{hearing.class}.#{file_type}" }
+    let(:tmp_location) { File.join(Rails.root, "tmp", "transcription_files", file_type, file_name) }
+    let!(:create_transcription_task) do
+      Hearings::TranscriptionFile.create!(
+        hearing_id: hearing.id,
+        hearing_type: "Hearing",
+        file_name: file_name,
+        file_type: file_type.to_s,
+        docket_number: hearing.docket_number,
+        file_status: "Successful upload (AWS)",
+        date_upload_aws: Time.zone.today,
+        aws_link: "vaec-appeals-caseflow-test/transcript_pdf/#{file_name}"
+      )
+    end
+    let(:transcription_file) { Hearings::TranscriptionFile.find_by(file_name: file_name) }
+    let(:user) { create(:default_user) }
+    let(:root_task) { create(:root_task, appeal: hearing.appeal) }
+    let(:distribution_task) { create(:distribution_task, parent: root_task) }
+    let(:parent_hearing_task) { create(:hearing_task, parent: distribution_task) }
+    let!(:review_transcript_task) do
+      ReviewTranscriptTask.create!(
+        appeal: hearing.appeal,
+        parent: root_task,
+        assigned_to: user
+      )
+    end
+
+    let(:params) do
+      {
+        task: {
+          instructions: "testing"
+        },
+        id: review_transcript_task.id.to_s
+      }
+    end
+
+    before do
+      review_transcript_task.update!(status: Constants.TASK_STATUSES.in_progress)
+    end
+
+    subject { patch :upload_transcription_to_vbms, params: params }
+
+    it "updates status ReviewTranscriptTask to completed" do
+      subject
+      expect(response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [APPEALS-64077](https://jira.devops.va.gov/browse/APPEALS-64077)

# Description
As a Caseflow User I need the ability to upload the "final PDF" to the selected Appellants eFolder endpoint in VBMS so that files can be retrieved when needed.

As a Caseflow Developer I need to;

Create a new method on submit for 'No Errors Found'
1- DocketNumber_interenalHearingID_HearingClassName.pdf
 - Found in the transcription_files table
 - aws_link column for the pdf file

2- Upload the PDF file to the Appellants eFolder location in VBMS

## Acceptance Criteria
- [x] Code compiles correctly

## Testing Plan
# Frontend

1. Open claseflow demo application.
2. Login like a admin Hearing
3. Go to demo/hearings/transcription_files
4. Switch the view and select `Hearing Admin Team cases`
5. Select any hearing with a Review Transcript task open
6. In the action Select `No errors found: Upload transcript to VBMS`
7. Add a description in the text area and click `Upload to VBMS`

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec
- [ ] Jest
- [ ] Other

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added
