### PR TITLE
Kev ma/corr mail task rspec fix

### DIFF
--- a/spec/models/correspondence_mail_task_spec.rb
+++ b/spec/models/correspondence_mail_task_spec.rb
@@ -43,9 +43,9 @@ RSpec.describe CorrespondenceMailTask, type: :model do
         Constants.TASK_ACTIONS.CHANGE_TASK_TYPE.to_h,
         Constants.TASK_ACTIONS.ASSIGN_CORR_TASK_TO_TEAM.to_h,
         Constants.TASK_ACTIONS.ASSIGN_CORR_TASK_TO_PERSON.to_h,
-        Constants.TASK_ACTIONS.CANCEL_CORRESPONDENCE_TASK.to_h,
         Constants.TASK_ACTIONS.COMPLETE_CORRESPONDENCE_TASK.to_h,
-        Constants.TASK_ACTIONS.COR_RETURN_TO_INBOUND_OPS.to_h
+        Constants.TASK_ACTIONS.COR_RETURN_TO_INBOUND_OPS.to_h,
+        Constants.TASK_ACTIONS.CANCEL_CORRESPONDENCE_TASK.to_h
       ]
     end
 


### PR DESCRIPTION
Fixes failing correspondence_mail_task_rspec.rb

# Description
Changed ordering of task action dropdown in test to match wireframes

## Acceptance Criteria
- [x] Code compiles correctly