### PR TITLE
Fix Bad Param Name Causing 500 Error

### DIFF
--- a/app/services/error_handlers/vefs_api_error_handler.rb
+++ b/app/services/error_handlers/vefs_api_error_handler.rb
@@ -2,7 +2,7 @@
 
 class ErrorHandlers::VefsApiErrorHandler
   def handle_error(error:, error_details:)
-    report_error_to_sentry(error: error, error_details: error_details)
+    report_error_to_sentry(error: error, _error_details: error_details)
   end
 
   private


### PR DESCRIPTION
<!-- Change JIRA-12345 to reflect the URL of the Jira item this PR is associated with -->
Resolves [Update Review Package to use S3 Bucket](https://jira.devops.va.gov/browse/APPEALS-59149)

# Description
- Fix bad param name causing 500 error.

## Acceptance Criteria
- [ ] See Jira ticket

## Testing Plan
- [ ] Run specs for changed files:
    - `bundle exec rspec spec/requests/correspondence_review_package_controller_spec.rb`
    - `bundle exec rspec spec/services/cmp_document_fetcher_spec.rb`
    - `bundle exec rspec spec/services/external_api/vefs_api_client_spec.rb`