### PR TITLE
lthompson/APPEALS-65140

### DIFF
--- a/app/controllers/hearings/national_hearing_queue_controller.rb
+++ b/app/controllers/hearings/national_hearing_queue_controller.rb
@@ -31,7 +31,7 @@ class Hearings::NationalHearingQueueController < ApplicationController
       return does_not_persist
     end
 
-    render json: { cutoff_date_record: record }, status: :ok
+    render json: { cutoff_date_record: record }, status: :created
   end
 
   private
@@ -41,7 +41,8 @@ class Hearings::NationalHearingQueueController < ApplicationController
       "errors": [
         "status": "400",
         "title": "Invalid Date",
-        "detail": "Please enter a valid date"
+        "detail": "Please enter a valid date",
+        "error_code": error_uuid
       ]
     }, status: :bad_request
   end
@@ -51,7 +52,8 @@ class Hearings::NationalHearingQueueController < ApplicationController
       "errors": [
         "status": "500",
         "title": "Internal Service Error",
-        "detail": "Cutoff date unable to persist, try again at a later time"
+        "detail": "Cutoff date unable to persist, try again at a later time",
+        "error_code": error_uuid
       ]
     }, status: :internal_server_error
   end
@@ -59,5 +61,6 @@ class Hearings::NationalHearingQueueController < ApplicationController
   def log_error(error)
     Rails.logger.error(error)
     Rails.logger.error(error.backtrace.join("\n"))
+    Rails.logger.error(error_uuid)
   end
 end

--- a/app/controllers/hearings/national_hearing_queue_controller.rb
+++ b/app/controllers/hearings/national_hearing_queue_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Hearings::NationalHearingQueueController < ApplicationController
-  # skip_before_action :verify_authenticity_token
+  skip_before_action :verify_authenticity_token
 
   def index
     respond_to do |format|
@@ -13,8 +13,6 @@ class Hearings::NationalHearingQueueController < ApplicationController
   # have their hearings scheduled as well as if the current_user is authorized to provide new
   # cutoff dates.
   def cutoff_date
-    byebug
-
     date = SchedulableCutoffDate.most_recently_added&.cutoff_date
     # December 31, 2019 is the fallback date in the event no user-defined cutoff dates exist.
     date ||= Date.new(2019, 12, 31)
@@ -23,13 +21,13 @@ class Hearings::NationalHearingQueueController < ApplicationController
   end
 
   def update_cutoff_date
-    required_params = params.require(:cutoff_date)
+    params.require(:cutoff_date)
 
     begin
-      Date.iso8601(required_params[:cutoff_date])
+      Date.iso8601(params[:cutoff_date])
 
       record = SchedulableCutoffDate.create!(
-        cutoff_date: required_params[:cutoff_date],
+        cutoff_date: params[:cutoff_date],
         created_by_id: current_user.id,
         created_at: Time.zone.now
       )

--- a/app/controllers/hearings/national_hearing_queue_controller.rb
+++ b/app/controllers/hearings/national_hearing_queue_controller.rb
@@ -13,13 +13,13 @@ class Hearings::NationalHearingQueueController < ApplicationController
   end
 
   def update_cutoff_date
-    required_params = params.require(:cutoff_date)
+    params.require(:cutoff_date)
 
     begin
-      Date.iso8601(required_params[:cutoff_date])
+      Date.iso8601(params[:cutoff_date])
 
       record = SchedulableCutoffDate.create!(
-        cutoff_date: required_params[:cutoff_date],
+        cutoff_date: params[:cutoff_date],
         created_by_id: current_user.id,
         created_at: Time.zone.now
       )

--- a/app/controllers/hearings/national_hearing_queue_controller.rb
+++ b/app/controllers/hearings/national_hearing_queue_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Hearings::NationalHearingQueueController < ApplicationController
-  skip_before_action :verify_authenticity_token
-
   def index
     respond_to do |format|
       format.html { render "national_hearing_queue/index" }

--- a/app/controllers/hearings/national_hearing_queue_controller.rb
+++ b/app/controllers/hearings/national_hearing_queue_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Hearings::NationalHearingQueueController < ApplicationController
+  # skip_before_action :verify_authenticity_token
+
   def index
     respond_to do |format|
       format.html { render "national_hearing_queue/index" }
@@ -11,6 +13,8 @@ class Hearings::NationalHearingQueueController < ApplicationController
   # have their hearings scheduled as well as if the current_user is authorized to provide new
   # cutoff dates.
   def cutoff_date
+    byebug
+
     date = SchedulableCutoffDate.most_recently_added&.cutoff_date
     # December 31, 2019 is the fallback date in the event no user-defined cutoff dates exist.
     date ||= Date.new(2019, 12, 31)
