### PR TITLE
SeanC/Restrict Decision Date Fix

### DIFF
--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -133,6 +133,10 @@ class NonCompDispositions extends React.PureComponent {
     const dateIsValid = Boolean((new Date(decisionDate)) >= new Date(receiptDate)) &&
       Boolean(Date.parse(decisionDate) < new Date());
 
+    if (this.props.task.business_line !== 'vha') {
+      return true;
+    }
+
     if (dateIsValid) {
       this.setState({ errorMessage: '' });
     } else {
@@ -313,9 +317,9 @@ class NonCompDispositions extends React.PureComponent {
               value={decisionDate}
               onChange={this.handleDecisionDate}
               readOnly={disableIssueFields}
-              minDate={receiptDate}
-              errorMessage={this.state.errorMessage}
-              noFutureDates
+              minDate={this.props.task.business_line === 'vha' ? receiptDate : null}
+              errorMessage={this.props.task.business_line === 'vha' ? this.state.errorMessage : null}
+              noFutureDates={this.props.task.business_line === 'vha'}
               type="date"
             />
           </InlineForm>

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -255,6 +255,8 @@ class NonCompDispositions extends React.PureComponent {
 
     const disableIssueFields = Boolean(task.closed_at) || decisionHasPendingRequestIssues;
 
+    const isVhaBusinessLine = this.props.task.business_line === 'vha';
+
     return <div>
       {displayPOAComponent && <div className="cf-decisions">
         <div className="cf-decision">
@@ -317,9 +319,9 @@ class NonCompDispositions extends React.PureComponent {
               value={decisionDate}
               onChange={this.handleDecisionDate}
               readOnly={disableIssueFields}
-              minDate={this.props.task.business_line === 'vha' ? receiptDate : null}
-              errorMessage={this.props.task.business_line === 'vha' ? this.state.errorMessage : null}
-              noFutureDates={this.props.task.business_line === 'vha'}
+              minDate={isVhaBusinessLine ? receiptDate : null}
+              errorMessage={isVhaBusinessLine ? this.state.errorMessage : null}
+              noFutureDates={isVhaBusinessLine}
               type="date"
             />
           </InlineForm>

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -217,7 +217,7 @@ class NonCompDispositions extends React.PureComponent {
     const displayRequestIssueModification = (!displayPOAComponent || isBusinessLineAdmin);
 
     const decisionHasPendingRequestIssues = task.pending_issue_modification_count > 0;
-    const receiptDate = formatDateStrUtc(appeal.receiptDate, 'YYYY-MM-DD');
+    const receiptDate = moment(appeal.receiptDate, 'YYYY/MM/DD');
 
     if (!task.closed_at) {
       completeDiv = <React.Fragment>

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -127,15 +127,15 @@ class NonCompDispositions extends React.PureComponent {
   }
 
   validateDecisionDate = () => {
+    if (this.props.businessLineUrl !== 'vha') {
+      return true;
+    }
+
     const decisionDate = formatDateStr(this.state.decisionDate);
     const receiptDate = formatDateStr(this.props.appeal.receiptDate);
 
     const dateIsValid = Boolean((new Date(decisionDate)) >= new Date(receiptDate)) &&
       Boolean(Date.parse(decisionDate) < new Date());
-
-    if (this.props.task.business_line !== 'vha') {
-      return true;
-    }
 
     if (dateIsValid) {
       this.setState({ errorMessage: '' });
@@ -213,8 +213,8 @@ class NonCompDispositions extends React.PureComponent {
     let editIssuesLink = null;
     const editIssuesDisabled = task.type === 'Remand';
     const editIssuesButtonType = editIssuesDisabled ? 'disabled' : 'secondary';
-    const displayPOAComponent = task.business_line === 'vha';
-    const displayRequestIssueModification = (!displayPOAComponent || isBusinessLineAdmin);
+    const isVhaBusinessLine = this.props.businessLineUrl === 'vha';
+    const displayRequestIssueModification = (!isVhaBusinessLine || isBusinessLineAdmin);
 
     const decisionHasPendingRequestIssues = task.pending_issue_modification_count > 0;
     const receiptDate = moment(appeal.receiptDate, 'YYYY/MM/DD');
@@ -255,10 +255,8 @@ class NonCompDispositions extends React.PureComponent {
 
     const disableIssueFields = Boolean(task.closed_at) || decisionHasPendingRequestIssues;
 
-    const isVhaBusinessLine = this.props.task.business_line === 'vha';
-
     return <div>
-      {displayPOAComponent && <div className="cf-decisions">
+      {isVhaBusinessLine && <div className="cf-decisions">
         <div className="cf-decision">
           <hr />
           <div className="usa-grid-full">
@@ -271,7 +269,7 @@ class NonCompDispositions extends React.PureComponent {
       </div>}
       <div className="cf-decisions">
         <div className="cf-decision">
-          {displayPOAComponent && <hr />}
+          {isVhaBusinessLine && <hr />}
           <div className="usa-grid-full">
             <div className="usa-width-one-half">
               <h2 style={{ marginBottom: '30px' }}>Decision</h2>
@@ -348,7 +346,8 @@ NonCompDispositions.propTypes = {
   appeal: PropTypes.object,
   decisionIssuesStatus: PropTypes.object,
   isBusinessLineAdmin: PropTypes.bool,
-  handleSave: PropTypes.func
+  handleSave: PropTypes.func,
+  businessLineUrl: PropTypes.string
 };
 
 export default connect(
@@ -356,6 +355,7 @@ export default connect(
     appeal: state.nonComp.appeal,
     task: state.nonComp.task,
     decisionIssuesStatus: state.nonComp.decisionIssuesStatus,
-    isBusinessLineAdmin: state.nonComp.isBusinessLineAdmin
+    isBusinessLineAdmin: state.nonComp.isBusinessLineAdmin,
+    businessLineUrl: state.nonComp.businessLineUrl
   })
 )(NonCompDispositions);

--- a/client/app/nonComp/components/Disposition.jsx
+++ b/client/app/nonComp/components/Disposition.jsx
@@ -217,7 +217,7 @@ class NonCompDispositions extends React.PureComponent {
     const displayRequestIssueModification = (!isVhaBusinessLine || isBusinessLineAdmin);
 
     const decisionHasPendingRequestIssues = task.pending_issue_modification_count > 0;
-    const receiptDate = moment(appeal.receiptDate, 'YYYY/MM/DD');
+    const receiptDate = formatDateStrUtc(appeal.receiptDate, 'YYYY-MM-DD');
 
     if (!task.closed_at) {
       completeDiv = <React.Fragment>

--- a/spec/feature/non_comp/dispositions_spec.rb
+++ b/spec/feature/non_comp/dispositions_spec.rb
@@ -84,7 +84,8 @@ feature "NonComp Dispositions Task Page", :postgres do
     let(:business_line_url) { "decision_reviews/nca" }
     let(:dispositions_url) { "#{business_line_url}/tasks/#{in_progress_task.id}" }
     let(:arbitrary_decision_date) { "01/01/2019" }
-    let(:valid_decision_date) { decision_review.created_at.strftime("%m/%d") }
+    let(:valid_decision_date) { decision_review.created_at.strftime("%m/%d/%Y") }
+    let(:future_decision_date) { 5.days.from_now.strftime("%m/%d/%Y") }
 
     let(:vet_id_column_value) { veteran.ssn }
 
@@ -154,13 +155,10 @@ feature "NonComp Dispositions Task Page", :postgres do
       before do
         visit dispositions_url
         FeatureToggle.enable!(:poa_button_refresh)
+        expect(page).to have_button("Complete", disabled: true)
       end
 
       after { FeatureToggle.disable!(:poa_button_refresh) }
-
-      scenario "neither disposition nor date is set" do
-        expect(page).to have_button("Complete", disabled: true)
-      end
 
       scenario "only date is set" do
         fill_in "decision-date", with: valid_decision_date
@@ -182,11 +180,18 @@ feature "NonComp Dispositions Task Page", :postgres do
         fill_in_disposition(1, "DTA Error", "test description")
         fill_in_disposition(2, "Denied", "denied")
 
-        expect(page).to have_text("Decision date must be between Form Receipt Date")
-        expect(page).to have_button("Complete", disabled: true)
-        fill_in "decision-date", with: valid_decision_date
+        expect(page).to have_button("Complete", disabled: false)
+      end
+
+      scenario "still allows future decision dates" do
+        fill_in "decision-date", with: future_decision_date
+        fill_in_disposition(0, "Granted")
+        fill_in_disposition(1, "DTA Error", "test description")
+        fill_in_disposition(2, "Denied", "denied")
 
         expect(page).to have_button("Complete", disabled: false)
+        click_on "Complete"
+        expect(page).to have_content("Decision Completed")
       end
     end
 
@@ -271,7 +276,6 @@ feature "NonComp Dispositions Task Page", :postgres do
     before do
       User.stub = user
       vha_org.add_user(user)
-      Timecop.travel(Time.zone.local(2023, 0o2, 0o1))
 
       OrganizationsUser.make_user_admin(admin_user, VhaBusinessLine.singleton)
     end
@@ -281,14 +285,17 @@ feature "NonComp Dispositions Task Page", :postgres do
     end
 
     after do
-      Timecop.return
       FeatureToggle.disable!(:poa_button_refresh)
     end
 
     let!(:vha_org) { VhaBusinessLine.singleton }
     let(:user) { create(:default_user, roles: ["Mail Intake"]) }
     let(:veteran) { create(:veteran) }
-    let(:decision_date) { Time.zone.now - 2.days }
+    let(:decision_date) { 2.days.ago }
+    # The date picker disables entering the year if the min/max values are a 1 year span
+    let(:decision_date_formatted_for_datepicker) { decision_date.strftime("%m/%d") }
+    let(:future_decision_date) { 5.days.from_now.strftime("%m/%d/%Y") }
+    let(:before_receipt_date) { 1.year.ago.strftime("%m/%d/%Y") }
 
     let!(:in_progress_task) do
       create(:higher_level_review,
@@ -298,7 +305,8 @@ feature "NonComp Dispositions Task Page", :postgres do
              :update_assigned_at,
              benefit_type: "vha",
              veteran: veteran,
-             claimant_type: :veteran_claimant)
+             claimant_type: :veteran_claimant,
+             receipt_date: 5.days.ago)
     end
 
     let(:poa_task) do
@@ -325,7 +333,9 @@ feature "NonComp Dispositions Task Page", :postgres do
 
       step "completing a task should redirect to completed task tab" do
         visit dispositions_url
-        fill_in "decision-date", with: decision_date.strftime("%m/%d/%Y")
+        expect(page).to have_selector("h1", text: "Veterans Health Administration")
+        expect(page).to have_content(veteran.name)
+        fill_in "decision-date", with: decision_date_formatted_for_datepicker
         fill_in_disposition(0, "Granted", "granted")
         scroll_to(page, align: :bottom)
         expect(page).to have_button("Complete", disabled: false)
@@ -345,6 +355,26 @@ feature "NonComp Dispositions Task Page", :postgres do
         expect(page).to have_text(COPY::DISPOSITION_DECISION_DATE_LABEL)
         expect(page.find_by_id("decision-date").value).to have_content(decision_date.strftime("%Y-%m-%d"))
       end
+    end
+
+    it "should not allow disposition with an invalid decision date" do
+      visit dispositions_url
+      expect(page).to have_button("Complete", disabled: true)
+
+      fill_in "decision-date", with: future_decision_date
+      fill_in_disposition(0, "Granted")
+      scroll_to(page, align: :bottom)
+
+      # Do not allow future dates
+      expect(page).to have_button("Complete", disabled: true)
+      expect(page).to have_content("Decision date must be between Form Receipt Date")
+
+      # Do not allow a date before the receipt date of the appeal
+      visit dispositions_url
+      fill_in_disposition(0, "Granted")
+      fill_in "decision-date", with: before_receipt_date
+      expect(page).to have_button("Complete", disabled: true)
+      expect(page).to have_content("Decision date must be between Form Receipt Date")
     end
 
     it "VHA Decision Review should have Power of Attorney Section" do


### PR DESCRIPTION
Resolves [Jira Issue Title](https://jira.devops.va.gov/browse/JIRA-12345)

# Description
Added logic to the frontend NonCompDispositions component to restrict the minimum date, future dates and the date error message props to only the VHA team.

## Acceptance Criteria
- [x] Code compiles correctly
- [x] When on a disposition assigned to any team other than VHA, the date picker should allow for dates in the future
- [x] When a future date is selected there is no error message displayed
- [x] When a future date is selected and the disposition is filled in, the 'Complete' button is enabled

## Testing Plan
1. Date setup: run the following commands in the rails console:
```
user = User.find_by_css_id('ACBAUERVVHAH')
organization=Organization.find_by_url('insurance')
OrganizationsUser.make_user_admin(user)
FactoryBot.create(:higher_level_review_vha_task, assigned_to: organization))
```
2. Go to `/decision_reviews/insurance`
3. In the 'In Progress Tasks' tab, click on the newly created claim
4. In the Disposition drop down select any of the options
5. Click on the decision date input and select a date in the future
6. Click the 'Completed' button
7. Go to 'decision_reviews/vha'
8. In the In the 'In Progress Tasks' tab, click on a claim
9. In the Disposition drop down select any of the options
10. Click on the decision date input and verify that dates in the future are disabled