@@ -19,13 +23,13 @@ class Hearings::NationalHearingQueueController < ApplicationController
   end
 
   def update_cutoff_date
-    params.require(:cutoff_date)
+    required_params = params.require(:cutoff_date)
 
     begin
-      Date.iso8601(params[:cutoff_date])
+      Date.iso8601(required_params[:cutoff_date])
 
       record = SchedulableCutoffDate.create!(
-        cutoff_date: params[:cutoff_date],
+        cutoff_date: required_params[:cutoff_date],
         created_by_id: current_user.id,
         created_at: Time.zone.now
       )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -261,10 +261,6 @@ Rails.application.routes.draw do
   get 'hearings/find_closest_hearing_locations', to: 'hearings#find_closest_hearing_locations'
   get 'hearings/transcription_file/:file_id/download', to: 'hearings/transcription_files#download_transcription_file'
 
-  scope module: 'hearings/national_hearing_queue', path: '/national_hearing_queue' do
-    get "/(*params)", action: "index"
-  end
-
   post 'hearings/hearing_view/:id', to: 'hearings/hearing_view#create'
 
   resources :hearings, only: [:update, :show]
@@ -272,6 +268,7 @@ Rails.application.routes.draw do
   scope module: "hearings/national_hearing_queue", path: "/national_hearing_queue" do
     get "/cutoff_date", action: "cutoff_date"
     post "/cutoff_date", action: "update_cutoff_date"
+    get "/(*params)", action: "index"
   end
 
   patch "certifications" => "certifications#create"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -267,6 +267,7 @@ Rails.application.routes.draw do
 
   scope module: "hearings/national_hearing_queue", path: "/national_hearing_queue" do
     get "/cutoff_date", action: "cutoff_date"
+    post "/cutoff_date", action: "update_cutoff_date"
   end
 
   patch "certifications" => "certifications#create"

--- a/spec/controllers/hearings/national_hearing_queue_controller_spec.rb
+++ b/spec/controllers/hearings/national_hearing_queue_controller_spec.rb
@@ -29,4 +29,31 @@ describe Hearings::NationalHearingQueueController, type: :controller do
       end
     end
   end
+
+  context "POST cutoff_date" do
+    context "Whenever the cutoff date is not a valid date" do
+      subject { post :update_cutoff_date, params: { cutoff_date: "not a valid date" } }
+
+      it "Returns a 400 error" do
+        expect(subject.response_code).to eq 400
+      end
+    end
+
+    context "Whenever the record fails to persist in the database" do
+      subject { post :update_cutoff_date, params: { cutoff_date: "2019-12-31" } }
+
+      it "Returns a 500 error" do
+        allow(SchedulableCutoffDate).to receive(:create!).and_raise(StandardError.new("error"))
+        expect(subject.response_code).to eq 500
+      end
+    end
+
+    context "Whenever the new record persists in the database" do
+      subject { post :update_cutoff_date, params: { cutoff_date: "2019-12-31" } }
+
+      it "Returns a 201 success" do
+        expect(subject.response_code).to eq 201
+      end
+    end
+  end
 end


### PR DESCRIPTION
Resolves [APPEALS-65140](https://jira.devops.va.gov/browse/APPEALS-65140)

# Description
As a Hearings Division Supervisor, I need the ability to update the "schedulability cutoff date" for appeals to manage the business rules that dictate hearing scheduling.

## Acceptance Criteria
- [x] A controller action named update_cutoff_date is added to the Hearings::NationalHearingQueueController
    - [x] It accepts a parameter named "cutoff_date," which is a string that represents the new cutoff date.
        - [x] AIt must be in the format "YYYY-MM-DD"
        - [x] It must represent a valid date.
        - [x] Failure to meet any of the above should cause a 400 error to be raised.
    - [x] It will create a new schedulable_cutoff_dates record that includes cutoff_date, created_by_id, and created_at
        - [x] cutoff_date: The cutoff_date value provided by the user
        - [x] created_by_id: The ID of the current_user 
        - [x] created_at: Time.zone.now
    - [x] If the record fails to persist in the database, then raise a 500 error
    - [x] The error type and message should be logged to Rails.logger.error for troubleshooting purposes
- [x] A route is added to accept a POST request at /national_hearing_queue/cutoff_date
    - [x] The route definition is configured to route POST requests to that address to the newly created controller action

## Testing Plan
1. Go to [APPEALS-67652](https://jira.devops.va.gov/browse/APPEALS-67652)

## Tests
### Test Coverage
Did you include any test coverage for your code? Check below:
- [x] RSpec

### Code Climate
Your code does not add any new code climate offenses? If so why?
- [x] No new code climate issues added


